### PR TITLE
Link preview issue solved and also description added to Needy pages

### DIFF
--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -1,625 +1,948 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>
+                      Incorrect user name or password.
+                      <a href="/cgi/reset_password.pl">Forgotten password?</a>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {});
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>Incorrect user name or password. <a href="/cgi/reset_password.pl">Forgotten password?</a></p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -1,625 +1,974 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Erreur</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//be-fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//be.openfoodfacts.localhost/">Nederlands</a></li><li><a href="//be-de.openfoodfacts.localhost/">Deutsch</a></li><li><a href="//be-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//be-fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//be.openfoodfacts.localhost/">Nederlands</a>
+                      </li>
+                      <li>
+                        <a href="//be-de.openfoodfacts.localhost/">Deutsch</a>
+                      </li>
+                      <li>
+                        <a href="//be-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Chaque don compte ! Nous apprécions votre soutien pour
+                          une plus grande transparence alimentaire dans le
+                          monde.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Erreur</h1>
+                    <p>
+                      Mauvais nom d'utilisateur ou mot de passe.
+                      <a href="/cgi/reset_password.pl">Mot de passe oublié ?</a>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {});
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Erreur</h1>
-									<p>Mauvais nom d'utilisateur ou mot de passe. <a href="/cgi/reset_password.pl">Mot de passe oublié ?</a></p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -1,1116 +1,1522 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Hazelnut spreads</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Hazelnut spreads</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Category</a>:
-                    <a href="/facets/categories/hazelnut-spreads">Hazelnut spreads</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Belongs to:</p>
-<p><a href="/facets/categories/fr:pates-a-tartiner" class="tag user_defined" lang="fr">fr:Pâtes à tartiner</a>, <a href="/facets/categories/sweet-spreads" class="tag well_known">Sweet spreads</a>, <a href="/facets/categories/spreads" class="tag well_known">Spreads</a>, <a href="/facets/categories/breakfasts" class="tag well_known">Breakfasts</a></p>
-<p>Contains:</p><ul>
-<li><a href="/facets/categories/cocoa-and-hazelnuts-spreads" class="tag well_known">Cocoa and hazelnuts spreads</a></li>
-</ul>
-
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
                 </div>
-                
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-                
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-                
+            <!-- full width banner on mobile -->
 
-            
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-            
+                <!-- Donation banner @ footer -->
 
-            
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Hazelnut spreads</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Category</a>:
+                          <a href="/facets/categories/hazelnut-spreads"
+                            >Hazelnut spreads</a
+                          >
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Belongs to:</p>
+                          <p>
+                            <a
+                              href="/facets/categories/fr:pates-a-tartiner"
+                              class="tag user_defined"
+                              lang="fr"
+                              >fr:Pâtes à tartiner</a
+                            >,
+                            <a
+                              href="/facets/categories/sweet-spreads"
+                              class="tag well_known"
+                              >Sweet spreads</a
+                            >,
+                            <a
+                              href="/facets/categories/spreads"
+                              class="tag well_known"
+                              >Spreads</a
+                            >,
+                            <a
+                              href="/facets/categories/breakfasts"
+                              class="tag well_known"
+                              >Breakfasts</a
+                            >
+                          </p>
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/categories/cocoa-and-hazelnuts-spreads"
+                                class="tag well_known"
+                                >Cocoa and hazelnuts spreads</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
-        
-            
-        
-    </div>
-</div>
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
+        <!-- Donation banner @ footer -->
 
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
- 
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
 
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
-        
-        
-        
-      </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 31,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                  id: "labels_organic",
+                  name: "Organic farming",
+                  status: "unknown",
+                  title: "Missing information: organic product?",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                  id: "labels_fair_trade",
+                  name: "Fair trade",
+                  status: "unknown",
+                  title: "Missing information: fair trade product?",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000235",
+          product_display_name: "Only-Product - Nutella - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":31,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
-                  "id":"labels_organic",
-                  "name":"Organic farming",
-                  "status":"unknown",
-                  "title":"Missing information: organic product?"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
-                  "id":"labels_fair_trade",
-                  "name":"Fair trade",
-                  "status":"unknown",
-                  "title":"Missing information: fair trade product?"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000235",
-      "product_display_name":"Only-Product - Nutella - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -1,1181 +1,1826 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Cakes</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/en:cakes/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/en:cakes/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/en:cakes/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/en:cakes/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Cakes</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Category</a>:
-                    <a href="/facets/categories/cakes">Cakes</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Belongs to:</p>
-<p><a href="/facets/categories/biscuits-and-cakes" class="tag well_known">Biscuits and cakes</a>, <a href="/facets/categories/sweet-snacks" class="tag well_known">Sweet snacks</a>, <a href="/facets/categories/snacks" class="tag well_known">Snacks</a></p>
-<p>Contains:</p><ul>
-<li><a href="/facets/categories/almond-cakes" class="tag well_known">Almond cakes</a></li>
-<li><a href="/facets/categories/banana-breads" class="tag well_known">Banana breads</a></li>
-<li><a href="/facets/categories/black-forest-gateau" class="tag well_known">Black Forest gâteau</a></li>
-<li><a href="/facets/categories/breton-cakes" class="tag well_known">Breton cakes</a></li>
-<li><a href="/facets/categories/caneles" class="tag well_known">Canelés</a></li>
-<li><a href="/facets/categories/carrot-cakes" class="tag well_known">Carrot cakes</a></li>
-<li><a href="/facets/categories/cheesecakes" class="tag well_known">Cheesecakes</a></li>
-<li><a href="/facets/categories/chocolate-cakes" class="tag well_known">Chocolate cakes</a></li>
-<li><a href="/facets/categories/chocolate-soft-cake" class="tag well_known">Chocolate soft cake</a></li>
-<li><a href="/facets/categories/clafoutis" class="tag well_known">Clafoutis</a></li>
-<li><a href="/facets/categories/dorayaki" class="tag well_known">Dorayaki</a></li>
-<li><a href="/facets/categories/doughnuts" class="tag well_known">Doughnuts</a></li>
-<li><a href="/facets/categories/fairy-cakes" class="tag well_known">Fairy cakes</a></li>
-<li><a href="/facets/categories/filled-cakes" class="tag well_known">Filled cakes</a></li>
-<li><a href="/facets/categories/filled-sponge-cake-slices" class="tag well_known">Filled sponge cake slices</a></li>
-<li><a href="/facets/categories/financiers" class="tag well_known">Financiers</a></li>
-<li><a href="/facets/categories/fresh-cakes" class="tag well_known">Fresh cakes</a></li>
-<li><a href="/facets/categories/fruit-cakes" class="tag well_known">Fruit cakes</a></li>
-<li><a href="/facets/categories/kouign-amann" class="tag well_known">Kouign-amann</a></li>
-<li><a href="/facets/categories/lemon-cake" class="tag well_known">Lemon cake</a></li>
-<li><a href="/facets/categories/marble-cakes" class="tag well_known">Marble cakes</a></li>
-<li><a href="/facets/categories/mooncake" class="tag well_known">Mooncake</a></li>
-<li><a href="/facets/categories/muffins" class="tag well_known">Muffins</a></li>
-<li><a href="/facets/categories/plum-cakes" class="tag well_known">Plum cakes</a></li>
-<li><a href="/facets/categories/pound-cake" class="tag well_known">Pound Cake</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-chocolate" class="tag well_known">Soft cake filled with chocolate</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-fruit-paste-and-coated-with-sugar-icing" class="tag well_known">Soft cake filled with fruit paste and coated with sugar icing</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-fruits" class="tag well_known">Soft cake filled with fruits</a></li>
-<li><a href="/facets/categories/soft-cake-with-nuts" class="tag well_known">Soft cake with nuts</a></li>
-<li><a href="/facets/categories/soft-fruit-cakes" class="tag well_known">Soft fruit cakes</a></li>
-<li><a href="/facets/categories/spit-cakes" class="tag well_known">Spit cakes</a></li>
-<li><a href="/facets/categories/sponge-cakes" class="tag well_known">Sponge cakes</a></li>
-<li><a href="/facets/categories/stollen" class="tag well_known">Stollen</a></li>
-<li><a href="/facets/categories/walnut-and-almond-cake" class="tag well_known">Walnut and almond cake</a></li>
-<li><a href="/facets/categories/yogurt-cake" class="tag well_known">Yogurt cake</a></li>
-<li><a href="/facets/categories/es:rosquillas-fritas" class="tag user_defined" lang="es">es:Rosquillas fritas</a></li>
-<li><a href="/facets/categories/it:ciambelle-e-ciambelloni" class="tag user_defined" lang="it">it:Ciambelle e ciambelloni</a></li>
-<li><a href="/facets/categories/nl:roze-koeken" class="tag user_defined" lang="nl">nl:Roze koeken</a></li>
-</ul>
-
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
                 </div>
-                
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-                
-                <div class="description">
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Cakes</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
                     <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Category</a>:
+                          <a href="/facets/categories/cakes">Cakes</a>
+                        </div>
 
-	<div id="tag_description" class="large-12 columns">
-		<p>Cake is a form of sweet food that is usually baked. The most commonly used cake ingredients include flour, sugar, eggs, butter or oil or margarine, a liquid, and leavening agents, such as baking soda or baking powder. Common additional ingredients and flavourings include dried, candied, or fresh fruit, nuts, cocoa, and extracts such as vanilla, with numerous substitutions for the primary ingredients. Cakes can also be filled with fruit preserves, nuts or dessert sauces -like pastry cream-, iced with buttercream or other icings, and decorated with marzipan, piped borders, or candied fruit.</p>
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
+                        <div class="parents_and_children">
+                          <p>Belongs to:</p>
+                          <p>
+                            <a
+                              href="/facets/categories/biscuits-and-cakes"
+                              class="tag well_known"
+                              >Biscuits and cakes</a
+                            >,
+                            <a
+                              href="/facets/categories/sweet-snacks"
+                              class="tag well_known"
+                              >Sweet snacks</a
+                            >,
+                            <a
+                              href="/facets/categories/snacks"
+                              class="tag well_known"
+                              >Snacks</a
+                            >
+                          </p>
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/categories/almond-cakes"
+                                class="tag well_known"
+                                >Almond cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/banana-breads"
+                                class="tag well_known"
+                                >Banana breads</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/black-forest-gateau"
+                                class="tag well_known"
+                                >Black Forest gâteau</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/breton-cakes"
+                                class="tag well_known"
+                                >Breton cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/caneles"
+                                class="tag well_known"
+                                >Canelés</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/carrot-cakes"
+                                class="tag well_known"
+                                >Carrot cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/cheesecakes"
+                                class="tag well_known"
+                                >Cheesecakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/chocolate-cakes"
+                                class="tag well_known"
+                                >Chocolate cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/chocolate-soft-cake"
+                                class="tag well_known"
+                                >Chocolate soft cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/clafoutis"
+                                class="tag well_known"
+                                >Clafoutis</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/dorayaki"
+                                class="tag well_known"
+                                >Dorayaki</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/doughnuts"
+                                class="tag well_known"
+                                >Doughnuts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fairy-cakes"
+                                class="tag well_known"
+                                >Fairy cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/filled-cakes"
+                                class="tag well_known"
+                                >Filled cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/filled-sponge-cake-slices"
+                                class="tag well_known"
+                                >Filled sponge cake slices</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/financiers"
+                                class="tag well_known"
+                                >Financiers</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fresh-cakes"
+                                class="tag well_known"
+                                >Fresh cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruit-cakes"
+                                class="tag well_known"
+                                >Fruit cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/kouign-amann"
+                                class="tag well_known"
+                                >Kouign-amann</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/lemon-cake"
+                                class="tag well_known"
+                                >Lemon cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/marble-cakes"
+                                class="tag well_known"
+                                >Marble cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/mooncake"
+                                class="tag well_known"
+                                >Mooncake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/muffins"
+                                class="tag well_known"
+                                >Muffins</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/plum-cakes"
+                                class="tag well_known"
+                                >Plum cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/pound-cake"
+                                class="tag well_known"
+                                >Pound Cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-chocolate"
+                                class="tag well_known"
+                                >Soft cake filled with chocolate</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-fruit-paste-and-coated-with-sugar-icing"
+                                class="tag well_known"
+                                >Soft cake filled with fruit paste and coated
+                                with sugar icing</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-fruits"
+                                class="tag well_known"
+                                >Soft cake filled with fruits</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-with-nuts"
+                                class="tag well_known"
+                                >Soft cake with nuts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-fruit-cakes"
+                                class="tag well_known"
+                                >Soft fruit cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/spit-cakes"
+                                class="tag well_known"
+                                >Spit cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sponge-cakes"
+                                class="tag well_known"
+                                >Sponge cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/stollen"
+                                class="tag well_known"
+                                >Stollen</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/walnut-and-almond-cake"
+                                class="tag well_known"
+                                >Walnut and almond cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/yogurt-cake"
+                                class="tag well_known"
+                                >Yogurt cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/es:rosquillas-fritas"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Rosquillas fritas</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/it:ciambelle-e-ciambelloni"
+                                class="tag user_defined"
+                                lang="it"
+                                >it:Ciambelle e ciambelloni</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/nl:roze-koeken"
+                                class="tag user_defined"
+                                lang="nl"
+                                >nl:Roze koeken</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
 
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        <div class="description">
+                          <div class="row">
+                            <div id="tag_description" class="large-12 columns">
+                              <p>
+                                Cake is a form of sweet food that is usually
+                                baked. The most commonly used cake ingredients
+                                include flour, sugar, eggs, butter or oil or
+                                margarine, a liquid, and leavening agents, such
+                                as baking soda or baking powder. Common
+                                additional ingredients and flavourings include
+                                dried, candied, or fresh fruit, nuts, cocoa, and
+                                extracts such as vanilla, with numerous
+                                substitutions for the primary ingredients. Cakes
+                                can also be filled with fruit preserves, nuts or
+                                dessert sauces -like pastry cream-, iced with
+                                buttercream or other icings, and decorated with
+                                marzipan, piped borders, or candied fruit.
+                              </p>
+                            </div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
 
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q13276"]);
-  });
-</script>
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q13276"]);
+                              }
+                            );
+                          </script>
 
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+                      </div>
+                    </div>
+                  </div>
 
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
                 </div>
-                
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-                
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
 
-            
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
 
-            
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
 
-            
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
-        
-            
-        
-    </div>
-</div>
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
+        <!-- Donation banner @ footer -->
 
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
- 
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
 
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/cakes?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
-        
-        
-        
-      </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 31,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                  id: "labels_organic",
+                  name: "Organic farming",
+                  status: "unknown",
+                  title: "Missing information: organic product?",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                  id: "labels_fair_trade",
+                  name: "Fair trade",
+                  status: "unknown",
+                  title: "Missing information: fair trade product?",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000235",
+          product_display_name: "Only-Product - Nutella - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":31,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
-                  "id":"labels_organic",
-                  "name":"Organic farming",
-                  "status":"unknown",
-                  "title":"Missing information: organic product?"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
-                  "id":"labels_fair_trade",
-                  "name":"Fair trade",
-                  "status":"unknown",
-                  "title":"Missing information: fair trade product?"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000235",
-      "product_display_name":"Only-Product - Nutella - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -1,1157 +1,1569 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Hazelnut spreads</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Hazelnut spreads</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Category</a>:
-                    <a href="/facets/categories/hazelnut-spreads">Hazelnut spreads</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Belongs to:</p>
-<p><a href="/facets/categories/fr:pates-a-tartiner" class="tag user_defined" lang="fr">fr:Pâtes à tartiner</a>, <a href="/facets/categories/sweet-spreads" class="tag well_known">Sweet spreads</a>, <a href="/facets/categories/spreads" class="tag well_known">Spreads</a>, <a href="/facets/categories/breakfasts" class="tag well_known">Breakfasts</a></p>
-<p>Contains:</p><ul>
-<li><a href="/facets/categories/cocoa-and-hazelnuts-spreads" class="tag well_known">Cocoa and hazelnuts spreads</a></li>
-</ul>
-
-                </div>
-                
-
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=categories&value_tag=en:hazelnut-spreads";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Hazelnut spreads</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Category</a>:
+                          <a href="/facets/categories/hazelnut-spreads"
+                            >Hazelnut spreads</a
+                          >
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Belongs to:</p>
+                          <p>
+                            <a
+                              href="/facets/categories/fr:pates-a-tartiner"
+                              class="tag user_defined"
+                              lang="fr"
+                              >fr:Pâtes à tartiner</a
+                            >,
+                            <a
+                              href="/facets/categories/sweet-spreads"
+                              class="tag well_known"
+                              >Sweet spreads</a
+                            >,
+                            <a
+                              href="/facets/categories/spreads"
+                              class="tag well_known"
+                              >Spreads</a
+                            >,
+                            <a
+                              href="/facets/categories/breakfasts"
+                              class="tag well_known"
+                              >Breakfasts</a
+                            >
+                          </p>
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/categories/cocoa-and-hazelnuts-spreads"
+                                class="tag well_known"
+                                >Cocoa and hazelnuts spreads</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=categories&value_tag=en:hazelnut-spreads";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 31,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                  id: "labels_organic",
+                  name: "Organic farming",
+                  status: "unknown",
+                  title: "Missing information: organic product?",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                  id: "labels_fair_trade",
+                  name: "Fair trade",
+                  status: "unknown",
+                  title: "Missing information: fair trade product?",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000235",
+          product_display_name: "Only-Product - Nutella - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":31,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
-                  "id":"labels_organic",
-                  "name":"Organic farming",
-                  "status":"unknown",
-                  "title":"Missing information: organic product?"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
-                  "id":"labels_fair_trade",
-                  "name":"Fair trade",
-                  "status":"unknown",
-                  "title":"Missing information: fair trade product?"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000235",
-      "product_display_name":"Only-Product - Nutella - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -1,627 +1,952 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>Unknown user.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {});
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>Unknown user.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -1,682 +1,1150 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>List of categories - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">List of categories - World</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>9 categories:</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Category</th><th>Products</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/categories/biscuits-and-cakes" class="tag known">Biscuits and cakes</a></td>
-<td style="text-align:right"><a href="/facets/categories/biscuits-and-cakes" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/breakfasts" class="tag known">Breakfasts</a></td>
-<td style="text-align:right"><a href="/facets/categories/breakfasts" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/cakes" class="tag known">Cakes</a></td>
-<td style="text-align:right"><a href="/facets/categories/cakes" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/hazelnut-spreads" class="tag known">Hazelnut spreads</a></td>
-<td style="text-align:right"><a href="/facets/categories/hazelnut-spreads" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/snacks" class="tag known">Snacks</a></td>
-<td style="text-align:right"><a href="/facets/categories/snacks" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/spreads" class="tag known">Spreads</a></td>
-<td style="text-align:right"><a href="/facets/categories/spreads" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/sweet-snacks" class="tag known">Sweet snacks</a></td>
-<td style="text-align:right"><a href="/facets/categories/sweet-snacks" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/sweet-spreads" class="tag known">Sweet spreads</a></td>
-<td style="text-align:right"><a href="/facets/categories/sweet-spreads" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/categories/fr:pates-a-tartiner" class="tag known">fr:Pâtes à tartiner</a></td>
-<td style="text-align:right"><a href="/facets/categories/fr:pates-a-tartiner" class="tag known">1</a></td><td></td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <!-- full width banner on mobile -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- Donation banner @ footer -->
 
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
-<!-- Donation banner @ footer -->
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-				
+                    return "";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">List of categories - World</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>9 categories:</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Category</th>
+                            <th>Products</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/biscuits-and-cakes"
+                                class="tag known"
+                                >Biscuits and cakes</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/biscuits-and-cakes"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/breakfasts"
+                                class="tag known"
+                                >Breakfasts</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/breakfasts"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/cakes"
+                                class="tag known"
+                                >Cakes</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/cakes"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/hazelnut-spreads"
+                                class="tag known"
+                                >Hazelnut spreads</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/hazelnut-spreads"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/snacks"
+                                class="tag known"
+                                >Snacks</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/snacks"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/spreads"
+                                class="tag known"
+                                >Spreads</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/spreads"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/sweet-snacks"
+                                class="tag known"
+                                >Sweet snacks</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/sweet-snacks"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/sweet-spreads"
+                                class="tag known"
+                                >Sweet spreads</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/sweet-spreads"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/categories/fr:pates-a-tartiner"
+                                class="tag known"
+                                >fr:Pâtes à tartiner</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/categories/fr:pates-a-tartiner"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Search:",
+            info: "_TOTAL_ categories",
+            infoFiltered: " - out of _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Search:",
-		info: "_TOTAL_ categories",
-		infoFiltered: " - out of _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -1,1152 +1,1537 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Hazelnut spreads / nutella</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/brands/en:nutella/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/brands/en:nutella/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/brands/en:nutella/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/en:hazelnut-spreads/brands/en:nutella/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Hazelnut spreads / nutella</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Category</a>:
-                    <a href="/facets/categories/hazelnut-spreads">Hazelnut spreads</a>
-                     / 
-                
-                    <a href="/facets/brands">Brand</a>:
-                    <a href="/facets/brands/nutella">Nutella</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=categories&value_tag=en:hazelnut-spreads";
-                    if ("1") {
-                        params += "&sec_facet_tag=brands&sec_value_tag=xx:nutella"
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Hazelnut spreads / nutella</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Category</a>:
+                          <a href="/facets/categories/hazelnut-spreads"
+                            >Hazelnut spreads</a
+                          >
+                          /
+
+                          <a href="/facets/brands">Brand</a>:
+                          <a href="/facets/brands/nutella">Nutella</a>
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=categories&value_tag=en:hazelnut-spreads";
+                          if ("1") {
+                            params +=
+                              "&sec_facet_tag=brands&sec_value_tag=xx:nutella";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/hazelnut-spreads/brands/nutella?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 31,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                  id: "labels_organic",
+                  name: "Organic farming",
+                  status: "unknown",
+                  title: "Missing information: organic product?",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                  id: "labels_fair_trade",
+                  name: "Fair trade",
+                  status: "unknown",
+                  title: "Missing information: fair trade product?",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000235",
+          product_display_name: "Only-Product - Nutella - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":31,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
-                  "id":"labels_organic",
-                  "name":"Organic farming",
-                  "status":"unknown",
-                  "title":"Missing information: organic product?"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
-                  "id":"labels_fair_trade",
-                  "name":"Fair trade",
-                  "status":"unknown",
-                  "title":"Missing information: fair trade product?"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000235",
-      "product_display_name":"Only-Product - Nutella - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -1,1222 +1,1873 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Cakes</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/en:cakes/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/en:cakes/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/en:cakes/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/en:cakes/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Cakes</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Category</a>:
-                    <a href="/facets/categories/cakes">Cakes</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Belongs to:</p>
-<p><a href="/facets/categories/biscuits-and-cakes" class="tag well_known">Biscuits and cakes</a>, <a href="/facets/categories/sweet-snacks" class="tag well_known">Sweet snacks</a>, <a href="/facets/categories/snacks" class="tag well_known">Snacks</a></p>
-<p>Contains:</p><ul>
-<li><a href="/facets/categories/almond-cakes" class="tag well_known">Almond cakes</a></li>
-<li><a href="/facets/categories/banana-breads" class="tag well_known">Banana breads</a></li>
-<li><a href="/facets/categories/black-forest-gateau" class="tag well_known">Black Forest gâteau</a></li>
-<li><a href="/facets/categories/breton-cakes" class="tag well_known">Breton cakes</a></li>
-<li><a href="/facets/categories/caneles" class="tag well_known">Canelés</a></li>
-<li><a href="/facets/categories/carrot-cakes" class="tag well_known">Carrot cakes</a></li>
-<li><a href="/facets/categories/cheesecakes" class="tag well_known">Cheesecakes</a></li>
-<li><a href="/facets/categories/chocolate-cakes" class="tag well_known">Chocolate cakes</a></li>
-<li><a href="/facets/categories/chocolate-soft-cake" class="tag well_known">Chocolate soft cake</a></li>
-<li><a href="/facets/categories/clafoutis" class="tag well_known">Clafoutis</a></li>
-<li><a href="/facets/categories/dorayaki" class="tag well_known">Dorayaki</a></li>
-<li><a href="/facets/categories/doughnuts" class="tag well_known">Doughnuts</a></li>
-<li><a href="/facets/categories/fairy-cakes" class="tag well_known">Fairy cakes</a></li>
-<li><a href="/facets/categories/filled-cakes" class="tag well_known">Filled cakes</a></li>
-<li><a href="/facets/categories/filled-sponge-cake-slices" class="tag well_known">Filled sponge cake slices</a></li>
-<li><a href="/facets/categories/financiers" class="tag well_known">Financiers</a></li>
-<li><a href="/facets/categories/fresh-cakes" class="tag well_known">Fresh cakes</a></li>
-<li><a href="/facets/categories/fruit-cakes" class="tag well_known">Fruit cakes</a></li>
-<li><a href="/facets/categories/kouign-amann" class="tag well_known">Kouign-amann</a></li>
-<li><a href="/facets/categories/lemon-cake" class="tag well_known">Lemon cake</a></li>
-<li><a href="/facets/categories/marble-cakes" class="tag well_known">Marble cakes</a></li>
-<li><a href="/facets/categories/mooncake" class="tag well_known">Mooncake</a></li>
-<li><a href="/facets/categories/muffins" class="tag well_known">Muffins</a></li>
-<li><a href="/facets/categories/plum-cakes" class="tag well_known">Plum cakes</a></li>
-<li><a href="/facets/categories/pound-cake" class="tag well_known">Pound Cake</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-chocolate" class="tag well_known">Soft cake filled with chocolate</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-fruit-paste-and-coated-with-sugar-icing" class="tag well_known">Soft cake filled with fruit paste and coated with sugar icing</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-fruits" class="tag well_known">Soft cake filled with fruits</a></li>
-<li><a href="/facets/categories/soft-cake-with-nuts" class="tag well_known">Soft cake with nuts</a></li>
-<li><a href="/facets/categories/soft-fruit-cakes" class="tag well_known">Soft fruit cakes</a></li>
-<li><a href="/facets/categories/spit-cakes" class="tag well_known">Spit cakes</a></li>
-<li><a href="/facets/categories/sponge-cakes" class="tag well_known">Sponge cakes</a></li>
-<li><a href="/facets/categories/stollen" class="tag well_known">Stollen</a></li>
-<li><a href="/facets/categories/walnut-and-almond-cake" class="tag well_known">Walnut and almond cake</a></li>
-<li><a href="/facets/categories/yogurt-cake" class="tag well_known">Yogurt cake</a></li>
-<li><a href="/facets/categories/es:rosquillas-fritas" class="tag user_defined" lang="es">es:Rosquillas fritas</a></li>
-<li><a href="/facets/categories/it:ciambelle-e-ciambelloni" class="tag user_defined" lang="it">it:Ciambelle e ciambelloni</a></li>
-<li><a href="/facets/categories/nl:roze-koeken" class="tag user_defined" lang="nl">nl:Roze koeken</a></li>
-</ul>
-
-                </div>
-                
-
-                
-                <div class="description">
-                    <div class="row">
-
-	<div id="tag_description" class="large-12 columns">
-		<p>Cake is a form of sweet food that is usually baked. The most commonly used cake ingredients include flour, sugar, eggs, butter or oil or margarine, a liquid, and leavening agents, such as baking soda or baking powder. Common additional ingredients and flavourings include dried, candied, or fresh fruit, nuts, cocoa, and extracts such as vanilla, with numerous substitutions for the primary ingredients. Cakes can also be filled with fruit preserves, nuts or dessert sauces -like pastry cream-, iced with buttercream or other icings, and decorated with marzipan, piped borders, or candied fruit.</p>
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
-
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q13276"]);
-  });
-</script>
-
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-                </div>
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=categories&value_tag=en:cakes";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Cakes</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Category</a>:
+                          <a href="/facets/categories/cakes">Cakes</a>
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Belongs to:</p>
+                          <p>
+                            <a
+                              href="/facets/categories/biscuits-and-cakes"
+                              class="tag well_known"
+                              >Biscuits and cakes</a
+                            >,
+                            <a
+                              href="/facets/categories/sweet-snacks"
+                              class="tag well_known"
+                              >Sweet snacks</a
+                            >,
+                            <a
+                              href="/facets/categories/snacks"
+                              class="tag well_known"
+                              >Snacks</a
+                            >
+                          </p>
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/categories/almond-cakes"
+                                class="tag well_known"
+                                >Almond cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/banana-breads"
+                                class="tag well_known"
+                                >Banana breads</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/black-forest-gateau"
+                                class="tag well_known"
+                                >Black Forest gâteau</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/breton-cakes"
+                                class="tag well_known"
+                                >Breton cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/caneles"
+                                class="tag well_known"
+                                >Canelés</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/carrot-cakes"
+                                class="tag well_known"
+                                >Carrot cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/cheesecakes"
+                                class="tag well_known"
+                                >Cheesecakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/chocolate-cakes"
+                                class="tag well_known"
+                                >Chocolate cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/chocolate-soft-cake"
+                                class="tag well_known"
+                                >Chocolate soft cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/clafoutis"
+                                class="tag well_known"
+                                >Clafoutis</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/dorayaki"
+                                class="tag well_known"
+                                >Dorayaki</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/doughnuts"
+                                class="tag well_known"
+                                >Doughnuts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fairy-cakes"
+                                class="tag well_known"
+                                >Fairy cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/filled-cakes"
+                                class="tag well_known"
+                                >Filled cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/filled-sponge-cake-slices"
+                                class="tag well_known"
+                                >Filled sponge cake slices</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/financiers"
+                                class="tag well_known"
+                                >Financiers</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fresh-cakes"
+                                class="tag well_known"
+                                >Fresh cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruit-cakes"
+                                class="tag well_known"
+                                >Fruit cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/kouign-amann"
+                                class="tag well_known"
+                                >Kouign-amann</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/lemon-cake"
+                                class="tag well_known"
+                                >Lemon cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/marble-cakes"
+                                class="tag well_known"
+                                >Marble cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/mooncake"
+                                class="tag well_known"
+                                >Mooncake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/muffins"
+                                class="tag well_known"
+                                >Muffins</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/plum-cakes"
+                                class="tag well_known"
+                                >Plum cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/pound-cake"
+                                class="tag well_known"
+                                >Pound Cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-chocolate"
+                                class="tag well_known"
+                                >Soft cake filled with chocolate</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-fruit-paste-and-coated-with-sugar-icing"
+                                class="tag well_known"
+                                >Soft cake filled with fruit paste and coated
+                                with sugar icing</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-fruits"
+                                class="tag well_known"
+                                >Soft cake filled with fruits</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-with-nuts"
+                                class="tag well_known"
+                                >Soft cake with nuts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-fruit-cakes"
+                                class="tag well_known"
+                                >Soft fruit cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/spit-cakes"
+                                class="tag well_known"
+                                >Spit cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sponge-cakes"
+                                class="tag well_known"
+                                >Sponge cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/stollen"
+                                class="tag well_known"
+                                >Stollen</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/walnut-and-almond-cake"
+                                class="tag well_known"
+                                >Walnut and almond cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/yogurt-cake"
+                                class="tag well_known"
+                                >Yogurt cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/es:rosquillas-fritas"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Rosquillas fritas</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/it:ciambelle-e-ciambelloni"
+                                class="tag user_defined"
+                                lang="it"
+                                >it:Ciambelle e ciambelloni</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/nl:roze-koeken"
+                                class="tag user_defined"
+                                lang="nl"
+                                >nl:Roze koeken</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div class="description">
+                          <div class="row">
+                            <div id="tag_description" class="large-12 columns">
+                              <p>
+                                Cake is a form of sweet food that is usually
+                                baked. The most commonly used cake ingredients
+                                include flour, sugar, eggs, butter or oil or
+                                margarine, a liquid, and leavening agents, such
+                                as baking soda or baking powder. Common
+                                additional ingredients and flavourings include
+                                dried, candied, or fresh fruit, nuts, cocoa, and
+                                extracts such as vanilla, with numerous
+                                substitutions for the primary ingredients. Cakes
+                                can also be filled with fruit preserves, nuts or
+                                dessert sauces -like pastry cream-, iced with
+                                buttercream or other icings, and decorated with
+                                marzipan, piped borders, or candied fruit.
+                              </p>
+                            </div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q13276"]);
+                              }
+                            );
+                          </script>
+
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=categories&value_tag=en:cakes";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/cakes?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/cakes?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/cakes?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 31,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                  id: "labels_organic",
+                  name: "Organic farming",
+                  status: "unknown",
+                  title: "Missing information: organic product?",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                  id: "labels_fair_trade",
+                  name: "Fair trade",
+                  status: "unknown",
+                  title: "Missing information: fair trade product?",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000235",
+          product_display_name: "Only-Product - Nutella - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":31,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
-                  "id":"labels_organic",
-                  "name":"Organic farming",
-                  "status":"unknown",
-                  "title":"Missing information: organic product?"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
-                  "id":"labels_fair_trade",
-                  "name":"Fair trade",
-                  "status":"unknown",
-                  "title":"Missing information: fair trade product?"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000235",
-      "product_display_name":"Only-Product - Nutella - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000235/only-product-nutella"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -1,696 +1,1085 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="es" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="es"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Open Food Facts - Suiza</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//ch-es.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//ch-es.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//ch-es.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//ch-es.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//ch-es.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//ch-es.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Saltar al Contenido</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/descubrir">Descubrir</a></li>
-									<li><a href="/contribuir">Contribuir</a></li>
-									<li class="divider"></li>
-									<li><label>Agrega productos</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_es">Instalar la aplicación para agregar productos</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Añadir un producto</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Buscar y analizar productos</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Búsqueda avanzada</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Gráficos y mapas</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="País">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									
-									<ul class="dropdown">
-										<li><a href="//ch.openfoodfacts.localhost/">Deutsch</a></li><li><a href="//ch-fr.openfoodfacts.localhost/">Français</a></li><li><a href="//ch-it.openfoodfacts.localhost/">Italiano</a></li><li><a href="//ch-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Iniciar sesión
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Buscar un producto" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Buscar" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/descubrir" class="top-bar-links">Descubrir</a></li>
-						<li><a href="/contribuir" class="top-bar-links">Contribuir</a></li>
-						<li class="show-for-xlarge-up"><a href="//world-es.pro.openfoodfacts.org/" class="top-bar-links">Productores</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_es" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Descargar la aplicación</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Buscar un producto" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Búsqueda avanzada"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Ayúdanos a informar a millones de consumidores de todo el mundo sobre lo que comen.</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip">
+      <a href="#content" tabindex="0">Saltar al Contenido</a>
+    </div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/descubrir">Descubrir</a></li>
+                  <li><a href="/contribuir">Contribuir</a></li>
+                  <li class="divider"></li>
+                  <li><label>Agrega productos</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_es"
+                      >Instalar la aplicación para agregar productos</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Añadir un producto</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Buscar y analizar productos</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Búsqueda avanzada</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Gráficos y mapas</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="País"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//ch.openfoodfacts.localhost/">Deutsch</a>
+                      </li>
+                      <li>
+                        <a href="//ch-fr.openfoodfacts.localhost/">Français</a>
+                      </li>
+                      <li>
+                        <a href="//ch-it.openfoodfacts.localhost/">Italiano</a>
+                      </li>
+                      <li>
+                        <a href="//ch-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Iniciar sesión
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          ¡Cada donación cuenta! Agradecemos su apoyo para lograr una mayor transparencia alimentaria en el mundo.  
-          
-        </p>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Buscar un producto"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Buscar"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/descubrir" class="top-bar-links">Descubrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuir" class="top-bar-links">Contribuir</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world-es.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Productores</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_es"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Descargar la aplicación</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Buscar un producto"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Búsqueda avanzada"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Ayúdanos a informar a millones de consumidores de todo
+                        el mundo sobre lo que comen.
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          ¡Cada donación cuenta! Agradecemos su apoyo para
+                          lograr una mayor transparencia alimentaria en el
+                          mundo.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>YO APOYO</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Open Food Facts - Suiza</h1>
+                  </div>
+                </div>
+
+                <div class="hide-when-logged-in homepage-greeter-wrapper">
+                  <div class="homepage-greeter">
+                    <div class="homepage-greeter__discover">
+                      <div class="homepage-greeter__discover--content">
+                        <div>
+                          <h2>Discover</h2>
+                          <p>
+                            Open Food Facts is a food products database made by
+                            everyone, for everyone. You can use it to make
+                            better food choices, and as it is open data, anyone
+                            can re-use it for any purpose.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/discover"
+                          ><span class="material-icons">auto_stories</span>Learn
+                          more about Open Food Facts</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__discover--image">
+                        <img
+                          src="images/illustrations/globe.svg"
+                          alt="Discover Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                    <div class="homepage-greeter__contribute">
+                      <div class="homepage-greeter__contribute--content">
+                        <div>
+                          <h2>Contribute</h2>
+                          <p>
+                            Open Food Facts is a non-profit project developed by
+                            thousands of volunteers from around the world. You
+                            can start contributing by
+                            <a href="/open-food-facts-mobile-app"
+                              >adding a product from your kitchen with our app
+                              for iPhone or Android</a
+                            >, and we have lots of exciting projects you can
+                            contribute to in many different ways.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/contribute"
+                          ><span class="material-icons">add_task</span>Learn
+                          more about how you can join us</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__contribute--image">
+                        <img
+                          src="images/illustrations/puzzle-big.svg"
+                          alt="Contribute to Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>No hay productos.</p>
+
+                    <p>
+                      &rarr;
+                      <a href="//world-es.openfoodfacts.localhost">
+                        Ver los resultados de todo el mundo</a
+                      >
+                    </p>
+
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>YO APOYO</button>
-        </a>
-      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">¡Instala la aplicación!</div>
+                  Escanea <span id="everyday">cada día</span>
+                  <span id="foods">alimentos</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"
+                    ><img
+                      src="/images/misc/playstore/img/es_get.svg"
+                      alt="Disponible en Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_es"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_ES.svg"
+                      alt="Descargar en la App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Ayúdanos a informar a millones de consumidores de todo el mundo
+                sobre lo que comen.
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  ¡Cada donación cuenta! Agradecemos su apoyo para lograr una
+                  mayor transparencia alimentaria en el mundo.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>YO APOYO</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Únete a la comunidad</h3>
+              <p>
+                Descubra nuestro
+                <a href="/codigo-de-conducta">código de conducta</a>
+              </p>
+              <p>
+                Únete a nosotros en
+                <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Síguenos:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-es"
+                  >Suscríbete a nuestro boletín</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Descubre el proyecto</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/quienes-somos"
+                    >Quiénes somos</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Visión, misión, valores y programas</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/es-es"
+                    >Preguntas frecuentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/es/"
+                    >El blog Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/prensa"
+                    >Prensa</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//es.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (es)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traductores</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/asociados"
+                    >Asociados</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts (cosméticos)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//ch-es.pro.openfoodfacts.localhost/"
+                    >Open Food Facts para los productores</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Una base de datos colaborativa, libre y abierta de productos
+                    alimenticios de todo el mundo.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Menciones legales</a></li>
+                    <li><a href="/privacidad">Privacidad</a></li>
+                    <li>
+                      <a href="/condiciones-de-uso">Condiciones de uso</a>
+                    </li>
+                    <li><a href="/data">Datos, API y SDK</a></li>
+                    <li>
+                      <a
+                        href="//world-es.openfoodfacts.org/dar-a-open-food-facts"
+                        >Donar a Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world-es.pro.openfoodfacts.org/"
+                        >Productores</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-es"
+                        >Suscríbete a nuestro boletín</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Clasifica los productos 0 de acuerdo a tus preferencias";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Open Food Facts - Suiza</h1>
-									</div>
-								</div>
-								
-<div class="hide-when-logged-in homepage-greeter-wrapper">
-<div class="homepage-greeter">
-	<div class="homepage-greeter__discover">
-    <div class="homepage-greeter__discover--content">
-      <div>
-        <h2>Discover</h2>
-        <p>Open Food Facts is a food products database made by everyone, for everyone. You can use it to make better food choices, and as it is open data, anyone can re-use it for any purpose.</p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/discover"><span class="material-icons">auto_stories</span>Learn more about Open Food Facts</a>
-    </div>
-    <div class="homepage-greeter__discover--image">
-      <img src="images/illustrations/globe.svg" alt="Discover Open Food Facts." />
-    </div>
-	</div>
-	<div class="homepage-greeter__contribute">
-    <div class="homepage-greeter__contribute--content"> 
-      <div>
-        <h2>Contribute</h2>
-        <p>
-        Open Food Facts is a non-profit project developed by thousands of volunteers from around the world.
-        You can start contributing by <a href="/open-food-facts-mobile-app">adding a product from your kitchen with our app for iPhone or Android</a>, and we have lots of
-        exciting projects you can contribute to in many different ways.
-        </p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/contribute"><span class="material-icons">add_task</span>Learn more about how you can join us</a>
-    </div>
-    <div class="homepage-greeter__contribute--image">
-      <img src="images/illustrations/puzzle-big.svg" alt="Contribute to Open Food Facts." />
-    </div>
-	</div>
-</div>
-</div>
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-      <p>No hay productos.</p>
-    
-    
-      
-      
-        <p>&rarr; <a href= "//world-es.openfoodfacts.localhost"> Ver los resultados de todo el mundo</a></p>
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
-
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									¡Instala la aplicación!
-								</div>
-								Escanea <span id="everyday">cada día</span> <span id="foods">alimentos</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"><img src="/images/misc/playstore/img/es_get.svg" alt="Disponible en Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"><img src="/images/misc/android-apk.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_es"><img src="/images/misc/appstore/black/appstore_ES.svg" alt="Descargar en la App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Ayúdanos a informar a millones de consumidores de todo el mundo sobre lo que comen.</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          ¡Cada donación cuenta! Agradecemos su apoyo para lograr una mayor transparencia alimentaria en el mundo.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>YO APOYO</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Únete a la comunidad</h3>
-						<p>Descubra nuestro <a href="/codigo-de-conducta">código de conducta</a></p>
-						<p>Únete a nosotros en <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Síguenos: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-es">Suscríbete a nuestro boletín</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Descubre el proyecto</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/quienes-somos">Quiénes somos</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Visión, misión, valores y programas</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/es-es">Preguntas frecuentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/es/">El blog Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/prensa">Prensa</a></li>
-							<li><a class="button small white-button radius" href="//es.wiki.openfoodfacts.org">Open Food Facts wiki (es)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traductores</a></li>
-							<li><a class="button small white-button radius" href="/asociados">Asociados</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts (cosméticos)</a></li>
-							<li><a class="button small white-button radius" href="//ch-es.pro.openfoodfacts.localhost/">Open Food Facts para los productores</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Una base de datos colaborativa, libre y abierta de productos alimenticios de todo el mundo.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Menciones legales</a></li>
-									<li><a href="/privacidad">Privacidad</a></li>
-									<li><a href="/condiciones-de-uso">Condiciones de uso</a></li>
-									<li><a href="/data">Datos, API y SDK</a></li>
-									<li><a href="//world-es.openfoodfacts.org/dar-a-open-food-facts">Donar a Open Food Facts</a></li>
-									<li><a href="//world-es.pro.openfoodfacts.org/">Productores</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-es">Suscríbete a nuestro boletín</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Clasifica los productos 0 de acuerdo a tus preferencias";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = []
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//ch-es.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//ch-es.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//ch-es.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//ch-es.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//ch-es.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//ch-es.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost/product/2000000000034/some-product">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -1,637 +1,966 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No product listed for barcode 3000000000034.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        $(".f-dropdown").on("opened.fndtn.dropdown", function () {
+          $(document).foundation("equalizer", "reflow");
+        });
+        $(".f-dropdown").on("closed.fndtn.dropdown", function () {
+          $(document).foundation("equalizer", "reflow");
+        });
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/off-webcomponents-utils.js"></script>
+    <script
+      type="module"
+      src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"
+    ></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No product listed for barcode 3000000000034.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-$('.f-dropdown').on('opened.fndtn.dropdown', function() {
-   $(document).foundation('equalizer', 'reflow');
-});
-$('.f-dropdown').on('closed.fndtn.dropdown', function() {
-   $(document).foundation('equalizer', 'reflow');
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/off-webcomponents-utils.js"></script>
-<script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//be-fr.openfoodfacts.localhost">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//be-fr.openfoodfacts.localhost">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//be-fr.openfoodfacts.localhost">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
+++ b/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
@@ -1,945 +1,1136 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Search results - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+            <!-- Right Nav Section -->
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Search results - World</h1>
-									</div>
-								</div>
-								<!-- start templates/web/pages/recipes/recipes.tt.html -->
-<table>
-    <caption style="text-align:left">Ingredients statistics for all products</caption>
-    <thead>
-        <tr>
-            <th scope="col"></th>
-            
-            <th scope="col">
-                
-                    Cheese
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Flour
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Tomato
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Olive oil
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Other
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Unknown
-                
-            </th>
-            
-        </tr>
-    </thead>
-
-    <tbody>
-    
-        <tr>
-            <th scope="col">Mean</th>
-            
-                <td>
-                        13.33
-                    
-                </td>
-            
-                <td>
-                        52.92
-                    
-                </td>
-            
-                <td>
-                        17.88
-                    
-                </td>
-            
-                <td>
-                        5.00
-                    
-                </td>
-            
-                <td>
-                        10.67
-                    
-                </td>
-            
-                <td>
-                        0.00
-                    
-                </td>
-            
-        </tr>
-    
-        <tr>
-            <th scope="col">Min</th>
-            
-                <td>
-                        10.00
-                    
-                </td>
-            
-                <td>
-                        40.00
-                    
-                </td>
-            
-                <td>
-                        0.00
-                    
-                </td>
-            
-                <td>
-                        2.00
-                    
-                </td>
-            
-                <td>
-                        0.00
-                    
-                </td>
-            
-                <td>
-                        0.00
-                    
-                </td>
-            
-        </tr>
-    
-        <tr>
-            <th scope="col">Max</th>
-            
-                <td>
-                        20.00
-                    
-                </td>
-            
-                <td>
-                        60.00
-                    
-                </td>
-            
-                <td>
-                        28.00
-                    
-                </td>
-            
-                <td>
-                        8.00
-                    
-                </td>
-            
-                <td>
-                        28.00
-                    
-                </td>
-            
-                <td>
-                        0.00
-                    
-                </td>
-            
-        </tr>
-    
-        <tr>
-            <th scope="col">Number of products</th>
-            
-                <td>
-                        3
-                    
-                </td>
-            
-                <td>
-                        3
-                    
-                </td>
-            
-                <td>
-                        2
-                    
-                </td>
-            
-                <td>
-                        3
-                    
-                </td>
-            
-                <td>
-                        2
-                    
-                </td>
-            
-                <td>
-                        0
-                    
-                </td>
-            
-        </tr>
-    
-    </tbody>
-
-</table>
-
-<table>
-    <caption style="text-align:left">Ingredients for each product</caption>
-    <thead>
-        <tr>
-            <th scope="col">Product</th>
-            
-            <th scope="col">
-                
-                    Cheese
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Flour
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Tomato
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Olive oil
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Other
-                
-            </th>
-            
-            <th scope="col">
-                
-                    Unknown
-                
-            </th>
-            
-        </tr>
-    </thead>
-
-    <tbody>
-    
-        <tr>
-            <td>
-                <a href="/product/0200000000001/pizza-1"
-                    title="wheat flour, tomato, cheese 10%, olive oil 5%"
-                >
-                    Pizza 1 - 100 g
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
                 </a>
-                
-            </td>
-            
-                <td>10.00</td>
-            
-                <td>58.75</td>
-            
-                <td>25.62</td>
-            
-                <td>5.00</td>
-            
-                <td>0.00</td>
-            
-                <td>0.00</td>
-            
-        </tr>
-    
-        <tr>
-            <td>
-                <a href="/product/0200000000002/pizza-2"
-                    title="flour, tomato sauce, cheese 10%, olive oil 2%, capers"
+              </li>
+            </ul>
+          </section>
+        </nav>
+      </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Search results - World</h1>
+                  </div>
+                </div>
+                <!-- start templates/web/pages/recipes/recipes.tt.html -->
+                <table>
+                  <caption style="text-align: left">
+                    Ingredients statistics for all products
+                  </caption>
+                  <thead>
+                    <tr>
+                      <th scope="col"></th>
+
+                      <th scope="col">Cheese</th>
+
+                      <th scope="col">Flour</th>
+
+                      <th scope="col">Tomato</th>
+
+                      <th scope="col">Olive oil</th>
+
+                      <th scope="col">Other</th>
+
+                      <th scope="col">Unknown</th>
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    <tr>
+                      <th scope="col">Mean</th>
+
+                      <td>13.33</td>
+
+                      <td>52.92</td>
+
+                      <td>17.88</td>
+
+                      <td>5.00</td>
+
+                      <td>10.67</td>
+
+                      <td>0.00</td>
+                    </tr>
+
+                    <tr>
+                      <th scope="col">Min</th>
+
+                      <td>10.00</td>
+
+                      <td>40.00</td>
+
+                      <td>0.00</td>
+
+                      <td>2.00</td>
+
+                      <td>0.00</td>
+
+                      <td>0.00</td>
+                    </tr>
+
+                    <tr>
+                      <th scope="col">Max</th>
+
+                      <td>20.00</td>
+
+                      <td>60.00</td>
+
+                      <td>28.00</td>
+
+                      <td>8.00</td>
+
+                      <td>28.00</td>
+
+                      <td>0.00</td>
+                    </tr>
+
+                    <tr>
+                      <th scope="col">Number of products</th>
+
+                      <td>3</td>
+
+                      <td>3</td>
+
+                      <td>2</td>
+
+                      <td>3</td>
+
+                      <td>2</td>
+
+                      <td>0</td>
+                    </tr>
+                  </tbody>
+                </table>
+
+                <table>
+                  <caption style="text-align: left">
+                    Ingredients for each product
+                  </caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Product</th>
+
+                      <th scope="col">Cheese</th>
+
+                      <th scope="col">Flour</th>
+
+                      <th scope="col">Tomato</th>
+
+                      <th scope="col">Olive oil</th>
+
+                      <th scope="col">Other</th>
+
+                      <th scope="col">Unknown</th>
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    <tr>
+                      <td>
+                        <a
+                          href="/product/0200000000001/pizza-1"
+                          title="wheat flour, tomato, cheese 10%, olive oil 5%"
+                        >
+                          Pizza 1 - 100 g
+                        </a>
+                      </td>
+
+                      <td>10.00</td>
+
+                      <td>58.75</td>
+
+                      <td>25.62</td>
+
+                      <td>5.00</td>
+
+                      <td>0.00</td>
+
+                      <td>0.00</td>
+                    </tr>
+
+                    <tr>
+                      <td>
+                        <a
+                          href="/product/0200000000002/pizza-2"
+                          title="flour, tomato sauce, cheese 10%, olive oil 2%, capers"
+                        >
+                          Pizza 2 - 100 g
+                        </a>
+                      </td>
+
+                      <td>10.00</td>
+
+                      <td>60.00</td>
+
+                      <td>0.00</td>
+
+                      <td>2.00</td>
+
+                      <td>28.00</td>
+
+                      <td>0.00</td>
+                    </tr>
+
+                    <tr>
+                      <td>
+                        <a
+                          href="/product/0200000000003/pizza-3"
+                          title="wholemeal flour, tomato, mozzarella 20%, olive oil 8%, salt"
+                        >
+                          Pizza 3 - 100 g
+                        </a>
+                      </td>
+
+                      <td>20.00</td>
+
+                      <td>40.00</td>
+
+                      <td>28.00</td>
+
+                      <td>8.00</td>
+
+                      <td>4.00</td>
+
+                      <td>0.00</td>
+                    </tr>
+                  </tbody>
+                </table>
+
+                <!-- end templates/web/pages/recipes/recipes.tt.html -->
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
                 >
-                    Pizza 2 - 100 g
-                </a>
-                
-            </td>
-            
-                <td>10.00</td>
-            
-                <td>60.00</td>
-            
-                <td>0.00</td>
-            
-                <td>2.00</td>
-            
-                <td>28.00</td>
-            
-                <td>0.00</td>
-            
-        </tr>
-    
-        <tr>
-            <td>
-                <a href="/product/0200000000003/pizza-3"
-                    title="wholemeal flour, tomato, mozzarella 20%, olive oil 8%, salt"
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
                 >
-                    Pizza 3 - 100 g
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
                 </a>
-                
-            </td>
-            
-                <td>20.00</td>
-            
-                <td>40.00</td>
-            
-                <td>28.00</td>
-            
-                <td>8.00</td>
-            
-                <td>4.00</td>
-            
-                <td>0.00</td>
-            
-        </tr>
-    
-    </tbody>
+              </div>
+            </div>
+          </div>
+        </section>
 
-</table>
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
 
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
 
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
 
-<!-- end templates/web/pages/recipes/recipes.tt.html -->
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {});
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -1,775 +1,1098 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Cambodia</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/countries/en:cambodia/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/countries/en:cambodia/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/countries/en:cambodia/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/countries/en:cambodia/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Cambodia</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/countries">Country</a>:
-                    <a href="/facets/countries/cambodia">Cambodia</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-
-                
-                <div class="description">
-                    <div class="row">
-
-	<div id="tag_description" class="large-12 columns">
-		
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
-
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q424"]);
-  });
-</script>
-
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-                </div>
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=countries&value_tag=en:cambodia";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Cambodia</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/countries">Country</a>:
+                          <a href="/facets/countries/cambodia">Cambodia</a>
+                        </div>
+
+                        <div class="description">
+                          <div class="row">
+                            <div
+                              id="tag_description"
+                              class="large-12 columns"
+                            ></div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q424"]);
+                              }
+                            );
+                          </script>
+
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=countries&value_tag=en:cambodia";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <p>No products.</p>
+
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-      <p>No products.</p>
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
-
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 0 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 0 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = []
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -1,639 +1,983 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No products.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 0 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No products.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 0 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = []
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -1,625 +1,952 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No products.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {});
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No products.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -1,639 +1,983 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No products.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 0 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No products.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 0 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = []
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -1,1150 +1,1532 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/countries/en:france/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/countries/en:france/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/countries/en:france/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/countries/en:france/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">France</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/countries">Country</a>:
-                    <a href="/facets/countries/france">France</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=countries&value_tag=en:france";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">France</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/countries">Country</a>:
+                          <a href="/facets/countries/france">France</a>
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=countries&value_tag=en:france";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/countries/france?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/countries/france?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/countries/france?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/countries/france?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/countries/france?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/countries/france?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/countries/france?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/countries/france?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/countries/france?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/countries/france?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000034",
+          product_display_name: "test - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000034/test",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000034",
-      "product_display_name":"test - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000034/test"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -1,1211 +1,1767 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Apple</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/ingredients/en:apple/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/ingredients/en:apple/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/ingredients/en:apple/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/ingredients/en:apple/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Apple</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/ingredients">Ingredient</a>:
-                    <a href="/facets/ingredients/apple">Apple</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Belongs to:</p>
-<p><a href="/facets/ingredients/malaceous-fruit" class="tag well_known">Malaceous fruit</a>, <a href="/facets/ingredients/fruit" class="tag well_known">Fruit</a></p>
-<p>Contains:</p><ul>
-<li><a href="/facets/ingredients/apple-juice" class="tag well_known">Apple juice</a></li>
-<li><a href="/facets/ingredients/apple-pieces" class="tag well_known">Apple pieces</a></li>
-<li><a href="/facets/ingredients/apple-pulp" class="tag well_known">Apple pulp</a></li>
-<li><a href="/facets/ingredients/apple-puree" class="tag well_known">Apple puree</a></li>
-<li><a href="/facets/ingredients/apple-wine" class="tag well_known">Apple wine</a></li>
-<li><a href="/facets/ingredients/apple-with-orange-juice" class="tag well_known">Apple with orange juice</a></li>
-<li><a href="/facets/ingredients/bramley-apple" class="tag well_known">Bramley apple</a></li>
-<li><a href="/facets/ingredients/cider-apples" class="tag well_known">Cider apples</a></li>
-<li><a href="/facets/ingredients/cinnamon-apple" class="tag well_known">Cinnamon apple</a></li>
-<li><a href="/facets/ingredients/cooking-apple" class="tag well_known">Cooking apple</a></li>
-<li><a href="/facets/ingredients/dessert-apple" class="tag well_known">Dessert apple</a></li>
-<li><a href="/facets/ingredients/dried-apple" class="tag well_known">Dried apple</a></li>
-<li><a href="/facets/ingredients/gala-apple" class="tag well_known">Gala apple</a></li>
-<li><a href="/facets/ingredients/golden-delicious-apple" class="tag well_known">Golden Delicious apple</a></li>
-<li><a href="/facets/ingredients/green-apple" class="tag well_known">Green apple</a></li>
-<li><a href="/facets/ingredients/idared-apple" class="tag well_known">Idared apple</a></li>
-<li><a href="/facets/ingredients/organic-apple" class="tag well_known">Organic apple</a></li>
-<li><a href="/facets/ingredients/pink-lady-apple" class="tag well_known">Pink Lady apple</a></li>
-<li><a href="/facets/ingredients/red-apple" class="tag well_known">Red apple</a></li>
-<li><a href="/facets/ingredients/royal-gala-apple" class="tag well_known">Royal Gala apple</a></li>
-<li><a href="/facets/ingredients/fr:compote-de-pommes" class="tag user_defined" lang="fr">fr:Compote de pommes</a></li>
-<li><a href="/facets/ingredients/fr:flocons-de-pomme" class="tag user_defined" lang="fr">fr:Flocons de pomme</a></li>
-<li><a href="/facets/ingredients/fr:pommes-d-aquitaine" class="tag user_defined" lang="fr">fr:Pommes d'Aquitaine</a></li>
-<li><a href="/facets/ingredients/fr:pommes-en-poudre" class="tag user_defined" lang="fr">fr:Pommes en poudre</a></li>
-<li><a href="/facets/ingredients/nl:appels-van-biologisch-dynamische-teelt" class="tag user_defined" lang="nl">nl:Appels van biologisch-dynamische teelt</a></li>
-</ul>
-
-                </div>
-                
-
-                
-                <div class="description">
-                    <div class="row">
-
-	<div id="tag_description" class="large-12 columns">
-		
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
-
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q89"]);
-  });
-</script>
-
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-                </div>
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=ingredients&value_tag=en:apple";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Apple</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/ingredients">Ingredient</a>:
+                          <a href="/facets/ingredients/apple">Apple</a>
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Belongs to:</p>
+                          <p>
+                            <a
+                              href="/facets/ingredients/malaceous-fruit"
+                              class="tag well_known"
+                              >Malaceous fruit</a
+                            >,
+                            <a
+                              href="/facets/ingredients/fruit"
+                              class="tag well_known"
+                              >Fruit</a
+                            >
+                          </p>
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/ingredients/apple-juice"
+                                class="tag well_known"
+                                >Apple juice</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/apple-pieces"
+                                class="tag well_known"
+                                >Apple pieces</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/apple-pulp"
+                                class="tag well_known"
+                                >Apple pulp</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/apple-puree"
+                                class="tag well_known"
+                                >Apple puree</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/apple-wine"
+                                class="tag well_known"
+                                >Apple wine</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/apple-with-orange-juice"
+                                class="tag well_known"
+                                >Apple with orange juice</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/bramley-apple"
+                                class="tag well_known"
+                                >Bramley apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/cider-apples"
+                                class="tag well_known"
+                                >Cider apples</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/cinnamon-apple"
+                                class="tag well_known"
+                                >Cinnamon apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/cooking-apple"
+                                class="tag well_known"
+                                >Cooking apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/dessert-apple"
+                                class="tag well_known"
+                                >Dessert apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/dried-apple"
+                                class="tag well_known"
+                                >Dried apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/gala-apple"
+                                class="tag well_known"
+                                >Gala apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/golden-delicious-apple"
+                                class="tag well_known"
+                                >Golden Delicious apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/green-apple"
+                                class="tag well_known"
+                                >Green apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/idared-apple"
+                                class="tag well_known"
+                                >Idared apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/organic-apple"
+                                class="tag well_known"
+                                >Organic apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/pink-lady-apple"
+                                class="tag well_known"
+                                >Pink Lady apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/red-apple"
+                                class="tag well_known"
+                                >Red apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/royal-gala-apple"
+                                class="tag well_known"
+                                >Royal Gala apple</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/fr:compote-de-pommes"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Compote de pommes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/fr:flocons-de-pomme"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Flocons de pomme</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/fr:pommes-d-aquitaine"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Pommes d'Aquitaine</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/fr:pommes-en-poudre"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Pommes en poudre</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/ingredients/nl:appels-van-biologisch-dynamische-teelt"
+                                class="tag user_defined"
+                                lang="nl"
+                                >nl:Appels van biologisch-dynamische teelt</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div class="description">
+                          <div class="row">
+                            <div
+                              id="tag_description"
+                              class="large-12 columns"
+                            ></div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q89"]);
+                              }
+                            );
+                          </script>
+
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=ingredients&value_tag=en:apple";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/ingredients/apple?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/apple?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/apple?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/apple?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/apple?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/ingredients/apple?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/apple?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/apple?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/apple?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/apple?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000034",
+          product_display_name: "test - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000034/test",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000034",
-      "product_display_name":"test - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000034/test"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -1,639 +1,983 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No products.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 0 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No products.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 0 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = []
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -1,713 +1,1068 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>List of labels - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/labels/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/labels/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/labels/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/labels/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">List of labels - World</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/ingredients">Ingredient</a>:
-                    <a href="/facets/ingredients/someunknowningredient">Someunknowningredient</a>
-                    
-                
-            </div>
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=ingredients&value_tag=en:someunknowningredient";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">List of labels - World</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation">
+                            <a href="/facets/ingredients">Ingredient</a>:
+                            <a href="/facets/ingredients/someunknowningredient"
+                              >Someunknowningredient</a
+                            >
+                          </div>
+                        </div>
+
+                        <div class="large-6 column">
+                          <!-- injecting facet-knowledge-panel -->
+                          <div
+                            id="facet-knowledge-panel"
+                            style="margin-left: 70px; z-index: 1"
+                          >
+                            <h2 id="facet_panels_title"></h2>
+                            <div id="facet_panels_content"></div>
+                          </div>
+                          <!-- Fetching facet knowledge panel -->
+                          <script>
+                            let facet_kp =
+                              "//facets-kp.openfoodfacts.org/render-to-html";
+                            let params =
+                              "?facet_tag=ingredients&value_tag=en:someunknowningredient";
+                            if ("") {
+                              params += "&sec_facet_tag=&sec_value_tag=";
+                            }
+
+                            // Adding language code to get translated data
+                            params += "&lang_code=en&country=world";
+
+                            fetch(facet_kp + params)
+                              .then((response) => {
+                                if (response.ok) {
+                                  return response.text();
+                                } else {
+                                  throw new Error(
+                                    "Network Response Error while fetching facet kp"
+                                  );
+                                }
+                              })
+                              .then((data) => {
+                                let title =
+                                  document.getElementById("facet_panels_title");
+                                title.innerHTML = "Facet knowledge panel";
+                                let knowledgepanel = document.getElementById(
+                                  "facet_panels_content"
+                                );
+                                knowledgepanel.innerHTML = data;
+                                // Keeping Hungergames and Lastedits panel open by default
+                                jQuery("#HungerGames").attr("open", true);
+                                jQuery("#LastEdits").attr("open", true);
+                              });
+                          </script>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>1 labels:</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Label</th>
+                            <th>Products</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredients/someunknowningredient/labels/organic"
+                                class="tag known"
+                                rel="nofollow"
+                                >Organic</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredients/someunknowningredient/labels/organic"
+                                class="tag known"
+                                rel="nofollow"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>1 labels:</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Label</th><th>Products</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/ingredients/someunknowningredient/labels/organic" class="tag known" rel="nofollow">Organic</a></td>
-<td style="text-align:right"><a href="/facets/ingredients/someunknowningredient/labels/organic" class="tag known" rel="nofollow">1</a></td><td></td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Search:",
+            info: "_TOTAL_ labels",
+            infoFiltered: " - out of _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Search:",
-		info: "_TOTAL_ labels",
-		infoFiltered: " - out of _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -1,1150 +1,1534 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Someunknowningredient</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/ingredients/en:someunknowningredient/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Someunknowningredient</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/ingredients">Ingredient</a>:
-                    <a href="/facets/ingredients/someunknowningredient">Someunknowningredient</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=ingredients&value_tag=en:someunknowningredient";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Someunknowningredient</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/ingredients">Ingredient</a>:
+                          <a href="/facets/ingredients/someunknowningredient"
+                            >Someunknowningredient</a
+                          >
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=ingredients&value_tag=en:someunknowningredient";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            1 product
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/ingredients/someunknowningredient?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/someunknowningredient?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/someunknowningredient?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/someunknowningredient?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/ingredients/someunknowningredient?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          1 product
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/ingredients/someunknowningredient?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/someunknowningredient?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/someunknowningredient?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/someunknowningredient?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/ingredients/someunknowningredient?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 1 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
+                  id: "allergens_no_gluten",
+                  name: "Gluten",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Gluten",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
+                  id: "allergens_no_milk",
+                  name: "Milk",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Milk",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
+                  id: "allergens_no_eggs",
+                  name: "Eggs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Eggs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
+                  id: "allergens_no_nuts",
+                  name: "Nuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Nuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
+                  id: "allergens_no_peanuts",
+                  name: "Peanuts",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Peanuts",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
+                  id: "allergens_no_sesame_seeds",
+                  name: "Sesame seeds",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sesame seeds",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
+                  id: "allergens_no_soybeans",
+                  name: "Soybeans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Soybeans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
+                  id: "allergens_no_celery",
+                  name: "Celery",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Celery",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
+                  id: "allergens_no_mustard",
+                  name: "Mustard",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Mustard",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
+                  id: "allergens_no_lupin",
+                  name: "Lupin",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Lupin",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
+                  id: "allergens_no_fish",
+                  name: "Fish",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Fish",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
+                  id: "allergens_no_crustaceans",
+                  name: "Crustaceans",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Crustaceans",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
+                  id: "allergens_no_molluscs",
+                  name: "Molluscs",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Molluscs",
+                },
+                {
+                  debug:
+                    "too many unknown ingredients: 2 ingredients (1 unknown)",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  name: "Sulphur dioxide and sulphites",
+                  panel_id: "ingredients_analysis_details",
+                  status: "unknown",
+                  title: "Presence unknown: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
+                  id: "vegan",
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan-status-unknown",
+                  status: "unknown",
+                  title: "Vegan status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
+                  id: "palm_oil_free",
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-content-unknown",
+                  status: "unknown",
+                  title: "Palm oil content unknown",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "0200000000034",
+          product_display_name: "test - 100 g",
+          url: "//world.openfoodfacts.localhost/product/0200000000034/test",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 1 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/gluten-content-unknown.svg",
-                  "id":"allergens_no_gluten",
-                  "name":"Gluten",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Gluten"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/milk-content-unknown.svg",
-                  "id":"allergens_no_milk",
-                  "name":"Milk",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Milk"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/eggs-content-unknown.svg",
-                  "id":"allergens_no_eggs",
-                  "name":"Eggs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Eggs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nuts-content-unknown.svg",
-                  "id":"allergens_no_nuts",
-                  "name":"Nuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Nuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/peanuts-content-unknown.svg",
-                  "id":"allergens_no_peanuts",
-                  "name":"Peanuts",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Peanuts"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sesame-seeds-content-unknown.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "name":"Sesame seeds",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sesame seeds"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/soybeans-content-unknown.svg",
-                  "id":"allergens_no_soybeans",
-                  "name":"Soybeans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Soybeans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/celery-content-unknown.svg",
-                  "id":"allergens_no_celery",
-                  "name":"Celery",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Celery"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/mustard-content-unknown.svg",
-                  "id":"allergens_no_mustard",
-                  "name":"Mustard",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Mustard"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/lupin-content-unknown.svg",
-                  "id":"allergens_no_lupin",
-                  "name":"Lupin",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Lupin"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fish-content-unknown.svg",
-                  "id":"allergens_no_fish",
-                  "name":"Fish",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Fish"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/crustaceans-content-unknown.svg",
-                  "id":"allergens_no_crustaceans",
-                  "name":"Crustaceans",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Crustaceans"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/molluscs-content-unknown.svg",
-                  "id":"allergens_no_molluscs",
-                  "name":"Molluscs",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Molluscs"
-               },
-               {
-                  "debug":"too many unknown ingredients: 2 ingredients (1 unknown)",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/sulphur-dioxide-and-sulphites-content-unknown.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "name":"Sulphur dioxide and sulphites",
-                  "panel_id":"ingredients_analysis_details",
-                  "status":"unknown",
-                  "title":"Presence unknown: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan-status-unknown.svg",
-                  "id":"vegan",
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegan status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-content-unknown.svg",
-                  "id":"palm_oil_free",
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-content-unknown",
-                  "status":"unknown",
-                  "title":"Palm oil content unknown"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"0200000000034",
-      "product_display_name":"test - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/0200000000034/test"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -1,637 +1,966 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No product listed for barcode 321342143242343243423.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        $(".f-dropdown").on("opened.fndtn.dropdown", function () {
+          $(document).foundation("equalizer", "reflow");
+        });
+        $(".f-dropdown").on("closed.fndtn.dropdown", function () {
+          $(document).foundation("equalizer", "reflow");
+        });
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/off-webcomponents-utils.js"></script>
+    <script
+      type="module"
+      src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"
+    ></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No product listed for barcode 321342143242343243423.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-$('.f-dropdown').on('opened.fndtn.dropdown', function() {
-   $(document).foundation('equalizer', 'reflow');
-});
-$('.f-dropdown').on('closed.fndtn.dropdown', function() {
-   $(document).foundation('equalizer', 'reflow');
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/off-webcomponents-utils.js"></script>
-<script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -1,742 +1,1667 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="es" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="es"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Lista de ingredientes - España</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//es.openfoodfacts.localhost/facets/ingredientes/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//es.openfoodfacts.localhost/facets/ingredientes/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//es.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//es.openfoodfacts.localhost/facets/ingredientes/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//es.openfoodfacts.localhost/facets/ingredientes/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//es.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Saltar al Contenido</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/descubrir">Descubrir</a></li>
-									<li><a href="/contribuir">Contribuir</a></li>
-									<li class="divider"></li>
-									<li><label>Agrega productos</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_es">Instalar la aplicación para agregar productos</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Añadir un producto</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Buscar y analizar productos</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Búsqueda avanzada</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Gráficos y mapas</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="País">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//es.openfoodfacts.localhost/">Español</a>
-
-									<ul class="dropdown">
-										<li><a href="//es-ca.openfoodfacts.localhost/">Català</a></li><li><a href="//es-eu.openfoodfacts.localhost/">Euskara</a></li><li><a href="//es-gl.openfoodfacts.localhost/">Lingua galega</a></li><li><a href="//es-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Iniciar sesión
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Buscar un producto" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Buscar" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/descubrir" class="top-bar-links">Descubrir</a></li>
-						<li><a href="/contribuir" class="top-bar-links">Contribuir</a></li>
-						<li class="show-for-xlarge-up"><a href="//world-es.pro.openfoodfacts.org/" class="top-bar-links">Productores</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_es" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Descargar la aplicación</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Buscar un producto" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Búsqueda avanzada"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Ayúdanos a informar a millones de consumidores de todo el mundo sobre lo que comen.</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip">
+      <a href="#content" tabindex="0">Saltar al Contenido</a>
+    </div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/descubrir">Descubrir</a></li>
+                  <li><a href="/contribuir">Contribuir</a></li>
+                  <li class="divider"></li>
+                  <li><label>Agrega productos</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_es"
+                      >Instalar la aplicación para agregar productos</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Añadir un producto</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Buscar y analizar productos</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Búsqueda avanzada</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Gráficos y mapas</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="País"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//es.openfoodfacts.localhost/">Español</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//es-ca.openfoodfacts.localhost/">Català</a>
+                      </li>
+                      <li>
+                        <a href="//es-eu.openfoodfacts.localhost/">Euskara</a>
+                      </li>
+                      <li>
+                        <a href="//es-gl.openfoodfacts.localhost/"
+                          >Lingua galega</a
+                        >
+                      </li>
+                      <li>
+                        <a href="//es-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Iniciar sesión
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          ¡Cada donación cuenta! Agradecemos su apoyo para lograr una mayor transparencia alimentaria en el mundo.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>YO APOYO</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Lista de ingredientes - España</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-            <p>País: España
-                - <a href="//world-es.openfoodfacts.localhost/facets/ingredientes">Ver la lista de los productos especificados de todo el mundo</a>
-            </p>
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Buscar un producto"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Buscar"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/descubrir" class="top-bar-links">Descubrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuir" class="top-bar-links">Contribuir</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world-es.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Productores</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_es"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Descargar la aplicación</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Buscar un producto"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Búsqueda avanzada"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>37 ingredientes:</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Ingrediente</th><th>Productos</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/ingredientes/aceites-y-grasas" class="tag known">Aceites y grasas</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/aceites-y-grasas" class="tag known">3</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/aceites-y-grasas-vegetales" class="tag known">Aceites y grasas vegetales</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/aceites-y-grasas-vegetales" class="tag known">3</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/cereales" class="tag known">Cereales</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/cereales" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/harina-de-cereales" class="tag known">Harina de cereales</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/harina-de-cereales" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/productos-lacteos" class="tag known">Productos lácteos</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/productos-lacteos" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/harina" class="tag known">Harina</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/harina" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/aceite-de-oliva" class="tag known">Aceite de oliva</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/aceite-de-oliva" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/sal" class="tag known">Sal</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/sal" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/aceite-vegetal" class="tag known">Aceite vegetal</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/aceite-vegetal" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/trigo" class="tag known">Trigo</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/trigo" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/harina-de-trigo" class="tag known">Harina de trigo</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/harina-de-trigo" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/acidulante" class="tag known">Acidulante</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/acidulante" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/azucares-anadidos" class="tag known">Azúcares añadidos</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/azucares-anadidos" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/manzana" class="tag known">Manzana</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/manzana" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/albahaca" class="tag known">Albahaca</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/albahaca" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/mantequilla" class="tag known">Mantequilla</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/mantequilla" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/crema-de-leche" class="tag known">Crema de leche</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/crema-de-leche" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/disacarido" class="tag known">Disacárido</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/disacarido" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/e330" class="tag known">E330</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/e330" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/e500" class="tag known">E500</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/e500" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/e500ii" class="tag known">E500ii</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/e500ii" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/huevo" class="tag known">Huevo</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/huevo" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/fruta" class="tag known">Fruta</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/fruta" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/en:fruit-vegetable" class="tag known">en:Fruit vegetable</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/en:fruit-vegetable" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/hierba" class="tag known">Hierba</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/hierba" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/en:malaceous-fruit" class="tag known">en:Malaceous fruit</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/en:malaceous-fruit" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/leche" class="tag known">Leche</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/leche" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/oregano" class="tag known">Orégano</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/oregano" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/aceite-de-palma" class="tag known">Aceite de palma</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/aceite-de-palma" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/aceite-y-grasa-de-palma" class="tag known">Aceite y grasa de palma</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/aceite-y-grasa-de-palma" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/planta" class="tag known">Planta</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/planta" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/gasificante" class="tag known">Gasificante</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/gasificante" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/azucar" class="tag known">Azúcar</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/azucar" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/tomate" class="tag known">Tomate</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/tomate" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/vainilla" class="tag known">Vainilla</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/vainilla" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/verduras" class="tag known">Verduras</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/verduras" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/ingredientes/lavadura" class="tag known">Lavadura</a></td>
-<td style="text-align:right"><a href="/facets/ingredientes/lavadura" class="tag known">1</a></td><td></td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									¡Instala la aplicación!
-								</div>
-								Escanea <span id="everyday">cada día</span> <span id="foods">alimentos</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"><img src="/images/misc/playstore/img/es_get.svg" alt="Disponible en Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <!-- full width banner on mobile -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"><img src="/images/misc/android-apk.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_es"><img src="/images/misc/appstore/black/appstore_ES.svg" alt="Descargar en la App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- Donation banner @ footer -->
 
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Ayúdanos a informar a millones de consumidores de todo
+                        el mundo sobre lo que comen.
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          ¡Cada donación cuenta! Agradecemos su apoyo para
+                          lograr una mayor transparencia alimentaria en el
+                          mundo.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>YO APOYO</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
-<!-- Donation banner @ footer -->
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-				
+                    return "";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Ayúdanos a informar a millones de consumidores de todo el mundo sobre lo que comen.</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">
+                      Lista de ingredientes - España
+                    </h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+
+                          <p>
+                            País: España -
+                            <a
+                              href="//world-es.openfoodfacts.localhost/facets/ingredientes"
+                              >Ver la lista de los productos especificados de
+                              todo el mundo</a
+                            >
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>37 ingredientes:</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Ingrediente</th>
+                            <th>Productos</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/aceites-y-grasas"
+                                class="tag known"
+                                >Aceites y grasas</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/aceites-y-grasas"
+                                class="tag known"
+                                >3</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/aceites-y-grasas-vegetales"
+                                class="tag known"
+                                >Aceites y grasas vegetales</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/aceites-y-grasas-vegetales"
+                                class="tag known"
+                                >3</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/cereales"
+                                class="tag known"
+                                >Cereales</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/cereales"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/harina-de-cereales"
+                                class="tag known"
+                                >Harina de cereales</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/harina-de-cereales"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/productos-lacteos"
+                                class="tag known"
+                                >Productos lácteos</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/productos-lacteos"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/harina"
+                                class="tag known"
+                                >Harina</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/harina"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/aceite-de-oliva"
+                                class="tag known"
+                                >Aceite de oliva</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/aceite-de-oliva"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/sal"
+                                class="tag known"
+                                >Sal</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/sal"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/aceite-vegetal"
+                                class="tag known"
+                                >Aceite vegetal</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/aceite-vegetal"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/trigo"
+                                class="tag known"
+                                >Trigo</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/trigo"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/harina-de-trigo"
+                                class="tag known"
+                                >Harina de trigo</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/harina-de-trigo"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/acidulante"
+                                class="tag known"
+                                >Acidulante</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/acidulante"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/azucares-anadidos"
+                                class="tag known"
+                                >Azúcares añadidos</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/azucares-anadidos"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/manzana"
+                                class="tag known"
+                                >Manzana</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/manzana"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/albahaca"
+                                class="tag known"
+                                >Albahaca</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/albahaca"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/mantequilla"
+                                class="tag known"
+                                >Mantequilla</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/mantequilla"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/crema-de-leche"
+                                class="tag known"
+                                >Crema de leche</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/crema-de-leche"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/disacarido"
+                                class="tag known"
+                                >Disacárido</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/disacarido"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/e330"
+                                class="tag known"
+                                >E330</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/e330"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/e500"
+                                class="tag known"
+                                >E500</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/e500"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/e500ii"
+                                class="tag known"
+                                >E500ii</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/e500ii"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/huevo"
+                                class="tag known"
+                                >Huevo</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/huevo"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/fruta"
+                                class="tag known"
+                                >Fruta</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/fruta"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/en:fruit-vegetable"
+                                class="tag known"
+                                >en:Fruit vegetable</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/en:fruit-vegetable"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/hierba"
+                                class="tag known"
+                                >Hierba</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/hierba"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/en:malaceous-fruit"
+                                class="tag known"
+                                >en:Malaceous fruit</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/en:malaceous-fruit"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/leche"
+                                class="tag known"
+                                >Leche</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/leche"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/oregano"
+                                class="tag known"
+                                >Orégano</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/oregano"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/aceite-de-palma"
+                                class="tag known"
+                                >Aceite de palma</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/aceite-de-palma"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/aceite-y-grasa-de-palma"
+                                class="tag known"
+                                >Aceite y grasa de palma</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/aceite-y-grasa-de-palma"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/planta"
+                                class="tag known"
+                                >Planta</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/planta"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/gasificante"
+                                class="tag known"
+                                >Gasificante</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/gasificante"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/azucar"
+                                class="tag known"
+                                >Azúcar</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/azucar"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/tomate"
+                                class="tag known"
+                                >Tomate</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/tomate"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/vainilla"
+                                class="tag known"
+                                >Vainilla</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/vainilla"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/verduras"
+                                class="tag known"
+                                >Verduras</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/verduras"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/ingredientes/lavadura"
+                                class="tag known"
+                                >Lavadura</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/ingredientes/lavadura"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">¡Instala la aplicación!</div>
+                  Escanea <span id="everyday">cada día</span>
+                  <span id="foods">alimentos</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"
+                    ><img
+                      src="/images/misc/playstore/img/es_get.svg"
+                      alt="Disponible en Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_es"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_ES.svg"
+                      alt="Descargar en la App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Ayúdanos a informar a millones de consumidores de todo el mundo
+                sobre lo que comen.
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  ¡Cada donación cuenta! Agradecemos su apoyo para lograr una
+                  mayor transparencia alimentaria en el mundo.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>YO APOYO</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Únete a la comunidad</h3>
+              <p>
+                Descubra nuestro
+                <a href="/codigo-de-conducta">código de conducta</a>
+              </p>
+              <p>
+                Únete a nosotros en
+                <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Síguenos:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-es"
+                  >Suscríbete a nuestro boletín</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Descubre el proyecto</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/quienes-somos"
+                    >Quiénes somos</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Visión, misión, valores y programas</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/es-es"
+                    >Preguntas frecuentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/es/"
+                    >El blog Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/prensa"
+                    >Prensa</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//es.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (es)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traductores</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/asociados"
+                    >Asociados</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts (cosméticos)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//es.pro.openfoodfacts.localhost/"
+                    >Open Food Facts para los productores</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Una base de datos colaborativa, libre y abierta de productos
+                    alimenticios de todo el mundo.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Menciones legales</a></li>
+                    <li><a href="/privacidad">Privacidad</a></li>
+                    <li>
+                      <a href="/condiciones-de-uso">Condiciones de uso</a>
+                    </li>
+                    <li><a href="/data">Datos, API y SDK</a></li>
+                    <li>
+                      <a
+                        href="//world-es.openfoodfacts.org/dar-a-open-food-facts"
+                        >Donar a Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world-es.pro.openfoodfacts.org/"
+                        >Productores</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-es"
+                        >Suscríbete a nuestro boletín</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          ¡Cada donación cuenta! Agradecemos su apoyo para lograr una mayor transparencia alimentaria en el mundo.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>YO APOYO</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Únete a la comunidad</h3>
-						<p>Descubra nuestro <a href="/codigo-de-conducta">código de conducta</a></p>
-						<p>Únete a nosotros en <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Síguenos: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-es">Suscríbete a nuestro boletín</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Descubre el proyecto</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/quienes-somos">Quiénes somos</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Visión, misión, valores y programas</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/es-es">Preguntas frecuentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/es/">El blog Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/prensa">Prensa</a></li>
-							<li><a class="button small white-button radius" href="//es.wiki.openfoodfacts.org">Open Food Facts wiki (es)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traductores</a></li>
-							<li><a class="button small white-button radius" href="/asociados">Asociados</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts (cosméticos)</a></li>
-							<li><a class="button small white-button radius" href="//es.pro.openfoodfacts.localhost/">Open Food Facts para los productores</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Buscar:",
+            info: "_TOTAL_ ingredientes",
+            infoFiltered: " - fuera de _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Una base de datos colaborativa, libre y abierta de productos alimenticios de todo el mundo.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Menciones legales</a></li>
-									<li><a href="/privacidad">Privacidad</a></li>
-									<li><a href="/condiciones-de-uso">Condiciones de uso</a></li>
-									<li><a href="/data">Datos, API y SDK</a></li>
-									<li><a href="//world-es.openfoodfacts.org/dar-a-open-food-facts">Donar a Open Food Facts</a></li>
-									<li><a href="//world-es.pro.openfoodfacts.org/">Productores</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-es">Suscríbete a nuestro boletín</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Buscar:",
-		info: "_TOTAL_ ingredientes",
-		infoFiltered: " - fuera de _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//es.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//es.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//es.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//es.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//es.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//es.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -1,678 +1,1110 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Liste des marques - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/facets/marques/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/facets/marques/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/facets/marques/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//fr.openfoodfacts.localhost/facets/marques/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Liste des marques - France</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-            <p>Pays : France
-                - <a href="//world-fr.openfoodfacts.localhost/facets/marques">Voir la liste pour les produits correspondants du monde entier</a>
-            </p>
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>5 marques :</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Marque</th><th>Produits</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/marques/bob-s-juices" class="tag user_defined">bob-s-juices</a></td>
-<td style="text-align:right"><a href="/facets/marques/bob-s-juices" class="tag user_defined">2</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/marques/les-tartes-de-robert" class="tag user_defined">les-tartes-de-robert</a></td>
-<td style="text-align:right"><a href="/facets/marques/les-tartes-de-robert" class="tag user_defined">2</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/marques/alice-s-ice-creams" class="tag user_defined">alice-s-ice-creams</a></td>
-<td style="text-align:right"><a href="/facets/marques/alice-s-ice-creams" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/marques/bob-s-creme" class="tag user_defined">bob-s-creme</a></td>
-<td style="text-align:right"><a href="/facets/marques/bob-s-creme" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/marques/bob-s-salads" class="tag user_defined">bob-s-salads</a></td>
-<td style="text-align:right"><a href="/facets/marques/bob-s-salads" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <!-- full width banner on mobile -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- Donation banner @ footer -->
 
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
-<!-- Donation banner @ footer -->
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-				
+                    return "";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Liste des marques - France</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+
+                          <p>
+                            Pays : France -
+                            <a
+                              href="//world-fr.openfoodfacts.localhost/facets/marques"
+                              >Voir la liste pour les produits correspondants du
+                              monde entier</a
+                            >
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>5 marques :</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Marque</th>
+                            <th>Produits</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/marques/bob-s-juices"
+                                class="tag user_defined"
+                                >bob-s-juices</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/marques/bob-s-juices"
+                                class="tag user_defined"
+                                >2</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/marques/les-tartes-de-robert"
+                                class="tag user_defined"
+                                >les-tartes-de-robert</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/marques/les-tartes-de-robert"
+                                class="tag user_defined"
+                                >2</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/marques/alice-s-ice-creams"
+                                class="tag user_defined"
+                                >alice-s-ice-creams</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/marques/alice-s-ice-creams"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/marques/bob-s-creme"
+                                class="tag user_defined"
+                                >bob-s-creme</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/marques/bob-s-creme"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/marques/bob-s-salads"
+                                class="tag user_defined"
+                                >bob-s-salads</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/marques/bob-s-salads"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Recherche :",
+            info: "_TOTAL_ marques",
+            infoFiltered: " - parmi _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Recherche :",
-		info: "_TOTAL_ marques",
-		infoFiltered: " - parmi _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -1,1909 +1,2690 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Desserts</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/facets/categories/fr:desserts/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/facets/categories/fr:desserts/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/facets/categories/fr:desserts/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//fr.openfoodfacts.localhost/facets/categories/fr:desserts/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Desserts</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Catégorie</a> :
-                    <a href="/facets/categories/desserts">Desserts</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Contient :</p><ul>
-<li><a href="/facets/categories/baklava" class="tag well_known">Baklava</a></li>
-<li><a href="/facets/categories/foret-noires" class="tag well_known">Forêt-noires</a></li>
-<li><a href="/facets/categories/charlottes" class="tag well_known">Charlottes</a></li>
-<li><a href="/facets/categories/desserts-au-chocolat" class="tag well_known">Desserts au chocolat</a></li>
-<li><a href="/facets/categories/gateau-moelleux-au-chocolat" class="tag well_known">Gâteau moelleux au chocolat</a></li>
-<li><a href="/facets/categories/clafoutis" class="tag well_known">Clafoutis</a></li>
-<li><a href="/facets/categories/desserts-au-cafe" class="tag well_known">Desserts au café</a></li>
-<li><a href="/facets/categories/compotes" class="tag well_known">Compotes</a></li>
-<li><a href="/facets/categories/crumbles" class="tag well_known">Crumbles</a></li>
-<li><a href="/facets/categories/desserts-lactes" class="tag well_known">Desserts lactés</a></li>
-<li><a href="/facets/categories/ile-flottante" class="tag well_known">Ile flottante</a></li>
-<li><a href="/facets/categories/pain-perdu" class="tag well_known">Pain perdu</a></li>
-<li><a href="/facets/categories/desserts-glaces" class="tag well_known">Desserts glacés</a></li>
-<li><a href="/facets/categories/liegeois-aux-fruits" class="tag well_known">Liégeois aux fruits</a></li>
-<li><a href="/facets/categories/compote-de-fruits-allegee-en-sucres" class="tag well_known">Compote de fruits allégée en sucres</a></li>
-<li><a href="/facets/categories/desserts-de-fruits" class="tag well_known">Desserts de fruits</a></li>
-<li><a href="/facets/categories/fruits-au-sirop" class="tag well_known">Fruits au sirop</a></li>
-<li><a href="/facets/categories/puree-de-fruits-sans-sucres-ajoutes" class="tag well_known">Purée de fruits sans sucres ajoutés</a></li>
-<li><a href="/facets/categories/corne-de-gazelle" class="tag well_known">Corne de gazelle</a></li>
-<li><a href="/facets/categories/coupe-glacee-parfum-poire-belle-helene" class="tag well_known">Coupe glacée parfum poire Belle-Hélène</a></li>
-<li><a href="/facets/categories/coupe-glacee-au-chocolat" class="tag well_known">Coupe glacée au chocolat</a></li>
-<li><a href="/facets/categories/coupe-glacee-au-cafe" class="tag well_known">Coupe glacée au café</a></li>
-<li><a href="/facets/categories/coupe-glacee-parfum-peche-melba" class="tag well_known">Coupe glacée parfum pêche Melba</a></li>
-<li><a href="/facets/categories/desserts-gelifies" class="tag well_known">Desserts gélifiés</a></li>
-<li><a href="/facets/categories/kadayif" class="tag well_known">Kadayif</a></li>
-<li><a href="/facets/categories/liegeois" class="tag well_known">Liégeois</a></li>
-<li><a href="/facets/categories/macarons" class="tag well_known">Macarons</a></li>
-<li><a href="/facets/categories/en:meringue-roulades" class="tag well_known" lang="en">en:Meringue roulades</a></li>
-<li><a href="/facets/categories/mochi" class="tag well_known">Mochi</a></li>
-<li><a href="/facets/categories/desserts-vegetaliens" class="tag well_known">Desserts végétaliens</a></li>
-<li><a href="/facets/categories/macarons-aux-fruits-a-coques" class="tag well_known">Macarons aux fruits à coques</a></li>
-<li><a href="/facets/categories/panforte" class="tag well_known">Panforte</a></li>
-<li><a href="/facets/categories/peche-melba" class="tag well_known">Pêche melba</a></li>
-<li><a href="/facets/categories/puddings" class="tag well_known">Puddings</a></li>
-<li><a href="/facets/categories/en:refrigerated-desserts" class="tag well_known" lang="en">en:Refrigerated desserts</a></li>
-<li><a href="/facets/categories/en:shelf-stable-desserts" class="tag well_known" lang="en">en:Shelf stable desserts</a></li>
-<li><a href="/facets/categories/gateau-moelleux-fourre-au-chocolat" class="tag well_known">Gâteau moelleux fourré au chocolat</a></li>
-<li><a href="/facets/categories/biscuit-moelleux-fourre-a-l-orange-et-enrobe-de-sucre-glace" class="tag well_known">Biscuit moelleux fourré à l'orange et enrobé de sucre glace</a></li>
-<li><a href="/facets/categories/bavarois-aux-fruits" class="tag well_known">Bavarois aux fruits</a></li>
-<li><a href="/facets/categories/genoise" class="tag well_known">Génoise</a></li>
-<li><a href="/facets/categories/en:sponge-puddings" class="tag well_known" lang="en">en:Sponge puddings</a></li>
-<li><a href="/facets/categories/en:sushki" class="tag well_known" lang="en">en:Sushki</a></li>
-<li><a href="/facets/categories/mousses-sucrees" class="tag well_known">Mousses sucrées</a></li>
-<li><a href="/facets/categories/tartufo" class="tag well_known">Tartufo</a></li>
-<li><a href="/facets/categories/en:trifles" class="tag well_known" lang="en">en:Trifles</a></li>
-<li><a href="/facets/categories/gateaux-des-rois" class="tag well_known">Gâteaux des rois</a></li>
-<li><a href="/facets/categories/fi:m%C3%A4mmi" class="tag user_defined" lang="fi">fi:Mämmi</a></li>
-<li><a href="/facets/categories/buches-patissieres" class="tag well_known">Bûches pâtissières</a></li>
-<li><a href="/facets/categories/entremets-macaron-framboise" class="tag well_known">Entremets macaron framboise</a></li>
-<li><a href="/facets/categories/pastel-de-nata" class="tag well_known">Pastel de nata</a></li>
-</ul>
-
-                </div>
-                
-
-                
-                <div class="description">
-                    <div class="row">
-
-	<div id="tag_description" class="large-12 columns">
-		
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
-
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q182940"]);
-  });
-</script>
-
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-                </div>
-                
-
-                
-
-            
-
-            
-            <p>Pays : France
-                - <a href="//world-fr.openfoodfacts.localhost/facets/categories/desserts">Voir les produits correspondants du monde entier</a>
-            </p>
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=categories&value_tag=en:desserts";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=fr&country=fr";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Desserts</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Catégorie</a> :
+                          <a href="/facets/categories/desserts">Desserts</a>
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Contient :</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/categories/baklava"
+                                class="tag well_known"
+                                >Baklava</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/foret-noires"
+                                class="tag well_known"
+                                >Forêt-noires</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/charlottes"
+                                class="tag well_known"
+                                >Charlottes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-au-chocolat"
+                                class="tag well_known"
+                                >Desserts au chocolat</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/gateau-moelleux-au-chocolat"
+                                class="tag well_known"
+                                >Gâteau moelleux au chocolat</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/clafoutis"
+                                class="tag well_known"
+                                >Clafoutis</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-au-cafe"
+                                class="tag well_known"
+                                >Desserts au café</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/compotes"
+                                class="tag well_known"
+                                >Compotes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/crumbles"
+                                class="tag well_known"
+                                >Crumbles</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-lactes"
+                                class="tag well_known"
+                                >Desserts lactés</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/ile-flottante"
+                                class="tag well_known"
+                                >Ile flottante</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/pain-perdu"
+                                class="tag well_known"
+                                >Pain perdu</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-glaces"
+                                class="tag well_known"
+                                >Desserts glacés</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/liegeois-aux-fruits"
+                                class="tag well_known"
+                                >Liégeois aux fruits</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/compote-de-fruits-allegee-en-sucres"
+                                class="tag well_known"
+                                >Compote de fruits allégée en sucres</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-de-fruits"
+                                class="tag well_known"
+                                >Desserts de fruits</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruits-au-sirop"
+                                class="tag well_known"
+                                >Fruits au sirop</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/puree-de-fruits-sans-sucres-ajoutes"
+                                class="tag well_known"
+                                >Purée de fruits sans sucres ajoutés</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/corne-de-gazelle"
+                                class="tag well_known"
+                                >Corne de gazelle</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/coupe-glacee-parfum-poire-belle-helene"
+                                class="tag well_known"
+                                >Coupe glacée parfum poire Belle-Hélène</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/coupe-glacee-au-chocolat"
+                                class="tag well_known"
+                                >Coupe glacée au chocolat</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/coupe-glacee-au-cafe"
+                                class="tag well_known"
+                                >Coupe glacée au café</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/coupe-glacee-parfum-peche-melba"
+                                class="tag well_known"
+                                >Coupe glacée parfum pêche Melba</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-gelifies"
+                                class="tag well_known"
+                                >Desserts gélifiés</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/kadayif"
+                                class="tag well_known"
+                                >Kadayif</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/liegeois"
+                                class="tag well_known"
+                                >Liégeois</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/macarons"
+                                class="tag well_known"
+                                >Macarons</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/en:meringue-roulades"
+                                class="tag well_known"
+                                lang="en"
+                                >en:Meringue roulades</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/mochi"
+                                class="tag well_known"
+                                >Mochi</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/desserts-vegetaliens"
+                                class="tag well_known"
+                                >Desserts végétaliens</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/macarons-aux-fruits-a-coques"
+                                class="tag well_known"
+                                >Macarons aux fruits à coques</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/panforte"
+                                class="tag well_known"
+                                >Panforte</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/peche-melba"
+                                class="tag well_known"
+                                >Pêche melba</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/puddings"
+                                class="tag well_known"
+                                >Puddings</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/en:refrigerated-desserts"
+                                class="tag well_known"
+                                lang="en"
+                                >en:Refrigerated desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/en:shelf-stable-desserts"
+                                class="tag well_known"
+                                lang="en"
+                                >en:Shelf stable desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/gateau-moelleux-fourre-au-chocolat"
+                                class="tag well_known"
+                                >Gâteau moelleux fourré au chocolat</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/biscuit-moelleux-fourre-a-l-orange-et-enrobe-de-sucre-glace"
+                                class="tag well_known"
+                                >Biscuit moelleux fourré à l'orange et enrobé de
+                                sucre glace</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/bavarois-aux-fruits"
+                                class="tag well_known"
+                                >Bavarois aux fruits</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/genoise"
+                                class="tag well_known"
+                                >Génoise</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/en:sponge-puddings"
+                                class="tag well_known"
+                                lang="en"
+                                >en:Sponge puddings</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/en:sushki"
+                                class="tag well_known"
+                                lang="en"
+                                >en:Sushki</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/mousses-sucrees"
+                                class="tag well_known"
+                                >Mousses sucrées</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/tartufo"
+                                class="tag well_known"
+                                >Tartufo</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/en:trifles"
+                                class="tag well_known"
+                                lang="en"
+                                >en:Trifles</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/gateaux-des-rois"
+                                class="tag well_known"
+                                >Gâteaux des rois</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fi:m%C3%A4mmi"
+                                class="tag user_defined"
+                                lang="fi"
+                                >fi:Mämmi</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/buches-patissieres"
+                                class="tag well_known"
+                                >Bûches pâtissières</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/entremets-macaron-framboise"
+                                class="tag well_known"
+                                >Entremets macaron framboise</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/pastel-de-nata"
+                                class="tag well_known"
+                                >Pastel de nata</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div class="description">
+                          <div class="row">
+                            <div
+                              id="tag_description"
+                              class="large-12 columns"
+                            ></div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q182940"]);
+                              }
+                            );
+                          </script>
+
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+
+                        <p>
+                          Pays : France -
+                          <a
+                            href="//world-fr.openfoodfacts.localhost/facets/categories/desserts"
+                            >Voir les produits correspondants du monde entier</a
+                          >
+                        </p>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=categories&value_tag=en:desserts";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=fr&country=fr";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <p>
+                        &rarr;
+                        <a
+                          href="//world-fr.openfoodfacts.localhost/facets/categories/desserts"
+                        >
+                          Voir les résultats du monde entier</a
+                        >
+                      </p>
+
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            3 produits
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Produits les plus scannés</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Produits avec le meilleur Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Produits avec le meilleur Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Produits récemment ajoutés</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Produits récemment modifiés</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-        <p>&rarr; <a href= "//world-fr.openfoodfacts.localhost/facets/categories/desserts"> Voir les résultats du monde entier</a></p>
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          3 produits
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/desserts?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Produits les plus scannés</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Produits avec le meilleur Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Produits avec le meilleur Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Produits récemment ajoutés</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Produits récemment modifiés</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classer les 3 produits ci-dessous suivant vos préférences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Caractère végétarien inconnu",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short:
+                    "Données manquantes pour calculer le Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score inconnu",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Ne contient pas : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Ne contient pas : Œufs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Sans additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Empreinte forêt non calculée",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Pas un produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Ne provient pas du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000005",
+          product_display_name:
+            "Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classer les 3 produits ci-dessous suivant vos préférences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Caractère végétarien inconnu"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Données manquantes pour calculer le Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score inconnu"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Ne contient pas : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Ne contient pas : Œufs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Sans additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Empreinte forêt non calculée"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Les produits bios encouragent la durabilité écologique et la biodiversité.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Pas un produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Ne provient pas du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000005",
-      "product_display_name":"Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -1,688 +1,1144 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Liste des pays - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/facets/pays/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/facets/pays/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/facets/pays/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//fr.openfoodfacts.localhost/facets/pays/1" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Liste des pays - France</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-            <p>Pays : France
-                - <a href="//world-fr.openfoodfacts.localhost/facets/pays">Voir la liste pour les produits correspondants du monde entier</a>
-            </p>
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-  <div id="world-map" style="min-width: 250px; max-width: 600px; min-height: 250px; max-height: 400px;"></div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-<p>7 pays :</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Pays</th><th>Produits</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/pays/france" class="tag known">France</a></td>
-<td style="text-align:right"><a href="/facets/pays/france" class="tag known">7</a></td><td></td></tr>
-<tr><td><a href="/facets/pays/allemagne" class="tag known">Allemagne</a></td>
-<td style="text-align:right"><a href="/facets/pays/allemagne" class="tag known">5</a></td><td></td></tr>
-<tr><td><a href="/facets/pays/royaume-uni" class="tag known">Royaume-Uni</a></td>
-<td style="text-align:right"><a href="/facets/pays/royaume-uni" class="tag known">4</a></td><td></td></tr>
-<tr><td><a href="/facets/pays/italie" class="tag known">Italie</a></td>
-<td style="text-align:right"><a href="/facets/pays/italie" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/pays/belgique" class="tag known">Belgique</a></td>
-<td style="text-align:right"><a href="/facets/pays/belgique" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/pays/espagne" class="tag known">Espagne</a></td>
-<td style="text-align:right"><a href="/facets/pays/espagne" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/pays/suisse" class="tag known">Suisse</a></td>
-<td style="text-align:right"><a href="/facets/pays/suisse" class="tag known">1</a></td><td></td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+            <!-- full width banner on mobile -->
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+                <!-- Donation banner @ footer -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
-<!-- Donation banner @ footer -->
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                    return "";
+                  }
 
-				
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Liste des pays - France</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+
+                          <p>
+                            Pays : France -
+                            <a
+                              href="//world-fr.openfoodfacts.localhost/facets/pays"
+                              >Voir la liste pour les produits correspondants du
+                              monde entier</a
+                            >
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <div
+                      id="world-map"
+                      style="
+                        min-width: 250px;
+                        max-width: 600px;
+                        min-height: 250px;
+                        max-height: 400px;
+                      "
+                    ></div>
+
+                    <p>7 pays :</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Pays</th>
+                            <th>Produits</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a href="/facets/pays/france" class="tag known"
+                                >France</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/pays/france" class="tag known"
+                                >7</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/pays/allemagne" class="tag known"
+                                >Allemagne</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/pays/allemagne" class="tag known"
+                                >5</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/pays/royaume-uni"
+                                class="tag known"
+                                >Royaume-Uni</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/pays/royaume-uni"
+                                class="tag known"
+                                >4</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/pays/italie" class="tag known"
+                                >Italie</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/pays/italie" class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/pays/belgique" class="tag known"
+                                >Belgique</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/pays/belgique" class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/pays/espagne" class="tag known"
+                                >Espagne</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/pays/espagne" class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/pays/suisse" class="tag known"
+                                >Suisse</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/pays/suisse" class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        var countries_map_data = JSON.parse(
+          '{"BE":1,"CH":1,"DE":5,"ES":1,"FR":7,"GB":4,"IT":2}'
+        );
+        var countries_map_links = JSON.parse(
+          '{"BE":"/facets/pays/belgique","CH":"/facets/pays/suisse","DE":"/facets/pays/allemagne","ES":"/facets/pays/espagne","FR":"/facets/pays/france","GB":"/facets/pays/royaume-uni","IT":"/facets/pays/italie"}'
+        );
+        var countries_map_names = JSON.parse(
+          '{"BE":"Belgique","CH":"Suisse","DE":"Allemagne","ES":"Espagne","FR":"France","GB":"Royaume-Uni","IT":"Italie"}'
+        );
+        displayWorldMap("#world-map", {
+          data: countries_map_data,
+          links: countries_map_links,
+          names: countries_map_names,
+        });
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Recherche :",
+            info: "_TOTAL_ pays",
+            infoFiltered: " - parmi _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jsvectormap.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/world-merc.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display-list-of-tags.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-var countries_map_data=JSON.parse("{\"BE\":1,\"CH\":1,\"DE\":5,\"ES\":1,\"FR\":7,\"GB\":4,\"IT\":2}");var countries_map_links=JSON.parse("{\"BE\":\"/facets/pays/belgique\",\"CH\":\"/facets/pays/suisse\",\"DE\":\"/facets/pays/allemagne\",\"ES\":\"/facets/pays/espagne\",\"FR\":\"/facets/pays/france\",\"GB\":\"/facets/pays/royaume-uni\",\"IT\":\"/facets/pays/italie\"}");var countries_map_names=JSON.parse("{\"BE\":\"Belgique\",\"CH\":\"Suisse\",\"DE\":\"Allemagne\",\"ES\":\"Espagne\",\"FR\":\"France\",\"GB\":\"Royaume-Uni\",\"IT\":\"Italie\"}");displayWorldMap('#world-map', { 'data': countries_map_data, 'links': countries_map_links, 'names': countries_map_names });
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Recherche :",
-		info: "_TOTAL_ pays",
-		infoFiltered: " - parmi _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jsvectormap.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/world-merc.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-list-of-tags.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -1,4280 +1,5382 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Modifier un produit</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" type="text/css" href="/css/dist/cropper.css" />
-<link rel="stylesheet" type="text/css" href="/css/dist/tagify.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//fr.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//fr.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link rel="stylesheet" type="text/css" href="/css/dist/cropper.css" />
+    <link rel="stylesheet" type="text/css" href="/css/dist/tagify.css" />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.hide-when-logged-in {display:none}
-.ui-selectable li {
-	margin: 3px;
-	padding: 0px;
-	float: left;
-	width: 120px;
-	height: 120px;
-	line-height: 120px;
-	text-align: center;
-}
-.show_for_manage_images {
-	line-height:normal;
-	font-weight:normal;
-	font-size:0.8rem;
-}
-.select_manage .ui-selectable li { 
-	height: 180px
-}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .hide-when-logged-in {
+        display: none;
+      }
+      .ui-selectable li {
+        margin: 3px;
+        padding: 0px;
+        float: left;
+        width: 120px;
+        height: 120px;
+        line-height: 120px;
+        text-align: center;
+      }
+      .show_for_manage_images {
+        line-height: normal;
+        font-weight: normal;
+        font-size: 0.8rem;
+      }
+      .select_manage .ui-selectable li {
+        height: 180px;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="product_edit_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="has-dropdown">
-								<a href="#" class="userlink h-space-tiny">
-									<span class="material-icons">
-										account_circle
-									</span>
-									Test
-								</a>
-								<ul class="dropdown">
-									<li><a href="/cgi/user.pl?type=edit&userid=tests"><span class="material-icons">settings</span> Paramètres du compte</a></li>
-
-									
-
-									
-									
-									<li class="divider"></li>			
-									<li><label>Vos contributions</label></li>
-									<li><a href="/facets/contributeurs/tests">Produits ajoutés</a></li>
-									<li><a href="/facets/editeurs/tests">Produits modifiés</a></li>
-									<li><a href="/facets/photographes/tests">Produits photographiés</a></li>
-									
-									<li class="divider"></li>			
-									<li class="has-form">
-										<form method="post" action="/cgi/session.pl">
-											<input type="hidden" name="length" value="logout">
-											<input type="submit" name=".submit" value="Se déconnecter" class="button small">
-										</form>
-									</li>
-								</ul>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix loggedin">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="product_edit_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="has-dropdown">
+                <a href="#" class="userlink h-space-tiny">
+                  <span class="material-icons"> account_circle </span>
+                  Test
+                </a>
+                <ul class="dropdown">
+                  <li>
+                    <a href="/cgi/user.pl?type=edit&userid=tests"
+                      ><span class="material-icons">settings</span> Paramètres
+                      du compte</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Vos contributions</label></li>
+                  <li>
+                    <a href="/facets/contributeurs/tests">Produits ajoutés</a>
+                  </li>
+                  <li>
+                    <a href="/facets/editeurs/tests">Produits modifiés</a>
+                  </li>
+                  <li>
+                    <a href="/facets/photographes/tests"
+                      >Produits photographiés</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li class="has-form">
+                    <form method="post" action="/cgi/session.pl">
+                      <input type="hidden" name="length" value="logout" />
+                      <input
+                        type="submit"
+                        name=".submit"
+                        value="Se déconnecter"
+                        class="button small"
+                      />
+                    </form>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<!-- banner pages such as product, product edit form and landing pages have their own h1 title -->
-							<!-- start templates/web/pages/product_edit/product_edit_form.tt.html -->
-
-
-
-
-<!-- end templates/web/pages/product_edit/product_edit_form.tt.html --><!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-
-<a href="#upNav" class="back-to-top scrollto button">
-    <span class="material-icons size-20 ">
-        arrow_upward
-    </span>
-</a>
-
-<div class="block v-space-tiny product_banner_unranked" id="prodHead">
-    <div class="row">
-        <div class="small-12 columns">
-            <h1></h1>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-    </div>
-</div>
 
-    
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix loggedin"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-    
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-    <form id="product_form" action="/cgi/product.pl" method="POST" enctype="multipart/form-data">
+            <!-- full width banner on mobile -->
 
-        <div class="block v-space-tiny prod-nav product_banner_unranked" id="prodNav">
-            <div class="row h-space-normal">
-                <div class="large-12">
-                   <nav id="navbar" class="navbar h-space-tiny">
-                        <ul class="inline-list">
-                            <li><a class="nav-link scrollto button small round white-button" href="#product_characteristics"><span>Caractéristiques du produit</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#ingredients"><span>Ingrédients</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#nutrition"><span>Nutrition</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#packaging_section"><span>Emballage</span></a></li>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
                         </ul>
-                    </nav><!-- .navbar -->
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <!-- banner pages such as product, product edit form and landing pages have their own h1 title -->
+                <!-- start templates/web/pages/product_edit/product_edit_form.tt.html -->
+
+                <!-- end templates/web/pages/product_edit/product_edit_form.tt.html --><!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+
+                <a href="#upNav" class="back-to-top scrollto button">
+                  <span class="material-icons size-20"> arrow_upward </span>
+                </a>
+
+                <div
+                  class="block v-space-tiny product_banner_unranked"
+                  id="prodHead"
+                >
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <h1></h1>
+                    </div>
+                  </div>
                 </div>
+
+                <form
+                  id="product_form"
+                  action="/cgi/product.pl"
+                  method="POST"
+                  enctype="multipart/form-data"
+                >
+                  <div
+                    class="block v-space-tiny prod-nav product_banner_unranked"
+                    id="prodNav"
+                  >
+                    <div class="row h-space-normal">
+                      <div class="large-12">
+                        <nav id="navbar" class="navbar h-space-tiny">
+                          <ul class="inline-list">
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#product_characteristics"
+                                ><span>Caractéristiques du produit</span></a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#ingredients"
+                                ><span>Ingrédients</span></a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#nutrition"
+                                ><span>Nutrition</span></a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#packaging_section"
+                                ><span>Emballage</span></a
+                              >
+                            </li>
+                          </ul>
+                        </nav>
+                        <!-- .navbar -->
+                      </div>
+                    </div>
+                  </div>
+
+                  <div id="prodInfos">
+                    <div class="row">
+                      <div class="small-12 columns">
+                        <section id="misc" class="card fieldset">
+                          <div class="card-section">
+                            <p id="barcode_paragraph">
+                              Code-barres :
+                              <span
+                                id="barcode"
+                                property="food:code"
+                                itemprop="gtin13"
+                                style="speak-as: digits"
+                                >3300000000002</span
+                              >
+                            </p>
+
+                            <label for="product_type" id="label_product_type"
+                              >Type de produit</label
+                            >
+                            <select name="product_type" id="product_type">
+                              <option value="food" selected="selected">
+                                Nourriture
+                              </option>
+
+                              <option value="petfood">
+                                Nourriture pour animaux de compagnie
+                              </option>
+
+                              <option value="beauty">Beauté</option>
+
+                              <option value="product">Produit</option>
+                            </select>
+
+                            <div
+                              data-alert
+                              class="alert-box info store-state"
+                              id="warning_3rd_party_content"
+                              style="display: none"
+                            >
+                              <span
+                                >Les informations et les données doivent
+                                provenir de l'emballage et de l'étiquette du
+                                produit (et non pas d'autres sites ou du site du
+                                fabricant), et vous devez avoir pris les photos
+                                vous-même.<br />
+                                →
+                                <a
+                                  href="//support.openfoodfacts.org/help/fr-fr/9/27"
+                                  >Pourquoi c'est important</a
+                                ></span
+                              >
+                              <a href="#" class="close">&times;</a>
+                            </div>
+
+                            <div
+                              data-alert
+                              class="alert-box secondary store-state"
+                              id="licence_accept"
+                              style="display: none"
+                            >
+                              <span
+                                >En ajoutant des informations et/ou des
+                                photographies, vous acceptez de placer
+                                irrévocablement votre contribution sous licence
+                                <a
+                                  href="//opendatacommons.org/licenses/dbcl/1.0/"
+                                  >Database Contents Licence 1.0</a
+                                >
+                                pour les informations et sous licence
+                                <a
+                                  href="//creativecommons.org/licenses/by-sa/3.0/deed.fr"
+                                  >Creative Commons Paternité - Partage des
+                                  conditions initiales à l'identique 3.0</a
+                                >
+                                pour les photos. Vous acceptez d'être crédité
+                                par les ré-utilisateurs par un lien vers le
+                                produit auquel vous contribuez.</span
+                              >
+                              <a href="#" class="close">&times;</a>
+                            </div>
+                          </div>
+                        </section>
+
+                        <section id="product_image" class="card fieldset">
+                          <div class="card-section">
+                            <legend>Photo du produit</legend>
+                            <input
+                              type="hidden"
+                              id="sorted_langs"
+                              name="sorted_langs"
+                              value="fr,en"
+                            />
+
+                            <label for="lang"> Langue principale </label>
+                            <select name="lang" id="lang">
+                              <option value="ab">Abkhaze</option>
+
+                              <option value="aa">Afar</option>
+
+                              <option value="af">Afrikaans</option>
+
+                              <option value="ak">Akan</option>
+
+                              <option value="sq">Albanais</option>
+
+                              <option value="de">Allemand</option>
+
+                              <option value="am">Amharique</option>
+
+                              <option value="en">Anglais</option>
+
+                              <option value="ar">Arabe</option>
+
+                              <option value="an">Aragonais</option>
+
+                              <option value="hy">Arménien</option>
+
+                              <option value="as">Assamais</option>
+
+                              <option value="av">Avar</option>
+
+                              <option value="ae">Avestique</option>
+
+                              <option value="ay">Aymara</option>
+
+                              <option value="az">Azéri</option>
+
+                              <option value="ba">Bachkir</option>
+
+                              <option value="bm">Bambara</option>
+
+                              <option value="eu">Basque</option>
+
+                              <option value="bn">Bengali</option>
+
+                              <option value="bi">Bichelamar</option>
+
+                              <option value="be">Biélorusse</option>
+
+                              <option value="bh">Bihari</option>
+
+                              <option value="my">Birman</option>
+
+                              <option value="nb">Bokmål</option>
+
+                              <option value="bs">Bosnien</option>
+
+                              <option value="br">Breton</option>
+
+                              <option value="bg">Bulgare</option>
+
+                              <option value="ks">Cachemiri</option>
+
+                              <option value="ca">Catalan</option>
+
+                              <option value="ch">Chamorro</option>
+
+                              <option value="ny">Chewa</option>
+
+                              <option value="si">Cingalais</option>
+
+                              <option value="ko">Coréen</option>
+
+                              <option value="kw">Cornique</option>
+
+                              <option value="co">Corse</option>
+
+                              <option value="cr">Cri</option>
+
+                              <option value="hr">Croate</option>
+
+                              <option value="da">Danois</option>
+
+                              <option value="dz">Dzongkha</option>
+
+                              <option value="es">Espagnol</option>
+
+                              <option value="eo">Espéranto</option>
+
+                              <option value="et">Estonien</option>
+
+                              <option value="ee">Ewe</option>
+
+                              <option value="fo">Féroïen</option>
+
+                              <option value="fj">Fidjien</option>
+
+                              <option value="fi">Finnois</option>
+
+                              <option value="fr" selected="selected">
+                                Français
+                              </option>
+
+                              <option value="fy">Frison occidental</option>
+
+                              <option value="gd">Gaélique écossais</option>
+
+                              <option value="gl">Galicien</option>
+
+                              <option value="cy">Gallois</option>
+
+                              <option value="ka">Géorgien</option>
+
+                              <option value="el">Grec</option>
+
+                              <option value="kl">Groenlandais</option>
+
+                              <option value="gn">Guarani</option>
+
+                              <option value="gu">Gujarati</option>
+
+                              <option value="ht">Haïtien</option>
+
+                              <option value="ha">Haoussa</option>
+
+                              <option value="he">Hébreu</option>
+
+                              <option value="hz">Héréro</option>
+
+                              <option value="hi">Hindi</option>
+
+                              <option value="ho">Hiri motu</option>
+
+                              <option value="hu">Hongrois</option>
+
+                              <option value="io">Ido</option>
+
+                              <option value="ig">Igbo</option>
+
+                              <option value="id">Indonésien</option>
+
+                              <option value="ia">Interlingua</option>
+
+                              <option value="iu">Inuktitut</option>
+
+                              <option value="ik">Inupiak</option>
+
+                              <option value="ga">Irlandais</option>
+
+                              <option value="is">Islandais</option>
+
+                              <option value="it">Italien</option>
+
+                              <option value="ja">Japonais</option>
+
+                              <option value="jv">Javanais</option>
+
+                              <option value="kn">Kannada</option>
+
+                              <option value="kr">Kanouri</option>
+
+                              <option value="kk">Kazakh</option>
+
+                              <option value="km">Khmer</option>
+
+                              <option value="kg">Kikongo</option>
+
+                              <option value="ki">Kikuyu</option>
+
+                              <option value="rw">Kinyarwanda</option>
+
+                              <option value="ky">Kirghize</option>
+
+                              <option value="rn">Kirundi</option>
+
+                              <option value="kv">Komi</option>
+
+                              <option value="kj">Kuanyama</option>
+
+                              <option value="ku">Kurde</option>
+
+                              <option value="xx">Langue inconnue</option>
+
+                              <option value="zh">Langues chinoises</option>
+
+                              <option value="lo">Lao</option>
+
+                              <option value="la">Latin</option>
+
+                              <option value="lv">Letton</option>
+
+                              <option value="li">Limbourgeois</option>
+
+                              <option value="ln">Lingala</option>
+
+                              <option value="lt">Lituanien</option>
+
+                              <option value="lu">Luba-katanga</option>
+
+                              <option value="lg">Luganda</option>
+
+                              <option value="lb">Luxembourgeois</option>
+
+                              <option value="mk">Macédonien</option>
+
+                              <option value="ms">Malais</option>
+
+                              <option value="ml">Malayalam</option>
+
+                              <option value="dv">Maldivien</option>
+
+                              <option value="mg">Malgache</option>
+
+                              <option value="mt">Maltais</option>
+
+                              <option value="gv">Mannois</option>
+
+                              <option value="mi">
+                                Maori de Nouvelle-Zélande
+                              </option>
+
+                              <option value="mr">Marathi</option>
+
+                              <option value="mh">Marshallais</option>
+
+                              <option value="mo">Moldave</option>
+
+                              <option value="mn">Mongol</option>
+
+                              <option value="me">Monténégrin</option>
+
+                              <option value="na">Nauruan</option>
+
+                              <option value="nv">Navajo</option>
+
+                              <option value="ng">Ndonga</option>
+
+                              <option value="nl">Néerlandais</option>
+
+                              <option value="ne">Népalais</option>
+
+                              <option value="no">Norvégien</option>
+
+                              <option value="nr">Nrebele</option>
+
+                              <option value="ii">Nuosu language</option>
+
+                              <option value="nn">Nynorsk</option>
+
+                              <option value="ie">Occidental</option>
+
+                              <option value="oc">Occitan</option>
+
+                              <option value="oj">Ojibwé</option>
+
+                              <option value="or">Oriya</option>
+
+                              <option value="om">Oromo</option>
+
+                              <option value="os">Ossète</option>
+
+                              <option value="ug">Ouïghour</option>
+
+                              <option value="ur">Ourdou</option>
+
+                              <option value="uz">Ouzbek</option>
+
+                              <option value="ps">Pachto</option>
+
+                              <option value="pi">Pali</option>
+
+                              <option value="pa">Panjābī</option>
+
+                              <option value="fa">Persan</option>
+
+                              <option value="ff">Peul</option>
+
+                              <option value="pl">Polonais</option>
+
+                              <option value="pt">Portugais</option>
+
+                              <option value="qu">Quechua</option>
+
+                              <option value="rm">Romanche</option>
+
+                              <option value="ro">Roumain</option>
+
+                              <option value="ru">Russe</option>
+
+                              <option value="ry">Rusyn</option>
+
+                              <option value="se">Same du Nord</option>
+
+                              <option value="sm">Samoan</option>
+
+                              <option value="sg">Sango</option>
+
+                              <option value="sa">Sanskrit</option>
+
+                              <option value="sc">Sarde</option>
+
+                              <option value="sr">Serbe</option>
+
+                              <option value="sh">Serbo-croate</option>
+
+                              <option value="sn">Shona</option>
+
+                              <option value="nd">Sindebele</option>
+
+                              <option value="sd">Sindhi</option>
+
+                              <option value="cu">Slavon liturgique</option>
+
+                              <option value="sk">Slovaque</option>
+
+                              <option value="sl">Slovène</option>
+
+                              <option value="so">Somali</option>
+
+                              <option value="st">Sotho du Sud</option>
+
+                              <option value="su">Soundanais</option>
+
+                              <option value="sv">Suédois</option>
+
+                              <option value="sw">Swahili</option>
+
+                              <option value="ss">Swati</option>
+
+                              <option value="tg">Tadjik</option>
+
+                              <option value="tl">Tagalog</option>
+
+                              <option value="ty">Tahitien</option>
+
+                              <option value="ta">Tamoul</option>
+
+                              <option value="tt">Tatar</option>
+
+                              <option value="cs">Tchèque</option>
+
+                              <option value="ce">Tchétchène</option>
+
+                              <option value="cv">Tchouvache</option>
+
+                              <option value="te">Télougou</option>
+
+                              <option value="th">Thaï</option>
+
+                              <option value="bo">Tibétain</option>
+
+                              <option value="ti">Tigrigna</option>
+
+                              <option value="to">Tongien</option>
+
+                              <option value="ts">Tsonga</option>
+
+                              <option value="tn">Tswana</option>
+
+                              <option value="tr">Turc</option>
+
+                              <option value="tk">Turkmène</option>
+
+                              <option value="tw">Twi</option>
+
+                              <option value="uk">Ukrainien</option>
+
+                              <option value="ve">Venda</option>
+
+                              <option value="vi">Vietnamien</option>
+
+                              <option value="vo">Volapük</option>
+
+                              <option value="wa">Wallon</option>
+
+                              <option value="wo">Wolof</option>
+
+                              <option value="xh">Xhosa</option>
+
+                              <option value="yi">Yiddish</option>
+
+                              <option value="yo">Yoruba</option>
+
+                              <option value="za">Zhuang</option>
+
+                              <option value="zu">Zoulou</option>
+                            </select>
+
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul id="tabs_front_image" class="tabs" data-tab>
+                              <li
+                                class="tabs tab-title active tabs_fr"
+                                id="tabs_front_image_fr_tab"
+                                data-language="fr"
+                              >
+                                <a
+                                  href="#tabs_front_image_fr"
+                                  class="tab_language"
+                                  >Français</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_en"
+                                id="tabs_front_image_en_tab"
+                                data-language="en"
+                              >
+                                <a
+                                  href="#tabs_front_image_en"
+                                  class="tab_language"
+                                  >Anglais</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_front_image_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_front_image_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div
+                              id="tabs_content_front_image"
+                              class="tabs-content"
+                            >
+                              <div
+                                class="tabs content active tabs_fr"
+                                id="tabs_front_image_fr"
+                              >
+                                <label for="front_fr"
+                                  >Photo du produit (recto) (<span
+                                    class="tab_language"
+                                    >Français</span
+                                  >)</label
+                                >
+
+                                <div class="select_crop" id="front_fr"></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_imgid"
+                                  id="front_fr_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_x1"
+                                  id="front_fr_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_y1"
+                                  id="front_fr_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_x2"
+                                  id="front_fr_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_y2"
+                                  id="front_fr_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_display_url"
+                                  id="front_fr_display_url"
+                                  value=""
+                                />
+                              </div>
+
+                              <div
+                                class="tabs content tabs_en"
+                                id="tabs_front_image_en"
+                              >
+                                <label for="front_en"
+                                  >Photo du produit (recto) (<span
+                                    class="tab_language"
+                                    >Anglais</span
+                                  >)</label
+                                >
+
+                                <div class="select_crop" id="front_en"></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="front_en_imgid"
+                                  id="front_en_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_x1"
+                                  id="front_en_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_y1"
+                                  id="front_en_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_x2"
+                                  id="front_en_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_y2"
+                                  id="front_en_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_display_url"
+                                  id="front_en_display_url"
+                                  value=""
+                                />
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_front_image_new_lc"
+                              >
+                                <label for="front_new_lc"
+                                  >Photo du produit (recto) (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="front_new_lc"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_imgid"
+                                  id="front_new_lc_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_x1"
+                                  id="front_new_lc_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_y1"
+                                  id="front_new_lc_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_x2"
+                                  id="front_new_lc_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_y2"
+                                  id="front_new_lc_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_display_url"
+                                  id="front_new_lc_display_url"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+                          </div>
+                        </section>
+
+                        <section
+                          id="product_characteristics"
+                          class="fieldset card"
+                        >
+                          <div class="card-section">
+                            <legend>Caractéristiques du produit</legend>
+
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul id="tabs_product" class="tabs" data-tab>
+                              <li
+                                class="tabs tab-title active tabs_fr"
+                                id="tabs_product_fr_tab"
+                                data-language="fr"
+                              >
+                                <a href="#tabs_product_fr" class="tab_language"
+                                  >Français</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_en"
+                                id="tabs_product_en_tab"
+                                data-language="en"
+                              >
+                                <a href="#tabs_product_en" class="tab_language"
+                                  >Anglais</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_product_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_product_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div id="tabs_content_product" class="tabs-content">
+                              <div
+                                class="tabs content active tabs_fr"
+                                id="tabs_product_fr"
+                              >
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="product_name_fr">
+                                  Nom du produit (<span class="tab_language"
+                                    >Français</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="product_name_fr"
+                                  id="product_name_fr"
+                                  class="text"
+                                  value="Tarte aux pommes et aux framboise bio"
+                                  lang="fr"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Exemple : Kinder Bueno White
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="generic_name_fr">
+                                  Dénomination générique (<span
+                                    class="tab_language"
+                                    >Français</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="generic_name_fr"
+                                  id="generic_name_fr"
+                                  class="text"
+                                  value=""
+                                  lang="fr"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Exemple : Barre chocolatée au lait et aux
+                                  noisettes
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content tabs_en"
+                                id="tabs_product_en"
+                              >
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="product_name_en">
+                                  Nom du produit (<span class="tab_language"
+                                    >Anglais</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="product_name_en"
+                                  id="product_name_en"
+                                  class="text"
+                                  value="Organic apple and raspberry pie"
+                                  lang="en"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Exemple : Kinder Bueno White
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="generic_name_en">
+                                  Dénomination générique (<span
+                                    class="tab_language"
+                                    >Anglais</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="generic_name_en"
+                                  id="generic_name_en"
+                                  class="text"
+                                  value="default_name"
+                                  lang="en"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Exemple : Barre chocolatée au lait et aux
+                                  noisettes
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_product_new_lc"
+                              >
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="product_name_new_lc">
+                                  Nom du produit (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="product_name_new_lc"
+                                  id="product_name_new_lc"
+                                  class="text"
+                                  value=""
+                                  lang="new_lc"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Exemple : Kinder Bueno White
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="generic_name_new_lc">
+                                  Dénomination générique (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="generic_name_new_lc"
+                                  id="generic_name_new_lc"
+                                  class="text"
+                                  value=""
+                                  lang="new_lc"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Exemple : Barre chocolatée au lait et aux
+                                  noisettes
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="quantity"> Quantité </label>
+
+                            <input
+                              type="text"
+                              name="quantity"
+                              id="quantity"
+                              class="text"
+                              value="100 g"
+                              lang="fr"
+                              data-autocomplete=""
+                            />
+
+                            <p class="example">
+                              Exemples : 2 l, 250 g, 1 kg, 25 cl
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="brands"> Marques </label>
+
+                            <input
+                              type="text"
+                              name="brands"
+                              id="brands"
+                              class="text tagify-me"
+                              value="Les tartes de Robert"
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=brands"
+                            />
+
+                            <p class="example">
+                              Exemples : Kinder Bueno White, Kinder Bueno,
+                              Kinder, Ferrero
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="categories"> Catégories </label>
+
+                            <input
+                              type="text"
+                              name="categories"
+                              id="categories"
+                              class="text tagify-me"
+                              value="Desserts, Tartes, Tartes sucrées, Tartes aux pommes"
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=categories"
+                            />
+
+                            <p class="note">
+                              &rarr; Il suffit d'indiquer la catégorie la plus
+                              spécifique, les catégories "parentes" seront
+                              ajoutées automatiquement.
+                            </p>
+
+                            <p class="example">
+                              Exemples : Sardines à l'huile d'olive, Mayonnaises
+                              allégées, Jus d'orange à base de concentré
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="labels">
+                              Labels, certifications, récompenses
+                            </label>
+
+                            <input
+                              type="text"
+                              name="labels"
+                              id="labels"
+                              class="text tagify-me"
+                              value="Commerce équitable, Bio
+
+"
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=labels"
+                            />
+
+                            <p class="note">
+                              &rarr; Indiquez les labels les plus spécifiques.
+                              Les catégories "parentes" comme 'Bio' ou 'Commerce
+                              équitable' seront ajoutées automatiquement.
+                            </p>
+
+                            <p class="example">Exemple : Bio</p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="manufacturing_places">
+                              Lieux de fabrication ou de transformation
+                            </label>
+
+                            <input
+                              type="text"
+                              name="manufacturing_places"
+                              id="manufacturing_places"
+                              class="text tagify-me"
+                              value=""
+                              lang="fr"
+                              data-autocomplete=""
+                            />
+
+                            <p class="example">Exemples : Provence, France</p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="emb_codes"> Code de traçabilité </label>
+
+                            <input
+                              type="text"
+                              name="emb_codes"
+                              id="emb_codes"
+                              class="text tagify-me"
+                              value=""
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=emb_codes"
+                            />
+
+                            <p class="note">
+                              &rarr; En Europe, le code est une ellipse
+                              contenant les deux initiales du pays suivies par
+                              un nombre et CE.
+                            </p>
+
+                            <p class="example">
+                              Exemples : EMB 53062, FR 62.448.034 CE, 84 R 20,
+                              33 RECOLTANT 522
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="link">
+                              Lien vers la page du produit sur le site officiel
+                              du fabricant
+                            </label>
+
+                            <input
+                              type="text"
+                              name="link"
+                              id="link"
+                              class="text"
+                              value="//world.openfoodfacts.org/"
+                              lang="fr"
+                              data-autocomplete=""
+                            />
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="expiration_date">
+                              Date limite de consommation
+                            </label>
+
+                            <input
+                              type="text"
+                              name="expiration_date"
+                              id="expiration_date"
+                              class="text"
+                              value=""
+                              lang="fr"
+                              data-autocomplete=""
+                            />
+
+                            <p class="note">
+                              &rarr; La date limite permet de repérer les
+                              changements des produits dans le temps et
+                              d'identifier la plus récente version.
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="purchase_places">
+                              Ville et pays d'achat
+                            </label>
+
+                            <input
+                              type="text"
+                              name="purchase_places"
+                              id="purchase_places"
+                              class="text tagify-me"
+                              value=""
+                              lang="fr"
+                              data-autocomplete=""
+                            />
+
+                            <p class="note">
+                              &rarr; Indiquez le lieu où vous avez acheté ou vu
+                              le produit (au moins le pays)
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="stores"> Magasins </label>
+
+                            <input
+                              type="text"
+                              name="stores"
+                              id="stores"
+                              class="text tagify-me"
+                              value=""
+                              lang="fr"
+                              data-autocomplete=""
+                            />
+
+                            <p class="note">
+                              &rarr; Enseigne du magasin où vous avez acheté ou
+                              vu le produit
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="countries"> Pays de vente </label>
+
+                            <input
+                              type="text"
+                              name="countries"
+                              id="countries"
+                              class="text tagify-me"
+                              value="France, Allemagne, Royaume-Uni"
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=countries"
+                            />
+
+                            <p class="note">
+                              &rarr; Pays dans lesquels le produit est largement
+                              distribué (hors magasins spécialisés dans
+                              l'import)
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                          </div>
+                        </section>
+
+                        <section id="ingredients" class="card fieldset">
+                          <div class="card-section">
+                            <legend>Ingrédients</legend>
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul
+                              id="tabs_ingredients_image"
+                              class="tabs"
+                              data-tab
+                            >
+                              <li
+                                class="tabs tab-title active tabs_fr"
+                                id="tabs_ingredients_image_fr_tab"
+                                data-language="fr"
+                              >
+                                <a
+                                  href="#tabs_ingredients_image_fr"
+                                  class="tab_language"
+                                  >Français</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_en"
+                                id="tabs_ingredients_image_en_tab"
+                                data-language="en"
+                              >
+                                <a
+                                  href="#tabs_ingredients_image_en"
+                                  class="tab_language"
+                                  >Anglais</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_ingredients_image_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_ingredients_image_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div
+                              id="tabs_content_ingredients_image"
+                              class="tabs-content"
+                            >
+                              <div
+                                class="tabs content active tabs_fr"
+                                id="tabs_ingredients_image_fr"
+                              >
+                                <label for="ingredients_fr"
+                                  >Photo de la liste des ingrédients (<span
+                                    class="tab_language"
+                                    >Français</span
+                                  >)</label
+                                >
+                                <p class="note">
+                                  &rarr; Si elle est suffisamment nette et
+                                  droite, les ingrédients peuvent être extraits
+                                  automatiquement de la photo.
+                                </p>
+                                <div
+                                  class="select_crop"
+                                  id="ingredients_fr"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_imgid"
+                                  id="ingredients_fr_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_x1"
+                                  id="ingredients_fr_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_y1"
+                                  id="ingredients_fr_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_x2"
+                                  id="ingredients_fr_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_y2"
+                                  id="ingredients_fr_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_display_url"
+                                  id="ingredients_fr_display_url"
+                                  value=""
+                                />
+
+                                <div id="ingredients_fr_image_full"></div>
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="ingredients_text_fr">
+                                  Liste des ingrédients (<span
+                                    class="tab_language"
+                                    >Français</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="ingredients_text_fr"
+                                  id="ingredients_text_fr"
+                                  lang="fr"
+                                >
+Farine de blé, pommes, framboises 10%, sucre, beurre, oeufs, sel, huile de palme, acidifiant: acide citrique, agent levant: bicarbonate de sodium</textarea
+                                >
+
+                                <p class="note">
+                                  &rarr; Conserver l'ordre, indiquer le %
+                                  lorsqu'il est précisé, séparer par une virgule
+                                  ou - , Utiliser les ( ) pour les ingrédients
+                                  d'un ingrédient, indiquer les allergènes entre
+                                  _ : farine de _blé_
+                                </p>
+
+                                <p class="example">
+                                  Exemples : Céréales 85,5% (farine de _blé_,
+                                  farine de _blé_ complet 11%), extrait de malt
+                                  (orge), cacao 4,8%, vitamine C
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="origin_fr">
+                                  Origine du produit et/ou de ses ingrédients
+                                  (<span class="tab_language">Français</span>)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="origin_fr"
+                                  id="origin_fr"
+                                  class="text"
+                                  value=""
+                                  lang="fr"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="note">
+                                  &rarr; Mentions sur l'emballage indiquant le
+                                  lieu de fabrication et/ou l'origine des
+                                  ingrédients
+                                </p>
+
+                                <p class="example">
+                                  Exemples : Fabriqué en France. Tomates
+                                  d'Italie. Origine du riz : Inde, Thaïlande.
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content tabs_en"
+                                id="tabs_ingredients_image_en"
+                              >
+                                <label for="ingredients_en"
+                                  >Photo de la liste des ingrédients (<span
+                                    class="tab_language"
+                                    >Anglais</span
+                                  >)</label
+                                >
+                                <p class="note">
+                                  &rarr; Si elle est suffisamment nette et
+                                  droite, les ingrédients peuvent être extraits
+                                  automatiquement de la photo.
+                                </p>
+                                <div
+                                  class="select_crop"
+                                  id="ingredients_en"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_imgid"
+                                  id="ingredients_en_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_x1"
+                                  id="ingredients_en_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_y1"
+                                  id="ingredients_en_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_x2"
+                                  id="ingredients_en_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_y2"
+                                  id="ingredients_en_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_display_url"
+                                  id="ingredients_en_display_url"
+                                  value=""
+                                />
+
+                                <div id="ingredients_en_image_full"></div>
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="ingredients_text_en">
+                                  Liste des ingrédients (<span
+                                    class="tab_language"
+                                    >Anglais</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="ingredients_text_en"
+                                  id="ingredients_text_en"
+                                  lang="en"
+                                >
+Wheat flour, apples, raspberries 10%, sugar, butter, eggs, salt, palm oil, acidifier: citric acid, raising agent: sodium bicarbonate</textarea
+                                >
+
+                                <p class="note">
+                                  &rarr; Conserver l'ordre, indiquer le %
+                                  lorsqu'il est précisé, séparer par une virgule
+                                  ou - , Utiliser les ( ) pour les ingrédients
+                                  d'un ingrédient, indiquer les allergènes entre
+                                  _ : farine de _blé_
+                                </p>
+
+                                <p class="example">
+                                  Exemples : Céréales 85,5% (farine de _blé_,
+                                  farine de _blé_ complet 11%), extrait de malt
+                                  (orge), cacao 4,8%, vitamine C
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="origin_en">
+                                  Origine du produit et/ou de ses ingrédients
+                                  (<span class="tab_language">Anglais</span>)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="origin_en"
+                                  id="origin_en"
+                                  class="text"
+                                  value="Germany"
+                                  lang="en"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="note">
+                                  &rarr; Mentions sur l'emballage indiquant le
+                                  lieu de fabrication et/ou l'origine des
+                                  ingrédients
+                                </p>
+
+                                <p class="example">
+                                  Exemples : Fabriqué en France. Tomates
+                                  d'Italie. Origine du riz : Inde, Thaïlande.
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_ingredients_image_new_lc"
+                              >
+                                <label for="ingredients_new_lc"
+                                  >Photo de la liste des ingrédients (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)</label
+                                >
+                                <p class="note">
+                                  &rarr; Si elle est suffisamment nette et
+                                  droite, les ingrédients peuvent être extraits
+                                  automatiquement de la photo.
+                                </p>
+                                <div
+                                  class="select_crop"
+                                  id="ingredients_new_lc"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_imgid"
+                                  id="ingredients_new_lc_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_x1"
+                                  id="ingredients_new_lc_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_y1"
+                                  id="ingredients_new_lc_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_x2"
+                                  id="ingredients_new_lc_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_y2"
+                                  id="ingredients_new_lc_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_display_url"
+                                  id="ingredients_new_lc_display_url"
+                                  value=""
+                                />
+
+                                <div id="ingredients_new_lc_image_full"></div>
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="ingredients_text_new_lc">
+                                  Liste des ingrédients (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="ingredients_text_new_lc"
+                                  id="ingredients_text_new_lc"
+                                  lang="new_lc"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; Conserver l'ordre, indiquer le %
+                                  lorsqu'il est précisé, séparer par une virgule
+                                  ou - , Utiliser les ( ) pour les ingrédients
+                                  d'un ingrédient, indiquer les allergènes entre
+                                  _ : farine de _blé_
+                                </p>
+
+                                <p class="example">
+                                  Exemples : Céréales 85,5% (farine de _blé_,
+                                  farine de _blé_ complet 11%), extrait de malt
+                                  (orge), cacao 4,8%, vitamine C
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="origin_new_lc">
+                                  Origine du produit et/ou de ses ingrédients
+                                  (<span class="tab_language"></span>)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="origin_new_lc"
+                                  id="origin_new_lc"
+                                  class="text"
+                                  value=""
+                                  lang="new_lc"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="note">
+                                  &rarr; Mentions sur l'emballage indiquant le
+                                  lieu de fabrication et/ou l'origine des
+                                  ingrédients
+                                </p>
+
+                                <p class="example">
+                                  Exemples : Fabriqué en France. Tomates
+                                  d'Italie. Origine du riz : Inde, Thaïlande.
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="allergens">
+                              Substances ou produits provoquant des allergies ou
+                              intolérances
+                            </label>
+
+                            <input
+                              type="text"
+                              name="allergens"
+                              id="allergens"
+                              class="text tagify-me"
+                              value="Œufs, Gluten, Lait"
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=allergens"
+                            />
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="traces"> Traces éventuelles </label>
+
+                            <input
+                              type="text"
+                              name="traces"
+                              id="traces"
+                              class="text tagify-me"
+                              value=""
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=traces"
+                            />
+
+                            <p class="note">
+                              &rarr; Indiquer les ingrédients des mentions "Peut
+                              contenir des traces de", "Fabriqué dans un atelier
+                              qui utilise aussi" etc.
+                            </p>
+
+                            <p class="example">
+                              Exemples : Lait, Gluten, Arachide, Fruits à coque
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="origins">
+                              Origine des ingrédients
+                            </label>
+
+                            <input
+                              type="text"
+                              name="origins"
+                              id="origins"
+                              class="text tagify-me"
+                              value=""
+                              lang="fr"
+                              data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=origins"
+                            />
+
+                            <p class="example">
+                              Exemples : Vallée des Baux-de-Provence, Provence,
+                              France
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                          </div>
+                        </section>
+
+                        <!--nutrient fieldset-->
+                        <section class="card fieldset" id="nutrition">
+                          <div class="card-section">
+                            <legend>Tableau nutritionnel</legend>
+                            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                            <input
+                              type="hidden"
+                              name="no_nutrition_data_displayed"
+                              value="1"
+                            />
+                            <input
+                              type="checkbox"
+                              id="no_nutrition_data"
+                              name="no_nutrition_data"
+                            />
+                            <label
+                              for="no_nutrition_data"
+                              class="checkbox_label"
+                              >Les informations nutritionnelles ne sont pas
+                              mentionnées sur le produit.</label
+                            ><br />
+                            <div id="nutrition_data_div">
+                              <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                              <!--html tab header starts-->
+                              <ul
+                                id="tabs_nutrition_image"
+                                class="tabs"
+                                data-tab
+                              >
+                                <li
+                                  class="tabs tab-title active tabs_fr"
+                                  id="tabs_nutrition_image_fr_tab"
+                                  data-language="fr"
+                                >
+                                  <a
+                                    href="#tabs_nutrition_image_fr"
+                                    class="tab_language"
+                                    >Français</a
+                                  >
+                                </li>
+
+                                <li
+                                  class="tabs tab-title tabs_en"
+                                  id="tabs_nutrition_image_en_tab"
+                                  data-language="en"
+                                >
+                                  <a
+                                    href="#tabs_nutrition_image_en"
+                                    class="tab_language"
+                                    >Anglais</a
+                                  >
+                                </li>
+
+                                <li
+                                  class="tabs tab-title new_lc hide tabs_new_lc"
+                                  id="tabs_nutrition_image_new_lc_tab"
+                                  data-language="new_lc"
+                                >
+                                  <a
+                                    href="#tabs_nutrition_image_new_lc"
+                                    class="tab_language"
+                                  ></a>
+                                </li>
+
+                                <li class="tabs tab-title new tabs_new">
+                                  <select
+                                    class="select_add_language"
+                                    style="width: 100%"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </li>
+                              </ul>
+                              <!--html tab header ends-->
+
+                              <!--The content tab starts-->
+                              <div
+                                id="tabs_content_nutrition_image"
+                                class="tabs-content"
+                              >
+                                <div
+                                  class="tabs content active tabs_fr"
+                                  id="tabs_nutrition_image_fr"
+                                >
+                                  <label for="nutrition_fr"
+                                    >Photo des informations nutritionnelles
+                                    (<span class="tab_language">Français</span
+                                    >)</label
+                                  >
+
+                                  <div
+                                    class="select_crop"
+                                    id="nutrition_fr"
+                                  ></div>
+                                  <hr class="floatclear" />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_imgid"
+                                    id="nutrition_fr_imgid"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_x1"
+                                    id="nutrition_fr_x1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_y1"
+                                    id="nutrition_fr_y1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_x2"
+                                    id="nutrition_fr_x2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_y2"
+                                    id="nutrition_fr_y2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_display_url"
+                                    id="nutrition_fr_display_url"
+                                    value=""
+                                  />
+                                </div>
+
+                                <div
+                                  class="tabs content tabs_en"
+                                  id="tabs_nutrition_image_en"
+                                >
+                                  <label for="nutrition_en"
+                                    >Photo des informations nutritionnelles
+                                    (<span class="tab_language">Anglais</span
+                                    >)</label
+                                  >
+
+                                  <div
+                                    class="select_crop"
+                                    id="nutrition_en"
+                                  ></div>
+                                  <hr class="floatclear" />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_imgid"
+                                    id="nutrition_en_imgid"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_x1"
+                                    id="nutrition_en_x1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_y1"
+                                    id="nutrition_en_y1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_x2"
+                                    id="nutrition_en_x2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_y2"
+                                    id="nutrition_en_y2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_display_url"
+                                    id="nutrition_en_display_url"
+                                    value=""
+                                  />
+                                </div>
+
+                                <div
+                                  class="tabs content new_lc hide tabs_new_lc"
+                                  id="tabs_nutrition_image_new_lc"
+                                >
+                                  <label for="nutrition_new_lc"
+                                    >Photo des informations nutritionnelles
+                                    (<span class="tab_language"></span>)</label
+                                  >
+
+                                  <div
+                                    class="select_crop"
+                                    id="nutrition_new_lc"
+                                  ></div>
+                                  <hr class="floatclear" />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_imgid"
+                                    id="nutrition_new_lc_imgid"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_x1"
+                                    id="nutrition_new_lc_x1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_y1"
+                                    id="nutrition_new_lc_y1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_x2"
+                                    id="nutrition_new_lc_x2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_y2"
+                                    id="nutrition_new_lc_y2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_display_url"
+                                    id="nutrition_new_lc_display_url"
+                                    value=""
+                                  />
+                                </div>
+                              </div>
+                              <!--The content tab ends-->
+
+                              <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+                              <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                              <label for="serving_size">
+                                Taille d'une portion
+                              </label>
+
+                              <input
+                                type="text"
+                                name="serving_size"
+                                id="serving_size"
+                                class="text"
+                                value="10 g"
+                                lang="fr"
+                                data-autocomplete=""
+                              />
+
+                              <p class="note">
+                                &rarr; Si le tableau nutritionnel contient des
+                                valeurs pour le produit préparé, indiquez la
+                                taille totale d'une portion de produit préparé
+                                (incluant l'eau ou le lait ajouté).
+                              </p>
+
+                              <p class="example">
+                                Exemples : 30 g, 2 biscuits 60 g, 5 cl, un verre
+                                20 cl
+                              </p>
+
+                              <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                              <!-- petfood nutriment are as sold only -->
+
+                              <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                              <input
+                                type="hidden"
+                                name="nutrition_data_displayed"
+                                value="1"
+                              />
+                              <input
+                                type="checkbox"
+                                id="nutrition_data"
+                                name="nutrition_data"
+                                checked="checked"
+                              />
+                              <label for="nutrition_data" class="checkbox_label"
+                                >Les informations nutritionnelles sont
+                                mentionnées pour le produit tel que
+                                vendu.</label
+                              >
+                              &nbsp;
+                              <input
+                                type="radio"
+                                id="nutrition_data_per_100g"
+                                value="100g"
+                                name="nutrition_data_per"
+                                checked="checked"
+                              />
+                              <label for="nutrition_data_per_100g"
+                                >pour 100 g / 100 ml</label
+                              >
+                              <input
+                                type="radio"
+                                id="nutrition_data_per_serving"
+                                value="serving"
+                                name="nutrition_data_per"
+                              />
+                              <label for="nutrition_data_per_serving"
+                                >par portion</label
+                              ><br />
+
+                              <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                              <input
+                                type="hidden"
+                                name="nutrition_data_prepared_displayed"
+                                value="1"
+                              />
+                              <input
+                                type="checkbox"
+                                id="nutrition_data_prepared"
+                                name="nutrition_data_prepared"
+                              />
+                              <label
+                                for="nutrition_data_prepared"
+                                class="checkbox_label"
+                                >Les informations nutritionnelles sont
+                                mentionnées pour le produit préparé.</label
+                              >
+                              &nbsp;
+                              <input
+                                type="radio"
+                                id="nutrition_data_prepared_per_100g"
+                                value="100g"
+                                name="nutrition_data_prepared_per"
+                                checked="checked"
+                              />
+                              <label for="nutrition_data_prepared_per_100g"
+                                >pour 100 g / 100 ml</label
+                              >
+                              <input
+                                type="radio"
+                                id="nutrition_data_prepared_per_serving"
+                                value="serving"
+                                name="nutrition_data_prepared_per"
+                              />
+                              <label for="nutrition_data_prepared_per_serving"
+                                >par portion</label
+                              ><br />
+
+                              <div style="position: relative">
+                                <table
+                                  id="nutrition_data_table"
+                                  class="data_table"
+                                  style="display: table"
+                                  aria-label="nutrition table"
+                                >
+                                  <thead class="nutriment_header">
+                                    <th id="col_1">Tableau nutritionnel</th>
+                                    <th id="col_2" class="nutriment_col">
+                                      Tel que vendu<br />
+
+                                      <span id="nutrition_data_100g"
+                                        >pour 100 g / 100 ml</span
+                                      >
+                                      <span
+                                        id="nutrition_data_serving"
+                                        style="display: none"
+                                        >par portion</span
+                                      >
+                                    </th>
+                                    <th
+                                      id="col_3"
+                                      class="nutriment_col_prepared"
+                                      style="display: none"
+                                    >
+                                      Préparé<br />
+                                      <span id="nutrition_data_prepared_100g"
+                                        >pour 100 g / 100 ml</span
+                                      >
+                                      <span
+                                        id="nutrition_data_prepared_serving"
+                                        style="display: none"
+                                        >par portion</span
+                                      >
+                                    </th>
+                                    <th id="col_4">Unité</th>
+                                  </thead>
+
+                                  <tbody>
+                                    <tr
+                                      id="nutriment_energy-kj_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_energy-kj"
+                                        >
+                                          Énergie (kJ) *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_energy-kj"
+                                          name="nutriment_energy-kj"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_energy-kj"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_energy-kj"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_energy-kj_prepared"
+                                          name="nutriment_energy-kj_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span class="nutriment_unit">kJ</span>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_energy-kcal_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_energy-kcal"
+                                        >
+                                          Énergie (kcal)
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_energy-kcal"
+                                          name="nutriment_energy-kcal"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_energy-kcal"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_energy-kcal"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_energy-kcal_prepared"
+                                          name="nutriment_energy-kcal_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span class="nutriment_unit">kcal</span>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_fat_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_fat"
+                                        >
+                                          Matières grasses *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_fat"
+                                          name="nutriment_fat"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_fat"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_fat"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_fat_prepared"
+                                          name="nutriment_fat_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_fat_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_fat_unit"
+                                          name="nutriment_fat_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_saturated-fat_tr"
+                                      class="nutriment_sub"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_saturated-fat"
+                                        >
+                                          Acides gras saturés *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_saturated-fat"
+                                          name="nutriment_saturated-fat"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_saturated-fat"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_saturated-fat"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_saturated-fat_prepared"
+                                          name="nutriment_saturated-fat_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_saturated-fat_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_saturated-fat_unit"
+                                          name="nutriment_saturated-fat_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_carbohydrates_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_carbohydrates"
+                                        >
+                                          Glucides
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_carbohydrates"
+                                          name="nutriment_carbohydrates"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_carbohydrates"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_carbohydrates"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_carbohydrates_prepared"
+                                          name="nutriment_carbohydrates_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_carbohydrates_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_carbohydrates_unit"
+                                          name="nutriment_carbohydrates_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_sugars_tr"
+                                      class="nutriment_sub"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_sugars"
+                                        >
+                                          Sucres *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_sugars"
+                                          name="nutriment_sugars"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_sugars"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_sugars"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_sugars_prepared"
+                                          name="nutriment_sugars_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_sugars_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_sugars_unit"
+                                          name="nutriment_sugars_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_fiber_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_fiber"
+                                        >
+                                          Fibres alimentaires *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_fiber"
+                                          name="nutriment_fiber"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_fiber"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_fiber"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_fiber_prepared"
+                                          name="nutriment_fiber_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_fiber_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_fiber_unit"
+                                          name="nutriment_fiber_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_proteins_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_proteins"
+                                        >
+                                          Protéines *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_proteins"
+                                          name="nutriment_proteins"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_proteins"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_proteins"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_proteins_prepared"
+                                          name="nutriment_proteins_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_proteins_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_proteins_unit"
+                                          name="nutriment_proteins_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_salt_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_salt"
+                                        >
+                                          Sel *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_salt"
+                                          name="nutriment_salt"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_salt"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_salt"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_salt_prepared"
+                                          name="nutriment_salt_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_salt_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_salt_unit"
+                                          name="nutriment_salt_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_sodium_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_sodium"
+                                        >
+                                          Sodium
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_sodium"
+                                          name="nutriment_sodium"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_sodium"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_sodium"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_sodium_prepared"
+                                          name="nutriment_sodium_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_sodium_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_sodium_unit"
+                                          name="nutriment_sodium_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_alcohol_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_alcohol"
+                                        >
+                                          Alcool
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_alcohol"
+                                          name="nutriment_alcohol"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_alcohol"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_alcohol"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_alcohol_prepared"
+                                          name="nutriment_alcohol_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span class="nutriment_unit"
+                                          >% vol / °</span
+                                        >
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_new_0_tr"
+                                      class="nutriment_main"
+                                      style="display: none"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <input
+                                          class="nutriment_label"
+                                          id="nutriment_new_0_label"
+                                          name="nutriment_new_0_label"
+                                          placeholder="Ajouter un nutriment"
+                                        />
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_new_0"
+                                          name="nutriment_new_0"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_new_0"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_new_0"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_new_0_prepared"
+                                          name="nutriment_new_0_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_new_0_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_new_0_unit"
+                                          name="nutriment_new_0_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+
+                                          <option value="% DV">% DV</option>
+
+                                          <option value="IU">IU</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_new_1_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <input
+                                          class="nutriment_label"
+                                          id="nutriment_new_1_label"
+                                          name="nutriment_new_1_label"
+                                          placeholder="Ajouter un nutriment"
+                                        />
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_new_1"
+                                          name="nutriment_new_1"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_new_1"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_new_1"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_new_1_prepared"
+                                          name="nutriment_new_1_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_new_1_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_new_1_unit"
+                                          name="nutriment_new_1_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+
+                                          <option value="% DV">% DV</option>
+
+                                          <option value="IU">IU</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+
+                                <input
+                                  type="hidden"
+                                  name="new_max"
+                                  id="new_max"
+                                  value="1"
+                                />
+                                <div
+                                  id="nutrition_image_copy"
+                                  style="position: absolute; bottom: 0"
+                                ></div>
+                              </div>
+
+                              <p class="asterisk">
+                                &rarr;* :Nutriments essentiels pour calculer le
+                                Nutri-Score.
+                              </p>
+
+                              <p class="note">
+                                &rarr; Le tableau liste par défaut les
+                                nutriments les plus couramment indiqués. Laissez
+                                le champ vide s'il n'est pas présent sur
+                                l'emballage.<br />Vous pouvez ajouter d'autres
+                                nutriments (vitamines, minéraux, cholestérol,
+                                oméga 3 et 6 etc.) en tapant les premières
+                                lettres de leur nom dans la dernière ligne du
+                                tableau.
+                              </p>
+                            </div>
+                          </div>
+                        </section>
+                        <!--nutrient field set-->
+
+                        <!--packaging field-->
+                        <section id="packaging_section" class="card fieldset">
+                          <div class="card-section">
+                            <legend>Emballage</legend>
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul id="tabs_packaging_image" class="tabs" data-tab>
+                              <li
+                                class="tabs tab-title active tabs_fr"
+                                id="tabs_packaging_image_fr_tab"
+                                data-language="fr"
+                              >
+                                <a
+                                  href="#tabs_packaging_image_fr"
+                                  class="tab_language"
+                                  >Français</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_en"
+                                id="tabs_packaging_image_en_tab"
+                                data-language="en"
+                              >
+                                <a
+                                  href="#tabs_packaging_image_en"
+                                  class="tab_language"
+                                  >Anglais</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_packaging_image_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_packaging_image_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div
+                              id="tabs_content_packaging_image"
+                              class="tabs-content"
+                            >
+                              <div
+                                class="tabs content active tabs_fr"
+                                id="tabs_packaging_image_fr"
+                              >
+                                <label for="packaging_fr"
+                                  >Image d'instructions de recyclage et/ou
+                                  information d'emballage (<span
+                                    class="tab_language"
+                                    >Français</span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="packaging_fr"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_imgid"
+                                  id="packaging_fr_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_x1"
+                                  id="packaging_fr_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_y1"
+                                  id="packaging_fr_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_x2"
+                                  id="packaging_fr_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_y2"
+                                  id="packaging_fr_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_display_url"
+                                  id="packaging_fr_display_url"
+                                  value=""
+                                />
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="packaging_text_fr">
+                                  Instruction de recyclage et/ou informations
+                                  d'emballage (<span class="tab_language"
+                                    >Français</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="packaging_text_fr"
+                                  id="packaging_text_fr"
+                                  lang="fr"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; Lister toutes les parties de
+                                  l'emballage séparées par une virgule ou un
+                                  retour à la ligne, avec leur quantité (ex : 1
+                                  ou 6), leur type (ex : bouteille, boîte,
+                                  canette), le matériau (ex : plastique, métal,
+                                  aluminium), et si possible leur taille (ex:
+                                  33cl) ainsi que les instructions de recyclage.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Essayez d'être aussi précis que
+                                  possible. Pour le plastique, merci d'indiquer
+                                  s'il est opaque ou transparent, coloré, PET ou
+                                  PEHD.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Les données de ce champ seront
+                                  combinées avec toutes les données fournies
+                                  pour chaque partie de l'emballage. Il est
+                                  possible de fournir l'un ou l'autre, ou les
+                                  deux.
+                                </p>
+
+                                <p class="example">
+                                  Exemples : 1 film plastique à jeter, 1 boîte
+                                  en carton FSC à recycler, 6 bouteilles en
+                                  plastique transparent PET de 1,5 L à recycler,
+                                  6 bouchons en plastique de couleur opaques, 12
+                                  canettes en aluminium de 33 cl
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content tabs_en"
+                                id="tabs_packaging_image_en"
+                              >
+                                <label for="packaging_en"
+                                  >Image d'instructions de recyclage et/ou
+                                  information d'emballage (<span
+                                    class="tab_language"
+                                    >Anglais</span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="packaging_en"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_imgid"
+                                  id="packaging_en_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_x1"
+                                  id="packaging_en_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_y1"
+                                  id="packaging_en_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_x2"
+                                  id="packaging_en_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_y2"
+                                  id="packaging_en_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_display_url"
+                                  id="packaging_en_display_url"
+                                  value=""
+                                />
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="packaging_text_en">
+                                  Instruction de recyclage et/ou informations
+                                  d'emballage (<span class="tab_language"
+                                    >Anglais</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="packaging_text_en"
+                                  id="packaging_text_en"
+                                  lang="en"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; Lister toutes les parties de
+                                  l'emballage séparées par une virgule ou un
+                                  retour à la ligne, avec leur quantité (ex : 1
+                                  ou 6), leur type (ex : bouteille, boîte,
+                                  canette), le matériau (ex : plastique, métal,
+                                  aluminium), et si possible leur taille (ex:
+                                  33cl) ainsi que les instructions de recyclage.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Essayez d'être aussi précis que
+                                  possible. Pour le plastique, merci d'indiquer
+                                  s'il est opaque ou transparent, coloré, PET ou
+                                  PEHD.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Les données de ce champ seront
+                                  combinées avec toutes les données fournies
+                                  pour chaque partie de l'emballage. Il est
+                                  possible de fournir l'un ou l'autre, ou les
+                                  deux.
+                                </p>
+
+                                <p class="example">
+                                  Exemples : 1 film plastique à jeter, 1 boîte
+                                  en carton FSC à recycler, 6 bouteilles en
+                                  plastique transparent PET de 1,5 L à recycler,
+                                  6 bouchons en plastique de couleur opaques, 12
+                                  canettes en aluminium de 33 cl
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_packaging_image_new_lc"
+                              >
+                                <label for="packaging_new_lc"
+                                  >Image d'instructions de recyclage et/ou
+                                  information d'emballage (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="packaging_new_lc"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_imgid"
+                                  id="packaging_new_lc_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_x1"
+                                  id="packaging_new_lc_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_y1"
+                                  id="packaging_new_lc_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_x2"
+                                  id="packaging_new_lc_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_y2"
+                                  id="packaging_new_lc_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_display_url"
+                                  id="packaging_new_lc_display_url"
+                                  value=""
+                                />
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="packaging_text_new_lc">
+                                  Instruction de recyclage et/ou informations
+                                  d'emballage (<span class="tab_language"></span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="packaging_text_new_lc"
+                                  id="packaging_text_new_lc"
+                                  lang="new_lc"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; Lister toutes les parties de
+                                  l'emballage séparées par une virgule ou un
+                                  retour à la ligne, avec leur quantité (ex : 1
+                                  ou 6), leur type (ex : bouteille, boîte,
+                                  canette), le matériau (ex : plastique, métal,
+                                  aluminium), et si possible leur taille (ex:
+                                  33cl) ainsi que les instructions de recyclage.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Essayez d'être aussi précis que
+                                  possible. Pour le plastique, merci d'indiquer
+                                  s'il est opaque ou transparent, coloré, PET ou
+                                  PEHD.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Les données de ce champ seront
+                                  combinées avec toutes les données fournies
+                                  pour chaque partie de l'emballage. Il est
+                                  possible de fournir l'un ou l'autre, ou les
+                                  deux.
+                                </p>
+
+                                <p class="example">
+                                  Exemples : 1 film plastique à jeter, 1 boîte
+                                  en carton FSC à recycler, 6 bouteilles en
+                                  plastique transparent PET de 1,5 L à recycler,
+                                  6 bouchons en plastique de couleur opaques, 12
+                                  canettes en aluminium de 33 cl
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+                            <p>Elements d'emballage</p>
+
+                            <div id="packagings_components_edit">
+                              <ul>
+                                <li>
+                                  <b>Nombre d'éléments :</b> Entrez le nombre
+                                  d'éléments d'emballage de la même forme et de
+                                  la même matière contenue dans le produit.
+                                </li>
+                                <li>
+                                  <b>Forme :</b> Entrez le nom de la forme
+                                  indiqué dans les instructions de recyclage si
+                                  elles sont disponibles, ou sélectionnez une
+                                  forme.
+                                </li>
+                                <li>
+                                  <b>Matière :</b> Entrez le matériau spécifique
+                                  s'il peut être déterminé (un code de matériau
+                                  à l'intérieur d'un triangle peut souvent être
+                                  trouvé sur les éléments d'emballage), ou un
+                                  matériau générique (par exemple du plastique
+                                  ou du métal) si vous n'êtes pas sûr.
+                                </li>
+                                <li>
+                                  <b>Recyclage :</b> Saisissez les consignes de
+                                  tri seulement si elles apparaîssent sur le
+                                  produit.
+                                </li>
+                                <li>
+                                  <b>Poids d'un élément vide :</b> Enlevez les
+                                  restes de nourriture et lavez et séchez les
+                                  éléments d'emballage avant de les peser. Si
+                                  possible, utilisez une balance avec une
+                                  précision de 0.1g ou 0.01g.
+                                </li>
+                                <li>
+                                  <b
+                                    >Quantité de produit contenue par
+                                    élément :</b
+                                  >
+                                  Entrez le poids net ou le volume net et
+                                  indiquez l'unité (par exemple g ou ml).
+                                </li>
+                              </ul>
+
+                              <!-- header row for large display -->
+                              <div
+                                class="row show-for-large-up"
+                                id="packagings_components_edit_header"
+                              >
+                                <div class="large-1 columns">
+                                  Nombre d'éléments
+                                </div>
+                                <div class="large-3 columns">Forme</div>
+                                <div class="large-3 columns">Matière</div>
+                                <div class="large-3 columns">Recyclage</div>
+                                <div class="large-1 columns">
+                                  Poids d'un élément vide (g)
+                                </div>
+                                <div class="large-1 columns">
+                                  Quantité de produit contenue par élément
+                                </div>
+                              </div>
+
+                              <div
+                                class="row packagings_components_edit_row"
+                                id="packaging_0_row"
+                              >
+                                <div class="small-12 large-1 columns">
+                                  <!-- label for small displays -->
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_number_of_units"
+                                    >Nombre d'éléments</label
+                                  >
+
+                                  <div class="row">
+                                    <div
+                                      class="small-12 large-4 columns delete_packaging_column"
+                                    >
+                                      <a
+                                        class="delete_packaging"
+                                        id="packaging_0_delete"
+                                      >
+                                        <span class="material-icons">
+                                          delete
+                                        </span>
+                                      </a>
+                                    </div>
+
+                                    <div class="small-12 large-8 columns">
+                                      <input
+                                        id="packaging_0_number_of_units"
+                                        name="packaging_0_number_of_units"
+                                        type="text"
+                                        value=""
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_shape"
+                                    >Forme</label
+                                  >
+                                  <select
+                                    id="packaging_0_shape"
+                                    name="packaging_0_shape"
+                                    class="form-control packaging_shapes_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_material"
+                                    >Matière</label
+                                  >
+                                  <select
+                                    id="packaging_0_material"
+                                    name="packaging_0_material"
+                                    class="form-control packaging_materials_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_recycling"
+                                    >Recyclage</label
+                                  >
+                                  <select
+                                    id="packaging_0_recycling"
+                                    name="packaging_0_recycling"
+                                    class="form-control packaging_recycling_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_weight_measured"
+                                    >Poids d'un élément vide (g)</label
+                                  >
+
+                                  <input id="packaging_0_weight_measured"
+                                  name="packaging_0_weight_measured" type="text"
+                                  value="" %]">
+                                </div>
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_quantity_per_unit"
+                                    >Quantité de produit contenue par
+                                    élément</label
+                                  >
+                                  <input id="packaging_0_quantity_per_unit"
+                                  name="packaging_0_quantity_per_unit"
+                                  type="text" value="" %]">
+                                </div>
+                              </div>
+
+                              <div
+                                class="row packagings_components_edit_row"
+                                id="packaging_1_row"
+                              >
+                                <div class="small-12 large-1 columns">
+                                  <!-- label for small displays -->
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_number_of_units"
+                                    >Nombre d'éléments</label
+                                  >
+
+                                  <div class="row">
+                                    <div
+                                      class="small-12 large-4 columns delete_packaging_column"
+                                    >
+                                      <a
+                                        class="delete_packaging"
+                                        id="packaging_1_delete"
+                                      >
+                                        <span class="material-icons">
+                                          delete
+                                        </span>
+                                      </a>
+                                    </div>
+
+                                    <div class="small-12 large-8 columns">
+                                      <input
+                                        id="packaging_1_number_of_units"
+                                        name="packaging_1_number_of_units"
+                                        type="text"
+                                        value=""
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_shape"
+                                    >Forme</label
+                                  >
+                                  <select
+                                    id="packaging_1_shape"
+                                    name="packaging_1_shape"
+                                    class="form-control packaging_shapes_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_material"
+                                    >Matière</label
+                                  >
+                                  <select
+                                    id="packaging_1_material"
+                                    name="packaging_1_material"
+                                    class="form-control packaging_materials_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_recycling"
+                                    >Recyclage</label
+                                  >
+                                  <select
+                                    id="packaging_1_recycling"
+                                    name="packaging_1_recycling"
+                                    class="form-control packaging_recycling_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_weight_measured"
+                                    >Poids d'un élément vide (g)</label
+                                  >
+
+                                  <input id="packaging_1_weight_measured"
+                                  name="packaging_1_weight_measured" type="text"
+                                  value="" %]">
+                                </div>
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_quantity_per_unit"
+                                    >Quantité de produit contenue par
+                                    élément</label
+                                  >
+                                  <input id="packaging_1_quantity_per_unit"
+                                  name="packaging_1_quantity_per_unit"
+                                  type="text" value="" %]">
+                                </div>
+                              </div>
+
+                              <input
+                                type="hidden"
+                                name="packaging_max"
+                                value="1"
+                              />
+                            </div>
+
+                            <input
+                              type="checkbox"
+                              id="packagings_complete"
+                              name="packagings_complete"
+                            />
+                            <label
+                              for="packagings_complete"
+                              class="checkbox_label"
+                              >Tous les éléments de l'emballage du produit sont
+                              listés.</label
+                            ><br />
+
+                            <!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+                          </div>
+                        </section>
+
+                        <input type="hidden" name="type" value="edit" />
+                        <input
+                          type="hidden"
+                          id="code"
+                          name="code"
+                          value="3300000000002"
+                        />
+                        <input type="hidden" name="action" value="process" />
+
+                        <div id="fixed_bar" class="bottom-validation">
+                          <div class="row">
+                            <div
+                              class="small-12 medium-12 large-8 xlarge-8 columns"
+                              style="margin-bottom: 0.5rem"
+                            >
+                              <input
+                                id="comment"
+                                name="comment"
+                                placeholder="Description de vos changements"
+                                value=""
+                                type="text"
+                                class="text"
+                                style="margin: 0"
+                              />
+                            </div>
+                            <div
+                              class="small-6 medium-6 large-2 xlarge-2 columns"
+                            >
+                              <button
+                                type="submit"
+                                id="save"
+                                name=".submit"
+                                class="button postfix success small"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                  <path
+                                    d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                  />
+                                </svg>
+                                Enregistrer
+                              </button>
+                            </div>
+                            <div
+                              class="small-6 medium-6 large-2 xlarge-2 columns"
+                            >
+                              <button
+                                type="button"
+                                id="back-btn"
+                                class="button postfix small secondary"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                                Annuler
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+
+                        <!-- start templates/web/pages/product/includes/edit_history.tt.html -->
+
+                        <h2 id="history">Historique des modifications</h2>
+                        <ul id="history_list">
+                          <li>
+                            <time datetime="--ignore--">--ignore--</time> -
+                            <a href="/facets/editeurs/tests" lang="no_language"
+                              >tests</a
+                            >
+                            Données (Ajout : product_type, code, lang,
+                            product_name, quantity, brands, categories, labels,
+                            link, countries, nutrition_data_per,
+                            nutrition_data_prepared_per, serving_size,
+                            ingredients_text, generic_name_en,
+                            ingredients_text_en, origin_en, product_name_en,
+                            ingredients_text_fr, product_name_fr) -- Nutriments
+                            (Ajout : nutrition-score-fr) - (app) &nbsp;
+                            <a
+                              href="/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert?rev=1"
+                              class="button tiny"
+                              >Voir cette révision</a
+                            >
+                          </li>
+                        </ul>
+
+                        <script>
+                          var revert_confirm_message =
+                            "Revenir à cette révision du produit ?";
+                        </script>
+
+                        <!-- end templates/web/pages/product/includes/edit_history.tt.html -->
+                      </div>
+                    </div>
+                  </div>
+                </form>
+
+                <style>
+                  .question_mark {
+                    display: none;
+                    position: relative;
+                    width: 20px;
+                    height: 20px;
+                    border-radius: 50%;
+                    background-color: #999;
+                    color: #fff;
+                    text-align: center;
+                    font-weight: bold;
+                    cursor: help;
+                  }
+
+                  .sugars_warning {
+                    display: none;
+                    position: absolute;
+                    left: 16%;
+                    transform: translateX(50%);
+                    padding: 0.5em;
+                    background-color: #333;
+                    color: #fff;
+                    font-size: 0.8em;
+                    white-space: nowrap;
+                    margin-top: 1%;
+                    z-index: 1;
+                  }
+
+                  .soft-background {
+                    background-color: #f5f5f5;
+                  }
+
+                  .question_mark:hover + .sugars_warning {
+                    display: inline-block;
+                  }
+
+                  .question_mark:hover {
+                    opacity: 0.7;
+                  }
+                </style>
+
+                <!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+              </div>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div id="prodInfos">
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-            <div class="row">
-                <div class="small-12 columns">
+        <!-- Donation banner @ footer -->
 
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
-        <section id="misc" class="card fieldset">
-            <div class="card-section">
-                <p id="barcode_paragraph"> Code-barres :
-                    <span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">3300000000002</span>
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
                 </p>
-
-
-        
-        
-        
-            <label for="product_type" id="label_product_type">Type de produit</label>
-            <select name="product_type" id="product_type">
-                
-                    <option value="food"  selected="selected" >Nourriture</option>
-                
-                    <option value="petfood" >Nourriture pour animaux de compagnie</option>
-                
-                    <option value="beauty" >Beauté</option>
-                
-                    <option value="product" >Produit</option>
-                
-            </select>
-        
-
-        
-
-        
-        
-        <div data-alert class="alert-box info store-state" id="warning_3rd_party_content" style="display:none;">
-            <span>Les informations et les données doivent provenir de l'emballage et de l'étiquette du produit (et non pas d'autres sites ou du site du fabricant), et vous devez avoir pris les photos vous-même.<br/>
-→ <a href="//support.openfoodfacts.org/help/fr-fr/9/27">Pourquoi c'est important</a></span>
-             <a href="#" class="close">&times;</a>
-        </div>
-        
-
-        <div data-alert class="alert-box secondary store-state" id="licence_accept" style="display:none;">
-            <span>En ajoutant des informations et/ou des photographies, vous acceptez de placer irrévocablement votre contribution sous licence <a href="//opendatacommons.org/licenses/dbcl/1.0/">Database Contents Licence 1.0</a>
-pour les informations et sous licence <a href="//creativecommons.org/licenses/by-sa/3.0/deed.fr">Creative Commons Paternité - Partage des conditions initiales à l'identique 3.0</a> pour les photos.
-Vous acceptez d'être crédité par les ré-utilisateurs par un lien vers le produit auquel vous contribuez.</span>
-             <a href="#" class="close">&times;</a>
-        </div>
-
-        
-
-        
-
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
             </div>
+          </div>
         </section>
 
-        <section id="product_image" class="card fieldset">
-            <div class="card-section">
-                <legend>Photo du produit</legend>
-                <input type="hidden" id="sorted_langs" name="sorted_langs" value="fr,en"/>
-
-                <label for="lang"> Langue principale </label>
-                <select name="lang" id="lang">
-                    
-                        <option value="ab" >Abkhaze</option>
-                    
-                        <option value="aa" >Afar</option>
-                    
-                        <option value="af" >Afrikaans</option>
-                    
-                        <option value="ak" >Akan</option>
-                    
-                        <option value="sq" >Albanais</option>
-                    
-                        <option value="de" >Allemand</option>
-                    
-                        <option value="am" >Amharique</option>
-                    
-                        <option value="en" >Anglais</option>
-                    
-                        <option value="ar" >Arabe</option>
-                    
-                        <option value="an" >Aragonais</option>
-                    
-                        <option value="hy" >Arménien</option>
-                    
-                        <option value="as" >Assamais</option>
-                    
-                        <option value="av" >Avar</option>
-                    
-                        <option value="ae" >Avestique</option>
-                    
-                        <option value="ay" >Aymara</option>
-                    
-                        <option value="az" >Azéri</option>
-                    
-                        <option value="ba" >Bachkir</option>
-                    
-                        <option value="bm" >Bambara</option>
-                    
-                        <option value="eu" >Basque</option>
-                    
-                        <option value="bn" >Bengali</option>
-                    
-                        <option value="bi" >Bichelamar</option>
-                    
-                        <option value="be" >Biélorusse</option>
-                    
-                        <option value="bh" >Bihari</option>
-                    
-                        <option value="my" >Birman</option>
-                    
-                        <option value="nb" >Bokmål</option>
-                    
-                        <option value="bs" >Bosnien</option>
-                    
-                        <option value="br" >Breton</option>
-                    
-                        <option value="bg" >Bulgare</option>
-                    
-                        <option value="ks" >Cachemiri</option>
-                    
-                        <option value="ca" >Catalan</option>
-                    
-                        <option value="ch" >Chamorro</option>
-                    
-                        <option value="ny" >Chewa</option>
-                    
-                        <option value="si" >Cingalais</option>
-                    
-                        <option value="ko" >Coréen</option>
-                    
-                        <option value="kw" >Cornique</option>
-                    
-                        <option value="co" >Corse</option>
-                    
-                        <option value="cr" >Cri</option>
-                    
-                        <option value="hr" >Croate</option>
-                    
-                        <option value="da" >Danois</option>
-                    
-                        <option value="dz" >Dzongkha</option>
-                    
-                        <option value="es" >Espagnol</option>
-                    
-                        <option value="eo" >Espéranto</option>
-                    
-                        <option value="et" >Estonien</option>
-                    
-                        <option value="ee" >Ewe</option>
-                    
-                        <option value="fo" >Féroïen</option>
-                    
-                        <option value="fj" >Fidjien</option>
-                    
-                        <option value="fi" >Finnois</option>
-                    
-                        <option value="fr"  selected="selected" >Français</option>
-                    
-                        <option value="fy" >Frison occidental</option>
-                    
-                        <option value="gd" >Gaélique écossais</option>
-                    
-                        <option value="gl" >Galicien</option>
-                    
-                        <option value="cy" >Gallois</option>
-                    
-                        <option value="ka" >Géorgien</option>
-                    
-                        <option value="el" >Grec</option>
-                    
-                        <option value="kl" >Groenlandais</option>
-                    
-                        <option value="gn" >Guarani</option>
-                    
-                        <option value="gu" >Gujarati</option>
-                    
-                        <option value="ht" >Haïtien</option>
-                    
-                        <option value="ha" >Haoussa</option>
-                    
-                        <option value="he" >Hébreu</option>
-                    
-                        <option value="hz" >Héréro</option>
-                    
-                        <option value="hi" >Hindi</option>
-                    
-                        <option value="ho" >Hiri motu</option>
-                    
-                        <option value="hu" >Hongrois</option>
-                    
-                        <option value="io" >Ido</option>
-                    
-                        <option value="ig" >Igbo</option>
-                    
-                        <option value="id" >Indonésien</option>
-                    
-                        <option value="ia" >Interlingua</option>
-                    
-                        <option value="iu" >Inuktitut</option>
-                    
-                        <option value="ik" >Inupiak</option>
-                    
-                        <option value="ga" >Irlandais</option>
-                    
-                        <option value="is" >Islandais</option>
-                    
-                        <option value="it" >Italien</option>
-                    
-                        <option value="ja" >Japonais</option>
-                    
-                        <option value="jv" >Javanais</option>
-                    
-                        <option value="kn" >Kannada</option>
-                    
-                        <option value="kr" >Kanouri</option>
-                    
-                        <option value="kk" >Kazakh</option>
-                    
-                        <option value="km" >Khmer</option>
-                    
-                        <option value="kg" >Kikongo</option>
-                    
-                        <option value="ki" >Kikuyu</option>
-                    
-                        <option value="rw" >Kinyarwanda</option>
-                    
-                        <option value="ky" >Kirghize</option>
-                    
-                        <option value="rn" >Kirundi</option>
-                    
-                        <option value="kv" >Komi</option>
-                    
-                        <option value="kj" >Kuanyama</option>
-                    
-                        <option value="ku" >Kurde</option>
-                    
-                        <option value="xx" >Langue inconnue</option>
-                    
-                        <option value="zh" >Langues chinoises</option>
-                    
-                        <option value="lo" >Lao</option>
-                    
-                        <option value="la" >Latin</option>
-                    
-                        <option value="lv" >Letton</option>
-                    
-                        <option value="li" >Limbourgeois</option>
-                    
-                        <option value="ln" >Lingala</option>
-                    
-                        <option value="lt" >Lituanien</option>
-                    
-                        <option value="lu" >Luba-katanga</option>
-                    
-                        <option value="lg" >Luganda</option>
-                    
-                        <option value="lb" >Luxembourgeois</option>
-                    
-                        <option value="mk" >Macédonien</option>
-                    
-                        <option value="ms" >Malais</option>
-                    
-                        <option value="ml" >Malayalam</option>
-                    
-                        <option value="dv" >Maldivien</option>
-                    
-                        <option value="mg" >Malgache</option>
-                    
-                        <option value="mt" >Maltais</option>
-                    
-                        <option value="gv" >Mannois</option>
-                    
-                        <option value="mi" >Maori de Nouvelle-Zélande</option>
-                    
-                        <option value="mr" >Marathi</option>
-                    
-                        <option value="mh" >Marshallais</option>
-                    
-                        <option value="mo" >Moldave</option>
-                    
-                        <option value="mn" >Mongol</option>
-                    
-                        <option value="me" >Monténégrin</option>
-                    
-                        <option value="na" >Nauruan</option>
-                    
-                        <option value="nv" >Navajo</option>
-                    
-                        <option value="ng" >Ndonga</option>
-                    
-                        <option value="nl" >Néerlandais</option>
-                    
-                        <option value="ne" >Népalais</option>
-                    
-                        <option value="no" >Norvégien</option>
-                    
-                        <option value="nr" >Nrebele</option>
-                    
-                        <option value="ii" >Nuosu language</option>
-                    
-                        <option value="nn" >Nynorsk</option>
-                    
-                        <option value="ie" >Occidental</option>
-                    
-                        <option value="oc" >Occitan</option>
-                    
-                        <option value="oj" >Ojibwé</option>
-                    
-                        <option value="or" >Oriya</option>
-                    
-                        <option value="om" >Oromo</option>
-                    
-                        <option value="os" >Ossète</option>
-                    
-                        <option value="ug" >Ouïghour</option>
-                    
-                        <option value="ur" >Ourdou</option>
-                    
-                        <option value="uz" >Ouzbek</option>
-                    
-                        <option value="ps" >Pachto</option>
-                    
-                        <option value="pi" >Pali</option>
-                    
-                        <option value="pa" >Panjābī</option>
-                    
-                        <option value="fa" >Persan</option>
-                    
-                        <option value="ff" >Peul</option>
-                    
-                        <option value="pl" >Polonais</option>
-                    
-                        <option value="pt" >Portugais</option>
-                    
-                        <option value="qu" >Quechua</option>
-                    
-                        <option value="rm" >Romanche</option>
-                    
-                        <option value="ro" >Roumain</option>
-                    
-                        <option value="ru" >Russe</option>
-                    
-                        <option value="ry" >Rusyn</option>
-                    
-                        <option value="se" >Same du Nord</option>
-                    
-                        <option value="sm" >Samoan</option>
-                    
-                        <option value="sg" >Sango</option>
-                    
-                        <option value="sa" >Sanskrit</option>
-                    
-                        <option value="sc" >Sarde</option>
-                    
-                        <option value="sr" >Serbe</option>
-                    
-                        <option value="sh" >Serbo-croate</option>
-                    
-                        <option value="sn" >Shona</option>
-                    
-                        <option value="nd" >Sindebele</option>
-                    
-                        <option value="sd" >Sindhi</option>
-                    
-                        <option value="cu" >Slavon liturgique</option>
-                    
-                        <option value="sk" >Slovaque</option>
-                    
-                        <option value="sl" >Slovène</option>
-                    
-                        <option value="so" >Somali</option>
-                    
-                        <option value="st" >Sotho du Sud</option>
-                    
-                        <option value="su" >Soundanais</option>
-                    
-                        <option value="sv" >Suédois</option>
-                    
-                        <option value="sw" >Swahili</option>
-                    
-                        <option value="ss" >Swati</option>
-                    
-                        <option value="tg" >Tadjik</option>
-                    
-                        <option value="tl" >Tagalog</option>
-                    
-                        <option value="ty" >Tahitien</option>
-                    
-                        <option value="ta" >Tamoul</option>
-                    
-                        <option value="tt" >Tatar</option>
-                    
-                        <option value="cs" >Tchèque</option>
-                    
-                        <option value="ce" >Tchétchène</option>
-                    
-                        <option value="cv" >Tchouvache</option>
-                    
-                        <option value="te" >Télougou</option>
-                    
-                        <option value="th" >Thaï</option>
-                    
-                        <option value="bo" >Tibétain</option>
-                    
-                        <option value="ti" >Tigrigna</option>
-                    
-                        <option value="to" >Tongien</option>
-                    
-                        <option value="ts" >Tsonga</option>
-                    
-                        <option value="tn" >Tswana</option>
-                    
-                        <option value="tr" >Turc</option>
-                    
-                        <option value="tk" >Turkmène</option>
-                    
-                        <option value="tw" >Twi</option>
-                    
-                        <option value="uk" >Ukrainien</option>
-                    
-                        <option value="ve" >Venda</option>
-                    
-                        <option value="vi" >Vietnamien</option>
-                    
-                        <option value="vo" >Volapük</option>
-                    
-                        <option value="wa" >Wallon</option>
-                    
-                        <option value="wo" >Wolof</option>
-                    
-                        <option value="xh" >Xhosa</option>
-                    
-                        <option value="yi" >Yiddish</option>
-                    
-                        <option value="yo" >Yoruba</option>
-                    
-                        <option value="za" >Zhuang</option>
-                    
-                        <option value="zu" >Zoulou</option>
-                    
-                </select>
-
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_front_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_fr" id="tabs_front_image_fr_tab" data-language="fr"><a href="#tabs_front_image_fr" class="tab_language">Français</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_en" id="tabs_front_image_en_tab" data-language="en"><a href="#tabs_front_image_en" class="tab_language">Anglais</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_front_image_new_lc_tab" data-language="new_lc"><a href="#tabs_front_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_front_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_fr" id="tabs_front_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="front_fr">Photo du produit (recto) (<span class="tab_language">Français</span>)</label>
-
-<div class="select_crop" id="front_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="front_fr_imgid" id="front_fr_imgid" value="" />
-<input type="hidden" name="front_fr_x1" id="front_fr_x1" value="" />
-<input type="hidden" name="front_fr_y1" id="front_fr_y1" value="" />
-<input type="hidden" name="front_fr_x2" id="front_fr_x2" value="" />
-<input type="hidden" name="front_fr_y2" id="front_fr_y2" value="" />
-<input type="hidden" name="front_fr_display_url" id="front_fr_display_url" value="" />
-
-                
-
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
             </div>
-        
-    
-        
-            <div class="tabs content tabs_en" id="tabs_front_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="front_en">Photo du produit (recto) (<span class="tab_language">Anglais</span>)</label>
-
-<div class="select_crop" id="front_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="front_en_imgid" id="front_en_imgid" value="" />
-<input type="hidden" name="front_en_x1" id="front_en_x1" value="" />
-<input type="hidden" name="front_en_y1" id="front_en_y1" value="" />
-<input type="hidden" name="front_en_x2" id="front_en_x2" value="" />
-<input type="hidden" name="front_en_y2" id="front_en_y2" value="" />
-<input type="hidden" name="front_en_display_url" id="front_en_display_url" value="" />
-
-                
-
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
             </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_front_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="front_new_lc">Photo du produit (recto) (<span class="tab_language"></span>)</label>
-
-<div class="select_crop" id="front_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="front_new_lc_imgid" id="front_new_lc_imgid" value="" />
-<input type="hidden" name="front_new_lc_x1" id="front_new_lc_x1" value="" />
-<input type="hidden" name="front_new_lc_y1" id="front_new_lc_y1" value="" />
-<input type="hidden" name="front_new_lc_x2" id="front_new_lc_x2" value="" />
-<input type="hidden" name="front_new_lc_y2" id="front_new_lc_y2" value="" />
-<input type="hidden" name="front_new_lc_display_url" id="front_new_lc_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-            </div>
-        </section>
-
-        <section id="product_characteristics" class="fieldset card">
-            <div class="card-section">
-                <legend>Caractéristiques du produit</legend>
-
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_product" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_fr" id="tabs_product_fr_tab" data-language="fr"><a href="#tabs_product_fr" class="tab_language">Français</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_en" id="tabs_product_en_tab" data-language="en"><a href="#tabs_product_en" class="tab_language">Anglais</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_product_new_lc_tab" data-language="new_lc"><a href="#tabs_product_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_product" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_fr" id="tabs_product_fr">
-                
-                                 
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="product_name_fr">
-    Nom du produit
-    
-        (<span class="tab_language">Français</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="product_name_fr" id="product_name_fr" class="text " value="Tarte aux pommes et aux framboise bio" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemple : Kinder Bueno White</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="generic_name_fr">
-    Dénomination générique
-    
-        (<span class="tab_language">Français</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="generic_name_fr" id="generic_name_fr" class="text " value="" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemple : Barre chocolatée au lait et aux noisettes</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_en" id="tabs_product_en">
-                
-                                 
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="product_name_en">
-    Nom du produit
-    
-        (<span class="tab_language">Anglais</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="product_name_en" id="product_name_en" class="text " value="Organic apple and raspberry pie" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemple : Kinder Bueno White</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="generic_name_en">
-    Dénomination générique
-    
-        (<span class="tab_language">Anglais</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="generic_name_en" id="generic_name_en" class="text " value="default_name" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemple : Barre chocolatée au lait et aux noisettes</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_product_new_lc">
-                
-                                 
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="product_name_new_lc">
-    Nom du produit
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <input type="text" name="product_name_new_lc" id="product_name_new_lc" class="text " value="" lang="new_lc" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemple : Kinder Bueno White</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="generic_name_new_lc">
-    Dénomination générique
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <input type="text" name="generic_name_new_lc" id="generic_name_new_lc" class="text " value="" lang="new_lc" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemple : Barre chocolatée au lait et aux noisettes</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="quantity">
-    Quantité
-    
-    
-</label>
-
-
-    <input type="text" name="quantity" id="quantity" class="text " value="100 g" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemples : 2 l, 250 g, 1 kg, 25 cl</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="brands">
-    Marques
-    
-    
-</label>
-
-
-    <input type="text" name="brands" id="brands" class="text tagify-me" value="Les tartes de Robert" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=brands" />
-
-
-
-
-
-
-    <p class="example">Exemples : Kinder Bueno White, Kinder Bueno, Kinder, Ferrero</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="categories">
-    Catégories
-    
-    
-</label>
-
-
-    <input type="text" name="categories" id="categories" class="text tagify-me" value="Desserts, Tartes, Tartes sucrées, Tartes aux pommes" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=categories" />
-
-
-
-
-    
-        <p class="note">&rarr; Il suffit d'indiquer la catégorie la plus spécifique, les catégories "parentes" seront ajoutées automatiquement.</p>
-    
-
-
-
-    <p class="example">Exemples : Sardines à l'huile d'olive, Mayonnaises allégées, Jus d'orange à base de concentré</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="labels">
-    Labels, certifications, récompenses
-    
-    
-</label>
-
-
-    <input type="text" name="labels" id="labels" class="text tagify-me" value="Commerce équitable, Bio
-
-" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=labels" />
-
-
-
-
-    
-        <p class="note">&rarr; Indiquez les labels les plus spécifiques. Les catégories "parentes" comme 'Bio' ou 'Commerce équitable' seront ajoutées automatiquement.</p>
-    
-
-
-
-    <p class="example">Exemple : Bio</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="manufacturing_places">
-    Lieux de fabrication ou de transformation
-    
-    
-</label>
-
-
-    <input type="text" name="manufacturing_places" id="manufacturing_places" class="text tagify-me" value="" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Exemples : Provence, France</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="emb_codes">
-    Code de traçabilité
-    
-    
-</label>
-
-
-    <input type="text" name="emb_codes" id="emb_codes" class="text tagify-me" value="" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=emb_codes" />
-
-
-
-
-    
-        <p class="note">&rarr; En Europe, le code est une ellipse contenant les deux initiales du pays suivies par un nombre et CE.</p>
-    
-
-
-
-    <p class="example">Exemples : EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="link">
-    Lien vers la page du produit sur le site officiel du fabricant
-    
-    
-</label>
-
-
-    <input type="text" name="link" id="link" class="text " value="//world.openfoodfacts.org/" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="expiration_date">
-    Date limite de consommation
-    
-    
-</label>
-
-
-    <input type="text" name="expiration_date" id="expiration_date" class="text " value="" lang="fr" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; La date limite permet de repérer les changements des produits dans le temps et d'identifier la plus récente version.</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="purchase_places">
-    Ville et pays d'achat
-    
-    
-</label>
-
-
-    <input type="text" name="purchase_places" id="purchase_places" class="text tagify-me" value="" lang="fr" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Indiquez le lieu où vous avez acheté ou vu le produit (au moins le pays)</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="stores">
-    Magasins
-    
-    
-</label>
-
-
-    <input type="text" name="stores" id="stores" class="text tagify-me" value="" lang="fr" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Enseigne du magasin où vous avez acheté ou vu le produit</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="countries">
-    Pays de vente
-    
-    
-</label>
-
-
-    <input type="text" name="countries" id="countries" class="text tagify-me" value="France, Allemagne, Royaume-Uni" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=countries" />
-
-
-
-
-    
-        <p class="note">&rarr; Pays dans lesquels le produit est largement distribué (hors magasins spécialisés dans l'import)</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-            </div>
-        </section>
-
-        <section id="ingredients" class="card fieldset">
-            <div class="card-section">
-                <legend>Ingrédients</legend>
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_ingredients_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_fr" id="tabs_ingredients_image_fr_tab" data-language="fr"><a href="#tabs_ingredients_image_fr" class="tab_language">Français</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_en" id="tabs_ingredients_image_en_tab" data-language="en"><a href="#tabs_ingredients_image_en" class="tab_language">Anglais</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_ingredients_image_new_lc_tab" data-language="new_lc"><a href="#tabs_ingredients_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_ingredients_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_fr" id="tabs_ingredients_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="ingredients_fr">Photo de la liste des ingrédients (<span class="tab_language">Français</span>)</label>
-<p class="note">&rarr; Si elle est suffisamment nette et droite, les ingrédients peuvent être extraits automatiquement de la photo.</p>
-<div class="select_crop" id="ingredients_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="ingredients_fr_imgid" id="ingredients_fr_imgid" value="" />
-<input type="hidden" name="ingredients_fr_x1" id="ingredients_fr_x1" value="" />
-<input type="hidden" name="ingredients_fr_y1" id="ingredients_fr_y1" value="" />
-<input type="hidden" name="ingredients_fr_x2" id="ingredients_fr_x2" value="" />
-<input type="hidden" name="ingredients_fr_y2" id="ingredients_fr_y2" value="" />
-<input type="hidden" name="ingredients_fr_display_url" id="ingredients_fr_display_url" value="" />
-
-                
-                    
-                        <div id="ingredients_fr_image_full"></div>
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="ingredients_text_fr">
-    Liste des ingrédients
-    
-        (<span class="tab_language">Français</span>)
-    
-    
-</label>
-
-
-    <textarea  name="ingredients_text_fr" id="ingredients_text_fr" lang="fr">Farine de blé, pommes, framboises 10%, sucre, beurre, oeufs, sel, huile de palme, acidifiant: acide citrique, agent levant: bicarbonate de sodium</textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Conserver l'ordre, indiquer le % lorsqu'il est précisé, séparer par une virgule ou - , Utiliser les ( ) pour  les ingrédients d'un ingrédient, indiquer les allergènes entre _ : farine de _blé_</p>
-    
-
-
-
-    <p class="example">Exemples : Céréales 85,5% (farine de _blé_, farine de _blé_ complet 11%), extrait de malt (orge), cacao 4,8%, vitamine C</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origin_fr">
-    Origine du produit et/ou de ses ingrédients
-    
-        (<span class="tab_language">Français</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="origin_fr" id="origin_fr" class="text " value="" lang="fr" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Mentions sur l'emballage indiquant le lieu de fabrication et/ou l'origine des ingrédients</p>
-    
-
-
-
-    <p class="example">Exemples : Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_en" id="tabs_ingredients_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="ingredients_en">Photo de la liste des ingrédients (<span class="tab_language">Anglais</span>)</label>
-<p class="note">&rarr; Si elle est suffisamment nette et droite, les ingrédients peuvent être extraits automatiquement de la photo.</p>
-<div class="select_crop" id="ingredients_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="ingredients_en_imgid" id="ingredients_en_imgid" value="" />
-<input type="hidden" name="ingredients_en_x1" id="ingredients_en_x1" value="" />
-<input type="hidden" name="ingredients_en_y1" id="ingredients_en_y1" value="" />
-<input type="hidden" name="ingredients_en_x2" id="ingredients_en_x2" value="" />
-<input type="hidden" name="ingredients_en_y2" id="ingredients_en_y2" value="" />
-<input type="hidden" name="ingredients_en_display_url" id="ingredients_en_display_url" value="" />
-
-                
-                    
-                        <div id="ingredients_en_image_full"></div>
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="ingredients_text_en">
-    Liste des ingrédients
-    
-        (<span class="tab_language">Anglais</span>)
-    
-    
-</label>
-
-
-    <textarea  name="ingredients_text_en" id="ingredients_text_en" lang="en">Wheat flour, apples, raspberries 10%, sugar, butter, eggs, salt, palm oil, acidifier: citric acid, raising agent: sodium bicarbonate</textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Conserver l'ordre, indiquer le % lorsqu'il est précisé, séparer par une virgule ou - , Utiliser les ( ) pour  les ingrédients d'un ingrédient, indiquer les allergènes entre _ : farine de _blé_</p>
-    
-
-
-
-    <p class="example">Exemples : Céréales 85,5% (farine de _blé_, farine de _blé_ complet 11%), extrait de malt (orge), cacao 4,8%, vitamine C</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origin_en">
-    Origine du produit et/ou de ses ingrédients
-    
-        (<span class="tab_language">Anglais</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="origin_en" id="origin_en" class="text " value="Germany" lang="en" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Mentions sur l'emballage indiquant le lieu de fabrication et/ou l'origine des ingrédients</p>
-    
-
-
-
-    <p class="example">Exemples : Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_ingredients_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="ingredients_new_lc">Photo de la liste des ingrédients (<span class="tab_language"></span>)</label>
-<p class="note">&rarr; Si elle est suffisamment nette et droite, les ingrédients peuvent être extraits automatiquement de la photo.</p>
-<div class="select_crop" id="ingredients_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="ingredients_new_lc_imgid" id="ingredients_new_lc_imgid" value="" />
-<input type="hidden" name="ingredients_new_lc_x1" id="ingredients_new_lc_x1" value="" />
-<input type="hidden" name="ingredients_new_lc_y1" id="ingredients_new_lc_y1" value="" />
-<input type="hidden" name="ingredients_new_lc_x2" id="ingredients_new_lc_x2" value="" />
-<input type="hidden" name="ingredients_new_lc_y2" id="ingredients_new_lc_y2" value="" />
-<input type="hidden" name="ingredients_new_lc_display_url" id="ingredients_new_lc_display_url" value="" />
-
-                
-                    
-                        <div id="ingredients_new_lc_image_full"></div>
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="ingredients_text_new_lc">
-    Liste des ingrédients
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <textarea  name="ingredients_text_new_lc" id="ingredients_text_new_lc" lang="new_lc"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Conserver l'ordre, indiquer le % lorsqu'il est précisé, séparer par une virgule ou - , Utiliser les ( ) pour  les ingrédients d'un ingrédient, indiquer les allergènes entre _ : farine de _blé_</p>
-    
-
-
-
-    <p class="example">Exemples : Céréales 85,5% (farine de _blé_, farine de _blé_ complet 11%), extrait de malt (orge), cacao 4,8%, vitamine C</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origin_new_lc">
-    Origine du produit et/ou de ses ingrédients
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <input type="text" name="origin_new_lc" id="origin_new_lc" class="text " value="" lang="new_lc" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Mentions sur l'emballage indiquant le lieu de fabrication et/ou l'origine des ingrédients</p>
-    
-
-
-
-    <p class="example">Exemples : Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="allergens">
-    Substances ou produits provoquant des allergies ou intolérances
-    
-    
-</label>
-
-
-    <input type="text" name="allergens" id="allergens" class="text tagify-me" value="Œufs, Gluten, Lait" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=allergens" />
-
-
-
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="traces">
-    Traces éventuelles
-    
-    
-</label>
-
-
-    <input type="text" name="traces" id="traces" class="text tagify-me" value="" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=traces" />
-
-
-
-
-    
-        <p class="note">&rarr; Indiquer les ingrédients des mentions "Peut contenir des traces de", "Fabriqué dans un atelier qui utilise aussi" etc.</p>
-    
-
-
-
-    <p class="example">Exemples : Lait, Gluten, Arachide, Fruits à coque</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origins">
-    Origine des ingrédients
-    
-    
-</label>
-
-
-    <input type="text" name="origins" id="origins" class="text tagify-me" value="" lang="fr" data-autocomplete="//fr.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=origins" />
-
-
-
-
-
-
-    <p class="example">Exemples : Vallée des Baux-de-Provence, Provence, France</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-            </div>
-        </section>
-
-        <!--nutrient fieldset-->
-        <section class="card fieldset" id="nutrition">
-            <div class="card-section">
-                <legend>Tableau nutritionnel</legend>
-                <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                <input type="hidden" name="no_nutrition_data_displayed" value="1" />
-                <input type="checkbox" id="no_nutrition_data" name="no_nutrition_data"  />
-                <label for="no_nutrition_data" class="checkbox_label">Les informations nutritionnelles ne sont pas mentionnées sur le produit.</label><br/>
-                <div id="nutrition_data_div">
-                    <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_nutrition_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_fr" id="tabs_nutrition_image_fr_tab" data-language="fr"><a href="#tabs_nutrition_image_fr" class="tab_language">Français</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_en" id="tabs_nutrition_image_en_tab" data-language="en"><a href="#tabs_nutrition_image_en" class="tab_language">Anglais</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_nutrition_image_new_lc_tab" data-language="new_lc"><a href="#tabs_nutrition_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_nutrition_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_fr" id="tabs_nutrition_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="nutrition_fr">Photo des informations nutritionnelles (<span class="tab_language">Français</span>)</label>
-
-<div class="select_crop" id="nutrition_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="nutrition_fr_imgid" id="nutrition_fr_imgid" value="" />
-<input type="hidden" name="nutrition_fr_x1" id="nutrition_fr_x1" value="" />
-<input type="hidden" name="nutrition_fr_y1" id="nutrition_fr_y1" value="" />
-<input type="hidden" name="nutrition_fr_x2" id="nutrition_fr_x2" value="" />
-<input type="hidden" name="nutrition_fr_y2" id="nutrition_fr_y2" value="" />
-<input type="hidden" name="nutrition_fr_display_url" id="nutrition_fr_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_en" id="tabs_nutrition_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="nutrition_en">Photo des informations nutritionnelles (<span class="tab_language">Anglais</span>)</label>
-
-<div class="select_crop" id="nutrition_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="nutrition_en_imgid" id="nutrition_en_imgid" value="" />
-<input type="hidden" name="nutrition_en_x1" id="nutrition_en_x1" value="" />
-<input type="hidden" name="nutrition_en_y1" id="nutrition_en_y1" value="" />
-<input type="hidden" name="nutrition_en_x2" id="nutrition_en_x2" value="" />
-<input type="hidden" name="nutrition_en_y2" id="nutrition_en_y2" value="" />
-<input type="hidden" name="nutrition_en_display_url" id="nutrition_en_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_nutrition_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="nutrition_new_lc">Photo des informations nutritionnelles (<span class="tab_language"></span>)</label>
-
-<div class="select_crop" id="nutrition_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="nutrition_new_lc_imgid" id="nutrition_new_lc_imgid" value="" />
-<input type="hidden" name="nutrition_new_lc_x1" id="nutrition_new_lc_x1" value="" />
-<input type="hidden" name="nutrition_new_lc_y1" id="nutrition_new_lc_y1" value="" />
-<input type="hidden" name="nutrition_new_lc_x2" id="nutrition_new_lc_x2" value="" />
-<input type="hidden" name="nutrition_new_lc_y2" id="nutrition_new_lc_y2" value="" />
-<input type="hidden" name="nutrition_new_lc_display_url" id="nutrition_new_lc_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="serving_size">
-    Taille d'une portion
-    
-    
-</label>
-
-
-    <input type="text" name="serving_size" id="serving_size" class="text " value="10 g" lang="fr" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Si le tableau nutritionnel contient des valeurs pour le produit préparé, indiquez la taille totale d'une portion de produit préparé (incluant l'eau ou le lait ajouté).</p>
-    
-
-
-
-    <p class="example">Exemples : 30 g, 2 biscuits 60 g, 5 cl, un verre 20 cl</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-
-                    <!-- petfood nutriment are as sold only -->
-                    
-                        
-                            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                            <input type="hidden" name="nutrition_data_displayed" value="1" />
-                            <input type="checkbox" id="nutrition_data" name="nutrition_data" checked="checked" />
-                            <label for="nutrition_data" class="checkbox_label">Les informations nutritionnelles sont mentionnées pour le produit tel que vendu.</label> &nbsp;
-                            <input type="radio" id="nutrition_data_per_100g" value="100g" name="nutrition_data_per" checked="checked" />
-                            <label for="nutrition_data_per_100g">pour 100 g / 100 ml</label>
-                            <input type="radio" id="nutrition_data_per_serving" value="serving" name="nutrition_data_per"  />
-                            <label for="nutrition_data_per_serving">par portion</label><br/>
-
-                            
-                        
-                            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                            <input type="hidden" name="nutrition_data_prepared_displayed" value="1" />
-                            <input type="checkbox" id="nutrition_data_prepared" name="nutrition_data_prepared"  />
-                            <label for="nutrition_data_prepared" class="checkbox_label">Les informations nutritionnelles sont mentionnées pour le produit préparé.</label> &nbsp;
-                            <input type="radio" id="nutrition_data_prepared_per_100g" value="100g" name="nutrition_data_prepared_per" checked="checked" />
-                            <label for="nutrition_data_prepared_per_100g">pour 100 g / 100 ml</label>
-                            <input type="radio" id="nutrition_data_prepared_per_serving" value="serving" name="nutrition_data_prepared_per"  />
-                            <label for="nutrition_data_prepared_per_serving">par portion</label><br/>
-
-                            
-                        
-                    
-
-                    <div style="position:relative">
-
-                        <table id="nutrition_data_table" class="data_table" style="display: table;" aria-label="nutrition table">
-                            <thead class="nutriment_header">
-                                <th id="col_1">
-                                    
-                                        Tableau nutritionnel
-                                    
-                                </th>
-                                <th id="col_2" class="nutriment_col" >
-                                    Tel que vendu<br/>
-                                    
-                                        <span id="nutrition_data_100g" >pour 100 g / 100 ml</span>
-                                        <span id="nutrition_data_serving"  style="display:none">par portion</span>
-                                    
-                                </th>
-                                <th id="col_3" class="nutriment_col_prepared" style="display:none">
-                                    Préparé<br/>
-                                    <span id="nutrition_data_prepared_100g" >pour 100 g / 100 ml</span>
-                                    <span id="nutrition_data_prepared_serving"  style="display:none">par portion</span>
-                                </th>
-                                <th id="col_4">
-                                    Unité
-                                </th>
-                            </thead>
-
-                            <tbody>
-
-                                
-
-                                    
-                                        <tr id="nutriment_energy-kj_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_energy-kj">
-                                                Énergie (kJ)
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_energy-kj" name="nutriment_energy-kj" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_energy-kj" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_energy-kj" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_energy-kj_prepared" name="nutriment_energy-kj_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit">kJ</span>
-
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_energy-kcal_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_energy-kcal">
-                                                Énergie (kcal)
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_energy-kcal" name="nutriment_energy-kcal" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_energy-kcal" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_energy-kcal" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_energy-kcal_prepared" name="nutriment_energy-kcal_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit">kcal</span>
-
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_fat_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_fat">
-                                                Matières grasses
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_fat" name="nutriment_fat" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_fat" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_fat" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_fat_prepared" name="nutriment_fat_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_fat_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_fat_unit" name="nutriment_fat_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_saturated-fat_tr" class="nutriment_sub">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_saturated-fat">
-                                                Acides gras saturés
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_saturated-fat" name="nutriment_saturated-fat" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_saturated-fat" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_saturated-fat" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_saturated-fat_prepared" name="nutriment_saturated-fat_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_saturated-fat_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_saturated-fat_unit" name="nutriment_saturated-fat_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_carbohydrates_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_carbohydrates">
-                                                Glucides
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_carbohydrates" name="nutriment_carbohydrates" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_carbohydrates" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_carbohydrates" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_carbohydrates_prepared" name="nutriment_carbohydrates_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_carbohydrates_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_carbohydrates_unit" name="nutriment_carbohydrates_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_sugars_tr" class="nutriment_sub">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_sugars">
-                                                Sucres
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_sugars" name="nutriment_sugars" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_sugars" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_sugars" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_sugars_prepared" name="nutriment_sugars_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_sugars_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_sugars_unit" name="nutriment_sugars_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_fiber_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_fiber">
-                                                Fibres alimentaires
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_fiber" name="nutriment_fiber" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_fiber" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_fiber" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_fiber_prepared" name="nutriment_fiber_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_fiber_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_fiber_unit" name="nutriment_fiber_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_proteins_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_proteins">
-                                                Protéines
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_proteins" name="nutriment_proteins" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_proteins" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_proteins" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_proteins_prepared" name="nutriment_proteins_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_proteins_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_proteins_unit" name="nutriment_proteins_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_salt_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_salt">
-                                                Sel
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_salt" name="nutriment_salt" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_salt" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_salt" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_salt_prepared" name="nutriment_salt_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_salt_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_salt_unit" name="nutriment_salt_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_sodium_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_sodium">
-                                                Sodium
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_sodium" name="nutriment_sodium" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_sodium" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_sodium" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_sodium_prepared" name="nutriment_sodium_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_sodium_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_sodium_unit" name="nutriment_sodium_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_alcohol_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_alcohol">
-                                                Alcool
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_alcohol" name="nutriment_alcohol" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_alcohol" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_alcohol" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_alcohol_prepared" name="nutriment_alcohol_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit">% vol / °</span>
-
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_new_0_tr" class="nutriment_main" style="display:none">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <input class="nutriment_label" id="nutriment_new_0_label" name="nutriment_new_0_label" placeholder="Ajouter un nutriment"/>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_new_0" name="nutriment_new_0" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_new_0" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_new_0" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_new_0_prepared" name="nutriment_new_0_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_new_0_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_new_0_unit" name="nutriment_new_0_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                            <option value="% DV" >% DV</option>
-                                                        
-                                                            <option value="IU" >IU</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_new_1_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <input class="nutriment_label" id="nutriment_new_1_label" name="nutriment_new_1_label" placeholder="Ajouter un nutriment"/>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_new_1" name="nutriment_new_1" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_new_1" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_new_1" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_new_1_prepared" name="nutriment_new_1_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_new_1_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_new_1_unit" name="nutriment_new_1_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                            <option value="% DV" >% DV</option>
-                                                        
-                                                            <option value="IU" >IU</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                            </tbody>
-                        </table>
-
-                        <input type="hidden" name="new_max" id="new_max" value="1" />
-                        <div id="nutrition_image_copy" style="position:absolute;bottom:0;"></div>
-                    </div>
-
-                
-
-                
-                    <p class="asterisk">&rarr;* :Nutriments essentiels pour calculer le Nutri-Score.</p>
-                
-                <p class="note">&rarr; Le tableau liste par défaut les nutriments les plus couramment indiqués. Laissez le champ vide s'il n'est pas présent sur l'emballage.<br />Vous pouvez ajouter d'autres nutriments
-(vitamines, minéraux, cholestérol, oméga 3 et 6 etc.) en tapant les premières lettres de leur nom dans la dernière ligne du tableau.</p>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
                 </div>
-
+              </div>
             </div>
-    </section><!--nutrient field set-->
-
-        <!--packaging field-->
-        <section id="packaging_section" class="card fieldset">
-            <div class="card-section">
-                <legend>Emballage</legend>
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_packaging_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_fr" id="tabs_packaging_image_fr_tab" data-language="fr"><a href="#tabs_packaging_image_fr" class="tab_language">Français</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_en" id="tabs_packaging_image_en_tab" data-language="en"><a href="#tabs_packaging_image_en" class="tab_language">Anglais</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_packaging_image_new_lc_tab" data-language="new_lc"><a href="#tabs_packaging_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_packaging_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_fr" id="tabs_packaging_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="packaging_fr">Image d'instructions de recyclage et/ou information d'emballage (<span class="tab_language">Français</span>)</label>
-
-<div class="select_crop" id="packaging_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="packaging_fr_imgid" id="packaging_fr_imgid" value="" />
-<input type="hidden" name="packaging_fr_x1" id="packaging_fr_x1" value="" />
-<input type="hidden" name="packaging_fr_y1" id="packaging_fr_y1" value="" />
-<input type="hidden" name="packaging_fr_x2" id="packaging_fr_x2" value="" />
-<input type="hidden" name="packaging_fr_y2" id="packaging_fr_y2" value="" />
-<input type="hidden" name="packaging_fr_display_url" id="packaging_fr_display_url" value="" />
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="packaging_text_fr">
-    Instruction de recyclage et/ou informations d'emballage
-    
-        (<span class="tab_language">Français</span>)
-    
-    
-</label>
-
-
-    <textarea  name="packaging_text_fr" id="packaging_text_fr" lang="fr"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Lister toutes les parties de l'emballage séparées par une virgule ou un retour à la ligne, avec leur quantité (ex : 1 ou 6), leur type (ex : bouteille, boîte, canette), le matériau (ex : plastique, métal, aluminium), et si possible leur taille (ex: 33cl) ainsi que les instructions de recyclage.</p>
-    
-
-    
-        <p class="note">&rarr; Essayez d'être aussi précis que possible. Pour le plastique, merci d'indiquer s'il est opaque ou transparent, coloré, PET ou PEHD.</p>
-    
-
-    
-        <p class="note">&rarr; Les données de ce champ seront combinées avec toutes les données fournies pour chaque partie de l'emballage. Il est possible de fournir l'un ou l'autre, ou les deux.</p>
-    
-
-
-
-    <p class="example">Exemples : 1 film plastique à jeter, 1 boîte en carton FSC à recycler, 6 bouteilles en plastique transparent PET de 1,5 L à recycler, 6 bouchons en plastique de couleur opaques, 12 canettes en aluminium de 33 cl</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_en" id="tabs_packaging_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="packaging_en">Image d'instructions de recyclage et/ou information d'emballage (<span class="tab_language">Anglais</span>)</label>
-
-<div class="select_crop" id="packaging_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="packaging_en_imgid" id="packaging_en_imgid" value="" />
-<input type="hidden" name="packaging_en_x1" id="packaging_en_x1" value="" />
-<input type="hidden" name="packaging_en_y1" id="packaging_en_y1" value="" />
-<input type="hidden" name="packaging_en_x2" id="packaging_en_x2" value="" />
-<input type="hidden" name="packaging_en_y2" id="packaging_en_y2" value="" />
-<input type="hidden" name="packaging_en_display_url" id="packaging_en_display_url" value="" />
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="packaging_text_en">
-    Instruction de recyclage et/ou informations d'emballage
-    
-        (<span class="tab_language">Anglais</span>)
-    
-    
-</label>
-
-
-    <textarea  name="packaging_text_en" id="packaging_text_en" lang="en"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Lister toutes les parties de l'emballage séparées par une virgule ou un retour à la ligne, avec leur quantité (ex : 1 ou 6), leur type (ex : bouteille, boîte, canette), le matériau (ex : plastique, métal, aluminium), et si possible leur taille (ex: 33cl) ainsi que les instructions de recyclage.</p>
-    
-
-    
-        <p class="note">&rarr; Essayez d'être aussi précis que possible. Pour le plastique, merci d'indiquer s'il est opaque ou transparent, coloré, PET ou PEHD.</p>
-    
-
-    
-        <p class="note">&rarr; Les données de ce champ seront combinées avec toutes les données fournies pour chaque partie de l'emballage. Il est possible de fournir l'un ou l'autre, ou les deux.</p>
-    
-
-
-
-    <p class="example">Exemples : 1 film plastique à jeter, 1 boîte en carton FSC à recycler, 6 bouteilles en plastique transparent PET de 1,5 L à recycler, 6 bouchons en plastique de couleur opaques, 12 canettes en aluminium de 33 cl</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_packaging_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="packaging_new_lc">Image d'instructions de recyclage et/ou information d'emballage (<span class="tab_language"></span>)</label>
-
-<div class="select_crop" id="packaging_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="packaging_new_lc_imgid" id="packaging_new_lc_imgid" value="" />
-<input type="hidden" name="packaging_new_lc_x1" id="packaging_new_lc_x1" value="" />
-<input type="hidden" name="packaging_new_lc_y1" id="packaging_new_lc_y1" value="" />
-<input type="hidden" name="packaging_new_lc_x2" id="packaging_new_lc_x2" value="" />
-<input type="hidden" name="packaging_new_lc_y2" id="packaging_new_lc_y2" value="" />
-<input type="hidden" name="packaging_new_lc_display_url" id="packaging_new_lc_display_url" value="" />
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="packaging_text_new_lc">
-    Instruction de recyclage et/ou informations d'emballage
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <textarea  name="packaging_text_new_lc" id="packaging_text_new_lc" lang="new_lc"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Lister toutes les parties de l'emballage séparées par une virgule ou un retour à la ligne, avec leur quantité (ex : 1 ou 6), leur type (ex : bouteille, boîte, canette), le matériau (ex : plastique, métal, aluminium), et si possible leur taille (ex: 33cl) ainsi que les instructions de recyclage.</p>
-    
-
-    
-        <p class="note">&rarr; Essayez d'être aussi précis que possible. Pour le plastique, merci d'indiquer s'il est opaque ou transparent, coloré, PET ou PEHD.</p>
-    
-
-    
-        <p class="note">&rarr; Les données de ce champ seront combinées avec toutes les données fournies pour chaque partie de l'emballage. Il est possible de fournir l'un ou l'autre, ou les deux.</p>
-    
-
-
-
-    <p class="example">Exemples : 1 film plastique à jeter, 1 boîte en carton FSC à recycler, 6 bouteilles en plastique transparent PET de 1,5 L à recycler, 6 bouchons en plastique de couleur opaques, 12 canettes en aluminium de 33 cl</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-                <!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-<p>Elements d'emballage</p>
-    
-<div id="packagings_components_edit">
-
-    <ul>
-        <li><b>Nombre d'éléments :</b> Entrez le nombre d'éléments d'emballage de la même forme et de la même matière contenue dans le produit.</li>
-        <li><b>Forme :</b> Entrez le nom de la forme indiqué dans les instructions de recyclage si elles sont disponibles, ou sélectionnez une forme.</li>
-        <li><b>Matière :</b> Entrez le matériau spécifique s'il peut être déterminé (un code de matériau à l'intérieur d'un triangle peut souvent être trouvé sur les éléments d'emballage), ou un matériau générique (par exemple du plastique ou du métal) si vous n'êtes pas sûr.</li>
-        <li><b>Recyclage :</b> Saisissez les consignes de tri seulement si elles apparaîssent sur le produit.</li>
-        <li><b>Poids d'un élément vide :</b> Enlevez les restes de nourriture et lavez et séchez les éléments d'emballage avant de les peser. Si possible, utilisez une balance avec une précision de 0.1g ou 0.01g.</li>
-        <li><b>Quantité de produit contenue par élément :</b> Entrez le poids net ou le volume net et indiquez l'unité (par exemple g ou ml).</li>
-    </ul>
-
-    <!-- header row for large display -->
-    <div class="row show-for-large-up" id="packagings_components_edit_header">
-        <div class="large-1 columns">Nombre d'éléments</div>
-        <div class="large-3 columns">Forme</div>
-        <div class="large-3 columns">Matière</div>
-        <div class="large-3 columns">Recyclage</div>
-        <div class="large-1 columns">Poids d'un élément vide (g)</div>
-        <div class="large-1 columns">Quantité de produit contenue par élément</div>
+          </div>
+        </div>
+      </footer>
     </div>
 
-
-    
-    <div class="row packagings_components_edit_row" id="packaging_0_row">
-        <div class="small-12 large-1 columns">
-
-            <!-- label for small displays -->
-            <label class="hide-for-large-up" for="packaging_0_number_of_units">Nombre d'éléments</label>
-
-            <div class="row">
-                <div class="small-12 large-4 columns delete_packaging_column">
-                    <a class="delete_packaging" id="packaging_0_delete">
-                        <span class="material-icons">
-                            delete
-                        </span>
-                    </a>
-                </div>
-
-                <div class="small-12 large-8 columns">
-                    <input id="packaging_0_number_of_units" name="packaging_0_number_of_units" type="text" value="">
-                </div>
-            </div>
-        </div>
-
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_0_shape">Forme</label>
-                <select id="packaging_0_shape" name="packaging_0_shape" class="form-control packaging_shapes_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_0_material">Matière</label>
-                <select id="packaging_0_material" name="packaging_0_material" class="form-control packaging_materials_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_0_recycling">Recyclage</label>
-                <select id="packaging_0_recycling" name="packaging_0_recycling" class="form-control packaging_recycling_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-        
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_0_weight_measured">Poids d'un élément vide (g)</label>
-            
-            
-                <input id="packaging_0_weight_measured" name="packaging_0_weight_measured" type="text" value="" %]">
-            
-        </div>
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_0_quantity_per_unit">Quantité de produit contenue par élément</label>
-            <input id="packaging_0_quantity_per_unit" name="packaging_0_quantity_per_unit" type="text" value="" %]">
-        </div>        
-
-    </div>
-
-    
-
-    
-    <div class="row packagings_components_edit_row" id="packaging_1_row">
-        <div class="small-12 large-1 columns">
-
-            <!-- label for small displays -->
-            <label class="hide-for-large-up" for="packaging_1_number_of_units">Nombre d'éléments</label>
-
-            <div class="row">
-                <div class="small-12 large-4 columns delete_packaging_column">
-                    <a class="delete_packaging" id="packaging_1_delete">
-                        <span class="material-icons">
-                            delete
-                        </span>
-                    </a>
-                </div>
-
-                <div class="small-12 large-8 columns">
-                    <input id="packaging_1_number_of_units" name="packaging_1_number_of_units" type="text" value="">
-                </div>
-            </div>
-        </div>
-
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_1_shape">Forme</label>
-                <select id="packaging_1_shape" name="packaging_1_shape" class="form-control packaging_shapes_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_1_material">Matière</label>
-                <select id="packaging_1_material" name="packaging_1_material" class="form-control packaging_materials_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_1_recycling">Recyclage</label>
-                <select id="packaging_1_recycling" name="packaging_1_recycling" class="form-control packaging_recycling_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-            
-                
-        
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_1_weight_measured">Poids d'un élément vide (g)</label>
-            
-            
-                <input id="packaging_1_weight_measured" name="packaging_1_weight_measured" type="text" value="" %]">
-            
-        </div>
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_1_quantity_per_unit">Quantité de produit contenue par élément</label>
-            <input id="packaging_1_quantity_per_unit" name="packaging_1_quantity_per_unit" type="text" value="" %]">
-        </div>        
-
-    </div>
-
-    
-
-
-<input type="hidden" name="packaging_max" value="1">
-
-
-
-</div>
-
-<input type="checkbox" id="packagings_complete" name="packagings_complete"  />
-<label for="packagings_complete" class="checkbox_label">Tous les éléments de l'emballage du produit sont listés.</label><br/>
-    
-<!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-
-            </div>
-        </section>
-
-        
-
-        
-
-        <input type="hidden" name="type" value="edit">
-        <input type="hidden" id="code" name="code" value="3300000000002">
-        <input type="hidden" name="action" value="process">
-
-        <div id="fixed_bar" class="bottom-validation">
-            
-
-                <div class="row">
-                    
-                        
-                        
-                    
-                    <div class="small-12 medium-12 large-8 xlarge-8 columns" style="margin-bottom:0.5rem;">
-                        <input id="comment" name="comment" placeholder="Description de vos changements" value="" type="text" class="text" style="margin:0" />
-                    </div>
-                    <div class="small-6 medium-6 large-2 xlarge-2 columns">
-                        <button type="submit" id="save" name=".submit" class="button postfix success small">
-                            <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg> Enregistrer
-                        </button>
-                    </div>
-                    <div class="small-6 medium-6 large-2 xlarge-2 columns">
-                        <button type="button" id="back-btn" class="button postfix small secondary">
-                            <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/><path d="M0 0h24v24H0z" fill="none"/></svg> Annuler
-                        </button>
-                    </div>
-                    
-                </div>
-
-            
-        </div>
-
-        <!-- start templates/web/pages/product/includes/edit_history.tt.html -->
-
-
-
-<h2 id="history">Historique des modifications</h2>
-<ul id="history_list">
-  
-  <li>
-    <time datetime="--ignore--">--ignore--</time> - <a href="/facets/editeurs/tests" lang="no_language">tests</a> Données (Ajout : product_type, code, lang, product_name, quantity, brands, categories, labels, link, countries, nutrition_data_per, nutrition_data_prepared_per, serving_size, ingredients_text, generic_name_en, ingredients_text_en, origin_en, product_name_en, ingredients_text_fr, product_name_fr) -- Nutriments (Ajout : nutrition-score-fr)   - (app)  &nbsp;
-    <a href="/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert?rev=1" class="button tiny">Voir cette révision</a>
-    
-  </li>
-  
-</ul>
-
-<script>var revert_confirm_message = "Revenir à cette révision du produit ?";</script>
-
-<!-- end templates/web/pages/product/includes/edit_history.tt.html -->
-
-
-        </div>
-
-        </div>
-
-        </div>
-
-    </form>
-
-
-<style>
-.question_mark {
-    display: none;
-    position: relative;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background-color: #999;
-    color: #fff;
-    text-align: center;
-    font-weight: bold;
-    cursor: help;
-}
-
-.sugars_warning {
-  display: none;
-  position: absolute;
-  left: 16%;
-  transform: translateX(50%);
-  padding: 0.5em;
-  background-color: #333;
-  color: #fff;
-  font-size: 0.8em;
-  white-space: nowrap;
-  margin-top: 1%;
-  z-index: 1;
-}
-
-.soft-background {
-    background-color: #f5f5f5;
-}
-
-.question_mark:hover + .sugars_warning {
-    display: inline-block;
-}
-
-.question_mark:hover {
-    opacity: 0.7;
-}
-</style>
-
-<!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-	$([]).selectcrop('init_images', [
-		
-	]);
-	$(".select_crop").selectcrop('init', {img_path : "//images.openfoodfacts.localhost/images/products/330/000/000/0002/"});
-	$(".select_crop").selectcrop('show');
-
-
-                    configure_packaging_select2("packaging_1_shape", "packaging_shapes", "Forme" )
-
-                    
-
-                    $("#packaging_1_delete").click(function(event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        $("#packaging_1_row").remove();
-                    });
-                
-                    configure_packaging_select2("packaging_1_material", "packaging_materials", "Matière" )
-
-                    
-
-                    $("#packaging_1_delete").click(function(event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        $("#packaging_1_row").remove();
-                    });
-                
-                    configure_packaging_select2("packaging_1_recycling", "packaging_recycling", "Recyclage" )
-
-                    
-
-                    $("#packaging_1_delete").click(function(event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        $("#packaging_1_row").remove();
-                    });
-                
-// defined by the FOREACH loop above
-var packaging_max = 1;
-
-/**
- * Configure the select2 dropdown with autocomplete for shape, material and recycling
- */
-function configure_packaging_select2(select2_id, taxonomy, placeholder) {
-    
-    $("#" + select2_id).select2({
-        placeholder: placeholder,
-        allowClear:true,
-        tags: true,
-        ajax: {
-            url: '/api/v3/taxonomy_suggestions?limit=400&tagtype=' + taxonomy,
-            data: function (params) {
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
+
+    <script>
+      $(function () {
+        $([]).selectcrop("init_images", []);
+        $(".select_crop").selectcrop("init", {
+          img_path:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0002/",
+        });
+        $(".select_crop").selectcrop("show");
+
+        configure_packaging_select2(
+          "packaging_1_shape",
+          "packaging_shapes",
+          "Forme"
+        );
+
+        $("#packaging_1_delete").click(function (event) {
+          event.stopPropagation();
+          event.preventDefault();
+          $("#packaging_1_row").remove();
+        });
+
+        configure_packaging_select2(
+          "packaging_1_material",
+          "packaging_materials",
+          "Matière"
+        );
+
+        $("#packaging_1_delete").click(function (event) {
+          event.stopPropagation();
+          event.preventDefault();
+          $("#packaging_1_row").remove();
+        });
+
+        configure_packaging_select2(
+          "packaging_1_recycling",
+          "packaging_recycling",
+          "Recyclage"
+        );
+
+        $("#packaging_1_delete").click(function (event) {
+          event.stopPropagation();
+          event.preventDefault();
+          $("#packaging_1_row").remove();
+        });
+
+        // defined by the FOREACH loop above
+        var packaging_max = 1;
+
+        /**
+         * Configure the select2 dropdown with autocomplete for shape, material and recycling
+         */
+        function configure_packaging_select2(
+          select2_id,
+          taxonomy,
+          placeholder
+        ) {
+          $("#" + select2_id).select2({
+            placeholder: placeholder,
+            allowClear: true,
+            tags: true,
+            ajax: {
+              url: "/api/v3/taxonomy_suggestions?limit=400&tagtype=" + taxonomy,
+              data: function (params) {
                 // tagify has values in a JSON array, parse it and convert it to a commas separated list
-                var categories_json = $("#categories").val()
-                
+                var categories_json = $("#categories").val();
+
                 var query = {
-                    string: params.term,
-                }
+                  string: params.term,
+                };
                 // If the product has categories, pass them to get better suggestions
                 if (categories_json) {
-                    var categories_array = JSON.parse(categories_json);
-                    query.categories = categories_array.map(item => item.value).join(',');
+                  var categories_array = JSON.parse(categories_json);
+                  query.categories = categories_array
+                    .map((item) => item.value)
+                    .join(",");
                 }
                 // If the select2 is for the material, send the corresponding selected shape
                 if (taxonomy == "packaging_materials") {
-                    
-                    var shape_select2_id = select2_id.replace('_material', '_shape');
-                    query.shape = $("#" + shape_select2_id).val();
+                  var shape_select2_id = select2_id.replace(
+                    "_material",
+                    "_shape"
+                  );
+                  query.shape = $("#" + shape_select2_id).val();
                 }
                 return query;
-            },
-            processResults: function (data) {
+              },
+              processResults: function (data) {
                 if (data.suggestions) {
-                    return {
-                        // transform the simple array of suggestions in array of objects expected by select2
-                        results: Array.from(data.suggestions, function (element) { return {"id": element, "text": element}; }) 
-                    };
+                  return {
+                    // transform the simple array of suggestions in array of objects expected by select2
+                    results: Array.from(data.suggestions, function (element) {
+                      return { id: element, text: element };
+                    }),
+                  };
                 }
-            }
+              },
+            },
+          });
         }
-    });
-}
 
-/**
- * Add a new row of packaging data
- */
-function add_packaging() {
+        /**
+         * Add a new row of packaging data
+         */
+        function add_packaging() {
+          // row that triggers new row addition is no more the last row
+          // remove events and let it be removed
+          $(this).unbind("select2:select");
+          $("#packaging_" + packaging_max + "_delete").show();
 
-    // row that triggers new row addition is no more the last row
-    // remove events and let it be removed
-    $(this).unbind("select2:select");
-    $("#packaging_" + packaging_max + "_delete").show();
+          packaging_max = packaging_max + 1;
+          $('input[name="packaging_max"]').val(packaging_max);
 
-    packaging_max = packaging_max + 1;
-    $('input[name="packaging_max"]').val(packaging_max);
+          var new_packaging_id = "packaging_" + packaging_max;
+          // row 0 is our template row
+          var new_packaging_html = $("#packaging_0_row")[0].outerHTML;
+          new_packaging_html = new_packaging_html.replaceAll(
+            "packaging_0",
+            new_packaging_id
+          );
 
-    var new_packaging_id = "packaging_" + packaging_max;
-    // row 0 is our template row
-    var new_packaging_html = $("#packaging_0_row")[0].outerHTML;
-    new_packaging_html = new_packaging_html.replaceAll("packaging_0", new_packaging_id);
-    
-    $("#packagings_components_edit").append(new_packaging_html);
+          $("#packagings_components_edit").append(new_packaging_html);
 
-    
+          configure_packaging_select2(
+            new_packaging_id + "_shape",
+            "packaging_shapes",
+            "Forme"
+          );
 
-        
-            
-        
-        
-         configure_packaging_select2(new_packaging_id + "_shape", "packaging_shapes", "Forme");
+          configure_packaging_select2(
+            new_packaging_id + "_material",
+            "packaging_materials",
+            "Matière"
+          );
 
-    
+          configure_packaging_select2(
+            new_packaging_id + "_recycling",
+            "packaging_recycling",
+            "Recyclage"
+          );
 
-        
-            
-        
-        
-         configure_packaging_select2(new_packaging_id + "_material", "packaging_materials", "Matière");
+          $("#" + new_packaging_id + "_delete")
+            .click(function (event) {
+              event.stopPropagation();
+              event.preventDefault();
+              $("#" + new_packaging_id + "_row").remove();
+            })
+            .hide();
 
-    
+          $("#" + new_packaging_id + "_shape").on(
+            "select2:select",
+            add_packaging
+          );
+        }
 
-        
-            
-        
-        
-         configure_packaging_select2(new_packaging_id + "_recycling", "packaging_recycling", "Recyclage");
+        // last row triggers addition of a new row
+        $("#packaging_1_shape").on("select2:select", add_packaging);
+        // disable removal of last row
+        $("#packaging_1_delete").hide();
 
-    
-
-    $("#" + new_packaging_id + "_delete").click(function(event) {
-        event.stopPropagation();
-        event.preventDefault();
-        $("#" + new_packaging_id + "_row").remove();
-    }).hide();    
-
-    $("#" + new_packaging_id + "_shape").on('select2:select', add_packaging);
-}
-
-
-// last row triggers addition of a new row
-$("#packaging_1_shape").on('select2:select', add_packaging);
-// disable removal of last row
-$("#packaging_1_delete").hide()
-
-
-/**
- * select2 auto-open options
- */
-$(document).on("focus", ".select2", function (e) {
-    if (e.originalEvent) {
-      var s2element = $(this).siblings("select:enabled");
-      s2element.select2("open");
-      // Set focus back to select2 element on closing.
-      s2element.on("select2:closing", function () {
-        if (s2element.val()) s2element.select2("focus");
+        /**
+         * select2 auto-open options
+         */
+        $(document).on("focus", ".select2", function (e) {
+          if (e.originalEvent) {
+            var s2element = $(this).siblings("select:enabled");
+            s2element.select2("open");
+            // Set focus back to select2 element on closing.
+            s2element.on("select2:closing", function () {
+              if (s2element.val()) s2element.select2("focus");
+            });
+          }
+        });
       });
-    }
-  });
+    </script>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/cropper.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/tagify.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/load-image.all.min.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/canvas-to-blob.js"
+    ></script>
+    <script type="text/javascript">
+      var admin = 0;
+    </script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/product-multilingual.js?v=--ignore--"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/product-history.js"
+    ></script>
 
+    <script type="text/javascript">
+      var nutriments = {
+        Énergie: "energy",
+        "Énergie provenant des graisses": "energy-from-fat",
+        "Acide butyrique": "butyric-acid",
+        "Acide caproïque": "caproic-acid",
+        "Acide caprylique": "caprylic-acid",
+        "Acide caprique": "capric-acid",
+        "Acide laurique": "lauric-acid",
+        "Acide myristique": "myristic-acid",
+        "Acide palmitique": "palmitic-acid",
+        "Acide stéarique": "stearic-acid",
+        "Acide arachidique": "arachidic-acid",
+        "Acide béhénique": "behenic-acid",
+        "Acide lignocérique": "lignoceric-acid",
+        "Acide cérotique": "cerotic-acid",
+        "Acide montanique": "montanic-acid",
+        "Acide mélissique": "melissic-acid",
+        "Unsaturated fat": "unsaturated-fat",
+        "Acides gras monoinsaturés": "monounsaturated-fat",
+        "Acides gras Oméga 9": "omega-9-fat",
+        "Acides gras polyinsaturés": "polyunsaturated-fat",
+        "Acides gras Oméga 3": "omega-3-fat",
+        "Acides gras Oméga 6": "omega-6-fat",
+        "Acide alpha-linolénique": "alpha-linolenic-acid",
+        "Acide eicosapentaénoïque": "eicosapentaenoic-acid",
+        "Acide docosahexaénoïque": "docosahexaenoic-acid",
+        "Acide linoléique": "linoleic-acid",
+        "Acide arachidonique": "arachidonic-acid",
+        "Acide gamma-linolénique": "gamma-linolenic-acid",
+        "Acide dihomo-gamma-linolénique": "dihomo-gamma-linolenic-acid",
+        "Acide oléique": "oleic-acid",
+        "Acide élaïdique": "elaidic-acid",
+        "Acide gadoléique": "gondoic-acid",
+        "Acide de Mead": "mead-acid",
+        "Acide érucique": "erucic-acid",
+        "Acide nervonique": "nervonic-acid",
+        "Acides gras trans": "trans-fat",
+        Cholestérol: "cholesterol",
+        "Sucres ajoutés": "added-sugars",
+        Saccharose: "sucrose",
+        Glucose: "glucose",
+        Fructose: "fructose",
+        Lactose: "lactose",
+        Maltose: "maltose",
+        Maltodextrines: "maltodextrins",
+        Amidon: "starch",
+        Polyols: "polyols",
+        Érythritol: "erythritol",
+        "Fibres solubles": "soluble-fiber",
+        "Fibres insolubles": "insoluble-fiber",
+        Caséine: "casein",
+        "Protéines sériques": "serum-proteins",
+        Nucléotides: "nucleotides",
+        "Sel ajouté": "added-salt",
+        "Vitamine A (rétinol)": "vitamin-a",
+        "Bêta carotène": "beta-carotene",
+        "Vitamine D": "vitamin-d",
+        "Vitamine E (tocophérol)": "vitamin-e",
+        "Vitamine K": "vitamin-k",
+        "Vitamine C (acide ascorbique)": "vitamin-c",
+        "Vitamine B1 (Thiamine)": "vitamin-b1",
+        "Vitamine B2 (Riboflavine)": "vitamin-b2",
+        "Vitamine B3/PP (Niacine)": "vitamin-pp",
+        "Vitamine B6 (Pyridoxine)": "vitamin-b6",
+        "Vitamine B9 (Acide folique)": "vitamin-b9",
+        "Folates (folates totaux)": "folates",
+        "Vitamine B12 (cobalamine)": "vitamin-b12",
+        "Biotine (Vitamine B8 ou B7 ou H)": "biotin",
+        "Vitamine B5 (Acide pantothénique)": "pantothenic-acid",
+        Silice: "silica",
+        Bicarbonate: "bicarbonate",
+        Potassium: "potassium",
+        Chlorure: "chloride",
+        Calcium: "calcium",
+        Phosphore: "phosphorus",
+        Fer: "iron",
+        Magnésium: "magnesium",
+        Zinc: "zinc",
+        Cuivre: "copper",
+        Manganèse: "manganese",
+        Fluorure: "fluoride",
+        Sélénium: "selenium",
+        Chrome: "chromium",
+        Molybdène: "molybdenum",
+        Iode: "iodine",
+        Caféine: "caffeine",
+        Taurine: "taurine",
+        PH: "ph",
+        "Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive":
+          "fruits-vegetables-nuts",
+        "Fruits‚ légumes et noix - séchés": "fruits-vegetables-nuts-dried",
+        "Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive (estimation manuelle avec la liste des ingrédients)":
+          "fruits-vegetables-nuts-estimate",
+        "Rapport collagène sur protéines de viande (maximum)":
+          "collagen-meat-protein-ratio",
+        "Cacao (minimum)": "cocoa",
+        Chlorophyl: "chlorophyl",
+        "Empreinte carbone": "carbon-footprint",
+        "Indice glycémique": "glycemic-index",
+        "Dureté de l'eau": "water-hardness",
+        Choline: "choline",
+        "Vitamine K1": "phylloquinone",
+        "Bêta-glucanes": "beta-glucan",
+        Inositol: "inositol",
+        Carnitine: "carnitine",
+        Sulfate: "sulphate",
+        Nitrate: "nitrate",
+        Acidité: "acidity",
+      };
 
-});
-</script>
+      var otherNutriments = [
+        { value: "Énergie", unit: "kj", iu: false },
+        { value: "Énergie provenant des graisses", unit: "kj", iu: false },
+        { value: "Acide butyrique", unit: "g", iu: false },
+        { value: "Acide caproïque", unit: "g", iu: false },
+        { value: "Acide caprylique", unit: "g", iu: false },
+        { value: "Acide caprique", unit: "g", iu: false },
+        { value: "Acide laurique", unit: "g", iu: false },
+        { value: "Acide myristique", unit: "g", iu: false },
+        { value: "Acide palmitique", unit: "g", iu: false },
+        { value: "Acide stéarique", unit: "g", iu: false },
+        { value: "Acide arachidique", unit: "g", iu: false },
+        { value: "Acide béhénique", unit: "g", iu: false },
+        { value: "Acide lignocérique", unit: "g", iu: false },
+        { value: "Acide cérotique", unit: "g", iu: false },
+        { value: "Acide montanique", unit: "g", iu: false },
+        { value: "Acide mélissique", unit: "g", iu: false },
+        { value: "Unsaturated fat", unit: "g", iu: false },
+        { value: "Acides gras monoinsaturés", unit: "g", iu: false },
+        { value: "Acides gras Oméga 9", unit: "mg", iu: false },
+        { value: "Acides gras polyinsaturés", unit: "g", iu: false },
+        { value: "Acides gras Oméga 3", unit: "mg", iu: false },
+        { value: "Acides gras Oméga 6", unit: "mg", iu: false },
+        { value: "Acide alpha-linolénique", unit: "g", iu: false },
+        { value: "Acide eicosapentaénoïque", unit: "g", iu: false },
+        { value: "Acide docosahexaénoïque", unit: "g", iu: false },
+        { value: "Acide linoléique", unit: "g", iu: false },
+        { value: "Acide arachidonique", unit: "g", iu: false },
+        { value: "Acide gamma-linolénique", unit: "g", iu: false },
+        { value: "Acide dihomo-gamma-linolénique", unit: "g", iu: false },
+        { value: "Acide oléique", unit: "g", iu: false },
+        { value: "Acide élaïdique", unit: "g", iu: false },
+        { value: "Acide gadoléique", unit: "g", iu: false },
+        { value: "Acide de Mead", unit: "g", iu: false },
+        { value: "Acide érucique", unit: "g", iu: false },
+        { value: "Acide nervonique", unit: "g", iu: false },
+        { value: "Acides gras trans", unit: "g", iu: false },
+        { value: "Cholestérol", unit: "mg", iu: false },
+        { value: "Sucres ajoutés", unit: "g", iu: false },
+        { value: "Saccharose", unit: "g", iu: false },
+        { value: "Glucose", unit: "g", iu: false },
+        { value: "Fructose", unit: "g", iu: false },
+        { value: "Lactose", unit: "g", iu: false },
+        { value: "Maltose", unit: "g", iu: false },
+        { value: "Maltodextrines", unit: "g", iu: false },
+        { value: "Amidon", unit: "g", iu: false },
+        { value: "Polyols", unit: "g", iu: false },
+        { value: "Érythritol", unit: "g", iu: false },
+        { value: "Fibres solubles", unit: "g", iu: false },
+        { value: "Fibres insolubles", unit: "g", iu: false },
+        { value: "Caséine", unit: "g", iu: false },
+        { value: "Protéines sériques", unit: "g", iu: false },
+        { value: "Nucléotides", unit: "g", iu: false },
+        { value: "Sel ajouté", unit: "g", iu: false },
+        { value: "Vitamine A (rétinol)", unit: "µg", iu: true },
+        { value: "Bêta carotène", unit: "g", iu: false },
+        { value: "Vitamine D", unit: "µg", iu: true },
+        { value: "Vitamine E (tocophérol)", unit: "mg", iu: true },
+        { value: "Vitamine K", unit: "µg", iu: false },
+        { value: "Vitamine C (acide ascorbique)", unit: "mg", iu: true },
+        { value: "Vitamine B1 (Thiamine)", unit: "mg", iu: false },
+        { value: "Vitamine B2 (Riboflavine)", unit: "mg", iu: false },
+        { value: "Vitamine B3/PP (Niacine)", unit: "mg", iu: false },
+        { value: "Vitamine B6 (Pyridoxine)", unit: "mg", iu: false },
+        { value: "Vitamine B9 (Acide folique)", unit: "µg", iu: false },
+        { value: "Folates (folates totaux)", unit: "µg", iu: false },
+        { value: "Vitamine B12 (cobalamine)", unit: "µg", iu: false },
+        { value: "Biotine (Vitamine B8 ou B7 ou H)", unit: "µg", iu: false },
+        { value: "Vitamine B5 (Acide pantothénique)", unit: "mg", iu: false },
+        { value: "Silice", unit: "mg", iu: false },
+        { value: "Bicarbonate", unit: "mg", iu: false },
+        { value: "Potassium", unit: "mg", iu: false },
+        { value: "Chlorure", unit: "mg", iu: false },
+        { value: "Calcium", unit: "mg", iu: false },
+        { value: "Phosphore", unit: "mg", iu: false },
+        { value: "Fer", unit: "mg", iu: false },
+        { value: "Magnésium", unit: "mg", iu: false },
+        { value: "Zinc", unit: "mg", iu: false },
+        { value: "Cuivre", unit: "mg", iu: false },
+        { value: "Manganèse", unit: "mg", iu: false },
+        { value: "Fluorure", unit: "mg", iu: false },
+        { value: "Sélénium", unit: "µg", iu: false },
+        { value: "Chrome", unit: "µg", iu: false },
+        { value: "Molybdène", unit: "µg", iu: false },
+        { value: "Iode", unit: "µg", iu: false },
+        { value: "Caféine", unit: "mg", iu: false },
+        { value: "Taurine", unit: "g", iu: false },
+        { value: "PH", unit: "", iu: false },
+        {
+          value: "Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive",
+          unit: "%",
+          iu: false,
+        },
+        { value: "Fruits‚ légumes et noix - séchés", unit: "%", iu: false },
+        {
+          value:
+            "Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive (estimation manuelle avec la liste des ingrédients)",
+          unit: "%",
+          iu: false,
+        },
+        {
+          value: "Rapport collagène sur protéines de viande (maximum)",
+          unit: "%",
+          iu: false,
+        },
+        { value: "Cacao (minimum)", unit: "%", iu: false },
+        { value: "Chlorophyl", unit: "g", iu: false },
+        { value: "Empreinte carbone", unit: "g", iu: false },
+        { value: "Indice glycémique", unit: "", iu: false },
+        { value: "Dureté de l'eau", unit: "mmol/l", iu: false },
+        { value: "Choline", unit: "g", iu: false },
+        { value: "Vitamine K1", unit: "g", iu: false },
+        { value: "Bêta-glucanes", unit: "g", iu: false },
+        { value: "Inositol", unit: "g", iu: false },
+        { value: "Carnitine", unit: "g", iu: false },
+        { value: "Sulfate", unit: "mg", iu: false },
+        { value: "Nitrate", unit: "mg", iu: false },
+        { value: "Acidité", unit: "% vol", iu: false },
+      ];
+    </script>
 
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/load-image.all.min.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/canvas-to-blob.js"></script>
-<script type="text/javascript">
-var admin = 0;
-</script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/product-multilingual.js?v=--ignore--"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
-
-<script type="text/javascript">
-var nutriments = {
-"Énergie" : "energy",
-"Énergie provenant des graisses" : "energy-from-fat",
-"Acide butyrique" : "butyric-acid",
-"Acide caproïque" : "caproic-acid",
-"Acide caprylique" : "caprylic-acid",
-"Acide caprique" : "capric-acid",
-"Acide laurique" : "lauric-acid",
-"Acide myristique" : "myristic-acid",
-"Acide palmitique" : "palmitic-acid",
-"Acide stéarique" : "stearic-acid",
-"Acide arachidique" : "arachidic-acid",
-"Acide béhénique" : "behenic-acid",
-"Acide lignocérique" : "lignoceric-acid",
-"Acide cérotique" : "cerotic-acid",
-"Acide montanique" : "montanic-acid",
-"Acide mélissique" : "melissic-acid",
-"Unsaturated fat" : "unsaturated-fat",
-"Acides gras monoinsaturés" : "monounsaturated-fat",
-"Acides gras Oméga 9" : "omega-9-fat",
-"Acides gras polyinsaturés" : "polyunsaturated-fat",
-"Acides gras Oméga 3" : "omega-3-fat",
-"Acides gras Oméga 6" : "omega-6-fat",
-"Acide alpha-linolénique" : "alpha-linolenic-acid",
-"Acide eicosapentaénoïque" : "eicosapentaenoic-acid",
-"Acide docosahexaénoïque" : "docosahexaenoic-acid",
-"Acide linoléique" : "linoleic-acid",
-"Acide arachidonique" : "arachidonic-acid",
-"Acide gamma-linolénique" : "gamma-linolenic-acid",
-"Acide dihomo-gamma-linolénique" : "dihomo-gamma-linolenic-acid",
-"Acide oléique" : "oleic-acid",
-"Acide élaïdique" : "elaidic-acid",
-"Acide gadoléique" : "gondoic-acid",
-"Acide de Mead" : "mead-acid",
-"Acide érucique" : "erucic-acid",
-"Acide nervonique" : "nervonic-acid",
-"Acides gras trans" : "trans-fat",
-"Cholestérol" : "cholesterol",
-"Sucres ajoutés" : "added-sugars",
-"Saccharose" : "sucrose",
-"Glucose" : "glucose",
-"Fructose" : "fructose",
-"Lactose" : "lactose",
-"Maltose" : "maltose",
-"Maltodextrines" : "maltodextrins",
-"Amidon" : "starch",
-"Polyols" : "polyols",
-"Érythritol" : "erythritol",
-"Fibres solubles" : "soluble-fiber",
-"Fibres insolubles" : "insoluble-fiber",
-"Caséine" : "casein",
-"Protéines sériques" : "serum-proteins",
-"Nucléotides" : "nucleotides",
-"Sel ajouté" : "added-salt",
-"Vitamine A (rétinol)" : "vitamin-a",
-"Bêta carotène" : "beta-carotene",
-"Vitamine D" : "vitamin-d",
-"Vitamine E (tocophérol)" : "vitamin-e",
-"Vitamine K" : "vitamin-k",
-"Vitamine C (acide ascorbique)" : "vitamin-c",
-"Vitamine B1 (Thiamine)" : "vitamin-b1",
-"Vitamine B2 (Riboflavine)" : "vitamin-b2",
-"Vitamine B3/PP (Niacine)" : "vitamin-pp",
-"Vitamine B6 (Pyridoxine)" : "vitamin-b6",
-"Vitamine B9 (Acide folique)" : "vitamin-b9",
-"Folates (folates totaux)" : "folates",
-"Vitamine B12 (cobalamine)" : "vitamin-b12",
-"Biotine (Vitamine B8 ou B7 ou H)" : "biotin",
-"Vitamine B5 (Acide pantothénique)" : "pantothenic-acid",
-"Silice" : "silica",
-"Bicarbonate" : "bicarbonate",
-"Potassium" : "potassium",
-"Chlorure" : "chloride",
-"Calcium" : "calcium",
-"Phosphore" : "phosphorus",
-"Fer" : "iron",
-"Magnésium" : "magnesium",
-"Zinc" : "zinc",
-"Cuivre" : "copper",
-"Manganèse" : "manganese",
-"Fluorure" : "fluoride",
-"Sélénium" : "selenium",
-"Chrome" : "chromium",
-"Molybdène" : "molybdenum",
-"Iode" : "iodine",
-"Caféine" : "caffeine",
-"Taurine" : "taurine",
-"PH" : "ph",
-"Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive" : "fruits-vegetables-nuts",
-"Fruits‚ légumes et noix - séchés" : "fruits-vegetables-nuts-dried",
-"Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive (estimation manuelle avec la liste des ingrédients)" : "fruits-vegetables-nuts-estimate",
-"Rapport collagène sur protéines de viande (maximum)" : "collagen-meat-protein-ratio",
-"Cacao (minimum)" : "cocoa",
-"Chlorophyl" : "chlorophyl",
-"Empreinte carbone" : "carbon-footprint",
-"Indice glycémique" : "glycemic-index",
-"Dureté de l'eau" : "water-hardness",
-"Choline" : "choline",
-"Vitamine K1" : "phylloquinone",
-"Bêta-glucanes" : "beta-glucan",
-"Inositol" : "inositol",
-"Carnitine" : "carnitine",
-"Sulfate" : "sulphate",
-"Nitrate" : "nitrate",
-"Acidité" : "acidity"
-};
-
-var otherNutriments = [
-{ "value" : "Énergie", "unit" : "kj", "iu": false  },
-{ "value" : "Énergie provenant des graisses", "unit" : "kj", "iu": false  },
-{ "value" : "Acide butyrique", "unit" : "g", "iu": false  },
-{ "value" : "Acide caproïque", "unit" : "g", "iu": false  },
-{ "value" : "Acide caprylique", "unit" : "g", "iu": false  },
-{ "value" : "Acide caprique", "unit" : "g", "iu": false  },
-{ "value" : "Acide laurique", "unit" : "g", "iu": false  },
-{ "value" : "Acide myristique", "unit" : "g", "iu": false  },
-{ "value" : "Acide palmitique", "unit" : "g", "iu": false  },
-{ "value" : "Acide stéarique", "unit" : "g", "iu": false  },
-{ "value" : "Acide arachidique", "unit" : "g", "iu": false  },
-{ "value" : "Acide béhénique", "unit" : "g", "iu": false  },
-{ "value" : "Acide lignocérique", "unit" : "g", "iu": false  },
-{ "value" : "Acide cérotique", "unit" : "g", "iu": false  },
-{ "value" : "Acide montanique", "unit" : "g", "iu": false  },
-{ "value" : "Acide mélissique", "unit" : "g", "iu": false  },
-{ "value" : "Unsaturated fat", "unit" : "g", "iu": false  },
-{ "value" : "Acides gras monoinsaturés", "unit" : "g", "iu": false  },
-{ "value" : "Acides gras Oméga 9", "unit" : "mg", "iu": false  },
-{ "value" : "Acides gras polyinsaturés", "unit" : "g", "iu": false  },
-{ "value" : "Acides gras Oméga 3", "unit" : "mg", "iu": false  },
-{ "value" : "Acides gras Oméga 6", "unit" : "mg", "iu": false  },
-{ "value" : "Acide alpha-linolénique", "unit" : "g", "iu": false  },
-{ "value" : "Acide eicosapentaénoïque", "unit" : "g", "iu": false  },
-{ "value" : "Acide docosahexaénoïque", "unit" : "g", "iu": false  },
-{ "value" : "Acide linoléique", "unit" : "g", "iu": false  },
-{ "value" : "Acide arachidonique", "unit" : "g", "iu": false  },
-{ "value" : "Acide gamma-linolénique", "unit" : "g", "iu": false  },
-{ "value" : "Acide dihomo-gamma-linolénique", "unit" : "g", "iu": false  },
-{ "value" : "Acide oléique", "unit" : "g", "iu": false  },
-{ "value" : "Acide élaïdique", "unit" : "g", "iu": false  },
-{ "value" : "Acide gadoléique", "unit" : "g", "iu": false  },
-{ "value" : "Acide de Mead", "unit" : "g", "iu": false  },
-{ "value" : "Acide érucique", "unit" : "g", "iu": false  },
-{ "value" : "Acide nervonique", "unit" : "g", "iu": false  },
-{ "value" : "Acides gras trans", "unit" : "g", "iu": false  },
-{ "value" : "Cholestérol", "unit" : "mg", "iu": false  },
-{ "value" : "Sucres ajoutés", "unit" : "g", "iu": false  },
-{ "value" : "Saccharose", "unit" : "g", "iu": false  },
-{ "value" : "Glucose", "unit" : "g", "iu": false  },
-{ "value" : "Fructose", "unit" : "g", "iu": false  },
-{ "value" : "Lactose", "unit" : "g", "iu": false  },
-{ "value" : "Maltose", "unit" : "g", "iu": false  },
-{ "value" : "Maltodextrines", "unit" : "g", "iu": false  },
-{ "value" : "Amidon", "unit" : "g", "iu": false  },
-{ "value" : "Polyols", "unit" : "g", "iu": false  },
-{ "value" : "Érythritol", "unit" : "g", "iu": false  },
-{ "value" : "Fibres solubles", "unit" : "g", "iu": false  },
-{ "value" : "Fibres insolubles", "unit" : "g", "iu": false  },
-{ "value" : "Caséine", "unit" : "g", "iu": false  },
-{ "value" : "Protéines sériques", "unit" : "g", "iu": false  },
-{ "value" : "Nucléotides", "unit" : "g", "iu": false  },
-{ "value" : "Sel ajouté", "unit" : "g", "iu": false  },
-{ "value" : "Vitamine A (rétinol)", "unit" : "µg", "iu": true  },
-{ "value" : "Bêta carotène", "unit" : "g", "iu": false  },
-{ "value" : "Vitamine D", "unit" : "µg", "iu": true  },
-{ "value" : "Vitamine E (tocophérol)", "unit" : "mg", "iu": true  },
-{ "value" : "Vitamine K", "unit" : "µg", "iu": false  },
-{ "value" : "Vitamine C (acide ascorbique)", "unit" : "mg", "iu": true  },
-{ "value" : "Vitamine B1 (Thiamine)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamine B2 (Riboflavine)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamine B3/PP (Niacine)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamine B6 (Pyridoxine)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamine B9 (Acide folique)", "unit" : "µg", "iu": false  },
-{ "value" : "Folates (folates totaux)", "unit" : "µg", "iu": false  },
-{ "value" : "Vitamine B12 (cobalamine)", "unit" : "µg", "iu": false  },
-{ "value" : "Biotine (Vitamine B8 ou B7 ou H)", "unit" : "µg", "iu": false  },
-{ "value" : "Vitamine B5 (Acide pantothénique)", "unit" : "mg", "iu": false  },
-{ "value" : "Silice", "unit" : "mg", "iu": false  },
-{ "value" : "Bicarbonate", "unit" : "mg", "iu": false  },
-{ "value" : "Potassium", "unit" : "mg", "iu": false  },
-{ "value" : "Chlorure", "unit" : "mg", "iu": false  },
-{ "value" : "Calcium", "unit" : "mg", "iu": false  },
-{ "value" : "Phosphore", "unit" : "mg", "iu": false  },
-{ "value" : "Fer", "unit" : "mg", "iu": false  },
-{ "value" : "Magnésium", "unit" : "mg", "iu": false  },
-{ "value" : "Zinc", "unit" : "mg", "iu": false  },
-{ "value" : "Cuivre", "unit" : "mg", "iu": false  },
-{ "value" : "Manganèse", "unit" : "mg", "iu": false  },
-{ "value" : "Fluorure", "unit" : "mg", "iu": false  },
-{ "value" : "Sélénium", "unit" : "µg", "iu": false  },
-{ "value" : "Chrome", "unit" : "µg", "iu": false  },
-{ "value" : "Molybdène", "unit" : "µg", "iu": false  },
-{ "value" : "Iode", "unit" : "µg", "iu": false  },
-{ "value" : "Caféine", "unit" : "mg", "iu": false  },
-{ "value" : "Taurine", "unit" : "g", "iu": false  },
-{ "value" : "PH", "unit" : "", "iu": false  },
-{ "value" : "Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive", "unit" : "%", "iu": false  },
-{ "value" : "Fruits‚ légumes et noix - séchés", "unit" : "%", "iu": false  },
-{ "value" : "Fruits‚ légumes‚ noix et huiles de colza‚ noix et olive (estimation manuelle avec la liste des ingrédients)", "unit" : "%", "iu": false  },
-{ "value" : "Rapport collagène sur protéines de viande (maximum)", "unit" : "%", "iu": false  },
-{ "value" : "Cacao (minimum)", "unit" : "%", "iu": false  },
-{ "value" : "Chlorophyl", "unit" : "g", "iu": false  },
-{ "value" : "Empreinte carbone", "unit" : "g", "iu": false  },
-{ "value" : "Indice glycémique", "unit" : "", "iu": false  },
-{ "value" : "Dureté de l'eau", "unit" : "mmol/l", "iu": false  },
-{ "value" : "Choline", "unit" : "g", "iu": false  },
-{ "value" : "Vitamine K1", "unit" : "g", "iu": false  },
-{ "value" : "Bêta-glucanes", "unit" : "g", "iu": false  },
-{ "value" : "Inositol", "unit" : "g", "iu": false  },
-{ "value" : "Carnitine", "unit" : "g", "iu": false  },
-{ "value" : "Sulfate", "unit" : "mg", "iu": false  },
-{ "value" : "Nitrate", "unit" : "mg", "iu": false  },
-{ "value" : "Acidité", "unit" : "% vol", "iu": false  }
-];
-</script>
-
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -1,3222 +1,3878 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Open Food Facts - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="" />
+    <meta property="og:url" content="//fr.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//fr.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Open Food Facts - France</h1>
-									</div>
-								</div>
-								
-<div class="hide-when-logged-in homepage-greeter-wrapper">
-<div class="homepage-greeter">
-	<div class="homepage-greeter__discover">
-    <div class="homepage-greeter__discover--content">
-      <div>
-        <h2>Discover</h2>
-        <p>Open Food Facts is a food products database made by everyone, for everyone. You can use it to make better food choices, and as it is open data, anyone can re-use it for any purpose.</p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/discover"><span class="material-icons">auto_stories</span>Learn more about Open Food Facts</a>
-    </div>
-    <div class="homepage-greeter__discover--image">
-      <img src="images/illustrations/globe.svg" alt="Discover Open Food Facts." />
-    </div>
-	</div>
-	<div class="homepage-greeter__contribute">
-    <div class="homepage-greeter__contribute--content"> 
-      <div>
-        <h2>Contribute</h2>
-        <p>
-        Open Food Facts is a non-profit project developed by thousands of volunteers from around the world.
-        You can start contributing by <a href="/open-food-facts-mobile-app">adding a product from your kitchen with our app for iPhone or Android</a>, and we have lots of
-        exciting projects you can contribute to in many different ways.
-        </p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/contribute"><span class="material-icons">add_task</span>Learn more about how you can join us</a>
-    </div>
-    <div class="homepage-greeter__contribute--image">
-      <img src="images/illustrations/puzzle-big.svg" alt="Contribute to Open Food Facts." />
-    </div>
-	</div>
-</div>
-</div>
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-        <p>&rarr; <a href= "//world-fr.openfoodfacts.localhost"> Voir les résultats du monde entier</a></p>
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          7 produits
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            Produits récemment modifiés
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Produits les plus scannés</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Produits avec le meilleur Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Produits avec le meilleur Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Produits récemment ajoutés</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Produits récemment modifiés</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        <div>
-          <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">sort</span>
-            Explorer les produits par…
-          </button>
-          <ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/notes-nutritionnelles">Notes nutritionnelles</a>
-            </li>
-          
-            <li>
-              <a href="/groupes-nova">Groupes NOVA</a>
-            </li>
-          
-            <li>
-              <a href="/environmental-score">Green-Score</a>
-            </li>
-          
-            <li>
-              <a href="/marques">Marques</a>
-            </li>
-          
-            <li>
-              <a href="/categories">Catégories</a>
-            </li>
-          
-            <li>
-              <a href="/labels">Labels</a>
-            </li>
-          
-            <li>
-              <a href="/conditionnements">Conditionnements</a>
-            </li>
-          
-            <li>
-              <a href="/origines">Origines des ingrédients</a>
-            </li>
-          
-            <li>
-              <a href="/lieux-de-fabrication">Lieux de fabrication ou de transformation</a>
-            </li>
-          
-            <li>
-              <a href="/codes-emballeurs">Codes de traçabilité</a>
-            </li>
-          
-            <li>
-              <a href="/ingredients">Ingrédients</a>
-            </li>
-          
-            <li>
-              <a href="/additifs">Additifs</a>
-            </li>
-          
-            <li>
-              <a href="/vitamines">Vitamines ajoutées</a>
-            </li>
-          
-            <li>
-              <a href="/mineraux">Minéraux ajoutés</a>
-            </li>
-          
-            <li>
-              <a href="/acides-amines">Acides aminés ajoutés</a>
-            </li>
-          
-            <li>
-              <a href="/nucleotides">Nucléotides ajoutés</a>
-            </li>
-          
-            <li>
-              <a href="/autres-substances-nutritives">Autres substances nutritives ajoutées</a>
-            </li>
-          
-            <li>
-              <a href="/allergenes">Allergènes</a>
-            </li>
-          
-            <li>
-              <a href="/traces">Traces</a>
-            </li>
-          
-            <li>
-              <a href="/misc">Divers</a>
-            </li>
-          
-            <li>
-              <a href="/langues">Langues</a>
-            </li>
-          
-            <li>
-              <a href="/contributeurs">Contributeurs</a>
-            </li>
-          
-            <li>
-              <a href="/etats">états</a>
-            </li>
-          
-            <li>
-              <a href="/sources-de-donnees">Sources de données</a>
-            </li>
-          
-            <li>
-              <a href="/dates-d-ajout">Dates d'ajout</a>
-            </li>
-          
-            <li>
-              <a href="/dates-de-derniere-modification">Dates de dernière modification</a>
-            </li>
-          
-            <li>
-              <a href="/dates-de-derniere-verification">Dates de dernière vérification</a>
-            </li>
-          
-            <li>
-              <a href="/teams">équipes</a>
-            </li>
-          
-          </ul>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Open Food Facts - France</h1>
+                  </div>
+                </div>
+
+                <div class="hide-when-logged-in homepage-greeter-wrapper">
+                  <div class="homepage-greeter">
+                    <div class="homepage-greeter__discover">
+                      <div class="homepage-greeter__discover--content">
+                        <div>
+                          <h2>Discover</h2>
+                          <p>
+                            Open Food Facts is a food products database made by
+                            everyone, for everyone. You can use it to make
+                            better food choices, and as it is open data, anyone
+                            can re-use it for any purpose.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/discover"
+                          ><span class="material-icons">auto_stories</span>Learn
+                          more about Open Food Facts</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__discover--image">
+                        <img
+                          src="images/illustrations/globe.svg"
+                          alt="Discover Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                    <div class="homepage-greeter__contribute">
+                      <div class="homepage-greeter__contribute--content">
+                        <div>
+                          <h2>Contribute</h2>
+                          <p>
+                            Open Food Facts is a non-profit project developed by
+                            thousands of volunteers from around the world. You
+                            can start contributing by
+                            <a href="/open-food-facts-mobile-app"
+                              >adding a product from your kitchen with our app
+                              for iPhone or Android</a
+                            >, and we have lots of exciting projects you can
+                            contribute to in many different ways.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/contribute"
+                          ><span class="material-icons">add_task</span>Learn
+                          more about how you can join us</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__contribute--image">
+                        <img
+                          src="images/illustrations/puzzle-big.svg"
+                          alt="Contribute to Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;
+                      <a href="//world-fr.openfoodfacts.localhost">
+                        Voir les résultats du monde entier</a
+                      >
+                    </p>
+
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          7 produits
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                            Produits récemment modifiés
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Produits les plus scannés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Produits récemment ajoutés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Produits récemment modifiés</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop1"
+                            aria-controls="drop1"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">sort</span>
+                            Explorer les produits par…
+                          </button>
+                          <ul
+                            id="drop1"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a href="/notes-nutritionnelles"
+                                >Notes nutritionnelles</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/groupes-nova">Groupes NOVA</a>
+                            </li>
+
+                            <li>
+                              <a href="/environmental-score">Green-Score</a>
+                            </li>
+
+                            <li>
+                              <a href="/marques">Marques</a>
+                            </li>
+
+                            <li>
+                              <a href="/categories">Catégories</a>
+                            </li>
+
+                            <li>
+                              <a href="/labels">Labels</a>
+                            </li>
+
+                            <li>
+                              <a href="/conditionnements">Conditionnements</a>
+                            </li>
+
+                            <li>
+                              <a href="/origines">Origines des ingrédients</a>
+                            </li>
+
+                            <li>
+                              <a href="/lieux-de-fabrication"
+                                >Lieux de fabrication ou de transformation</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/codes-emballeurs"
+                                >Codes de traçabilité</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/ingredients">Ingrédients</a>
+                            </li>
+
+                            <li>
+                              <a href="/additifs">Additifs</a>
+                            </li>
+
+                            <li>
+                              <a href="/vitamines">Vitamines ajoutées</a>
+                            </li>
+
+                            <li>
+                              <a href="/mineraux">Minéraux ajoutés</a>
+                            </li>
+
+                            <li>
+                              <a href="/acides-amines">Acides aminés ajoutés</a>
+                            </li>
+
+                            <li>
+                              <a href="/nucleotides">Nucléotides ajoutés</a>
+                            </li>
+
+                            <li>
+                              <a href="/autres-substances-nutritives"
+                                >Autres substances nutritives ajoutées</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/allergenes">Allergènes</a>
+                            </li>
+
+                            <li>
+                              <a href="/traces">Traces</a>
+                            </li>
+
+                            <li>
+                              <a href="/misc">Divers</a>
+                            </li>
+
+                            <li>
+                              <a href="/langues">Langues</a>
+                            </li>
+
+                            <li>
+                              <a href="/contributeurs">Contributeurs</a>
+                            </li>
+
+                            <li>
+                              <a href="/etats">états</a>
+                            </li>
+
+                            <li>
+                              <a href="/sources-de-donnees"
+                                >Sources de données</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/dates-d-ajout">Dates d'ajout</a>
+                            </li>
+
+                            <li>
+                              <a href="/dates-de-derniere-modification"
+                                >Dates de dernière modification</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/dates-de-derniere-verification"
+                                >Dates de dernière vérification</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/teams">équipes</a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+              </div>
+            </div>
+          </div>
         </div>
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classer les 7 produits ci-dessous suivant vos préférences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Caractère végétarien inconnu",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short:
+                    "Données manquantes pour calculer le Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score inconnu",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Ne contient pas : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Ne contient pas : Œufs",
+                },
+                {
+                  debug: "en:nuts in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 0,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Contient : Fruits à coque",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "en:soybeans in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 0,
+                  name: "Soja",
+                  status: "known",
+                  title: "Contient : Soja",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Caractère végétarien inconnu",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments ultra-transformés",
+                },
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/1-additives.svg",
+                  id: "additives",
+                  match: 80,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "1 additif",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Impact environnemental inconnu",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score non calculé",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Empreinte forêt non calculée",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Pas un produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Ne provient pas du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000011",
+          product_display_name: "Crema di nocciole - Bob's creme - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000011/crema-di-nocciole-bob-s-creme",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Qualité nutritionnelle moyenne",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-fr.svg",
+                  id: "nutriscore",
+                  match: 41,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Ne contient pas : Gluten",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Lait",
+                  status: "known",
+                  title: "Ne contient pas : Lait",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Ne contient pas : Œufs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments non transformés ou minimalement transformés",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Sans additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Impact modéré sur l'environnement",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Empreinte forêt non calculée",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000008",
+          product_display_name:
+            "Organic apple and raspberry juice - Bob's juices - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Qualité nutritionnelle moyenne",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-fr.svg",
+                  id: "nutriscore",
+                  match: 35.25,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Ne contient pas : Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Lait",
+                  status: "known",
+                  title: "Ne contient pas : Lait",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Ne contient pas : Œufs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments non transformés ou minimalement transformés",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Sans additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Impact modéré sur l'environnement",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Empreinte forêt non calculée",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000007",
+          product_display_name: "Organic apple juice - Bob's juices - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000007/organic-apple-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short:
+                    "Données manquantes pour calculer le Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score inconnu",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Ne contient pas : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Ne contient pas : Œufs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Sans additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Empreinte forêt non calculée",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Pas un produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Ne provient pas du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000005",
+          product_display_name:
+            "Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short:
+                    "Données manquantes pour calculer le Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score inconnu",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Ne contient pas : Gluten",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Lait",
+                  status: "known",
+                  title: "Ne contient pas : Lait",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Ne contient pas : Œufs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 0,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:non-vegetarian",
+                  status: "known",
+                  title: "Non végétarien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Sans additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Impact environnemental inconnu",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score non calculé",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Empreinte forêt non calculée",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Pas un produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Ne provient pas du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000003",
+          product_display_name: "Duck salad - Bob's salads - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000003/duck-salad-bob-s-salads",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classer les 7 produits ci-dessous suivant vos préférences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Caractère végétarien inconnu"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Données manquantes pour calculer le Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score inconnu"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Ne contient pas : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Ne contient pas : Œufs"
-               },
-               {
-                  "debug":"en:nuts in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":0,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Contient : Fruits à coque"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"en:soybeans in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":0,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Contient : Soja"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Caractère végétarien inconnu"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments ultra-transformés"
-               },
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/1-additives.svg",
-                  "id":"additives",
-                  "match":80,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"1 additif"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Impact environnemental inconnu",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score non calculé"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Empreinte forêt non calculée"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Les produits bios encouragent la durabilité écologique et la biodiversité.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Pas un produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Ne provient pas du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000011",
-      "product_display_name":"Crema di nocciole - Bob's creme - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000011/crema-di-nocciole-bob-s-creme"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Qualité nutritionnelle moyenne",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":41,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Ne contient pas : Gluten"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Ne contient pas : Lait"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Ne contient pas : Œufs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments non transformés ou minimalement transformés"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Sans additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Impact modéré sur l'environnement",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Empreinte forêt non calculée"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000008",
-      "product_display_name":"Organic apple and raspberry juice - Bob's juices - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Qualité nutritionnelle moyenne",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":35.25,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Ne contient pas : Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Ne contient pas : Lait"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Ne contient pas : Œufs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments non transformés ou minimalement transformés"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Sans additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Impact modéré sur l'environnement",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Empreinte forêt non calculée"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000007",
-      "product_display_name":"Organic apple juice - Bob's juices - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000007/organic-apple-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Données manquantes pour calculer le Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score inconnu"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Ne contient pas : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Ne contient pas : Œufs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Sans additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Empreinte forêt non calculée"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Les produits bios encouragent la durabilité écologique et la biodiversité.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Pas un produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Ne provient pas du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000005",
-      "product_display_name":"Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Données manquantes pour calculer le Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score inconnu"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Ne contient pas : Gluten"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Ne contient pas : Lait"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Ne contient pas : Œufs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":0,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:non-vegetarian",
-                  "status":"known",
-                  "title":"Non végétarien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Sans additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Impact environnemental inconnu",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score non calculé"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Empreinte forêt non calculée"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Les produits bios encouragent la durabilité écologique et la biodiversité.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Pas un produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Ne provient pas du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000003",
-      "product_display_name":"Duck salad - Bob's salads - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000003/duck-salad-bob-s-salads"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -1,678 +1,1103 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Liste des labels - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/facets/labels/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/facets/labels/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/facets/labels/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//fr.openfoodfacts.localhost/facets/labels/1" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Liste des labels - France</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-            <p>Pays : France
-                - <a href="//world-fr.openfoodfacts.localhost/facets/labels">Voir la liste pour les produits correspondants du monde entier</a>
-            </p>
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>5 labels :</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Label</th><th>Produits</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/labels/commerce-equitable" class="tag known">Commerce équitable</a></td>
-<td style="text-align:right"><a href="/facets/labels/commerce-equitable" class="tag known">4</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/bio" class="tag known">Bio</a></td>
-<td style="text-align:right"><a href="/facets/labels/bio" class="tag known">4</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/en:free-range-duck" class="tag user_defined">en:free-range-duck</a></td>
-<td style="text-align:right"><a href="/facets/labels/en:free-range-duck" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/labels/sans-huile-de-palme" class="tag known">Sans huile de palme</a></td>
-<td style="text-align:right"><a href="/facets/labels/sans-huile-de-palme" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/en:very-good" class="tag user_defined">en:very-good</a></td>
-<td style="text-align:right"><a href="/facets/labels/en:very-good" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <!-- full width banner on mobile -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- Donation banner @ footer -->
 
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
-<!-- Donation banner @ footer -->
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-				
+                    return "";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Liste des labels - France</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+
+                          <p>
+                            Pays : France -
+                            <a
+                              href="//world-fr.openfoodfacts.localhost/facets/labels"
+                              >Voir la liste pour les produits correspondants du
+                              monde entier</a
+                            >
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>5 labels :</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Label</th>
+                            <th>Produits</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/commerce-equitable"
+                                class="tag known"
+                                >Commerce équitable</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/commerce-equitable"
+                                class="tag known"
+                                >4</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/labels/bio" class="tag known"
+                                >Bio</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/labels/bio" class="tag known"
+                                >4</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/en:free-range-duck"
+                                class="tag user_defined"
+                                >en:free-range-duck</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/en:free-range-duck"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/sans-huile-de-palme"
+                                class="tag known"
+                                >Sans huile de palme</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/sans-huile-de-palme"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/en:very-good"
+                                class="tag user_defined"
+                                >en:very-good</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/en:very-good"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Recherche :",
+            info: "_TOTAL_ labels",
+            infoFiltered: " - parmi _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Recherche :",
-		info: "_TOTAL_ labels",
-		infoFiltered: " - parmi _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//fr.openfoodfacts.localhost/produit/3300000000001/apple-pie-bob-s-pies">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//fr.openfoodfacts.localhost">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -1,1430 +1,1930 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Résultats de la recherche - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="tarte" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Résultats de la recherche - France</h1>
-									</div>
-								</div>
-								<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-        <p>&rarr; <a href= "//world-fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"> Voir les résultats du monde entier</a></p>
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-        <p>&rarr; <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">Lien permanent vers ces résultats, partageable par e-mail et les réseaux sociaux</a></p>
-      
-    
-    
-      <p>&rarr; <a href="/cgi/search.pl?action=display&search_terms=tarte&sort_by=unique_scans_n&page_size=50">Modifier les critères de recherche</a></p>
-    
-  </div>
-</div>
-
- 
-  <div class="row">
-    <div class="small-12 columns"> 
-      <p>&rarr;Télécharger les résultats au format XLSX ou CSV. Pour des raisons de performance, vous pouvez télécharger jusqu'à 10 000 résultats seulement.</p>
-      
-      <ul>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx">Format XLSX</a>
-          (Excel ou LibreOffice)
-        </li>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=csv">Format CSV</a>
-          (Encodage des caractères : Unicode (UTF-8) - Séparateur : tabulation (tab))
-        </li>
-      </ul>
-      
-    </div>
-  </div>
-
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          2 produits
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Produits les plus scannés</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Produits avec le meilleur Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Produits avec le meilleur Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Produits récemment ajoutés</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Produits récemment modifiés</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value="tarte"
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">
+                      Résultats de la recherche - France
+                    </h1>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;
+                      <a
+                        href="//world-fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                      >
+                        Voir les résultats du monde entier</a
+                      >
+                    </p>
+
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                        >Lien permanent vers ces résultats, partageable par
+                        e-mail et les réseaux sociaux</a
+                      >
+                    </p>
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=display&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                        >Modifier les critères de recherche</a
+                      >
+                    </p>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;Télécharger les résultats au format XLSX ou CSV.
+                      Pour des raisons de performance, vous pouvez télécharger
+                      jusqu'à 10 000 résultats seulement.
+                    </p>
+
+                    <ul>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx"
+                          >Format XLSX</a
+                        >
+                        (Excel ou LibreOffice)
+                      </li>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=csv"
+                          >Format CSV</a
+                        >
+                        (Encodage des caractères : Unicode (UTF-8) - Séparateur
+                        : tabulation (tab))
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          2 produits
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Produits les plus scannés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Produits récemment ajoutés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Produits récemment modifiés</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                <div
+                  class="share_button right"
+                  style="float: right; margin-top: -10px; display: none"
+                >
+                  <a
+                    href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                    class="button small"
+                    title="Résultats de la recherche - France"
+                  >
+                    <?xml version="1.0" standalone="no"?><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      xmlns:xlink="//www.w3.org/1999/xlink"
+                      viewBox="0 0 1000 1000"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <metadata>IcoFont Icons</metadata>
+                      <title>share</title>
+                      <glyph
+                        glyph-name="share"
+                        unicode="î¿¥"
+                        horiz-adv-x="1000"
+                      />
+                      <path
+                        d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"
+                      />
+                    </svg>
+                    <span class="show-for-large-up"> Partager</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classer les 2 produits ci-dessous suivant vos préférences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Caractère végétarien inconnu",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-<div class="share_button right" style="float:right;margin-top:-10px;display:none;">
-<a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50" class="button small" title="Résultats de la recherche - France">
-	<?xml version="1.0" standalone="no"?><svg xmlns="//www.w3.org/2000/svg" xmlns:xlink="//www.w3.org/1999/xlink" viewBox="0 0 1000 1000" class="icon" aria-hidden="true" focusable="false"><metadata>IcoFont Icons</metadata><title>share</title><glyph glyph-name="share" unicode="î¿¥" horiz-adv-x="1000"/><path d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"/></svg>
-	<span class="show-for-large-up"> Partager</span>
-</a></div>
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classer les 2 produits ci-dessous suivant vos préférences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Caractère végétarien inconnu"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -1,1431 +1,1932 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Résultats de la recherche - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="tarte" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Résultats de la recherche - France</h1>
-									</div>
-								</div>
-								<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-        <p>&rarr; <a href= "//world-fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"> Voir les résultats du monde entier</a></p>
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-        <p>&rarr; <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">Lien permanent vers ces résultats, partageable par e-mail et les réseaux sociaux</a></p>
-      
-    
-    
-      <p>&rarr; <a href="/cgi/search.pl?action=display&search_terms=tarte&sort_by=unique_scans_n&page_size=50">Modifier les critères de recherche</a></p>
-    
-  </div>
-</div>
-
- 
-  <div class="row">
-    <div class="small-12 columns"> 
-      <p>&rarr;Télécharger les résultats au format XLSX ou CSV. Pour des raisons de performance, vous pouvez télécharger jusqu'à 10 000 résultats seulement.</p>
-      
-      <ul>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx">Format XLSX</a>
-          (Excel ou LibreOffice)
-        </li>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=csv">Format CSV</a>
-          (Encodage des caractères : Unicode (UTF-8) - Séparateur : tabulation (tab))
-        </li>
-      </ul>
-      
-    </div>
-  </div>
-
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          2 produits
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Produits les plus scannés</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Produits avec le meilleur Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Produits avec le meilleur Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Produits récemment ajoutés</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Produits récemment modifiés</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value="tarte"
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">
+                      Résultats de la recherche - France
+                    </h1>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;
+                      <a
+                        href="//world-fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                      >
+                        Voir les résultats du monde entier</a
+                      >
+                    </p>
+
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                        >Lien permanent vers ces résultats, partageable par
+                        e-mail et les réseaux sociaux</a
+                      >
+                    </p>
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=display&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                        >Modifier les critères de recherche</a
+                      >
+                    </p>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;Télécharger les résultats au format XLSX ou CSV.
+                      Pour des raisons de performance, vous pouvez télécharger
+                      jusqu'à 10 000 résultats seulement.
+                    </p>
+
+                    <ul>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx"
+                          >Format XLSX</a
+                        >
+                        (Excel ou LibreOffice)
+                      </li>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=csv"
+                          >Format CSV</a
+                        >
+                        (Encodage des caractères : Unicode (UTF-8) - Séparateur
+                        : tabulation (tab))
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          2 produits
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Produits les plus scannés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Produits récemment ajoutés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Produits récemment modifiés</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                <div
+                  class="share_button right"
+                  style="float: right; margin-top: -10px; display: none"
+                >
+                  <a
+                    href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                    class="button small"
+                    title="Résultats de la recherche - France"
+                  >
+                    <?xml version="1.0" standalone="no"?><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      xmlns:xlink="//www.w3.org/1999/xlink"
+                      viewBox="0 0 1000 1000"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <metadata>IcoFont Icons</metadata>
+                      <title>share</title>
+                      <glyph
+                        glyph-name="share"
+                        unicode="î¿¥"
+                        horiz-adv-x="1000"
+                      />
+                      <path
+                        d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"
+                      />
+                    </svg>
+                    <span class="show-for-large-up"> Partager</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classer les 2 produits ci-dessous suivant vos préférences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0002/front_fr.3.200.jpg",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Caractère végétarien inconnu",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-<div class="share_button right" style="float:right;margin-top:-10px;display:none;">
-<a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50" class="button small" title="Résultats de la recherche - France">
-	<?xml version="1.0" standalone="no"?><svg xmlns="//www.w3.org/2000/svg" xmlns:xlink="//www.w3.org/1999/xlink" viewBox="0 0 1000 1000" class="icon" aria-hidden="true" focusable="false"><metadata>IcoFont Icons</metadata><title>share</title><glyph glyph-name="share" unicode="î¿¥" horiz-adv-x="1000"/><path d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"/></svg>
-	<span class="show-for-large-up"> Partager</span>
-</a></div>
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classer les 2 produits ci-dessous suivant vos préférences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0002/front_fr.3.200.jpg",
-      "product_display_name":"Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Caractère végétarien inconnu"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -1,1430 +1,1930 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="fr" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="fr"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Résultats de la recherche - France</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//fr.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/decouvrir">Découvrir</a></li>
-									<li><a href="/contribuer">Contribuer</a></li>
-									<li class="divider"></li>
-									<li><label>Ajouter des produits</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr">Installez l'application pour ajouter des produits</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Ajouter un produit</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Rechercher et analyser des produits</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Recherche avancée</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Pays">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//fr.openfoodfacts.localhost/">Français</a>
-
-									<ul class="dropdown">
-										<li><a href="//fr-en.openfoodfacts.localhost/">English</a></li>
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Se connecter
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Chercher un produit" name="search_terms" value="tarte" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Rechercher" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/decouvrir" class="top-bar-links">Découvrir</a></li>
-						<li><a href="/contribuer" class="top-bar-links">Contribuer</a></li>
-						<li class="show-for-xlarge-up"><a href="//fr.pro.openfoodfacts.org/" class="top-bar-links">Producteurs</a></li>
-						<li class="flex-grid getapp"><a href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Installer l'app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Chercher un produit" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Recherche avancée"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-        <ul>
-          <li>
-            garder notre base de données ouverte et accessible à tous,
-            <ul>
-              <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/decouvrir">Découvrir</a></li>
+                  <li><a href="/contribuer">Contribuer</a></li>
+                  <li class="divider"></li>
+                  <li><label>Ajouter des produits</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_fr"
+                      >Installez l'application pour ajouter des produits</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Ajouter un produit</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Rechercher et analyser des produits</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Recherche avancée</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphiques et cartes</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Pays"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//fr.openfoodfacts.localhost/">Français</a>
+
+                    <ul class="dropdown">
+                      <li>
+                        <a href="//fr-en.openfoodfacts.localhost/">English</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>rester indépendant de l'industrie alimentaire,</p>
-          </li>
-          <li>
-            <p>mobiliser une communauté de citoyens engagés,</p>
-          </li>
-          <li>
-            <p>soutenir l’avancement de la recherche en santé publique.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Se connecter
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Résultats de la recherche - France</h1>
-									</div>
-								</div>
-								<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-        <p>&rarr; <a href= "//world-fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"> Voir les résultats du monde entier</a></p>
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-        <p>&rarr; <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50">Lien permanent vers ces résultats, partageable par e-mail et les réseaux sociaux</a></p>
-      
-    
-    
-      <p>&rarr; <a href="/cgi/search.pl?action=display&search_terms=tarte&sort_by=unique_scans_n&page_size=50">Modifier les critères de recherche</a></p>
-    
-  </div>
-</div>
-
- 
-  <div class="row">
-    <div class="small-12 columns"> 
-      <p>&rarr;Télécharger les résultats au format XLSX ou CSV. Pour des raisons de performance, vous pouvez télécharger jusqu'à 10 000 résultats seulement.</p>
-      
-      <ul>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx">Format XLSX</a>
-          (Excel ou LibreOffice)
-        </li>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=csv">Format CSV</a>
-          (Encodage des caractères : Unicode (UTF-8) - Séparateur : tabulation (tab))
-        </li>
-      </ul>
-      
-    </div>
-  </div>
-
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          2 produits
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Produits les plus scannés</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Produits avec le meilleur Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Produits avec le meilleur Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Produits récemment ajoutés</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Produits récemment modifiés</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Chercher un produit"
+                                name="search_terms"
+                                value="tarte"
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Rechercher"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/decouvrir" class="top-bar-links">Découvrir</a>
+                  </li>
+                  <li>
+                    <a href="/contribuer" class="top-bar-links">Contribuer</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a href="//fr.pro.openfoodfacts.org/" class="top-bar-links"
+                      >Producteurs</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/application-mobile-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_fr"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Installer l'app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Chercher un produit"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Recherche avancée"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Aidez-nous à informer des millions de consommateurs à
+                        travers le monde sur ce qu'ils mangent
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Merci de contribuer à notre collecte de fonds 2024
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Vos dons financent le fonctionnement quotidien de
+                          notre association à but non lucratif :
+                        </p>
+                        <ul>
+                          <li>
+                            garder notre base de données ouverte et accessible à
+                            tous,
+                            <ul>
+                              <li>
+                                infrastructure technique (site web/application
+                                mobile) et une petite équipe permanente
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              rester indépendant de l'industrie alimentaire,
+                            </p>
+                          </li>
+                          <li>
+                            <p>mobiliser une communauté de citoyens engagés,</p>
+                          </li>
+                          <li>
+                            <p>
+                              soutenir l’avancement de la recherche en santé
+                              publique.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          (déductible à 66 % de vos impôts: ex. un don de 20€
+                          vous reviendra à 6,80€)
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>JE SOUTIENS</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">
+                      Résultats de la recherche - France
+                    </h1>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;
+                      <a
+                        href="//world-fr.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                      >
+                        Voir les résultats du monde entier</a
+                      >
+                    </p>
+
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                        >Lien permanent vers ces résultats, partageable par
+                        e-mail et les réseaux sociaux</a
+                      >
+                    </p>
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=display&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                        >Modifier les critères de recherche</a
+                      >
+                    </p>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;Télécharger les résultats au format XLSX ou CSV.
+                      Pour des raisons de performance, vous pouvez télécharger
+                      jusqu'à 10 000 résultats seulement.
+                    </p>
+
+                    <ul>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx"
+                          >Format XLSX</a
+                        >
+                        (Excel ou LibreOffice)
+                      </li>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50&download=on&format=csv"
+                          >Format CSV</a
+                        >
+                        (Encodage des caractères : Unicode (UTF-8) - Séparateur
+                        : tabulation (tab))
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          2 produits
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Produits les plus scannés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Produits avec le meilleur Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Produits récemment ajoutés</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Produits récemment modifiés</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                <div
+                  class="share_button right"
+                  style="float: right; margin-top: -10px; display: none"
+                >
+                  <a
+                    href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50"
+                    class="button small"
+                    title="Résultats de la recherche - France"
+                  >
+                    <?xml version="1.0" standalone="no"?><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      xmlns:xlink="//www.w3.org/1999/xlink"
+                      viewBox="0 0 1000 1000"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <metadata>IcoFont Icons</metadata>
+                      <title>share</title>
+                      <glyph
+                        glyph-name="share"
+                        unicode="î¿¥"
+                        horiz-adv-x="1000"
+                      />
+                      <path
+                        d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"
+                      />
+                    </svg>
+                    <span class="show-for-large-up"> Partager</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Installer l'app!</div>
+                  Scannez les <span id="foods">aliments</span> de votre
+                  <span id="everyday">quotidien</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"
+                    ><img
+                      src="/images/misc/playstore/img/fr_get.svg"
+                      alt="Disponible sur Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"
+                    ><img
+                      src="/images/misc/android-apk.svg"
+                      alt="APK Android"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_FR.svg"
+                      alt="Disponible sur l'App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Aidez-nous à informer des millions de consommateurs à travers le
+                monde sur ce qu'ils mangent
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Merci de contribuer à notre collecte de fonds 2024
+                </h3>
+              </div>
+              <p>
+                Vos dons financent le fonctionnement quotidien de notre
+                association à but non lucratif :
+              </p>
+              <ul>
+                <li>
+                  garder notre base de données ouverte et accessible à tous,
+                  <ul>
+                    <li>
+                      infrastructure technique (site web/application mobile) et
+                      une petite équipe permanente
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>rester indépendant de l'industrie alimentaire,</p>
+                </li>
+                <li>
+                  <p>mobiliser une communauté de citoyens engagés,</p>
+                </li>
+                <li>
+                  <p>
+                    soutenir l’avancement de la recherche en santé publique.
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Chaque don compte ! Nous apprécions votre soutien pour une
+                  plus grande transparence alimentaire dans le monde.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>JE SOUTIENS</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Rejoignez la communauté</h3>
+              <p>
+                Découvrez notre <a href="/code-de-conduite">Code de conduite</a>
+              </p>
+              <p>
+                Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a>
+              </p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Suivez-nous :
+                <a href="//x.com/OpenFoodFactsfr"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a href="//www.facebook.com/OpenFoodFacts.fr"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-fr"
+                  >S'abonner à notre newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Découvrez le projet</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/qui-sommes-nous"
+                    >Qui sommes-nous ?</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, mission, valeurs et programmes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/fr-fr"
+                    >Questions fréquentes</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/fr/"
+                    >Le blog d'Open Food Facts</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/presse"
+                    >Presse</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (fr)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Traducteurs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/partenaires"
+                    >Partenaires</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world-fr.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmétiques</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//fr.pro.openfoodfacts.localhost/"
+                    >Open Food Facts pour les producteurs</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    Une base de données collaborative, libre et ouverte des
+                    produits alimentaires du monde entier.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/mentions-legales">Mentions légales</a></li>
+                    <li><a href="/privacy">Confidentialité</a></li>
+                    <li>
+                      <a href="/conditions-d-utilisation"
+                        >Conditions d'utilisation</a
+                      >
+                    </li>
+                    <li><a href="/data">Données, API et SDK</a></li>
+                    <li>
+                      <a
+                        href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts"
+                        >Faire un don à l'association Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//fr.pro.openfoodfacts.org/">Producteurs</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-fr"
+                        >S'abonner à notre newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classer les 2 produits ci-dessous suivant vos préférences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Végétarien",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moins bonne qualité nutritionnelle",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sel",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sel en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Matières grasses",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Matières grasses en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Sucres",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sucres en quantité inconnue",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Données nutritionnelles manquantes",
+                  name: "Acides gras saturés",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Acides gras saturés en quantité inconnue",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Qualité nutritionnelle",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contient : Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Lait",
+                  status: "known",
+                  title: "Contient : Lait",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Œufs",
+                  status: "known",
+                  title: "Contient : Œufs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Fruits à coque",
+                  status: "known",
+                  title: "Ne contient pas : Fruits à coque",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Arachides",
+                  status: "known",
+                  title: "Ne contient pas : Arachides",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Graines de sésame",
+                  status: "known",
+                  title: "Ne contient pas : Graines de sésame",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soja",
+                  status: "known",
+                  title: "Ne contient pas : Soja",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Céleri",
+                  status: "known",
+                  title: "Ne contient pas : Céleri",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Moutarde",
+                  status: "known",
+                  title: "Ne contient pas : Moutarde",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Ne contient pas : Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Poisson",
+                  status: "known",
+                  title: "Ne contient pas : Poisson",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustacés",
+                  status: "known",
+                  title: "Ne contient pas : Crustacés",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Mollusques",
+                  status: "known",
+                  title: "Ne contient pas : Mollusques",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Anhydride sulfureux et sulfites",
+                  status: "known",
+                  title: "Ne contient pas : Anhydride sulfureux et sulfites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergènes",
+              warning:
+                "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Végétalien",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non végétalien",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Végétarien",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Caractère végétarien inconnu",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Sans huile de palme",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Sans huile de palme",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingrédients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "Groupe NOVA",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Aliments transformés",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additifs",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additifs",
+                },
+              ],
+              id: "processing",
+              name: "Transformation des aliments",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Faible impact environnemental",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Pas de risque de déforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Empreinte forêt",
+                  status: "known",
+                  title: "Très petite empreinte forêt",
+                },
+              ],
+              id: "environment",
+              name: "Environnement",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+                  description_short:
+                    "Encourage la durabilité écologique et la biodiversité.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Agriculture biologique",
+                  status: "known",
+                  title: "Produit bio",
+                },
+                {
+                  description:
+                    "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+                  description_short:
+                    "Aide les producteurs des pays en développement.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Commerce équitable",
+                  status: "known",
+                  title: "Produit du commerce équitable",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
+          url: "//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-<div class="share_button right" style="float:right;margin-top:-10px;display:none;">
-<a href="/cgi/search.pl?action=process&search_terms=tarte&sort_by=unique_scans_n&page_size=50" class="button small" title="Résultats de la recherche - France">
-	<?xml version="1.0" standalone="no"?><svg xmlns="//www.w3.org/2000/svg" xmlns:xlink="//www.w3.org/1999/xlink" viewBox="0 0 1000 1000" class="icon" aria-hidden="true" focusable="false"><metadata>IcoFont Icons</metadata><title>share</title><glyph glyph-name="share" unicode="î¿¥" horiz-adv-x="1000"/><path d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"/></svg>
-	<span class="show-for-large-up"> Partager</span>
-</a></div>
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Installer l'app!
-								</div>
-								Scannez les <span id="foods">aliments</span> de votre <span id="everyday">quotidien</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/fr_get.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/android-apk.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_fr"><img src="/images/misc/appstore/black/appstore_FR.svg" alt="Disponible sur l'App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Merci de contribuer à notre collecte de fonds 2024</h3>
-      </div>
-      <p>Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</p>
-      <ul>
-        <li>
-          garder notre base de données ouverte et accessible à tous,
-          <ul>
-            <li>infrastructure technique (site web/application mobile) et une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendant de l'industrie alimentaire,</p>
-        </li>
-        <li>
-          <p>mobiliser une communauté de citoyens engagés,</p>
-        </li>
-        <li>
-          <p>soutenir l’avancement de la recherche en santé publique.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>JE SOUTIENS</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Rejoignez la communauté</h3>
-						<p>Découvrez notre <a href="/code-de-conduite">Code de conduite</a></p>
-						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//x.com/OpenFoodFactsfr"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Découvrez le projet</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/qui-sommes-nous">Qui sommes-nous ?</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, mission, valeurs et programmes</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/fr-fr">Questions fréquentes</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/fr/">Le blog d'Open Food Facts</a></li>
-							<li><a class="button small white-button radius" href="/presse">Presse</a></li>
-							<li><a class="button small white-button radius" href="//fr.wiki.openfoodfacts.org">Open Food Facts wiki (fr)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traducteurs</a></li>
-							<li><a class="button small white-button radius" href="/partenaires">Partenaires</a></li>
-							<li><a class="button small white-button radius" href="//world-fr.openbeautyfacts.org">Open Beauty Facts - Cosmétiques</a></li>
-							<li><a class="button small white-button radius" href="//fr.pro.openfoodfacts.localhost/">Open Food Facts pour les producteurs</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Confidentialité</a></li>
-									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
-									<li><a href="/data">Données, API et SDK</a></li>
-									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
-									<li><a href="//fr.pro.openfoodfacts.org/">Producteurs</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-fr">S'abonner à notre newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classer les 2 produits ci-dessous suivant vos préférences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Végétarien"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moins bonne qualité nutritionnelle",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-fr.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sel",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sel en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Matières grasses",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Matières grasses en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Sucres",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sucres en quantité inconnue"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Données nutritionnelles manquantes",
-                  "name":"Acides gras saturés",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Acides gras saturés en quantité inconnue"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Qualité nutritionnelle"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contient : Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Lait",
-                  "status":"known",
-                  "title":"Contient : Lait"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Œufs",
-                  "status":"known",
-                  "title":"Contient : Œufs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Fruits à coque",
-                  "status":"known",
-                  "title":"Ne contient pas : Fruits à coque"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Arachides",
-                  "status":"known",
-                  "title":"Ne contient pas : Arachides"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Graines de sésame",
-                  "status":"known",
-                  "title":"Ne contient pas : Graines de sésame"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soja",
-                  "status":"known",
-                  "title":"Ne contient pas : Soja"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Céleri",
-                  "status":"known",
-                  "title":"Ne contient pas : Céleri"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Moutarde",
-                  "status":"known",
-                  "title":"Ne contient pas : Moutarde"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Ne contient pas : Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Poisson",
-                  "status":"known",
-                  "title":"Ne contient pas : Poisson"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustacés",
-                  "status":"known",
-                  "title":"Ne contient pas : Crustacés"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Mollusques",
-                  "status":"known",
-                  "title":"Ne contient pas : Mollusques"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Anhydride sulfureux et sulfites",
-                  "status":"known",
-                  "title":"Ne contient pas : Anhydride sulfureux et sulfites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergènes",
-            "warning":"Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Végétalien",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non végétalien"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Végétarien",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Caractère végétarien inconnu"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Sans huile de palme",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Sans huile de palme"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingrédients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"Groupe NOVA",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Aliments transformés"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additifs",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additifs"
-               }
-            ],
-            "id":"processing",
-            "name":"Transformation des aliments"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Faible impact environnemental",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Pas de risque de déforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Empreinte forêt",
-                  "status":"known",
-                  "title":"Très petite empreinte forêt"
-               }
-            ],
-            "id":"environment",
-            "name":"Environnement"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
-                  "description_short":"Encourage la durabilité écologique et la biodiversité.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Agriculture biologique",
-                  "status":"known",
-                  "title":"Produit bio"
-               },
-               {
-                  "description":"Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
-                  "description_short":"Aide les producteurs des pays en développement.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Commerce équitable",
-                  "status":"known",
-                  "title":"Produit du commerce équitable"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Tarte aux pommes et aux framboise bio avec une photo - Les tartes de Robert - 100 g",
-      "url":"//fr.openfoodfacts.localhost/produit/3300000000013/tarte-aux-pommes-et-aux-framboise-bio-avec-une-photo-les-tartes-de-robert"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//fr.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//fr.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//x.com/OpenFoodFactsfr"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//fr.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//fr.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//fr.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts.fr",
+          "//x.com/OpenFoodFactsfr"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -1,1853 +1,2347 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Register</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
-
-		
-		.badge-container{
-			margin: 0 auto;
-		}
-
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
-    </style>
-</head>
-<body class="other_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
-
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
-
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Register</h1>
-									<!-- start templates/web/pages/user_form/user_form_page.tt.html -->
-
-<script>
-
-    function normalize_string_value(inputfield) {
-
-    var value = inputfield.value.toLowerCase();
-
-    // Chrome can autofill the username with an email address,
-    // remove everything after @ so that we don't end up with
-    // email addresses as usernames.
-
-    value = value.replace(/@.*/,"");
-
-    value = value.replace(/ /g,"-");
-    value = value.replace(/[àáâãäå]/g,"a");
-    value = value.replace(/æ/g,"ae");
-    value = value.replace(/ç/g,"c");
-    value = value.replace(/[èéêë]/g,"e");
-    value = value.replace(/[ìíîï]/g,"i");
-    value = value.replace(/ñ/g,"n");
-    value = value.replace(/[òóôõö]/g,"o");
-    value = value.replace(/œ/g,"oe");
-    value = value.replace(/[ùúûü]/g,"u");
-    value = value.replace(/[ýÿ]/g,"y");
-    value = value.replace(/[^a-zA-Z0-9-]/g,"-");
-    value = value.replace(/-+/g,"-");
-    value = value.replace(/^-/,"");
-
-    inputfield.value = value;
-    }
-    
-function togglePasswordVisibility(FieldID) {
-    const passwordInput = document.getElementById(FieldID);
-    const toggleIcon = passwordInput.nextElementSibling.querySelector(".material-icons");
-
-    if (passwordInput.type === "password") {
-        passwordInput.type = "text";
-        if (toggleIcon) {
-            toggleIcon.textContent = "visibility";
-        }
-       
-    } else {
-        passwordInput.type = "password";
-        if (toggleIcon) {
-            toggleIcon.textContent = "visibility_off";
-        }
-    }
-}
-</script>
-
-<style>
-    .pro_org_display {
+      .show-when-no-access-to-producers-platform {
         display: none;
-    }
-</style>
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
+      .badge-container {
+        margin: 0 auto;
+      }
 
-<!-- start templates/web/common/includes/error_list.tt.html -->
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
+    </style>
+  </head>
+  <body class="other_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
+        <img
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
 
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
 
-<!-- end templates/web/common/includes/error_list.tt.html -->
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
 
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
 
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
 
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
 
+            <!-- Right Nav Section -->
 
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
+      </div>
 
-    <!-- Start form -->
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-    <form method="post" action="/cgi/user.pl" enctype="multipart/form-data" id="user_form">
-        
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
 
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-            
-            <div class="form-wrapper">
-                <div class="form-container" style="width: 80%;margin-right: 20px;">
-                
-                    
-                    
-                        <div >
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Register</h1>
+                    <!-- start templates/web/pages/user_form/user_form_page.tt.html -->
+
+                    <script>
+                      function normalize_string_value(inputfield) {
+                        var value = inputfield.value.toLowerCase();
+
+                        // Chrome can autofill the username with an email address,
+                        // remove everything after @ so that we don't end up with
+                        // email addresses as usernames.
+
+                        value = value.replace(/@.*/, "");
+
+                        value = value.replace(/ /g, "-");
+                        value = value.replace(/[àáâãäå]/g, "a");
+                        value = value.replace(/æ/g, "ae");
+                        value = value.replace(/ç/g, "c");
+                        value = value.replace(/[èéêë]/g, "e");
+                        value = value.replace(/[ìíîï]/g, "i");
+                        value = value.replace(/ñ/g, "n");
+                        value = value.replace(/[òóôõö]/g, "o");
+                        value = value.replace(/œ/g, "oe");
+                        value = value.replace(/[ùúûü]/g, "u");
+                        value = value.replace(/[ýÿ]/g, "y");
+                        value = value.replace(/[^a-zA-Z0-9-]/g, "-");
+                        value = value.replace(/-+/g, "-");
+                        value = value.replace(/^-/, "");
+
+                        inputfield.value = value;
+                      }
+
+                      function togglePasswordVisibility(FieldID) {
+                        const passwordInput = document.getElementById(FieldID);
+                        const toggleIcon =
+                          passwordInput.nextElementSibling.querySelector(
+                            ".material-icons"
+                          );
+
+                        if (passwordInput.type === "password") {
+                          passwordInput.type = "text";
+                          if (toggleIcon) {
+                            toggleIcon.textContent = "visibility";
+                          }
+                        } else {
+                          passwordInput.type = "password";
+                          if (toggleIcon) {
+                            toggleIcon.textContent = "visibility_off";
+                          }
+                        }
+                      }
+                    </script>
+
+                    <style>
+                      .pro_org_display {
+                        display: none;
+                      }
+                    </style>
+
+                    <!-- start templates/web/common/includes/error_list.tt.html -->
+
+                    <!-- end templates/web/common/includes/error_list.tt.html -->
+
+                    <!-- Start form -->
+
+                    <form
+                      method="post"
+                      action="/cgi/user.pl"
+                      enctype="multipart/form-data"
+                      id="user_form"
+                    >
+                      <div class="form-wrapper">
+                        <div
+                          class="form-container"
+                          style="width: 80%; margin-right: 20px"
+                        >
+                          <div>
                             <label for="name">Name</label>
                             <input type="text" id="name" name="name" value="" />
-                            </div>
-                    
-                
-                    
-                    
-                        <label for="email">	E-mail address</label>
-                        <input type="email" id="email" name="email" value = "" autocomplete="email"/>
-                        
-                    
-                
-                    
-                    
-                        
-                            <label for="userid">  User name (non-accented letters, digits and/or dashes)</label>
-                            <input type="text" id="userid" name="userid" value="" autocomplete="username" onkeyup="normalize_string_value(this)" />
-                        
-                    
-                
-                    
-                    
-                        <label for="password">Password</label>
-                        <div class="password-container">
-                            <input type="password" id="password" name="password" value="" autocomplete="new-password"/>
-                            <span class="toggle-password" onclick="togglePasswordVisibility('password')">
-                                <span class="material-icons material-symbols-visibility">visibility_off</span>
-                                </span>
-                            </div>
-                    
-                
-                    
-                    
-                        <label for="confirm_password">Confirm password</label>
-                        <div class="password-container">
-                            <input type="password" id="confirm_password" name="confirm_password" value="" autocomplete="new-password"/>
-                            <span class="toggle-password" onclick="togglePasswordVisibility('confirm_password')">
-                                <span class="material-icons material-symbols-visibility">visibility_off</span>
-                                </span>
-                            </div>
-                    
-                
-                    
-                    
-                        <label for="preferred_language">	Preferred Language</label>
-                        <select name="preferred_language" id="preferred_language-select">
+                          </div>
+
+                          <label for="email"> E-mail address</label>
+                          <input
+                            type="email"
+                            id="email"
+                            name="email"
+                            value=""
+                            autocomplete="email"
+                          />
+
+                          <label for="userid">
+                            User name (non-accented letters, digits and/or
+                            dashes)</label
+                          >
+                          <input
+                            type="text"
+                            id="userid"
+                            name="userid"
+                            value=""
+                            autocomplete="username"
+                            onkeyup="normalize_string_value(this)"
+                          />
+
+                          <label for="password">Password</label>
+                          <div class="password-container">
+                            <input
+                              type="password"
+                              id="password"
+                              name="password"
+                              value=""
+                              autocomplete="new-password"
+                            />
+                            <span
+                              class="toggle-password"
+                              onclick="togglePasswordVisibility('password')"
+                            >
+                              <span
+                                class="material-icons material-symbols-visibility"
+                                >visibility_off</span
+                              >
+                            </span>
+                          </div>
+
+                          <label for="confirm_password">Confirm password</label>
+                          <div class="password-container">
+                            <input
+                              type="password"
+                              id="confirm_password"
+                              name="confirm_password"
+                              value=""
+                              autocomplete="new-password"
+                            />
+                            <span
+                              class="toggle-password"
+                              onclick="togglePasswordVisibility('confirm_password')"
+                            >
+                              <span
+                                class="material-icons material-symbols-visibility"
+                                >visibility_off</span
+                              >
+                            </span>
+                          </div>
+
+                          <label for="preferred_language">
+                            Preferred Language</label
+                          >
+                          <select
+                            name="preferred_language"
+                            id="preferred_language-select"
+                          >
                             <option value=""></option>
-                            
-                                <option value="ab" > Abkhaz</option>
-                            
-                                <option value="aa" > Afar</option>
-                            
-                                <option value="af" > Afrikaans</option>
-                            
-                                <option value="ak" > Akan</option>
-                            
-                                <option value="sq" > Albanian</option>
-                            
-                                <option value="am" > Amharic</option>
-                            
-                                <option value="ar" > Arabic</option>
-                            
-                                <option value="an" > Aragonese</option>
-                            
-                                <option value="hy" > Armenian</option>
-                            
-                                <option value="as" > Assamese</option>
-                            
-                                <option value="av" > Avar</option>
-                            
-                                <option value="ae" > Avestan</option>
-                            
-                                <option value="ay" > Aymara</option>
-                            
-                                <option value="az" > Azerbaijani</option>
-                            
-                                <option value="bm" > Bambara</option>
-                            
-                                <option value="ba" > Bashkir</option>
-                            
-                                <option value="eu" > Basque</option>
-                            
-                                <option value="be" > Belarusian</option>
-                            
-                                <option value="bn" > Bengali</option>
-                            
-                                <option value="bh" > Bihari languages</option>
-                            
-                                <option value="bi" > Bislama</option>
-                            
-                                <option value="nb" > Bokmål</option>
-                            
-                                <option value="bs" > Bosnian</option>
-                            
-                                <option value="br" > Breton</option>
-                            
-                                <option value="bg" > Bulgarian</option>
-                            
-                                <option value="my" > Burmese</option>
-                            
-                                <option value="ca" > Catalan</option>
-                            
-                                <option value="ch" > Chamorro</option>
-                            
-                                <option value="ce" > Chechen</option>
-                            
-                                <option value="ny" > Chewa</option>
-                            
-                                <option value="zh" > Chinese</option>
-                            
-                                <option value="cu" > Church Slavonic</option>
-                            
-                                <option value="cv" > Chuvash</option>
-                            
-                                <option value="kw" > Cornish</option>
-                            
-                                <option value="co" > Corsican</option>
-                            
-                                <option value="cr" > Cree</option>
-                            
-                                <option value="hr" > Croatian</option>
-                            
-                                <option value="cs" > Czech</option>
-                            
-                                <option value="da" > Danish</option>
-                            
-                                <option value="nl" > Dutch</option>
-                            
-                                <option value="dz" > Dzongkha language</option>
-                            
-                                <option value="en" selected> English</option>
-                            
-                                <option value="eo" > Esperanto</option>
-                            
-                                <option value="et" > Estonian</option>
-                            
-                                <option value="ee" > Ewe</option>
-                            
-                                <option value="fo" > Faroese</option>
-                            
-                                <option value="fj" > Fijian language</option>
-                            
-                                <option value="fi" > Finnish</option>
-                            
-                                <option value="fr" > French</option>
-                            
-                                <option value="ff" > Fula language</option>
-                            
-                                <option value="gl" > Galician</option>
-                            
-                                <option value="ka" > Georgian</option>
-                            
-                                <option value="de" > German</option>
-                            
-                                <option value="ki" > Gikuyu</option>
-                            
-                                <option value="el" > Greek</option>
-                            
-                                <option value="kl" > Greenlandic</option>
-                            
-                                <option value="gn" > Guarani</option>
-                            
-                                <option value="gu" > Gujarati</option>
-                            
-                                <option value="ht" > Haitian Creole</option>
-                            
-                                <option value="ha" > Hausa</option>
-                            
-                                <option value="he" > Hebrew</option>
-                            
-                                <option value="hz" > Herero</option>
-                            
-                                <option value="hi" > Hindi</option>
-                            
-                                <option value="ho" > Hiri Motu</option>
-                            
-                                <option value="hu" > Hungarian</option>
-                            
-                                <option value="is" > Icelandic</option>
-                            
-                                <option value="io" > Ido</option>
-                            
-                                <option value="ig" > Igbo language</option>
-                            
-                                <option value="id" > Indonesian</option>
-                            
-                                <option value="ia" > Interlingua</option>
-                            
-                                <option value="ie" > Interlingue</option>
-                            
-                                <option value="iu" > Inuktitut</option>
-                            
-                                <option value="ik" > Inupiat language</option>
-                            
-                                <option value="ga" > Irish</option>
-                            
-                                <option value="it" > Italian</option>
-                            
-                                <option value="ja" > Japanese</option>
-                            
-                                <option value="jv" > Javanese</option>
-                            
-                                <option value="kn" > Kannada</option>
-                            
-                                <option value="kr" > Kanuri</option>
-                            
-                                <option value="ks" > Kashmiri</option>
-                            
-                                <option value="kk" > Kazakh</option>
-                            
-                                <option value="km" > Khmer</option>
-                            
-                                <option value="rw" > Kinyarwanda</option>
-                            
-                                <option value="rn" > Kirundi</option>
-                            
-                                <option value="kv" > Komi</option>
-                            
-                                <option value="kg" > Kongo language</option>
-                            
-                                <option value="ko" > Korean</option>
-                            
-                                <option value="ku" > Kurdish</option>
-                            
-                                <option value="kj" > Kwanyama</option>
-                            
-                                <option value="ky" > Kyrgyz</option>
-                            
-                                <option value="lo" > Lao</option>
-                            
-                                <option value="la" > Latin</option>
-                            
-                                <option value="lv" > Latvian</option>
-                            
-                                <option value="li" > Limburgish language</option>
-                            
-                                <option value="ln" > Lingala language</option>
-                            
-                                <option value="lt" > Lithuanian</option>
-                            
-                                <option value="lu" > Luba-Katanga language</option>
-                            
-                                <option value="lg" > Luganda</option>
-                            
-                                <option value="lb" > Luxembourgish</option>
-                            
-                                <option value="mk" > Macedonian</option>
-                            
-                                <option value="mg" > Malagasy</option>
-                            
-                                <option value="ms" > Malay</option>
-                            
-                                <option value="ml" > Malayalam</option>
-                            
-                                <option value="dv" > Maldivian language</option>
-                            
-                                <option value="mt" > Maltese</option>
-                            
-                                <option value="gv" > Manx</option>
-                            
-                                <option value="mi" > Māori</option>
-                            
-                                <option value="mr" > Marathi</option>
-                            
-                                <option value="mh" > Marshallese</option>
-                            
-                                <option value="mo" > Moldovan</option>
-                            
-                                <option value="mn" > Mongolian</option>
-                            
-                                <option value="me" > Montenegrin</option>
-                            
-                                <option value="na" > Nauruan</option>
-                            
-                                <option value="nv" > Navajo</option>
-                            
-                                <option value="ng" > Ndonga dialect</option>
-                            
-                                <option value="ne" > Nepali</option>
-                            
-                                <option value="nd" > Northern Ndebele language</option>
-                            
-                                <option value="se" > Northern Sami</option>
-                            
-                                <option value="no" > Norwegian</option>
-                            
-                                <option value="ii" > Nuosu language</option>
-                            
-                                <option value="nn" > Nynorsk</option>
-                            
-                                <option value="oc" > Occitan</option>
-                            
-                                <option value="or" > Odia</option>
-                            
-                                <option value="oj" > Ojibwe</option>
-                            
-                                <option value="om" > Oromo</option>
-                            
-                                <option value="os" > Ossetian</option>
-                            
-                                <option value="pi" > Pali</option>
-                            
-                                <option value="ps" > Pashto</option>
-                            
-                                <option value="fa" > Persian</option>
-                            
-                                <option value="pl" > Polish</option>
-                            
-                                <option value="pt" > Portuguese</option>
-                            
-                                <option value="pa" > Punjabi</option>
-                            
-                                <option value="qu" > Quechua languages</option>
-                            
-                                <option value="ro" > Romanian</option>
-                            
-                                <option value="rm" > Romansh</option>
-                            
-                                <option value="ru" > Russian</option>
-                            
-                                <option value="ry" > Rusyn</option>
-                            
-                                <option value="sm" > Samoan</option>
-                            
-                                <option value="sg" > Sango</option>
-                            
-                                <option value="sa" > Sanskrit</option>
-                            
-                                <option value="sc" > Sardinian language</option>
-                            
-                                <option value="gd" > Scottish Gaelic</option>
-                            
-                                <option value="sr" > Serbian</option>
-                            
-                                <option value="sh" > Serbo-Croatian</option>
-                            
-                                <option value="sn" > Shona</option>
-                            
-                                <option value="sd" > Sindhi</option>
-                            
-                                <option value="si" > Sinhala</option>
-                            
-                                <option value="sk" > Slovak</option>
-                            
-                                <option value="sl" > Slovene</option>
-                            
-                                <option value="so" > Somali</option>
-                            
-                                <option value="st" > Sotho</option>
-                            
-                                <option value="nr" > Southern Ndebele</option>
-                            
-                                <option value="es" > Spanish</option>
-                            
-                                <option value="su" > Sundanese language</option>
-                            
-                                <option value="sw" > Swahili</option>
-                            
-                                <option value="ss" > Swazi</option>
-                            
-                                <option value="sv" > Swedish</option>
-                            
-                                <option value="tl" > Tagalog</option>
-                            
-                                <option value="ty" > Tahitian</option>
-                            
-                                <option value="tg" > Tajik</option>
-                            
-                                <option value="ta" > Tamil</option>
-                            
-                                <option value="tt" > Tatar</option>
-                            
-                                <option value="te" > Telugu</option>
-                            
-                                <option value="th" > Thai</option>
-                            
-                                <option value="bo" > Tibetan language</option>
-                            
-                                <option value="ti" > Tigrinya</option>
-                            
-                                <option value="to" > Tongan language</option>
-                            
-                                <option value="ts" > Tsonga</option>
-                            
-                                <option value="tn" > Tswana</option>
-                            
-                                <option value="tr" > Turkish</option>
-                            
-                                <option value="tk" > Turkmen</option>
-                            
-                                <option value="tw" > Twi</option>
-                            
-                                <option value="uk" > Ukrainian</option>
-                            
-                                <option value="xx" > Unknown language</option>
-                            
-                                <option value="ur" > Urdu</option>
-                            
-                                <option value="ug" > Uyghur</option>
-                            
-                                <option value="uz" > Uzbek</option>
-                            
-                                <option value="ve" > Venda</option>
-                            
-                                <option value="vi" > Vietnamese</option>
-                            
-                                <option value="vo" > Volapük</option>
-                            
-                                <option value="wa" > Walloon</option>
-                            
-                                <option value="cy" > Welsh</option>
-                            
-                                <option value="fy" > West Frisian</option>
-                            
-                                <option value="wo" > Wolof</option>
-                            
-                                <option value="xh" > Xhosa</option>
-                            
-                                <option value="yi" > Yiddish</option>
-                            
-                                <option value="yo" > Yoruba</option>
-                            
-                                <option value="za" > Zhuang languages</option>
-                            
-                                <option value="zu" > Zulu</option>
-                            
-                        </select>
-                    
-                
-                    
-                    
-                        <label for="country">	Country</label>
-                        <select name="country" id="country-select">
+
+                            <option value="ab">Abkhaz</option>
+
+                            <option value="aa">Afar</option>
+
+                            <option value="af">Afrikaans</option>
+
+                            <option value="ak">Akan</option>
+
+                            <option value="sq">Albanian</option>
+
+                            <option value="am">Amharic</option>
+
+                            <option value="ar">Arabic</option>
+
+                            <option value="an">Aragonese</option>
+
+                            <option value="hy">Armenian</option>
+
+                            <option value="as">Assamese</option>
+
+                            <option value="av">Avar</option>
+
+                            <option value="ae">Avestan</option>
+
+                            <option value="ay">Aymara</option>
+
+                            <option value="az">Azerbaijani</option>
+
+                            <option value="bm">Bambara</option>
+
+                            <option value="ba">Bashkir</option>
+
+                            <option value="eu">Basque</option>
+
+                            <option value="be">Belarusian</option>
+
+                            <option value="bn">Bengali</option>
+
+                            <option value="bh">Bihari languages</option>
+
+                            <option value="bi">Bislama</option>
+
+                            <option value="nb">Bokmål</option>
+
+                            <option value="bs">Bosnian</option>
+
+                            <option value="br">Breton</option>
+
+                            <option value="bg">Bulgarian</option>
+
+                            <option value="my">Burmese</option>
+
+                            <option value="ca">Catalan</option>
+
+                            <option value="ch">Chamorro</option>
+
+                            <option value="ce">Chechen</option>
+
+                            <option value="ny">Chewa</option>
+
+                            <option value="zh">Chinese</option>
+
+                            <option value="cu">Church Slavonic</option>
+
+                            <option value="cv">Chuvash</option>
+
+                            <option value="kw">Cornish</option>
+
+                            <option value="co">Corsican</option>
+
+                            <option value="cr">Cree</option>
+
+                            <option value="hr">Croatian</option>
+
+                            <option value="cs">Czech</option>
+
+                            <option value="da">Danish</option>
+
+                            <option value="nl">Dutch</option>
+
+                            <option value="dz">Dzongkha language</option>
+
+                            <option value="en" selected>English</option>
+
+                            <option value="eo">Esperanto</option>
+
+                            <option value="et">Estonian</option>
+
+                            <option value="ee">Ewe</option>
+
+                            <option value="fo">Faroese</option>
+
+                            <option value="fj">Fijian language</option>
+
+                            <option value="fi">Finnish</option>
+
+                            <option value="fr">French</option>
+
+                            <option value="ff">Fula language</option>
+
+                            <option value="gl">Galician</option>
+
+                            <option value="ka">Georgian</option>
+
+                            <option value="de">German</option>
+
+                            <option value="ki">Gikuyu</option>
+
+                            <option value="el">Greek</option>
+
+                            <option value="kl">Greenlandic</option>
+
+                            <option value="gn">Guarani</option>
+
+                            <option value="gu">Gujarati</option>
+
+                            <option value="ht">Haitian Creole</option>
+
+                            <option value="ha">Hausa</option>
+
+                            <option value="he">Hebrew</option>
+
+                            <option value="hz">Herero</option>
+
+                            <option value="hi">Hindi</option>
+
+                            <option value="ho">Hiri Motu</option>
+
+                            <option value="hu">Hungarian</option>
+
+                            <option value="is">Icelandic</option>
+
+                            <option value="io">Ido</option>
+
+                            <option value="ig">Igbo language</option>
+
+                            <option value="id">Indonesian</option>
+
+                            <option value="ia">Interlingua</option>
+
+                            <option value="ie">Interlingue</option>
+
+                            <option value="iu">Inuktitut</option>
+
+                            <option value="ik">Inupiat language</option>
+
+                            <option value="ga">Irish</option>
+
+                            <option value="it">Italian</option>
+
+                            <option value="ja">Japanese</option>
+
+                            <option value="jv">Javanese</option>
+
+                            <option value="kn">Kannada</option>
+
+                            <option value="kr">Kanuri</option>
+
+                            <option value="ks">Kashmiri</option>
+
+                            <option value="kk">Kazakh</option>
+
+                            <option value="km">Khmer</option>
+
+                            <option value="rw">Kinyarwanda</option>
+
+                            <option value="rn">Kirundi</option>
+
+                            <option value="kv">Komi</option>
+
+                            <option value="kg">Kongo language</option>
+
+                            <option value="ko">Korean</option>
+
+                            <option value="ku">Kurdish</option>
+
+                            <option value="kj">Kwanyama</option>
+
+                            <option value="ky">Kyrgyz</option>
+
+                            <option value="lo">Lao</option>
+
+                            <option value="la">Latin</option>
+
+                            <option value="lv">Latvian</option>
+
+                            <option value="li">Limburgish language</option>
+
+                            <option value="ln">Lingala language</option>
+
+                            <option value="lt">Lithuanian</option>
+
+                            <option value="lu">Luba-Katanga language</option>
+
+                            <option value="lg">Luganda</option>
+
+                            <option value="lb">Luxembourgish</option>
+
+                            <option value="mk">Macedonian</option>
+
+                            <option value="mg">Malagasy</option>
+
+                            <option value="ms">Malay</option>
+
+                            <option value="ml">Malayalam</option>
+
+                            <option value="dv">Maldivian language</option>
+
+                            <option value="mt">Maltese</option>
+
+                            <option value="gv">Manx</option>
+
+                            <option value="mi">Māori</option>
+
+                            <option value="mr">Marathi</option>
+
+                            <option value="mh">Marshallese</option>
+
+                            <option value="mo">Moldovan</option>
+
+                            <option value="mn">Mongolian</option>
+
+                            <option value="me">Montenegrin</option>
+
+                            <option value="na">Nauruan</option>
+
+                            <option value="nv">Navajo</option>
+
+                            <option value="ng">Ndonga dialect</option>
+
+                            <option value="ne">Nepali</option>
+
+                            <option value="nd">
+                              Northern Ndebele language
+                            </option>
+
+                            <option value="se">Northern Sami</option>
+
+                            <option value="no">Norwegian</option>
+
+                            <option value="ii">Nuosu language</option>
+
+                            <option value="nn">Nynorsk</option>
+
+                            <option value="oc">Occitan</option>
+
+                            <option value="or">Odia</option>
+
+                            <option value="oj">Ojibwe</option>
+
+                            <option value="om">Oromo</option>
+
+                            <option value="os">Ossetian</option>
+
+                            <option value="pi">Pali</option>
+
+                            <option value="ps">Pashto</option>
+
+                            <option value="fa">Persian</option>
+
+                            <option value="pl">Polish</option>
+
+                            <option value="pt">Portuguese</option>
+
+                            <option value="pa">Punjabi</option>
+
+                            <option value="qu">Quechua languages</option>
+
+                            <option value="ro">Romanian</option>
+
+                            <option value="rm">Romansh</option>
+
+                            <option value="ru">Russian</option>
+
+                            <option value="ry">Rusyn</option>
+
+                            <option value="sm">Samoan</option>
+
+                            <option value="sg">Sango</option>
+
+                            <option value="sa">Sanskrit</option>
+
+                            <option value="sc">Sardinian language</option>
+
+                            <option value="gd">Scottish Gaelic</option>
+
+                            <option value="sr">Serbian</option>
+
+                            <option value="sh">Serbo-Croatian</option>
+
+                            <option value="sn">Shona</option>
+
+                            <option value="sd">Sindhi</option>
+
+                            <option value="si">Sinhala</option>
+
+                            <option value="sk">Slovak</option>
+
+                            <option value="sl">Slovene</option>
+
+                            <option value="so">Somali</option>
+
+                            <option value="st">Sotho</option>
+
+                            <option value="nr">Southern Ndebele</option>
+
+                            <option value="es">Spanish</option>
+
+                            <option value="su">Sundanese language</option>
+
+                            <option value="sw">Swahili</option>
+
+                            <option value="ss">Swazi</option>
+
+                            <option value="sv">Swedish</option>
+
+                            <option value="tl">Tagalog</option>
+
+                            <option value="ty">Tahitian</option>
+
+                            <option value="tg">Tajik</option>
+
+                            <option value="ta">Tamil</option>
+
+                            <option value="tt">Tatar</option>
+
+                            <option value="te">Telugu</option>
+
+                            <option value="th">Thai</option>
+
+                            <option value="bo">Tibetan language</option>
+
+                            <option value="ti">Tigrinya</option>
+
+                            <option value="to">Tongan language</option>
+
+                            <option value="ts">Tsonga</option>
+
+                            <option value="tn">Tswana</option>
+
+                            <option value="tr">Turkish</option>
+
+                            <option value="tk">Turkmen</option>
+
+                            <option value="tw">Twi</option>
+
+                            <option value="uk">Ukrainian</option>
+
+                            <option value="xx">Unknown language</option>
+
+                            <option value="ur">Urdu</option>
+
+                            <option value="ug">Uyghur</option>
+
+                            <option value="uz">Uzbek</option>
+
+                            <option value="ve">Venda</option>
+
+                            <option value="vi">Vietnamese</option>
+
+                            <option value="vo">Volapük</option>
+
+                            <option value="wa">Walloon</option>
+
+                            <option value="cy">Welsh</option>
+
+                            <option value="fy">West Frisian</option>
+
+                            <option value="wo">Wolof</option>
+
+                            <option value="xh">Xhosa</option>
+
+                            <option value="yi">Yiddish</option>
+
+                            <option value="yo">Yoruba</option>
+
+                            <option value="za">Zhuang languages</option>
+
+                            <option value="zu">Zulu</option>
+                          </select>
+
+                          <label for="country"> Country</label>
+                          <select name="country" id="country-select">
                             <option value=""></option>
-                            
-                                <option value="en:afghanistan" > Afghanistan</option>
-                            
-                                <option value="en:aland-islands" > Åland Islands</option>
-                            
-                                <option value="en:albania" > Albania</option>
-                            
-                                <option value="en:alderney" > Alderney</option>
-                            
-                                <option value="en:algeria" > Algeria</option>
-                            
-                                <option value="en:american-samoa" > American Samoa</option>
-                            
-                                <option value="en:andorra" > Andorra</option>
-                            
-                                <option value="en:angola" > Angola</option>
-                            
-                                <option value="en:anguilla" > Anguilla</option>
-                            
-                                <option value="en:antarctic" > Antarctic</option>
-                            
-                                <option value="en:antarctica" > Antarctica</option>
-                            
-                                <option value="en:antigua-and-barbuda" > Antigua and Barbuda</option>
-                            
-                                <option value="en:argentina" > Argentina</option>
-                            
-                                <option value="en:armenia" > Armenia</option>
-                            
-                                <option value="en:aruba" > Aruba</option>
-                            
-                                <option value="en:ascension-island" > Ascension Island</option>
-                            
-                                <option value="en:australia" > Australia</option>
-                            
-                                <option value="en:austria" > Austria</option>
-                            
-                                <option value="en:azerbaijan" > Azerbaijan</option>
-                            
-                                <option value="en:bahrain" > Bahrain</option>
-                            
-                                <option value="en:bangladesh" > Bangladesh</option>
-                            
-                                <option value="en:barbados" > Barbados</option>
-                            
-                                <option value="en:belarus" > Belarus</option>
-                            
-                                <option value="en:belgium" > Belgium</option>
-                            
-                                <option value="en:belize" > Belize</option>
-                            
-                                <option value="en:benin" > Benin</option>
-                            
-                                <option value="en:bermuda" > Bermuda</option>
-                            
-                                <option value="en:bhutan" > Bhutan</option>
-                            
-                                <option value="en:bolivia" > Bolivia</option>
-                            
-                                <option value="en:bonaire" > Bonaire</option>
-                            
-                                <option value="en:bosnia-and-herzegovina" > Bosnia and Herzegovina</option>
-                            
-                                <option value="en:botswana" > Botswana</option>
-                            
-                                <option value="en:bouvet-island" > Bouvet Island</option>
-                            
-                                <option value="en:brazil" > Brazil</option>
-                            
-                                <option value="en:british-indian-ocean-territory" > British Indian Ocean Territory</option>
-                            
-                                <option value="en:british-virgin-islands" > British Virgin Islands</option>
-                            
-                                <option value="en:brunei" > Brunei</option>
-                            
-                                <option value="en:bulgaria" > Bulgaria</option>
-                            
-                                <option value="en:burkina-faso" > Burkina Faso</option>
-                            
-                                <option value="en:burundi" > Burundi</option>
-                            
-                                <option value="en:cambodia" > Cambodia</option>
-                            
-                                <option value="en:cameroon" > Cameroon</option>
-                            
-                                <option value="en:canada" > Canada</option>
-                            
-                                <option value="en:cape-verde" > Cape Verde</option>
-                            
-                                <option value="en:caribbean-netherlands" > Caribbean Netherlands</option>
-                            
-                                <option value="en:cayman-islands" > Cayman Islands</option>
-                            
-                                <option value="en:central-african-republic" > Central African Republic</option>
-                            
-                                <option value="en:chad" > Chad</option>
-                            
-                                <option value="en:chile" > Chile</option>
-                            
-                                <option value="en:china" > China</option>
-                            
-                                <option value="en:christmas-island" > Christmas Island</option>
-                            
-                                <option value="en:cocos-keeling-islands" > Cocos (Keeling) Islands</option>
-                            
-                                <option value="en:colombia" > Colombia</option>
-                            
-                                <option value="en:comoros" > Comoros</option>
-                            
-                                <option value="en:cook-islands" > Cook Islands</option>
-                            
-                                <option value="en:costa-rica" > Costa Rica</option>
-                            
-                                <option value="en:cote-d-ivoire" > Côte d'Ivoire</option>
-                            
-                                <option value="en:croatia" > Croatia</option>
-                            
-                                <option value="en:cuba" > Cuba</option>
-                            
-                                <option value="en:curacao" > Curaçao</option>
-                            
-                                <option value="en:cyprus" > Cyprus</option>
-                            
-                                <option value="en:czech-republic" > Czech Republic</option>
-                            
-                                <option value="en:democratic-republic-of-the-congo" > Democratic Republic of the Congo</option>
-                            
-                                <option value="en:denmark" > Denmark</option>
-                            
-                                <option value="en:djibouti" > Djibouti</option>
-                            
-                                <option value="en:dominica" > Dominica</option>
-                            
-                                <option value="en:dominican-republic" > Dominican Republic</option>
-                            
-                                <option value="en:east-germany" > East Germany</option>
-                            
-                                <option value="en:ecuador" > Ecuador</option>
-                            
-                                <option value="en:egypt" > Egypt</option>
-                            
-                                <option value="en:el-salvador" > El Salvador</option>
-                            
-                                <option value="en:equatorial-guinea" > Equatorial Guinea</option>
-                            
-                                <option value="en:eritrea" > Eritrea</option>
-                            
-                                <option value="en:estonia" > Estonia</option>
-                            
-                                <option value="en:ethiopia" > Ethiopia</option>
-                            
-                                <option value="en:european-union" > European Union</option>
-                            
-                                <option value="en:falkland-islands" > Falkland Islands</option>
-                            
-                                <option value="en:faroe-islands" > Faroe Islands</option>
-                            
-                                <option value="en:federated-states-of-micronesia" > Federated States of Micronesia</option>
-                            
-                                <option value="en:fiji" > Fiji</option>
-                            
-                                <option value="en:finland" > Finland</option>
-                            
-                                <option value="en:france" > France</option>
-                            
-                                <option value="en:french-guiana" > French Guiana</option>
-                            
-                                <option value="en:french-polynesia" > French Polynesia</option>
-                            
-                                <option value="en:french-southern-and-antarctic-lands" > French Southern and Antarctic Lands</option>
-                            
-                                <option value="en:gabon" > Gabon</option>
-                            
-                                <option value="en:galmudug" > Galmudug</option>
-                            
-                                <option value="en:gambia" > Gambia</option>
-                            
-                                <option value="en:georgia" > Georgia</option>
-                            
-                                <option value="en:germany" > Germany</option>
-                            
-                                <option value="en:ghana" > Ghana</option>
-                            
-                                <option value="en:gibraltar" > Gibraltar</option>
-                            
-                                <option value="en:greece" > Greece</option>
-                            
-                                <option value="en:greenland" > Greenland</option>
-                            
-                                <option value="en:grenada" > Grenada</option>
-                            
-                                <option value="en:guadeloupe" > Guadeloupe</option>
-                            
-                                <option value="en:guam" > Guam</option>
-                            
-                                <option value="en:guatemala" > Guatemala</option>
-                            
-                                <option value="en:guernsey" > Guernsey</option>
-                            
-                                <option value="en:guinea" > Guinea</option>
-                            
-                                <option value="en:guinea-bissau" > Guinea-Bissau</option>
-                            
-                                <option value="en:guyana" > Guyana</option>
-                            
-                                <option value="en:haiti" > Haiti</option>
-                            
-                                <option value="en:heard-island-and-mcdonald-islands" > Heard Island and McDonald Islands</option>
-                            
-                                <option value="en:honduras" > Honduras</option>
-                            
-                                <option value="en:hong-kong" > Hong Kong</option>
-                            
-                                <option value="en:hungary" > Hungary</option>
-                            
-                                <option value="en:iceland" > Iceland</option>
-                            
-                                <option value="en:india" > India</option>
-                            
-                                <option value="en:indonesia" > Indonesia</option>
-                            
-                                <option value="en:iran" > Iran</option>
-                            
-                                <option value="en:iraq" > Iraq</option>
-                            
-                                <option value="en:iraqi-kurdistan" > Iraqi Kurdistan</option>
-                            
-                                <option value="en:ireland" > Ireland</option>
-                            
-                                <option value="en:isle-of-man" > Isle of Man</option>
-                            
-                                <option value="en:israel" > Israel</option>
-                            
-                                <option value="en:italy" > Italy</option>
-                            
-                                <option value="en:jamaica" > Jamaica</option>
-                            
-                                <option value="en:jan-mayen" > Jan Mayen</option>
-                            
-                                <option value="en:japan" > Japan</option>
-                            
-                                <option value="en:jersey" > Jersey</option>
-                            
-                                <option value="en:jordan" > Jordan</option>
-                            
-                                <option value="en:kazakhstan" > Kazakhstan</option>
-                            
-                                <option value="en:kenya" > Kenya</option>
-                            
-                                <option value="en:kiribati" > Kiribati</option>
-                            
-                                <option value="en:kosovo" > Kosovo</option>
-                            
-                                <option value="en:kuwait" > Kuwait</option>
-                            
-                                <option value="en:kyrgyzstan" > Kyrgyzstan</option>
-                            
-                                <option value="en:laos" > Laos</option>
-                            
-                                <option value="en:latvia" > Latvia</option>
-                            
-                                <option value="en:lebanon" > Lebanon</option>
-                            
-                                <option value="en:lesotho" > Lesotho</option>
-                            
-                                <option value="en:liberia" > Liberia</option>
-                            
-                                <option value="en:libya" > Libya</option>
-                            
-                                <option value="en:liechtenstein" > Liechtenstein</option>
-                            
-                                <option value="en:lithuania" > Lithuania</option>
-                            
-                                <option value="en:luxembourg" > Luxembourg</option>
-                            
-                                <option value="en:macau" > Macau</option>
-                            
-                                <option value="en:madagascar" > Madagascar</option>
-                            
-                                <option value="en:malawi" > Malawi</option>
-                            
-                                <option value="en:malaysia" > Malaysia</option>
-                            
-                                <option value="en:maldives" > Maldives</option>
-                            
-                                <option value="en:mali" > Mali</option>
-                            
-                                <option value="en:malta" > Malta</option>
-                            
-                                <option value="en:marshall-islands" > Marshall Islands</option>
-                            
-                                <option value="en:martinique" > Martinique</option>
-                            
-                                <option value="en:mauritania" > Mauritania</option>
-                            
-                                <option value="en:mauritius" > Mauritius</option>
-                            
-                                <option value="en:mayotte" > Mayotte</option>
-                            
-                                <option value="en:mexico" > Mexico</option>
-                            
-                                <option value="en:moldova" > Moldova</option>
-                            
-                                <option value="en:monaco" > Monaco</option>
-                            
-                                <option value="en:mongolia" > Mongolia</option>
-                            
-                                <option value="en:montenegro" > Montenegro</option>
-                            
-                                <option value="en:montserrat" > Montserrat</option>
-                            
-                                <option value="en:morocco" > Morocco</option>
-                            
-                                <option value="en:mozambique" > Mozambique</option>
-                            
-                                <option value="en:myanmar" > Myanmar</option>
-                            
-                                <option value="en:nakhchivan-autonomous-republic" > Nakhchivan Autonomous Republic</option>
-                            
-                                <option value="en:namibia" > Namibia</option>
-                            
-                                <option value="en:nauru" > Nauru</option>
-                            
-                                <option value="en:nepal" > Nepal</option>
-                            
-                                <option value="en:netherlands" > Netherlands</option>
-                            
-                                <option value="en:new-caledonia" > New Caledonia</option>
-                            
-                                <option value="en:new-zealand" > New Zealand</option>
-                            
-                                <option value="en:nicaragua" > Nicaragua</option>
-                            
-                                <option value="en:niger" > Niger</option>
-                            
-                                <option value="en:nigeria" > Nigeria</option>
-                            
-                                <option value="en:niue" > Niue</option>
-                            
-                                <option value="en:norfolk-island" > Norfolk Island</option>
-                            
-                                <option value="en:northern-mariana-islands" > Northern Mariana Islands</option>
-                            
-                                <option value="en:north-korea" > North Korea</option>
-                            
-                                <option value="en:northland-state" > Northland State</option>
-                            
-                                <option value="en:north-macedonia" > North Macedonia</option>
-                            
-                                <option value="en:norway" > Norway</option>
-                            
-                                <option value="en:oman" > Oman</option>
-                            
-                                <option value="en:pakistan" > Pakistan</option>
-                            
-                                <option value="en:palau" > Palau</option>
-                            
-                                <option value="en:palestinian-territories" > Palestinian territories</option>
-                            
-                                <option value="en:panama" > Panama</option>
-                            
-                                <option value="en:papua-new-guinea" > Papua New Guinea</option>
-                            
-                                <option value="en:paraguay" > Paraguay</option>
-                            
-                                <option value="en:peru" > Peru</option>
-                            
-                                <option value="en:philippines" > Philippines</option>
-                            
-                                <option value="en:pitcairn" > Pitcairn</option>
-                            
-                                <option value="en:poland" > Poland</option>
-                            
-                                <option value="en:portugal" > Portugal</option>
-                            
-                                <option value="en:puerto-rico" > Puerto Rico</option>
-                            
-                                <option value="en:qatar" > Qatar</option>
-                            
-                                <option value="en:republic-of-the-congo" > Republic of the Congo</option>
-                            
-                                <option value="en:republika-srpska" > Republika Srpska</option>
-                            
-                                <option value="en:reunion" > Réunion</option>
-                            
-                                <option value="en:romania" > Romania</option>
-                            
-                                <option value="en:russia" > Russia</option>
-                            
-                                <option value="en:rwanda" > Rwanda</option>
-                            
-                                <option value="en:saba" > Saba</option>
-                            
-                                <option value="en:saint-barthelemy" > Saint-Barthélemy</option>
-                            
-                                <option value="en:saint-helena" > Saint Helena</option>
-                            
-                                <option value="en:saint-kitts-and-nevis" > Saint Kitts and Nevis</option>
-                            
-                                <option value="en:saint-lucia" > Saint Lucia</option>
-                            
-                                <option value="en:saint-martin" > Saint Martin</option>
-                            
-                                <option value="en:saint-pierre-and-miquelon" > Saint Pierre and Miquelon</option>
-                            
-                                <option value="en:saint-vincent-and-the-grenadines" > Saint Vincent and the Grenadines</option>
-                            
-                                <option value="en:samoa" > Samoa</option>
-                            
-                                <option value="en:san-marino" > San Marino</option>
-                            
-                                <option value="en:sao-tome-and-principe" > Sao Tomé and Príncipe</option>
-                            
-                                <option value="en:saudi-arabia" > Saudi Arabia</option>
-                            
-                                <option value="en:senegal" > Senegal</option>
-                            
-                                <option value="en:serbia" > Serbia</option>
-                            
-                                <option value="en:seychelles" > Seychelles</option>
-                            
-                                <option value="en:sierra-leone" > Sierra Leone</option>
-                            
-                                <option value="en:singapore" > Singapore</option>
-                            
-                                <option value="en:sint-eustatius" > Sint Eustatius</option>
-                            
-                                <option value="en:sint-maarten" > Sint Maarten</option>
-                            
-                                <option value="en:slovakia" > Slovakia</option>
-                            
-                                <option value="en:slovenia" > Slovenia</option>
-                            
-                                <option value="en:solomon-islands" > Solomon Islands</option>
-                            
-                                <option value="en:somalia" > Somalia</option>
-                            
-                                <option value="en:south-africa" > South Africa</option>
-                            
-                                <option value="en:south-georgia-and-the-south-sandwich-islands" > South Georgia and the South Sandwich Islands</option>
-                            
-                                <option value="en:south-korea" > South Korea</option>
-                            
-                                <option value="en:south-sudan" > South Sudan</option>
-                            
-                                <option value="en:soviet-union" > Soviet Union</option>
-                            
-                                <option value="en:spain" > Spain</option>
-                            
-                                <option value="en:sri-lanka" > Sri Lanka</option>
-                            
-                                <option value="en:state-of-palestine" > State of Palestine</option>
-                            
-                                <option value="en:sudan" > Sudan</option>
-                            
-                                <option value="en:suriname" > Suriname</option>
-                            
-                                <option value="en:svalbard-and-jan-mayen" > Svalbard and Jan Mayen</option>
-                            
-                                <option value="en:swaziland" > Swaziland</option>
-                            
-                                <option value="en:sweden" > Sweden</option>
-                            
-                                <option value="en:switzerland" > Switzerland</option>
-                            
-                                <option value="en:syria" > Syria</option>
-                            
-                                <option value="en:taiwan" > Taiwan</option>
-                            
-                                <option value="en:tajikistan" > Tajikistan</option>
-                            
-                                <option value="en:tanzania" > Tanzania</option>
-                            
-                                <option value="en:thailand" > Thailand</option>
-                            
-                                <option value="en:the-bahamas" > The Bahamas</option>
-                            
-                                <option value="en:timor-leste" > Timor-Leste</option>
-                            
-                                <option value="en:togo" > Togo</option>
-                            
-                                <option value="en:tokelau" > Tokelau</option>
-                            
-                                <option value="en:tonga" > Tonga</option>
-                            
-                                <option value="en:trinidad-and-tobago" > Trinidad and Tobago</option>
-                            
-                                <option value="en:tunisia" > Tunisia</option>
-                            
-                                <option value="en:turkey" > Turkey</option>
-                            
-                                <option value="en:turkmenistan" > Turkmenistan</option>
-                            
-                                <option value="en:turks-and-caicos-islands" > Turks and Caicos Islands</option>
-                            
-                                <option value="en:tuvalu" > Tuvalu</option>
-                            
-                                <option value="en:uganda" > Uganda</option>
-                            
-                                <option value="en:ukraine" > Ukraine</option>
-                            
-                                <option value="en:united-arab-emirates" > United Arab Emirates</option>
-                            
-                                <option value="en:united-kingdom" > United Kingdom</option>
-                            
-                                <option value="en:united-states" > United States</option>
-                            
-                                <option value="en:united-states-minor-outlying-islands" > United States Minor Outlying Islands</option>
-                            
-                                <option value="en:uruguay" > Uruguay</option>
-                            
-                                <option value="en:uzbekistan" > Uzbekistan</option>
-                            
-                                <option value="en:vanuatu" > Vanuatu</option>
-                            
-                                <option value="en:vatican-city" > Vatican City</option>
-                            
-                                <option value="en:venezuela" > Venezuela</option>
-                            
-                                <option value="en:vietnam" > Vietnam</option>
-                            
-                                <option value="en:virgin-islands-of-the-united-states" > Virgin Islands of the United States</option>
-                            
-                                <option value="en:wallis-and-futuna" > Wallis and Futuna</option>
-                            
-                                <option value="en:western-sahara" > Western Sahara</option>
-                            
-                                <option value="en:world" > World</option>
-                            
-                                <option value="en:yemen" > Yemen</option>
-                            
-                                <option value="en:yugoslavia" > Yugoslavia</option>
-                            
-                                <option value="en:zambia" > Zambia</option>
-                            
-                                <option value="en:zimbabwe" > Zimbabwe</option>
-                            
-                        </select>
-                    
-                
-                    
-                    
-                        
-                        <div style="display:none">
-                            <label for="faxnumber">Do not enter your fax number</label>
-                            <input type="text" id="faxnumber" name="faxnumber" value=""/>
+
+                            <option value="en:afghanistan">Afghanistan</option>
+
+                            <option value="en:aland-islands">
+                              Åland Islands
+                            </option>
+
+                            <option value="en:albania">Albania</option>
+
+                            <option value="en:alderney">Alderney</option>
+
+                            <option value="en:algeria">Algeria</option>
+
+                            <option value="en:american-samoa">
+                              American Samoa
+                            </option>
+
+                            <option value="en:andorra">Andorra</option>
+
+                            <option value="en:angola">Angola</option>
+
+                            <option value="en:anguilla">Anguilla</option>
+
+                            <option value="en:antarctic">Antarctic</option>
+
+                            <option value="en:antarctica">Antarctica</option>
+
+                            <option value="en:antigua-and-barbuda">
+                              Antigua and Barbuda
+                            </option>
+
+                            <option value="en:argentina">Argentina</option>
+
+                            <option value="en:armenia">Armenia</option>
+
+                            <option value="en:aruba">Aruba</option>
+
+                            <option value="en:ascension-island">
+                              Ascension Island
+                            </option>
+
+                            <option value="en:australia">Australia</option>
+
+                            <option value="en:austria">Austria</option>
+
+                            <option value="en:azerbaijan">Azerbaijan</option>
+
+                            <option value="en:bahrain">Bahrain</option>
+
+                            <option value="en:bangladesh">Bangladesh</option>
+
+                            <option value="en:barbados">Barbados</option>
+
+                            <option value="en:belarus">Belarus</option>
+
+                            <option value="en:belgium">Belgium</option>
+
+                            <option value="en:belize">Belize</option>
+
+                            <option value="en:benin">Benin</option>
+
+                            <option value="en:bermuda">Bermuda</option>
+
+                            <option value="en:bhutan">Bhutan</option>
+
+                            <option value="en:bolivia">Bolivia</option>
+
+                            <option value="en:bonaire">Bonaire</option>
+
+                            <option value="en:bosnia-and-herzegovina">
+                              Bosnia and Herzegovina
+                            </option>
+
+                            <option value="en:botswana">Botswana</option>
+
+                            <option value="en:bouvet-island">
+                              Bouvet Island
+                            </option>
+
+                            <option value="en:brazil">Brazil</option>
+
+                            <option value="en:british-indian-ocean-territory">
+                              British Indian Ocean Territory
+                            </option>
+
+                            <option value="en:british-virgin-islands">
+                              British Virgin Islands
+                            </option>
+
+                            <option value="en:brunei">Brunei</option>
+
+                            <option value="en:bulgaria">Bulgaria</option>
+
+                            <option value="en:burkina-faso">
+                              Burkina Faso
+                            </option>
+
+                            <option value="en:burundi">Burundi</option>
+
+                            <option value="en:cambodia">Cambodia</option>
+
+                            <option value="en:cameroon">Cameroon</option>
+
+                            <option value="en:canada">Canada</option>
+
+                            <option value="en:cape-verde">Cape Verde</option>
+
+                            <option value="en:caribbean-netherlands">
+                              Caribbean Netherlands
+                            </option>
+
+                            <option value="en:cayman-islands">
+                              Cayman Islands
+                            </option>
+
+                            <option value="en:central-african-republic">
+                              Central African Republic
+                            </option>
+
+                            <option value="en:chad">Chad</option>
+
+                            <option value="en:chile">Chile</option>
+
+                            <option value="en:china">China</option>
+
+                            <option value="en:christmas-island">
+                              Christmas Island
+                            </option>
+
+                            <option value="en:cocos-keeling-islands">
+                              Cocos (Keeling) Islands
+                            </option>
+
+                            <option value="en:colombia">Colombia</option>
+
+                            <option value="en:comoros">Comoros</option>
+
+                            <option value="en:cook-islands">
+                              Cook Islands
+                            </option>
+
+                            <option value="en:costa-rica">Costa Rica</option>
+
+                            <option value="en:cote-d-ivoire">
+                              Côte d'Ivoire
+                            </option>
+
+                            <option value="en:croatia">Croatia</option>
+
+                            <option value="en:cuba">Cuba</option>
+
+                            <option value="en:curacao">Curaçao</option>
+
+                            <option value="en:cyprus">Cyprus</option>
+
+                            <option value="en:czech-republic">
+                              Czech Republic
+                            </option>
+
+                            <option value="en:democratic-republic-of-the-congo">
+                              Democratic Republic of the Congo
+                            </option>
+
+                            <option value="en:denmark">Denmark</option>
+
+                            <option value="en:djibouti">Djibouti</option>
+
+                            <option value="en:dominica">Dominica</option>
+
+                            <option value="en:dominican-republic">
+                              Dominican Republic
+                            </option>
+
+                            <option value="en:east-germany">
+                              East Germany
+                            </option>
+
+                            <option value="en:ecuador">Ecuador</option>
+
+                            <option value="en:egypt">Egypt</option>
+
+                            <option value="en:el-salvador">El Salvador</option>
+
+                            <option value="en:equatorial-guinea">
+                              Equatorial Guinea
+                            </option>
+
+                            <option value="en:eritrea">Eritrea</option>
+
+                            <option value="en:estonia">Estonia</option>
+
+                            <option value="en:ethiopia">Ethiopia</option>
+
+                            <option value="en:european-union">
+                              European Union
+                            </option>
+
+                            <option value="en:falkland-islands">
+                              Falkland Islands
+                            </option>
+
+                            <option value="en:faroe-islands">
+                              Faroe Islands
+                            </option>
+
+                            <option value="en:federated-states-of-micronesia">
+                              Federated States of Micronesia
+                            </option>
+
+                            <option value="en:fiji">Fiji</option>
+
+                            <option value="en:finland">Finland</option>
+
+                            <option value="en:france">France</option>
+
+                            <option value="en:french-guiana">
+                              French Guiana
+                            </option>
+
+                            <option value="en:french-polynesia">
+                              French Polynesia
+                            </option>
+
+                            <option
+                              value="en:french-southern-and-antarctic-lands"
+                            >
+                              French Southern and Antarctic Lands
+                            </option>
+
+                            <option value="en:gabon">Gabon</option>
+
+                            <option value="en:galmudug">Galmudug</option>
+
+                            <option value="en:gambia">Gambia</option>
+
+                            <option value="en:georgia">Georgia</option>
+
+                            <option value="en:germany">Germany</option>
+
+                            <option value="en:ghana">Ghana</option>
+
+                            <option value="en:gibraltar">Gibraltar</option>
+
+                            <option value="en:greece">Greece</option>
+
+                            <option value="en:greenland">Greenland</option>
+
+                            <option value="en:grenada">Grenada</option>
+
+                            <option value="en:guadeloupe">Guadeloupe</option>
+
+                            <option value="en:guam">Guam</option>
+
+                            <option value="en:guatemala">Guatemala</option>
+
+                            <option value="en:guernsey">Guernsey</option>
+
+                            <option value="en:guinea">Guinea</option>
+
+                            <option value="en:guinea-bissau">
+                              Guinea-Bissau
+                            </option>
+
+                            <option value="en:guyana">Guyana</option>
+
+                            <option value="en:haiti">Haiti</option>
+
+                            <option
+                              value="en:heard-island-and-mcdonald-islands"
+                            >
+                              Heard Island and McDonald Islands
+                            </option>
+
+                            <option value="en:honduras">Honduras</option>
+
+                            <option value="en:hong-kong">Hong Kong</option>
+
+                            <option value="en:hungary">Hungary</option>
+
+                            <option value="en:iceland">Iceland</option>
+
+                            <option value="en:india">India</option>
+
+                            <option value="en:indonesia">Indonesia</option>
+
+                            <option value="en:iran">Iran</option>
+
+                            <option value="en:iraq">Iraq</option>
+
+                            <option value="en:iraqi-kurdistan">
+                              Iraqi Kurdistan
+                            </option>
+
+                            <option value="en:ireland">Ireland</option>
+
+                            <option value="en:isle-of-man">Isle of Man</option>
+
+                            <option value="en:israel">Israel</option>
+
+                            <option value="en:italy">Italy</option>
+
+                            <option value="en:jamaica">Jamaica</option>
+
+                            <option value="en:jan-mayen">Jan Mayen</option>
+
+                            <option value="en:japan">Japan</option>
+
+                            <option value="en:jersey">Jersey</option>
+
+                            <option value="en:jordan">Jordan</option>
+
+                            <option value="en:kazakhstan">Kazakhstan</option>
+
+                            <option value="en:kenya">Kenya</option>
+
+                            <option value="en:kiribati">Kiribati</option>
+
+                            <option value="en:kosovo">Kosovo</option>
+
+                            <option value="en:kuwait">Kuwait</option>
+
+                            <option value="en:kyrgyzstan">Kyrgyzstan</option>
+
+                            <option value="en:laos">Laos</option>
+
+                            <option value="en:latvia">Latvia</option>
+
+                            <option value="en:lebanon">Lebanon</option>
+
+                            <option value="en:lesotho">Lesotho</option>
+
+                            <option value="en:liberia">Liberia</option>
+
+                            <option value="en:libya">Libya</option>
+
+                            <option value="en:liechtenstein">
+                              Liechtenstein
+                            </option>
+
+                            <option value="en:lithuania">Lithuania</option>
+
+                            <option value="en:luxembourg">Luxembourg</option>
+
+                            <option value="en:macau">Macau</option>
+
+                            <option value="en:madagascar">Madagascar</option>
+
+                            <option value="en:malawi">Malawi</option>
+
+                            <option value="en:malaysia">Malaysia</option>
+
+                            <option value="en:maldives">Maldives</option>
+
+                            <option value="en:mali">Mali</option>
+
+                            <option value="en:malta">Malta</option>
+
+                            <option value="en:marshall-islands">
+                              Marshall Islands
+                            </option>
+
+                            <option value="en:martinique">Martinique</option>
+
+                            <option value="en:mauritania">Mauritania</option>
+
+                            <option value="en:mauritius">Mauritius</option>
+
+                            <option value="en:mayotte">Mayotte</option>
+
+                            <option value="en:mexico">Mexico</option>
+
+                            <option value="en:moldova">Moldova</option>
+
+                            <option value="en:monaco">Monaco</option>
+
+                            <option value="en:mongolia">Mongolia</option>
+
+                            <option value="en:montenegro">Montenegro</option>
+
+                            <option value="en:montserrat">Montserrat</option>
+
+                            <option value="en:morocco">Morocco</option>
+
+                            <option value="en:mozambique">Mozambique</option>
+
+                            <option value="en:myanmar">Myanmar</option>
+
+                            <option value="en:nakhchivan-autonomous-republic">
+                              Nakhchivan Autonomous Republic
+                            </option>
+
+                            <option value="en:namibia">Namibia</option>
+
+                            <option value="en:nauru">Nauru</option>
+
+                            <option value="en:nepal">Nepal</option>
+
+                            <option value="en:netherlands">Netherlands</option>
+
+                            <option value="en:new-caledonia">
+                              New Caledonia
+                            </option>
+
+                            <option value="en:new-zealand">New Zealand</option>
+
+                            <option value="en:nicaragua">Nicaragua</option>
+
+                            <option value="en:niger">Niger</option>
+
+                            <option value="en:nigeria">Nigeria</option>
+
+                            <option value="en:niue">Niue</option>
+
+                            <option value="en:norfolk-island">
+                              Norfolk Island
+                            </option>
+
+                            <option value="en:northern-mariana-islands">
+                              Northern Mariana Islands
+                            </option>
+
+                            <option value="en:north-korea">North Korea</option>
+
+                            <option value="en:northland-state">
+                              Northland State
+                            </option>
+
+                            <option value="en:north-macedonia">
+                              North Macedonia
+                            </option>
+
+                            <option value="en:norway">Norway</option>
+
+                            <option value="en:oman">Oman</option>
+
+                            <option value="en:pakistan">Pakistan</option>
+
+                            <option value="en:palau">Palau</option>
+
+                            <option value="en:palestinian-territories">
+                              Palestinian territories
+                            </option>
+
+                            <option value="en:panama">Panama</option>
+
+                            <option value="en:papua-new-guinea">
+                              Papua New Guinea
+                            </option>
+
+                            <option value="en:paraguay">Paraguay</option>
+
+                            <option value="en:peru">Peru</option>
+
+                            <option value="en:philippines">Philippines</option>
+
+                            <option value="en:pitcairn">Pitcairn</option>
+
+                            <option value="en:poland">Poland</option>
+
+                            <option value="en:portugal">Portugal</option>
+
+                            <option value="en:puerto-rico">Puerto Rico</option>
+
+                            <option value="en:qatar">Qatar</option>
+
+                            <option value="en:republic-of-the-congo">
+                              Republic of the Congo
+                            </option>
+
+                            <option value="en:republika-srpska">
+                              Republika Srpska
+                            </option>
+
+                            <option value="en:reunion">Réunion</option>
+
+                            <option value="en:romania">Romania</option>
+
+                            <option value="en:russia">Russia</option>
+
+                            <option value="en:rwanda">Rwanda</option>
+
+                            <option value="en:saba">Saba</option>
+
+                            <option value="en:saint-barthelemy">
+                              Saint-Barthélemy
+                            </option>
+
+                            <option value="en:saint-helena">
+                              Saint Helena
+                            </option>
+
+                            <option value="en:saint-kitts-and-nevis">
+                              Saint Kitts and Nevis
+                            </option>
+
+                            <option value="en:saint-lucia">Saint Lucia</option>
+
+                            <option value="en:saint-martin">
+                              Saint Martin
+                            </option>
+
+                            <option value="en:saint-pierre-and-miquelon">
+                              Saint Pierre and Miquelon
+                            </option>
+
+                            <option value="en:saint-vincent-and-the-grenadines">
+                              Saint Vincent and the Grenadines
+                            </option>
+
+                            <option value="en:samoa">Samoa</option>
+
+                            <option value="en:san-marino">San Marino</option>
+
+                            <option value="en:sao-tome-and-principe">
+                              Sao Tomé and Príncipe
+                            </option>
+
+                            <option value="en:saudi-arabia">
+                              Saudi Arabia
+                            </option>
+
+                            <option value="en:senegal">Senegal</option>
+
+                            <option value="en:serbia">Serbia</option>
+
+                            <option value="en:seychelles">Seychelles</option>
+
+                            <option value="en:sierra-leone">
+                              Sierra Leone
+                            </option>
+
+                            <option value="en:singapore">Singapore</option>
+
+                            <option value="en:sint-eustatius">
+                              Sint Eustatius
+                            </option>
+
+                            <option value="en:sint-maarten">
+                              Sint Maarten
+                            </option>
+
+                            <option value="en:slovakia">Slovakia</option>
+
+                            <option value="en:slovenia">Slovenia</option>
+
+                            <option value="en:solomon-islands">
+                              Solomon Islands
+                            </option>
+
+                            <option value="en:somalia">Somalia</option>
+
+                            <option value="en:south-africa">
+                              South Africa
+                            </option>
+
+                            <option
+                              value="en:south-georgia-and-the-south-sandwich-islands"
+                            >
+                              South Georgia and the South Sandwich Islands
+                            </option>
+
+                            <option value="en:south-korea">South Korea</option>
+
+                            <option value="en:south-sudan">South Sudan</option>
+
+                            <option value="en:soviet-union">
+                              Soviet Union
+                            </option>
+
+                            <option value="en:spain">Spain</option>
+
+                            <option value="en:sri-lanka">Sri Lanka</option>
+
+                            <option value="en:state-of-palestine">
+                              State of Palestine
+                            </option>
+
+                            <option value="en:sudan">Sudan</option>
+
+                            <option value="en:suriname">Suriname</option>
+
+                            <option value="en:svalbard-and-jan-mayen">
+                              Svalbard and Jan Mayen
+                            </option>
+
+                            <option value="en:swaziland">Swaziland</option>
+
+                            <option value="en:sweden">Sweden</option>
+
+                            <option value="en:switzerland">Switzerland</option>
+
+                            <option value="en:syria">Syria</option>
+
+                            <option value="en:taiwan">Taiwan</option>
+
+                            <option value="en:tajikistan">Tajikistan</option>
+
+                            <option value="en:tanzania">Tanzania</option>
+
+                            <option value="en:thailand">Thailand</option>
+
+                            <option value="en:the-bahamas">The Bahamas</option>
+
+                            <option value="en:timor-leste">Timor-Leste</option>
+
+                            <option value="en:togo">Togo</option>
+
+                            <option value="en:tokelau">Tokelau</option>
+
+                            <option value="en:tonga">Tonga</option>
+
+                            <option value="en:trinidad-and-tobago">
+                              Trinidad and Tobago
+                            </option>
+
+                            <option value="en:tunisia">Tunisia</option>
+
+                            <option value="en:turkey">Turkey</option>
+
+                            <option value="en:turkmenistan">
+                              Turkmenistan
+                            </option>
+
+                            <option value="en:turks-and-caicos-islands">
+                              Turks and Caicos Islands
+                            </option>
+
+                            <option value="en:tuvalu">Tuvalu</option>
+
+                            <option value="en:uganda">Uganda</option>
+
+                            <option value="en:ukraine">Ukraine</option>
+
+                            <option value="en:united-arab-emirates">
+                              United Arab Emirates
+                            </option>
+
+                            <option value="en:united-kingdom">
+                              United Kingdom
+                            </option>
+
+                            <option value="en:united-states">
+                              United States
+                            </option>
+
+                            <option
+                              value="en:united-states-minor-outlying-islands"
+                            >
+                              United States Minor Outlying Islands
+                            </option>
+
+                            <option value="en:uruguay">Uruguay</option>
+
+                            <option value="en:uzbekistan">Uzbekistan</option>
+
+                            <option value="en:vanuatu">Vanuatu</option>
+
+                            <option value="en:vatican-city">
+                              Vatican City
+                            </option>
+
+                            <option value="en:venezuela">Venezuela</option>
+
+                            <option value="en:vietnam">Vietnam</option>
+
+                            <option
+                              value="en:virgin-islands-of-the-united-states"
+                            >
+                              Virgin Islands of the United States
+                            </option>
+
+                            <option value="en:wallis-and-futuna">
+                              Wallis and Futuna
+                            </option>
+
+                            <option value="en:western-sahara">
+                              Western Sahara
+                            </option>
+
+                            <option value="en:world">World</option>
+
+                            <option value="en:yemen">Yemen</option>
+
+                            <option value="en:yugoslavia">Yugoslavia</option>
+
+                            <option value="en:zambia">Zambia</option>
+
+                            <option value="en:zimbabwe">Zimbabwe</option>
+                          </select>
+
+                          <div style="display: none">
+                            <label for="faxnumber"
+                              >Do not enter your fax number</label
+                            >
+                            <input
+                              type="text"
+                              id="faxnumber"
+                              name="faxnumber"
+                              value=""
+                            />
+                          </div>
                         </div>
-                    
-                
-                </div>
-                <!-- show video about account creation beside user form section-->
-                
-            </div>
-            
+                        <!-- show video about account creation beside user form section-->
+                      </div>
 
-            
+                      <fieldset id="professional_section">
+                        <legend>Professional account</legend>
 
-        
+                        <p>
+                          If you work for a producer or brand and will add or
+                          complete data for your own products only, you can get
+                          access to our completely free Platform for Producers.
+                        </p>
 
-            
-                <fieldset id="professional_section">
-                    <legend >Professional account</legend>
-            
+                        <p>
+                          The platform for producers allows manufacturers to
+                          easily import data and photos for all their products,
+                          to mark them as official, and to get free analysis of
+                          improvement opportunities for their products.
+                        </p>
 
-            
-                <p >If you work for a producer or brand and will add or complete data for your own products only, you can get access to our completely free Platform for Producers.</p>
-            
-
-            
-                <p >The platform for producers allows manufacturers to easily import data and photos for all their products, to mark them as official, and to get free analysis of improvement opportunities for their products.</p>
-            
-            <div class="form-wrapper">
-                <div class="form-container" style="width: 80%;margin-right: 20px;">
-                
-                    
-                    
-                        
+                        <div class="form-wrapper">
+                          <div
+                            class="form-container"
+                            style="width: 80%; margin-right: 20px"
+                          >
                             <label for="pro">
-                                <input type="checkbox" id="pro" name="pro"  />
-                                This is a producer or brand account.
+                              <input type="checkbox" id="pro" name="pro" />
+                              This is a producer or brand account.
                             </label>
-                        
-                    
-                
-                    
-                    
-                        <label for="pro">
-                            <input type="hidden" name="pro_checkbox" value="1">
-                        </label>
-                    
-                
-                    
-                    
-                        <div  class="pro_org_display" >
-                            <label for="requested_org">Name of producer or name of brand:</label>
-                            <input type="text" id="requested_org" name="requested_org" value="" />
+
+                            <label for="pro">
+                              <input
+                                type="hidden"
+                                name="pro_checkbox"
+                                value="1"
+                              />
+                            </label>
+
+                            <div class="pro_org_display">
+                              <label for="requested_org"
+                                >Name of producer or name of brand:</label
+                              >
+                              <input
+                                type="text"
+                                id="requested_org"
+                                name="requested_org"
+                                value=""
+                              />
                             </div>
-                    
-                
-                </div>
-                <!-- show video about account creation beside user form section-->
-                
-            </div>
-            
-            <div class="pro_org_display">
-                
-                    <p>Please enter the name of your organization (company name or brand).</p>
-                
-            </div>
-            
+                          </div>
+                          <!-- show video about account creation beside user form section-->
+                        </div>
 
-            
-                </fieldset>
-            
+                        <div class="pro_org_display">
+                          <p>
+                            Please enter the name of your organization (company
+                            name or brand).
+                          </p>
+                        </div>
+                      </fieldset>
 
-        
+                      <fieldset id="contributor_settings_section">
+                        <legend>Contributor (optional)</legend>
 
-            
-                <fieldset id="contributor_settings_section">
-                    <legend >Contributor (optional)</legend>
-            
+                        <p>
+                          Those settings allow you to personalize some aspects
+                          of the website
+                        </p>
 
-            
-                <p >Those settings allow you to personalize some aspects of the website</p>
-            
-
-            
-            <div class="form-wrapper">
-                <div class="form-container" style="width: 80%;margin-right: 20px;">
-                
-                    
-                    
-                        
+                        <div class="form-wrapper">
+                          <div
+                            class="form-container"
+                            style="width: 80%; margin-right: 20px"
+                          >
                             <label for="display_barcode">
-                                <input type="checkbox" id="display_barcode" name="display_barcode"  />
-                                <svg style="width:24px;height:24px" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M2,6H4V18H2V6M5,6H6V18H5V6M7,6H10V18H7V6M11,6H12V18H11V6M14,6H16V18H14V6M17,6H20V18H17V6M21,6H22V18H21V6Z"/></svg>Display barcode in search results
+                              <input
+                                type="checkbox"
+                                id="display_barcode"
+                                name="display_barcode"
+                              />
+                              <svg
+                                style="width: 24px; height: 24px"
+                                viewBox="0 0 24 24"
+                                class="icon"
+                                aria-hidden="true"
+                                focusable="false"
+                              >
+                                <path
+                                  d="M2,6H4V18H2V6M5,6H6V18H5V6M7,6H10V18H7V6M11,6H12V18H11V6M14,6H16V18H14V6M17,6H20V18H17V6M21,6H22V18H21V6Z"
+                                /></svg
+                              >Display barcode in search results
                             </label>
-                        
-                    
-                
-                    
-                    
-                        
+
                             <label for="edit_link">
-                                <input type="checkbox" id="edit_link" name="edit_link"  />
-                                <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/><path d="M0 0h24v24H0z" fill="none"/></svg>Add an edit link in search results
+                              <input
+                                type="checkbox"
+                                id="edit_link"
+                                name="edit_link"
+                              />
+                              <svg
+                                xmlns="//www.w3.org/2000/svg"
+                                viewBox="0 0 24 24"
+                                class="icon"
+                                aria-hidden="true"
+                                focusable="false"
+                              >
+                                <path
+                                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                />
+                                <path d="M0 0h24v24H0z" fill="none" /></svg
+                              >Add an edit link in search results
                             </label>
-                        
-                    
-                
+                          </div>
+                          <!-- show video about account creation beside user form section-->
+                        </div>
+                      </fieldset>
+
+                      <!--newsletter subscription-->
+
+                      <label>
+                        <input type="checkbox" name="newsletter" />
+                        Subscribe to the newsletter (2 emails per month maximum)
+                      </label>
+                      <p>You can unsubscribe from the lists at any time.</p>
+
+                      <input type="hidden" name="action" value="process" />
+                      <input type="hidden" name="type" value="add" />
+
+                      <input
+                        type="submit"
+                        name=".submit"
+                        class="button"
+                        value="Register"
+                      />
+                    </form>
+
+                    <!-- End form -->
+
+                    <!-- end templates/web/pages/user_form/user_form_page.tt.html -->
+                  </div>
                 </div>
-                <!-- show video about account creation beside user form section-->
-                
+              </div>
             </div>
-            
-
-            
-                </fieldset>
-            
-
-        
-
-        <!--newsletter subscription-->
-        
-            <label>
-                <input type="checkbox" name="newsletter"  />
-                Subscribe to the newsletter (2 emails per month maximum)
-            </label>
-            <p>You can unsubscribe from the lists at any time.</p>
-        
-
-        
-
-        <input type="hidden" name="action" value="process" />
-        <input type="hidden" name="type" value="add" />
-        
-            <input type="submit" name=".submit" class="button" value= "Register" />
-        
-    </form>
-
-    <!-- End form -->
-
-
-
-
-
-<!-- end templates/web/pages/user_form/user_form_page.tt.html -->
-
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        function checkboxChange(checkbox) {
+          if (checkbox.checked) {
+            $(".pro_org_display").show();
+            $("#teams_section").hide();
+            if (!$("#pro-email-warning").length) {
+              let pro_email_warning =
+                '<div style="color: red; font-weight: 600;" id="pro-email-warning">🚨 Please note that your Pro account will only be valid if you use your professional e-mail address. Our moderation team checks that the domain name is consistent with the organisation you wish to join.</div>';
+              $(".pro_org_display").first().prepend(pro_email_warning);
+            }
+          } else {
+            $(".pro_org_display").hide();
+            $("#teams_section").show();
+          }
+        }
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+        var proCheckbox = document.getElementById("pro");
+        checkboxChange(proCheckbox);
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
+        proCheckbox.addEventListener("change", function () {
+          checkboxChange(this);
+        });
+      });
+    </script>
 
-						<div class="row">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-function checkboxChange(checkbox) {
-	if (checkbox.checked) {
-		$('.pro_org_display').show();
-		$('#teams_section').hide();
-		if ( ! $('#pro-email-warning').length ) {
-			let pro_email_warning = '<div style="color: red; font-weight: 600;" id="pro-email-warning">🚨 Please note that your Pro account will only be valid if you use your professional e-mail address. Our moderation team checks that the domain name is consistent with the organisation you wish to join.</div>';
-			$('.pro_org_display').first().prepend(pro_email_warning);
-		}
-	} else {
-		$('.pro_org_display').hide();
-		$('#teams_section').show();
-	}
-}
-
-var proCheckbox = document.getElementById('pro');
-checkboxChange(proCheckbox);
-
-proCheckbox.addEventListener('change', function() {
-	checkboxChange(this);
-});
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -1,686 +1,1184 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>List of brands - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/brands/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/brands/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/brands/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/brands/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">List of brands - World</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>11 brands:</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Brand</th><th>Products</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/brands/bob-s-juices" class="tag user_defined">bob-s-juices</a></td>
-<td style="text-align:right"><a href="/facets/brands/bob-s-juices" class="tag user_defined">2</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/les-tartes-de-robert" class="tag user_defined">les-tartes-de-robert</a></td>
-<td style="text-align:right"><a href="/facets/brands/les-tartes-de-robert" class="tag user_defined">2</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/alice-s-ice-creams" class="tag user_defined">alice-s-ice-creams</a></td>
-<td style="text-align:right"><a href="/facets/brands/alice-s-ice-creams" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/bob-s-creme" class="tag user_defined">bob-s-creme</a></td>
-<td style="text-align:right"><a href="/facets/brands/bob-s-creme" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/bob-s-ice-creams" class="tag user_defined">bob-s-ice-creams</a></td>
-<td style="text-align:right"><a href="/facets/brands/bob-s-ice-creams" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/bob-s-pies" class="tag user_defined">bob-s-pies</a></td>
-<td style="text-align:right"><a href="/facets/brands/bob-s-pies" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/bob-s-pizzas" class="tag user_defined">bob-s-pizzas</a></td>
-<td style="text-align:right"><a href="/facets/brands/bob-s-pizzas" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/bob-s-salads" class="tag user_defined">bob-s-salads</a></td>
-<td style="text-align:right"><a href="/facets/brands/bob-s-salads" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/mario-s-olive-oils" class="tag user_defined">mario-s-olive-oils</a></td>
-<td style="text-align:right"><a href="/facets/brands/mario-s-olive-oils" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/pablo-s-tartas" class="tag user_defined">pablo-s-tartas</a></td>
-<td style="text-align:right"><a href="/facets/brands/pablo-s-tartas" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/brands/%E3%83%A9%E3%83%A0%E3%83%8D" class="tag user_defined">ラムネ</a></td>
-<td style="text-align:right"><a href="/facets/brands/%E3%83%A9%E3%83%A0%E3%83%8D" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <!-- full width banner on mobile -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- Donation banner @ footer -->
 
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
-<!-- Donation banner @ footer -->
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-				
+                    return "";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">List of brands - World</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>11 brands:</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Brand</th>
+                            <th>Products</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/bob-s-juices"
+                                class="tag user_defined"
+                                >bob-s-juices</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/bob-s-juices"
+                                class="tag user_defined"
+                                >2</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/les-tartes-de-robert"
+                                class="tag user_defined"
+                                >les-tartes-de-robert</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/les-tartes-de-robert"
+                                class="tag user_defined"
+                                >2</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/alice-s-ice-creams"
+                                class="tag user_defined"
+                                >alice-s-ice-creams</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/alice-s-ice-creams"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/bob-s-creme"
+                                class="tag user_defined"
+                                >bob-s-creme</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/bob-s-creme"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/bob-s-ice-creams"
+                                class="tag user_defined"
+                                >bob-s-ice-creams</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/bob-s-ice-creams"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/bob-s-pies"
+                                class="tag user_defined"
+                                >bob-s-pies</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/bob-s-pies"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/bob-s-pizzas"
+                                class="tag user_defined"
+                                >bob-s-pizzas</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/bob-s-pizzas"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/bob-s-salads"
+                                class="tag user_defined"
+                                >bob-s-salads</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/bob-s-salads"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/mario-s-olive-oils"
+                                class="tag user_defined"
+                                >mario-s-olive-oils</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/mario-s-olive-oils"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/pablo-s-tartas"
+                                class="tag user_defined"
+                                >pablo-s-tartas</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/pablo-s-tartas"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/brands/%E3%83%A9%E3%83%A0%E3%83%8D"
+                                class="tag user_defined"
+                                >ラムネ</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/brands/%E3%83%A9%E3%83%A0%E3%83%8D"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Search:",
+            info: "_TOTAL_ brands",
+            infoFiltered: " - out of _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Search:",
-		info: "_TOTAL_ brands",
-		infoFiltered: " - out of _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -1,3028 +1,3995 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Desserts</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/categories/en:desserts/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/categories/en:desserts/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/categories/en:desserts/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/categories/en:desserts/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Desserts</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/categories">Category</a>:
-                    <a href="/facets/categories/desserts">Desserts</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Contains:</p><ul>
-<li><a href="/facets/categories/baklava" class="tag well_known">Baklava</a></li>
-<li><a href="/facets/categories/black-forest-gateau" class="tag well_known">Black Forest gâteau</a></li>
-<li><a href="/facets/categories/charlottes" class="tag well_known">Charlottes</a></li>
-<li><a href="/facets/categories/chocolate-desserts" class="tag well_known">Chocolate desserts</a></li>
-<li><a href="/facets/categories/chocolate-soft-cake" class="tag well_known">Chocolate soft cake</a></li>
-<li><a href="/facets/categories/clafoutis" class="tag well_known">Clafoutis</a></li>
-<li><a href="/facets/categories/coffee-desserts" class="tag well_known">Coffee desserts</a></li>
-<li><a href="/facets/categories/compotes" class="tag well_known">Compotes</a></li>
-<li><a href="/facets/categories/crumbles" class="tag well_known">Crumbles</a></li>
-<li><a href="/facets/categories/dairy-desserts" class="tag well_known">Dairy desserts</a></li>
-<li><a href="/facets/categories/floating-island" class="tag well_known">Floating island</a></li>
-<li><a href="/facets/categories/french-toast" class="tag well_known">French toast</a></li>
-<li><a href="/facets/categories/frozen-desserts" class="tag well_known">Frozen desserts</a></li>
-<li><a href="/facets/categories/fruit-liegeois" class="tag well_known">Fruit liegeois</a></li>
-<li><a href="/facets/categories/fruits-compote-with-reduced-sugar" class="tag well_known">Fruits compote with reduced sugar</a></li>
-<li><a href="/facets/categories/fruits-desserts" class="tag well_known">Fruits desserts</a></li>
-<li><a href="/facets/categories/fruits-in-syrup" class="tag well_known">Fruits in syrup</a></li>
-<li><a href="/facets/categories/fruits-puree-without-sugar-added" class="tag well_known">Fruits puree without sugar added</a></li>
-<li><a href="/facets/categories/gazelle-horn" class="tag well_known">Gazelle horn</a></li>
-<li><a href="/facets/categories/goblet-of-belle-helene-pear-ice-cream" class="tag well_known">Goblet of Belle Helene pear ice cream</a></li>
-<li><a href="/facets/categories/goblet-of-chocolate-ice-cream-topped-with-whipped-cream" class="tag well_known">Goblet of chocolate ice cream topped with whipped cream</a></li>
-<li><a href="/facets/categories/goblet-of-coffee-ice-cream-topped-with-whipped-cream" class="tag well_known">Goblet of coffee ice cream topped with whipped cream</a></li>
-<li><a href="/facets/categories/goblet-of-peach-melba-ice-cream" class="tag well_known">Goblet of peach Melba ice cream</a></li>
-<li><a href="/facets/categories/jelly-desserts" class="tag well_known">Jelly desserts</a></li>
-<li><a href="/facets/categories/kadaif" class="tag well_known">Kadaif</a></li>
-<li><a href="/facets/categories/liegeois" class="tag well_known">Liégeois</a></li>
-<li><a href="/facets/categories/macarons" class="tag well_known">Macarons</a></li>
-<li><a href="/facets/categories/meringue-roulades" class="tag well_known">Meringue roulades</a></li>
-<li><a href="/facets/categories/mochi" class="tag well_known">Mochi</a></li>
-<li><a href="/facets/categories/non-dairy-desserts" class="tag well_known">Non-dairy desserts</a></li>
-<li><a href="/facets/categories/nut-macarons" class="tag well_known">Nut macarons</a></li>
-<li><a href="/facets/categories/panforte" class="tag well_known">Panforte</a></li>
-<li><a href="/facets/categories/peach-melba-with-vanilla-ice-cream-and-raspberry-sauce" class="tag well_known">Peach melba with vanilla ice cream and raspberry sauce</a></li>
-<li><a href="/facets/categories/puddings" class="tag well_known">Puddings</a></li>
-<li><a href="/facets/categories/refrigerated-desserts" class="tag well_known">Refrigerated desserts</a></li>
-<li><a href="/facets/categories/shelf-stable-desserts" class="tag well_known">Shelf stable desserts</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-chocolate" class="tag well_known">Soft cake filled with chocolate</a></li>
-<li><a href="/facets/categories/soft-cake-filled-with-fruit-paste-and-coated-with-sugar-icing" class="tag well_known">Soft cake filled with fruit paste and coated with sugar icing</a></li>
-<li><a href="/facets/categories/sponge-cake-with-fruit-mousse" class="tag well_known">Sponge cake with fruit mousse</a></li>
-<li><a href="/facets/categories/sponge-cakes" class="tag well_known">Sponge cakes</a></li>
-<li><a href="/facets/categories/sponge-puddings" class="tag well_known">Sponge puddings</a></li>
-<li><a href="/facets/categories/sushki" class="tag well_known">Sushki</a></li>
-<li><a href="/facets/categories/sweet-mousses" class="tag well_known">Sweet mousses</a></li>
-<li><a href="/facets/categories/tartufo" class="tag well_known">Tartufo</a></li>
-<li><a href="/facets/categories/trifles" class="tag well_known">Trifles</a></li>
-<li><a href="/facets/categories/es:roscon" class="tag user_defined" lang="es">es:Roscón</a></li>
-<li><a href="/facets/categories/fi:m%C3%A4mmi" class="tag user_defined" lang="fi">fi:Mämmi</a></li>
-<li><a href="/facets/categories/fr:buches-patissieres" class="tag user_defined" lang="fr">fr:Bûches pâtissières</a></li>
-<li><a href="/facets/categories/fr:entremets-macaron-framboise" class="tag user_defined" lang="fr">fr:Entremets macaron framboise</a></li>
-<li><a href="/facets/categories/fr:pastel-de-nata" class="tag user_defined" lang="fr">fr:Pastel de nata</a></li>
-</ul>
-
-                </div>
-                
-
-                
-                <div class="description">
-                    <div class="row">
-
-	<div id="tag_description" class="large-12 columns">
-		
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
-
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q182940"]);
-  });
-</script>
-
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-                </div>
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=categories&value_tag=en:desserts";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Desserts</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/categories">Category</a>:
+                          <a href="/facets/categories/desserts">Desserts</a>
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/categories/baklava"
+                                class="tag well_known"
+                                >Baklava</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/black-forest-gateau"
+                                class="tag well_known"
+                                >Black Forest gâteau</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/charlottes"
+                                class="tag well_known"
+                                >Charlottes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/chocolate-desserts"
+                                class="tag well_known"
+                                >Chocolate desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/chocolate-soft-cake"
+                                class="tag well_known"
+                                >Chocolate soft cake</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/clafoutis"
+                                class="tag well_known"
+                                >Clafoutis</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/coffee-desserts"
+                                class="tag well_known"
+                                >Coffee desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/compotes"
+                                class="tag well_known"
+                                >Compotes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/crumbles"
+                                class="tag well_known"
+                                >Crumbles</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/dairy-desserts"
+                                class="tag well_known"
+                                >Dairy desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/floating-island"
+                                class="tag well_known"
+                                >Floating island</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/french-toast"
+                                class="tag well_known"
+                                >French toast</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/frozen-desserts"
+                                class="tag well_known"
+                                >Frozen desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruit-liegeois"
+                                class="tag well_known"
+                                >Fruit liegeois</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruits-compote-with-reduced-sugar"
+                                class="tag well_known"
+                                >Fruits compote with reduced sugar</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruits-desserts"
+                                class="tag well_known"
+                                >Fruits desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruits-in-syrup"
+                                class="tag well_known"
+                                >Fruits in syrup</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fruits-puree-without-sugar-added"
+                                class="tag well_known"
+                                >Fruits puree without sugar added</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/gazelle-horn"
+                                class="tag well_known"
+                                >Gazelle horn</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/goblet-of-belle-helene-pear-ice-cream"
+                                class="tag well_known"
+                                >Goblet of Belle Helene pear ice cream</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/goblet-of-chocolate-ice-cream-topped-with-whipped-cream"
+                                class="tag well_known"
+                                >Goblet of chocolate ice cream topped with
+                                whipped cream</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/goblet-of-coffee-ice-cream-topped-with-whipped-cream"
+                                class="tag well_known"
+                                >Goblet of coffee ice cream topped with whipped
+                                cream</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/goblet-of-peach-melba-ice-cream"
+                                class="tag well_known"
+                                >Goblet of peach Melba ice cream</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/jelly-desserts"
+                                class="tag well_known"
+                                >Jelly desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/kadaif"
+                                class="tag well_known"
+                                >Kadaif</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/liegeois"
+                                class="tag well_known"
+                                >Liégeois</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/macarons"
+                                class="tag well_known"
+                                >Macarons</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/meringue-roulades"
+                                class="tag well_known"
+                                >Meringue roulades</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/mochi"
+                                class="tag well_known"
+                                >Mochi</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/non-dairy-desserts"
+                                class="tag well_known"
+                                >Non-dairy desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/nut-macarons"
+                                class="tag well_known"
+                                >Nut macarons</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/panforte"
+                                class="tag well_known"
+                                >Panforte</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/peach-melba-with-vanilla-ice-cream-and-raspberry-sauce"
+                                class="tag well_known"
+                                >Peach melba with vanilla ice cream and
+                                raspberry sauce</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/puddings"
+                                class="tag well_known"
+                                >Puddings</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/refrigerated-desserts"
+                                class="tag well_known"
+                                >Refrigerated desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/shelf-stable-desserts"
+                                class="tag well_known"
+                                >Shelf stable desserts</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-chocolate"
+                                class="tag well_known"
+                                >Soft cake filled with chocolate</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/soft-cake-filled-with-fruit-paste-and-coated-with-sugar-icing"
+                                class="tag well_known"
+                                >Soft cake filled with fruit paste and coated
+                                with sugar icing</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sponge-cake-with-fruit-mousse"
+                                class="tag well_known"
+                                >Sponge cake with fruit mousse</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sponge-cakes"
+                                class="tag well_known"
+                                >Sponge cakes</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sponge-puddings"
+                                class="tag well_known"
+                                >Sponge puddings</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sushki"
+                                class="tag well_known"
+                                >Sushki</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/sweet-mousses"
+                                class="tag well_known"
+                                >Sweet mousses</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/tartufo"
+                                class="tag well_known"
+                                >Tartufo</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/trifles"
+                                class="tag well_known"
+                                >Trifles</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/es:roscon"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Roscón</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fi:m%C3%A4mmi"
+                                class="tag user_defined"
+                                lang="fi"
+                                >fi:Mämmi</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fr:buches-patissieres"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Bûches pâtissières</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fr:entremets-macaron-framboise"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Entremets macaron framboise</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/categories/fr:pastel-de-nata"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Pastel de nata</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div class="description">
+                          <div class="row">
+                            <div
+                              id="tag_description"
+                              class="large-12 columns"
+                            ></div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q182940"]);
+                              }
+                            );
+                          </script>
+
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params =
+                            "?facet_tag=categories&value_tag=en:desserts";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            6 products
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop1"
+                              aria-controls="drop1"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">sort</span>
+                              Explore products by...
+                            </button>
+                            <ul
+                              id="drop1"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/countries"
+                                  rel="nofollow"
+                                  >Countries</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/nutrition-grades"
+                                  rel="nofollow"
+                                  >Nutrition grades</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/nova-groups"
+                                  rel="nofollow"
+                                  >NOVA groups</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/environmental-score"
+                                  rel="nofollow"
+                                  >Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/brands"
+                                  rel="nofollow"
+                                  >Brands</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/categories"
+                                  rel="nofollow"
+                                  >Categories</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/labels"
+                                  rel="nofollow"
+                                  >Labels</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/packaging"
+                                  rel="nofollow"
+                                  >Packaging</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/origins"
+                                  rel="nofollow"
+                                  >Origins of ingredients</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/manufacturing-places"
+                                  rel="nofollow"
+                                  >Manufacturing or processing places</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/packager-codes"
+                                  rel="nofollow"
+                                  >Traceability codes</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/ingredients"
+                                  rel="nofollow"
+                                  >Ingredients</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/additives"
+                                  rel="nofollow"
+                                  >Additives</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/vitamins"
+                                  rel="nofollow"
+                                  >Added vitamins</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/minerals"
+                                  rel="nofollow"
+                                  >Added minerals</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/amino-acids"
+                                  rel="nofollow"
+                                  >Added amino acids</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/nucleotides"
+                                  rel="nofollow"
+                                  >Added nucleotides</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/other-nutritional-substances"
+                                  rel="nofollow"
+                                  >Other nutritional substances added</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/allergens"
+                                  rel="nofollow"
+                                  >Allergens</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/traces"
+                                  rel="nofollow"
+                                  >Traces</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/misc"
+                                  rel="nofollow"
+                                  >Miscellaneous</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/languages"
+                                  rel="nofollow"
+                                  >Languages</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/contributors"
+                                  rel="nofollow"
+                                  >Contributors</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/states"
+                                  rel="nofollow"
+                                  >States</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/data-sources"
+                                  rel="nofollow"
+                                  >Data sources</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/entry-dates"
+                                  rel="nofollow"
+                                  >Entry dates</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/last-edit-dates"
+                                  rel="nofollow"
+                                  >Last edit dates</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/last-check-dates"
+                                  rel="nofollow"
+                                  >Last check dates</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/categories/desserts/teams"
+                                  rel="nofollow"
+                                  >Teams</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          6 products
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/desserts?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/categories/desserts?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        <div>
-          <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">sort</span>
-            Explore products by...
-          </button>
-          <ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/categories/desserts/countries" rel="nofollow">Countries</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/nutrition-grades" rel="nofollow">Nutrition grades</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/nova-groups" rel="nofollow">NOVA groups</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/environmental-score" rel="nofollow">Green-Score</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/brands" rel="nofollow">Brands</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/categories" rel="nofollow">Categories</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/labels" rel="nofollow">Labels</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/packaging" rel="nofollow">Packaging</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/origins" rel="nofollow">Origins of ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/manufacturing-places" rel="nofollow">Manufacturing or processing places</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/packager-codes" rel="nofollow">Traceability codes</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/ingredients" rel="nofollow">Ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/additives" rel="nofollow">Additives</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/vitamins" rel="nofollow">Added vitamins</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/minerals" rel="nofollow">Added minerals</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/amino-acids" rel="nofollow">Added amino acids</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/nucleotides" rel="nofollow">Added nucleotides</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/other-nutritional-substances" rel="nofollow">Other nutritional substances added</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/allergens" rel="nofollow">Allergens</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/traces" rel="nofollow">Traces</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/misc" rel="nofollow">Miscellaneous</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/languages" rel="nofollow">Languages</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/contributors" rel="nofollow">Contributors</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/states" rel="nofollow">States</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/data-sources" rel="nofollow">Data sources</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/entry-dates" rel="nofollow">Entry dates</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/last-edit-dates" rel="nofollow">Last edit dates</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/last-check-dates" rel="nofollow">Last check dates</a>
-            </li>
-          
-            <li>
-              <a href="/facets/categories/desserts/teams" rel="nofollow">Teams</a>
-            </li>
-          
-          </ul>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        
-        
-      </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 6 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000001",
+          product_display_name: "Apple pie - Bob's pies - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Organic apple and raspberry pie - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 50,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:maybe-vegetarian",
+                  status: "known",
+                  title: "Maybe vegetarian",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/may-contain-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 50,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:may-contain-palm-oil",
+                  status: "known",
+                  title: "May contain palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/6-additives.svg",
+                  id: "additives",
+                  match: 0,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "6 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000004",
+          product_display_name:
+            "Very bad vanilla ice cream with lots of sugar and additives - Bob's ice creams - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000004/very-bad-vanilla-ice-cream-with-lots-of-sugar-and-additives-bob-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000005",
+          product_display_name:
+            "Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000009",
+          product_display_name: "Tarta de manzana - Pablo's tartas - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000009/tarta-de-manzana-pablo-s-tartas",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 6 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000001",
-      "product_display_name":"Apple pie - Bob's pies - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Organic apple and raspberry pie - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":50,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:maybe-vegetarian",
-                  "status":"known",
-                  "title":"Maybe vegetarian"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/may-contain-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":50,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:may-contain-palm-oil",
-                  "status":"known",
-                  "title":"May contain palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/6-additives.svg",
-                  "id":"additives",
-                  "match":0,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"6 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000004",
-      "product_display_name":"Very bad vanilla ice cream with lots of sugar and additives - Bob's ice creams - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000004/very-bad-vanilla-ice-cream-with-lots-of-sugar-and-additives-bob-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000005",
-      "product_display_name":"Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000009",
-      "product_display_name":"Tarta de manzana - Pablo's tartas - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000009/tarta-de-manzana-pablo-s-tartas"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -1,700 +1,1279 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>List of countries - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/countries/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/countries/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/countries/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/countries/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">List of countries - World</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-  <div id="world-map" style="min-width: 250px; max-width: 600px; min-height: 250px; max-height: 400px;"></div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-<p>15 countries:</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Country</th><th>Products</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/countries/france" class="tag known">France</a></td>
-<td style="text-align:right"><a href="/facets/countries/france" class="tag known">7</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/germany" class="tag known">Germany</a></td>
-<td style="text-align:right"><a href="/facets/countries/germany" class="tag known">5</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/united-kingdom" class="tag known">United Kingdom</a></td>
-<td style="text-align:right"><a href="/facets/countries/united-kingdom" class="tag known">5</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/italy" class="tag known">Italy</a></td>
-<td style="text-align:right"><a href="/facets/countries/italy" class="tag known">4</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/spain" class="tag known">Spain</a></td>
-<td style="text-align:right"><a href="/facets/countries/spain" class="tag known">4</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/japan" class="tag known">Japan</a></td>
-<td style="text-align:right"><a href="/facets/countries/japan" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/united-states" class="tag known">United States</a></td>
-<td style="text-align:right"><a href="/facets/countries/united-states" class="tag known">2</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/argentina" class="tag known">Argentina</a></td>
-<td style="text-align:right"><a href="/facets/countries/argentina" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/belgium" class="tag known">Belgium</a></td>
-<td style="text-align:right"><a href="/facets/countries/belgium" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/canada" class="tag known">Canada</a></td>
-<td style="text-align:right"><a href="/facets/countries/canada" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/greece" class="tag known">Greece</a></td>
-<td style="text-align:right"><a href="/facets/countries/greece" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/india" class="tag known">India</a></td>
-<td style="text-align:right"><a href="/facets/countries/india" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/mexico" class="tag known">Mexico</a></td>
-<td style="text-align:right"><a href="/facets/countries/mexico" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/portugal" class="tag known">Portugal</a></td>
-<td style="text-align:right"><a href="/facets/countries/portugal" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/countries/switzerland" class="tag known">Switzerland</a></td>
-<td style="text-align:right"><a href="/facets/countries/switzerland" class="tag known">1</a></td><td></td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+            <!-- full width banner on mobile -->
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+                <!-- Donation banner @ footer -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
-<!-- Donation banner @ footer -->
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                    return "";
+                  }
 
-				
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">List of countries - World</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <div
+                      id="world-map"
+                      style="
+                        min-width: 250px;
+                        max-width: 600px;
+                        min-height: 250px;
+                        max-height: 400px;
+                      "
+                    ></div>
+
+                    <p>15 countries:</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Country</th>
+                            <th>Products</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/france"
+                                class="tag known"
+                                >France</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/france"
+                                class="tag known"
+                                >7</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/germany"
+                                class="tag known"
+                                >Germany</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/germany"
+                                class="tag known"
+                                >5</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/united-kingdom"
+                                class="tag known"
+                                >United Kingdom</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/united-kingdom"
+                                class="tag known"
+                                >5</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/italy"
+                                class="tag known"
+                                >Italy</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/italy"
+                                class="tag known"
+                                >4</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/spain"
+                                class="tag known"
+                                >Spain</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/spain"
+                                class="tag known"
+                                >4</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/japan"
+                                class="tag known"
+                                >Japan</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/japan"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/united-states"
+                                class="tag known"
+                                >United States</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/united-states"
+                                class="tag known"
+                                >2</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/argentina"
+                                class="tag known"
+                                >Argentina</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/argentina"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/belgium"
+                                class="tag known"
+                                >Belgium</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/belgium"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/canada"
+                                class="tag known"
+                                >Canada</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/canada"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/greece"
+                                class="tag known"
+                                >Greece</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/greece"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/india"
+                                class="tag known"
+                                >India</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/india"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/mexico"
+                                class="tag known"
+                                >Mexico</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/mexico"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/portugal"
+                                class="tag known"
+                                >Portugal</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/portugal"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/countries/switzerland"
+                                class="tag known"
+                                >Switzerland</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/countries/switzerland"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        var countries_map_data = JSON.parse(
+          '{"AR":1,"BE":1,"CA":1,"CH":1,"DE":5,"ES":4,"FR":7,"GB":5,"GR":1,"IN":1,"IT":4,"JP":2,"MX":1,"PT":1,"US":2}'
+        );
+        var countries_map_links = JSON.parse(
+          '{"AR":"/facets/countries/argentina","BE":"/facets/countries/belgium","CA":"/facets/countries/canada","CH":"/facets/countries/switzerland","DE":"/facets/countries/germany","ES":"/facets/countries/spain","FR":"/facets/countries/france","GB":"/facets/countries/united-kingdom","GR":"/facets/countries/greece","IN":"/facets/countries/india","IT":"/facets/countries/italy","JP":"/facets/countries/japan","MX":"/facets/countries/mexico","PT":"/facets/countries/portugal","US":"/facets/countries/united-states"}'
+        );
+        var countries_map_names = JSON.parse(
+          '{"AR":"Argentina","BE":"Belgium","CA":"Canada","CH":"Switzerland","DE":"Germany","ES":"Spain","FR":"France","GB":"United Kingdom","GR":"Greece","IN":"India","IT":"Italy","JP":"Japan","MX":"Mexico","PT":"Portugal","US":"United States"}'
+        );
+        displayWorldMap("#world-map", {
+          data: countries_map_data,
+          links: countries_map_links,
+          names: countries_map_names,
+        });
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Search:",
+            info: "_TOTAL_ countries",
+            infoFiltered: " - out of _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jsvectormap.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/world-merc.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display-list-of-tags.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-var countries_map_data=JSON.parse("{\"AR\":1,\"BE\":1,\"CA\":1,\"CH\":1,\"DE\":5,\"ES\":4,\"FR\":7,\"GB\":5,\"GR\":1,\"IN\":1,\"IT\":4,\"JP\":2,\"MX\":1,\"PT\":1,\"US\":2}");var countries_map_links=JSON.parse("{\"AR\":\"/facets/countries/argentina\",\"BE\":\"/facets/countries/belgium\",\"CA\":\"/facets/countries/canada\",\"CH\":\"/facets/countries/switzerland\",\"DE\":\"/facets/countries/germany\",\"ES\":\"/facets/countries/spain\",\"FR\":\"/facets/countries/france\",\"GB\":\"/facets/countries/united-kingdom\",\"GR\":\"/facets/countries/greece\",\"IN\":\"/facets/countries/india\",\"IT\":\"/facets/countries/italy\",\"JP\":\"/facets/countries/japan\",\"MX\":\"/facets/countries/mexico\",\"PT\":\"/facets/countries/portugal\",\"US\":\"/facets/countries/united-states\"}");var countries_map_names=JSON.parse("{\"AR\":\"Argentina\",\"BE\":\"Belgium\",\"CA\":\"Canada\",\"CH\":\"Switzerland\",\"DE\":\"Germany\",\"ES\":\"Spain\",\"FR\":\"France\",\"GB\":\"United Kingdom\",\"GR\":\"Greece\",\"IN\":\"India\",\"IT\":\"Italy\",\"JP\":\"Japan\",\"MX\":\"Mexico\",\"PT\":\"Portugal\",\"US\":\"United States\"}");displayWorldMap('#world-map', { 'data': countries_map_data, 'links': countries_map_links, 'names': countries_map_names });
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Search:",
-		info: "_TOTAL_ countries",
-		infoFiltered: " - out of _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jsvectormap.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/world-merc.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-list-of-tags.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -1,4278 +1,5310 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Edit a product</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" type="text/css" href="/css/dist/cropper.css" />
-<link rel="stylesheet" type="text/css" href="/css/dist/tagify.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link rel="stylesheet" type="text/css" href="/css/dist/cropper.css" />
+    <link rel="stylesheet" type="text/css" href="/css/dist/tagify.css" />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.hide-when-logged-in {display:none}
-.ui-selectable li {
-	margin: 3px;
-	padding: 0px;
-	float: left;
-	width: 120px;
-	height: 120px;
-	line-height: 120px;
-	text-align: center;
-}
-.show_for_manage_images {
-	line-height:normal;
-	font-weight:normal;
-	font-size:0.8rem;
-}
-.select_manage .ui-selectable li { 
-	height: 180px
-}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .hide-when-logged-in {
+        display: none;
+      }
+      .ui-selectable li {
+        margin: 3px;
+        padding: 0px;
+        float: left;
+        width: 120px;
+        height: 120px;
+        line-height: 120px;
+        text-align: center;
+      }
+      .show_for_manage_images {
+        line-height: normal;
+        font-weight: normal;
+        font-size: 0.8rem;
+      }
+      .select_manage .ui-selectable li {
+        height: 180px;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="product_edit_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="has-dropdown">
-								<a href="#" class="userlink h-space-tiny">
-									<span class="material-icons">
-										account_circle
-									</span>
-									Test
-								</a>
-								<ul class="dropdown">
-									<li><a href="/cgi/user.pl?type=edit&userid=tests"><span class="material-icons">settings</span> Account parameters</a></li>
-
-									
-
-									
-									
-									<li class="divider"></li>			
-									<li><label>Your contributions</label></li>
-									<li><a href="/facets/contributors/tests">Products added</a></li>
-									<li><a href="/facets/editors/tests">Products edited</a></li>
-									<li><a href="/facets/photographers/tests">Products photographed</a></li>
-									
-									<li class="divider"></li>			
-									<li class="has-form">
-										<form method="post" action="/cgi/session.pl">
-											<input type="hidden" name="length" value="logout">
-											<input type="submit" name=".submit" value="Sign out" class="button small">
-										</form>
-									</li>
-								</ul>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix loggedin">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="product_edit_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="has-dropdown">
+                <a href="#" class="userlink h-space-tiny">
+                  <span class="material-icons"> account_circle </span>
+                  Test
+                </a>
+                <ul class="dropdown">
+                  <li>
+                    <a href="/cgi/user.pl?type=edit&userid=tests"
+                      ><span class="material-icons">settings</span> Account
+                      parameters</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Your contributions</label></li>
+                  <li>
+                    <a href="/facets/contributors/tests">Products added</a>
+                  </li>
+                  <li><a href="/facets/editors/tests">Products edited</a></li>
+                  <li>
+                    <a href="/facets/photographers/tests"
+                      >Products photographed</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li class="has-form">
+                    <form method="post" action="/cgi/session.pl">
+                      <input type="hidden" name="length" value="logout" />
+                      <input
+                        type="submit"
+                        name=".submit"
+                        value="Sign out"
+                        class="button small"
+                      />
+                    </form>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<!-- banner pages such as product, product edit form and landing pages have their own h1 title -->
-							<!-- start templates/web/pages/product_edit/product_edit_form.tt.html -->
-
-
-
-
-<!-- end templates/web/pages/product_edit/product_edit_form.tt.html --><!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-
-<a href="#upNav" class="back-to-top scrollto button">
-    <span class="material-icons size-20 ">
-        arrow_upward
-    </span>
-</a>
-
-<div class="block v-space-tiny product_banner_unranked" id="prodHead">
-    <div class="row">
-        <div class="small-12 columns">
-            <h1></h1>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-    </div>
-</div>
 
-    
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix loggedin"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-    
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-    <form id="product_form" action="/cgi/product.pl" method="POST" enctype="multipart/form-data">
+            <!-- full width banner on mobile -->
 
-        <div class="block v-space-tiny prod-nav product_banner_unranked" id="prodNav">
-            <div class="row h-space-normal">
-                <div class="large-12">
-                   <nav id="navbar" class="navbar h-space-tiny">
-                        <ul class="inline-list">
-                            <li><a class="nav-link scrollto button small round white-button" href="#product_characteristics"><span>Product characteristics</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#ingredients"><span>Ingredients</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#nutrition"><span>Nutrition</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#packaging_section"><span>Packaging</span></a></li>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
                         </ul>
-                    </nav><!-- .navbar -->
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <!-- banner pages such as product, product edit form and landing pages have their own h1 title -->
+                <!-- start templates/web/pages/product_edit/product_edit_form.tt.html -->
+
+                <!-- end templates/web/pages/product_edit/product_edit_form.tt.html --><!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+
+                <a href="#upNav" class="back-to-top scrollto button">
+                  <span class="material-icons size-20"> arrow_upward </span>
+                </a>
+
+                <div
+                  class="block v-space-tiny product_banner_unranked"
+                  id="prodHead"
+                >
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <h1></h1>
+                    </div>
+                  </div>
                 </div>
+
+                <form
+                  id="product_form"
+                  action="/cgi/product.pl"
+                  method="POST"
+                  enctype="multipart/form-data"
+                >
+                  <div
+                    class="block v-space-tiny prod-nav product_banner_unranked"
+                    id="prodNav"
+                  >
+                    <div class="row h-space-normal">
+                      <div class="large-12">
+                        <nav id="navbar" class="navbar h-space-tiny">
+                          <ul class="inline-list">
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#product_characteristics"
+                                ><span>Product characteristics</span></a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#ingredients"
+                                ><span>Ingredients</span></a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#nutrition"
+                                ><span>Nutrition</span></a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                class="nav-link scrollto button small round white-button"
+                                href="#packaging_section"
+                                ><span>Packaging</span></a
+                              >
+                            </li>
+                          </ul>
+                        </nav>
+                        <!-- .navbar -->
+                      </div>
+                    </div>
+                  </div>
+
+                  <div id="prodInfos">
+                    <div class="row">
+                      <div class="small-12 columns">
+                        <section id="misc" class="card fieldset">
+                          <div class="card-section">
+                            <p id="barcode_paragraph">
+                              Barcode:
+                              <span
+                                id="barcode"
+                                property="food:code"
+                                itemprop="gtin13"
+                                style="speak-as: digits"
+                                >3300000000001</span
+                              >
+                            </p>
+
+                            <label for="product_type" id="label_product_type"
+                              >Product type</label
+                            >
+                            <select name="product_type" id="product_type">
+                              <option value="food" selected="selected">
+                                Food
+                              </option>
+
+                              <option value="petfood">Pet food</option>
+
+                              <option value="beauty">Beauty</option>
+
+                              <option value="product">Product</option>
+                            </select>
+
+                            <div
+                              data-alert
+                              class="alert-box info store-state"
+                              id="warning_3rd_party_content"
+                              style="display: none"
+                            >
+                              <span
+                                >Information and data must come from the product
+                                package and label (and not from other sites or
+                                the manufacturer's site), and you must have
+                                taken the pictures yourself.<br />
+                                →
+                                <a
+                                  href="//support.openfoodfacts.org/help/en-gb/9/27"
+                                  >Why it matters</a
+                                ></span
+                              >
+                              <a href="#" class="close">&times;</a>
+                            </div>
+
+                            <div
+                              data-alert
+                              class="alert-box secondary store-state"
+                              id="licence_accept"
+                              style="display: none"
+                            >
+                              <span
+                                >By adding information, data and/or images, you
+                                accept to place irrevocably your contribution
+                                under the
+                                <a
+                                  href="//opendatacommons.org/licenses/dbcl/1.0/"
+                                  >Database Contents Licence 1.0</a
+                                >
+                                licence for information and data, and under the
+                                <a
+                                  href="//creativecommons.org/licenses/by-sa/3.0/deed.en"
+                                  >Creative Commons Attribution - ShareAlike
+                                  3.0</a
+                                >
+                                licence for images. You accept to be credited by
+                                re-users by a link to the product your are
+                                contributing to.</span
+                              >
+                              <a href="#" class="close">&times;</a>
+                            </div>
+                          </div>
+                        </section>
+
+                        <section id="product_image" class="card fieldset">
+                          <div class="card-section">
+                            <legend>Product picture</legend>
+                            <input
+                              type="hidden"
+                              id="sorted_langs"
+                              name="sorted_langs"
+                              value="en,fr"
+                            />
+
+                            <label for="lang"> Main language </label>
+                            <select name="lang" id="lang">
+                              <option value="ab">Abkhaz</option>
+
+                              <option value="aa">Afar</option>
+
+                              <option value="af">Afrikaans</option>
+
+                              <option value="ak">Akan</option>
+
+                              <option value="sq">Albanian</option>
+
+                              <option value="am">Amharic</option>
+
+                              <option value="ar">Arabic</option>
+
+                              <option value="an">Aragonese</option>
+
+                              <option value="hy">Armenian</option>
+
+                              <option value="as">Assamese</option>
+
+                              <option value="av">Avar</option>
+
+                              <option value="ae">Avestan</option>
+
+                              <option value="ay">Aymara</option>
+
+                              <option value="az">Azerbaijani</option>
+
+                              <option value="bm">Bambara</option>
+
+                              <option value="ba">Bashkir</option>
+
+                              <option value="eu">Basque</option>
+
+                              <option value="be">Belarusian</option>
+
+                              <option value="bn">Bengali</option>
+
+                              <option value="bh">Bihari languages</option>
+
+                              <option value="bi">Bislama</option>
+
+                              <option value="nb">Bokmål</option>
+
+                              <option value="bs">Bosnian</option>
+
+                              <option value="br">Breton</option>
+
+                              <option value="bg">Bulgarian</option>
+
+                              <option value="my">Burmese</option>
+
+                              <option value="ca">Catalan</option>
+
+                              <option value="ch">Chamorro</option>
+
+                              <option value="ce">Chechen</option>
+
+                              <option value="ny">Chewa</option>
+
+                              <option value="zh">Chinese</option>
+
+                              <option value="cu">Church Slavonic</option>
+
+                              <option value="cv">Chuvash</option>
+
+                              <option value="kw">Cornish</option>
+
+                              <option value="co">Corsican</option>
+
+                              <option value="cr">Cree</option>
+
+                              <option value="hr">Croatian</option>
+
+                              <option value="cs">Czech</option>
+
+                              <option value="da">Danish</option>
+
+                              <option value="nl">Dutch</option>
+
+                              <option value="dz">Dzongkha language</option>
+
+                              <option value="en" selected="selected">
+                                English
+                              </option>
+
+                              <option value="eo">Esperanto</option>
+
+                              <option value="et">Estonian</option>
+
+                              <option value="ee">Ewe</option>
+
+                              <option value="fo">Faroese</option>
+
+                              <option value="fj">Fijian language</option>
+
+                              <option value="fi">Finnish</option>
+
+                              <option value="fr">French</option>
+
+                              <option value="ff">Fula language</option>
+
+                              <option value="gl">Galician</option>
+
+                              <option value="ka">Georgian</option>
+
+                              <option value="de">German</option>
+
+                              <option value="ki">Gikuyu</option>
+
+                              <option value="el">Greek</option>
+
+                              <option value="kl">Greenlandic</option>
+
+                              <option value="gn">Guarani</option>
+
+                              <option value="gu">Gujarati</option>
+
+                              <option value="ht">Haitian Creole</option>
+
+                              <option value="ha">Hausa</option>
+
+                              <option value="he">Hebrew</option>
+
+                              <option value="hz">Herero</option>
+
+                              <option value="hi">Hindi</option>
+
+                              <option value="ho">Hiri Motu</option>
+
+                              <option value="hu">Hungarian</option>
+
+                              <option value="is">Icelandic</option>
+
+                              <option value="io">Ido</option>
+
+                              <option value="ig">Igbo language</option>
+
+                              <option value="id">Indonesian</option>
+
+                              <option value="ia">Interlingua</option>
+
+                              <option value="ie">Interlingue</option>
+
+                              <option value="iu">Inuktitut</option>
+
+                              <option value="ik">Inupiat language</option>
+
+                              <option value="ga">Irish</option>
+
+                              <option value="it">Italian</option>
+
+                              <option value="ja">Japanese</option>
+
+                              <option value="jv">Javanese</option>
+
+                              <option value="kn">Kannada</option>
+
+                              <option value="kr">Kanuri</option>
+
+                              <option value="ks">Kashmiri</option>
+
+                              <option value="kk">Kazakh</option>
+
+                              <option value="km">Khmer</option>
+
+                              <option value="rw">Kinyarwanda</option>
+
+                              <option value="rn">Kirundi</option>
+
+                              <option value="kv">Komi</option>
+
+                              <option value="kg">Kongo language</option>
+
+                              <option value="ko">Korean</option>
+
+                              <option value="ku">Kurdish</option>
+
+                              <option value="kj">Kwanyama</option>
+
+                              <option value="ky">Kyrgyz</option>
+
+                              <option value="lo">Lao</option>
+
+                              <option value="la">Latin</option>
+
+                              <option value="lv">Latvian</option>
+
+                              <option value="li">Limburgish language</option>
+
+                              <option value="ln">Lingala language</option>
+
+                              <option value="lt">Lithuanian</option>
+
+                              <option value="lu">Luba-Katanga language</option>
+
+                              <option value="lg">Luganda</option>
+
+                              <option value="lb">Luxembourgish</option>
+
+                              <option value="mk">Macedonian</option>
+
+                              <option value="mg">Malagasy</option>
+
+                              <option value="ms">Malay</option>
+
+                              <option value="ml">Malayalam</option>
+
+                              <option value="dv">Maldivian language</option>
+
+                              <option value="mt">Maltese</option>
+
+                              <option value="gv">Manx</option>
+
+                              <option value="mi">Māori</option>
+
+                              <option value="mr">Marathi</option>
+
+                              <option value="mh">Marshallese</option>
+
+                              <option value="mo">Moldovan</option>
+
+                              <option value="mn">Mongolian</option>
+
+                              <option value="me">Montenegrin</option>
+
+                              <option value="na">Nauruan</option>
+
+                              <option value="nv">Navajo</option>
+
+                              <option value="ng">Ndonga dialect</option>
+
+                              <option value="ne">Nepali</option>
+
+                              <option value="nd">
+                                Northern Ndebele language
+                              </option>
+
+                              <option value="se">Northern Sami</option>
+
+                              <option value="no">Norwegian</option>
+
+                              <option value="ii">Nuosu language</option>
+
+                              <option value="nn">Nynorsk</option>
+
+                              <option value="oc">Occitan</option>
+
+                              <option value="or">Odia</option>
+
+                              <option value="oj">Ojibwe</option>
+
+                              <option value="om">Oromo</option>
+
+                              <option value="os">Ossetian</option>
+
+                              <option value="pi">Pali</option>
+
+                              <option value="ps">Pashto</option>
+
+                              <option value="fa">Persian</option>
+
+                              <option value="pl">Polish</option>
+
+                              <option value="pt">Portuguese</option>
+
+                              <option value="pa">Punjabi</option>
+
+                              <option value="qu">Quechua languages</option>
+
+                              <option value="ro">Romanian</option>
+
+                              <option value="rm">Romansh</option>
+
+                              <option value="ru">Russian</option>
+
+                              <option value="ry">Rusyn</option>
+
+                              <option value="sm">Samoan</option>
+
+                              <option value="sg">Sango</option>
+
+                              <option value="sa">Sanskrit</option>
+
+                              <option value="sc">Sardinian language</option>
+
+                              <option value="gd">Scottish Gaelic</option>
+
+                              <option value="sr">Serbian</option>
+
+                              <option value="sh">Serbo-Croatian</option>
+
+                              <option value="sn">Shona</option>
+
+                              <option value="sd">Sindhi</option>
+
+                              <option value="si">Sinhala</option>
+
+                              <option value="sk">Slovak</option>
+
+                              <option value="sl">Slovene</option>
+
+                              <option value="so">Somali</option>
+
+                              <option value="st">Sotho</option>
+
+                              <option value="nr">Southern Ndebele</option>
+
+                              <option value="es">Spanish</option>
+
+                              <option value="su">Sundanese language</option>
+
+                              <option value="sw">Swahili</option>
+
+                              <option value="ss">Swazi</option>
+
+                              <option value="sv">Swedish</option>
+
+                              <option value="tl">Tagalog</option>
+
+                              <option value="ty">Tahitian</option>
+
+                              <option value="tg">Tajik</option>
+
+                              <option value="ta">Tamil</option>
+
+                              <option value="tt">Tatar</option>
+
+                              <option value="te">Telugu</option>
+
+                              <option value="th">Thai</option>
+
+                              <option value="bo">Tibetan language</option>
+
+                              <option value="ti">Tigrinya</option>
+
+                              <option value="to">Tongan language</option>
+
+                              <option value="ts">Tsonga</option>
+
+                              <option value="tn">Tswana</option>
+
+                              <option value="tr">Turkish</option>
+
+                              <option value="tk">Turkmen</option>
+
+                              <option value="tw">Twi</option>
+
+                              <option value="uk">Ukrainian</option>
+
+                              <option value="xx">Unknown language</option>
+
+                              <option value="ur">Urdu</option>
+
+                              <option value="ug">Uyghur</option>
+
+                              <option value="uz">Uzbek</option>
+
+                              <option value="ve">Venda</option>
+
+                              <option value="vi">Vietnamese</option>
+
+                              <option value="vo">Volapük</option>
+
+                              <option value="wa">Walloon</option>
+
+                              <option value="cy">Welsh</option>
+
+                              <option value="fy">West Frisian</option>
+
+                              <option value="wo">Wolof</option>
+
+                              <option value="xh">Xhosa</option>
+
+                              <option value="yi">Yiddish</option>
+
+                              <option value="yo">Yoruba</option>
+
+                              <option value="za">Zhuang languages</option>
+
+                              <option value="zu">Zulu</option>
+                            </select>
+
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul id="tabs_front_image" class="tabs" data-tab>
+                              <li
+                                class="tabs tab-title active tabs_en"
+                                id="tabs_front_image_en_tab"
+                                data-language="en"
+                              >
+                                <a
+                                  href="#tabs_front_image_en"
+                                  class="tab_language"
+                                  >English</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_fr"
+                                id="tabs_front_image_fr_tab"
+                                data-language="fr"
+                              >
+                                <a
+                                  href="#tabs_front_image_fr"
+                                  class="tab_language"
+                                  >French</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_front_image_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_front_image_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div
+                              id="tabs_content_front_image"
+                              class="tabs-content"
+                            >
+                              <div
+                                class="tabs content active tabs_en"
+                                id="tabs_front_image_en"
+                              >
+                                <label for="front_en"
+                                  >Front picture (<span class="tab_language"
+                                    >English</span
+                                  >)</label
+                                >
+
+                                <div class="select_crop" id="front_en"></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="front_en_imgid"
+                                  id="front_en_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_x1"
+                                  id="front_en_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_y1"
+                                  id="front_en_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_x2"
+                                  id="front_en_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_y2"
+                                  id="front_en_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_en_display_url"
+                                  id="front_en_display_url"
+                                  value=""
+                                />
+                              </div>
+
+                              <div
+                                class="tabs content tabs_fr"
+                                id="tabs_front_image_fr"
+                              >
+                                <label for="front_fr"
+                                  >Front picture (<span class="tab_language"
+                                    >French</span
+                                  >)</label
+                                >
+
+                                <div class="select_crop" id="front_fr"></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_imgid"
+                                  id="front_fr_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_x1"
+                                  id="front_fr_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_y1"
+                                  id="front_fr_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_x2"
+                                  id="front_fr_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_y2"
+                                  id="front_fr_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_fr_display_url"
+                                  id="front_fr_display_url"
+                                  value=""
+                                />
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_front_image_new_lc"
+                              >
+                                <label for="front_new_lc"
+                                  >Front picture (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="front_new_lc"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_imgid"
+                                  id="front_new_lc_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_x1"
+                                  id="front_new_lc_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_y1"
+                                  id="front_new_lc_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_x2"
+                                  id="front_new_lc_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_y2"
+                                  id="front_new_lc_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="front_new_lc_display_url"
+                                  id="front_new_lc_display_url"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+                          </div>
+                        </section>
+
+                        <section
+                          id="product_characteristics"
+                          class="fieldset card"
+                        >
+                          <div class="card-section">
+                            <legend>Product characteristics</legend>
+
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul id="tabs_product" class="tabs" data-tab>
+                              <li
+                                class="tabs tab-title active tabs_en"
+                                id="tabs_product_en_tab"
+                                data-language="en"
+                              >
+                                <a href="#tabs_product_en" class="tab_language"
+                                  >English</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_fr"
+                                id="tabs_product_fr_tab"
+                                data-language="fr"
+                              >
+                                <a href="#tabs_product_fr" class="tab_language"
+                                  >French</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_product_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_product_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div id="tabs_content_product" class="tabs-content">
+                              <div
+                                class="tabs content active tabs_en"
+                                id="tabs_product_en"
+                              >
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="product_name_en">
+                                  Product name (<span class="tab_language"
+                                    >English</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="product_name_en"
+                                  id="product_name_en"
+                                  class="text"
+                                  value="Apple pie"
+                                  lang="en"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Example: Kinder Bueno White
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="generic_name_en">
+                                  Common name (<span class="tab_language"
+                                    >English</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="generic_name_en"
+                                  id="generic_name_en"
+                                  class="text"
+                                  value="default_name"
+                                  lang="en"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Example: Chocolate bar with milk and hazelnuts
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content tabs_fr"
+                                id="tabs_product_fr"
+                              >
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="product_name_fr">
+                                  Product name (<span class="tab_language"
+                                    >French</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="product_name_fr"
+                                  id="product_name_fr"
+                                  class="text"
+                                  value=""
+                                  lang="fr"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Example: Kinder Bueno White
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="generic_name_fr">
+                                  Common name (<span class="tab_language"
+                                    >French</span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="generic_name_fr"
+                                  id="generic_name_fr"
+                                  class="text"
+                                  value=""
+                                  lang="fr"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Example: Chocolate bar with milk and hazelnuts
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_product_new_lc"
+                              >
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="product_name_new_lc">
+                                  Product name (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="product_name_new_lc"
+                                  id="product_name_new_lc"
+                                  class="text"
+                                  value=""
+                                  lang="new_lc"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Example: Kinder Bueno White
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="generic_name_new_lc">
+                                  Common name (<span class="tab_language"></span
+                                  >)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="generic_name_new_lc"
+                                  id="generic_name_new_lc"
+                                  class="text"
+                                  value=""
+                                  lang="new_lc"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="example">
+                                  Example: Chocolate bar with milk and hazelnuts
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="quantity"> Quantity </label>
+
+                            <input
+                              type="text"
+                              name="quantity"
+                              id="quantity"
+                              class="text"
+                              value="100 g"
+                              lang="en"
+                              data-autocomplete=""
+                            />
+
+                            <p class="example">
+                              Examples: 2 l, 250 g, 1 kg, 25 cl, 6 fl oz, 1
+                              pound
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="brands"> Brands </label>
+
+                            <input
+                              type="text"
+                              name="brands"
+                              id="brands"
+                              class="text tagify-me"
+                              value="Bob's pies"
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=brands"
+                            />
+
+                            <p class="example">
+                              Examples: Kinder Bueno White, Kinder Bueno,
+                              Kinder, Ferrero
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="categories"> Categories </label>
+
+                            <input
+                              type="text"
+                              name="categories"
+                              id="categories"
+                              class="text tagify-me"
+                              value="Desserts, Pies, Sweet pies, Apple pies"
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=categories"
+                            />
+
+                            <p class="note">
+                              &rarr; Indicate only the most specific category.
+                              "Parents" categories will be automatically added.
+                            </p>
+
+                            <p class="example">
+                              Examples: Sardines in olive oil, Orange juice from
+                              concentrate
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="labels">
+                              Labels, certifications, awards
+                            </label>
+
+                            <input
+                              type="text"
+                              name="labels"
+                              id="labels"
+                              class="text tagify-me"
+                              value="Fair trade"
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=labels"
+                            />
+
+                            <p class="note">
+                              &rarr; Indicate only the most specific labels.
+                              "Parents" labels will be added automatically.
+                            </p>
+
+                            <p class="example">Example: Organic</p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="manufacturing_places">
+                              Manufacturing or processing places
+                            </label>
+
+                            <input
+                              type="text"
+                              name="manufacturing_places"
+                              id="manufacturing_places"
+                              class="text tagify-me"
+                              value=""
+                              lang="en"
+                              data-autocomplete=""
+                            />
+
+                            <p class="example">Examples: Montana, USA</p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="emb_codes"> Traceability code </label>
+
+                            <input
+                              type="text"
+                              name="emb_codes"
+                              id="emb_codes"
+                              class="text tagify-me"
+                              value=""
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=emb_codes"
+                            />
+
+                            <p class="note">
+                              &rarr; In Europe, the code is in an ellipse with
+                              the 2 country initials followed by a number and
+                              CE.
+                            </p>
+
+                            <p class="example">
+                              Examples: EMB 53062, FR 62.448.034 CE, 84 R 20, 33
+                              RECOLTANT 522
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="link">
+                              Link to the product page on the official site of
+                              the producer
+                            </label>
+
+                            <input
+                              type="text"
+                              name="link"
+                              id="link"
+                              class="text"
+                              value="//world.openfoodfacts.org/"
+                              lang="en"
+                              data-autocomplete=""
+                            />
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="expiration_date">
+                              Best before date
+                            </label>
+
+                            <input
+                              type="text"
+                              name="expiration_date"
+                              id="expiration_date"
+                              class="text"
+                              value=""
+                              lang="en"
+                              data-autocomplete=""
+                            />
+
+                            <p class="note">
+                              &rarr; The expiration date is a way to track
+                              product changes over time and to identify the most
+                              recent version.
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="purchase_places">
+                              City, state and country where purchased
+                            </label>
+
+                            <input
+                              type="text"
+                              name="purchase_places"
+                              id="purchase_places"
+                              class="text tagify-me"
+                              value=""
+                              lang="en"
+                              data-autocomplete=""
+                            />
+
+                            <p class="note">
+                              &rarr; Indicate where you bought or saw the
+                              product (at least the country)
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="stores"> Stores </label>
+
+                            <input
+                              type="text"
+                              name="stores"
+                              id="stores"
+                              class="text tagify-me"
+                              value=""
+                              lang="en"
+                              data-autocomplete=""
+                            />
+
+                            <p class="note">
+                              &rarr; Name of the shop or supermarket chain
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="countries">
+                              Countries where sold
+                            </label>
+
+                            <input
+                              type="text"
+                              name="countries"
+                              id="countries"
+                              class="text tagify-me"
+                              value="India, Japan, United States"
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=countries"
+                            />
+
+                            <p class="note">
+                              &rarr; Countries where the product is widely
+                              available (not including stores specialising in
+                              foreign products)
+                            </p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                          </div>
+                        </section>
+
+                        <section id="ingredients" class="card fieldset">
+                          <div class="card-section">
+                            <legend>Ingredients</legend>
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul
+                              id="tabs_ingredients_image"
+                              class="tabs"
+                              data-tab
+                            >
+                              <li
+                                class="tabs tab-title active tabs_en"
+                                id="tabs_ingredients_image_en_tab"
+                                data-language="en"
+                              >
+                                <a
+                                  href="#tabs_ingredients_image_en"
+                                  class="tab_language"
+                                  >English</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_fr"
+                                id="tabs_ingredients_image_fr_tab"
+                                data-language="fr"
+                              >
+                                <a
+                                  href="#tabs_ingredients_image_fr"
+                                  class="tab_language"
+                                  >French</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_ingredients_image_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_ingredients_image_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div
+                              id="tabs_content_ingredients_image"
+                              class="tabs-content"
+                            >
+                              <div
+                                class="tabs content active tabs_en"
+                                id="tabs_ingredients_image_en"
+                              >
+                                <label for="ingredients_en"
+                                  >Ingredients picture (<span
+                                    class="tab_language"
+                                    >English</span
+                                  >)</label
+                                >
+                                <p class="note">
+                                  &rarr; If the picture is neat enough, the
+                                  ingredients can be extracted automatically
+                                </p>
+                                <div
+                                  class="select_crop"
+                                  id="ingredients_en"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_imgid"
+                                  id="ingredients_en_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_x1"
+                                  id="ingredients_en_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_y1"
+                                  id="ingredients_en_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_x2"
+                                  id="ingredients_en_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_y2"
+                                  id="ingredients_en_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_en_display_url"
+                                  id="ingredients_en_display_url"
+                                  value=""
+                                />
+
+                                <div id="ingredients_en_image_full"></div>
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="ingredients_text_en">
+                                  Ingredients list (<span class="tab_language"
+                                    >English</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="ingredients_text_en"
+                                  id="ingredients_text_en"
+                                  lang="en"
+                                >
+Wheat flour, apples, sugar, butter, eggs, salt, palm oil, acidifier: citric acid, raising agent: sodium bicarbonate</textarea
+                                >
+
+                                <p class="note">
+                                  &rarr; Keep the order, indicate the % when
+                                  specified, separate with a comma or - , use (
+                                  ) for ingredients of an ingredient, surround
+                                  allergens with _ e.g. _milk_
+                                </p>
+
+                                <p class="example">
+                                  Examples: Cereals 85.5% (_wheat_ flour,
+                                  whole-_wheat_ flour 11%), malt extract, cocoa
+                                  4,8%, ascorbic acid
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="origin_en">
+                                  Origin of the product and/or its ingredients
+                                  (<span class="tab_language">English</span>)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="origin_en"
+                                  id="origin_en"
+                                  class="text"
+                                  value="Germany"
+                                  lang="en"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="note">
+                                  &rarr; Packaging mentions that indicate the
+                                  manufacturing place and/or the origins of the
+                                  ingredients
+                                </p>
+
+                                <p class="example">
+                                  Examples: Made in France. Tomatoes from Italy.
+                                  Origin of the rice: India, Thailand.
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content tabs_fr"
+                                id="tabs_ingredients_image_fr"
+                              >
+                                <label for="ingredients_fr"
+                                  >Ingredients picture (<span
+                                    class="tab_language"
+                                    >French</span
+                                  >)</label
+                                >
+                                <p class="note">
+                                  &rarr; If the picture is neat enough, the
+                                  ingredients can be extracted automatically
+                                </p>
+                                <div
+                                  class="select_crop"
+                                  id="ingredients_fr"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_imgid"
+                                  id="ingredients_fr_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_x1"
+                                  id="ingredients_fr_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_y1"
+                                  id="ingredients_fr_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_x2"
+                                  id="ingredients_fr_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_y2"
+                                  id="ingredients_fr_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_fr_display_url"
+                                  id="ingredients_fr_display_url"
+                                  value=""
+                                />
+
+                                <div id="ingredients_fr_image_full"></div>
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="ingredients_text_fr">
+                                  Ingredients list (<span class="tab_language"
+                                    >French</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="ingredients_text_fr"
+                                  id="ingredients_text_fr"
+                                  lang="fr"
+                                >
+Farine de blé, pommes, sucre, beurre, oeufs, sel, huile de palme, acidifiant: acide citrique, agent levant: bicarbonate de sodium</textarea
+                                >
+
+                                <p class="note">
+                                  &rarr; Keep the order, indicate the % when
+                                  specified, separate with a comma or - , use (
+                                  ) for ingredients of an ingredient, surround
+                                  allergens with _ e.g. _milk_
+                                </p>
+
+                                <p class="example">
+                                  Examples: Cereals 85.5% (_wheat_ flour,
+                                  whole-_wheat_ flour 11%), malt extract, cocoa
+                                  4,8%, ascorbic acid
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="origin_fr">
+                                  Origin of the product and/or its ingredients
+                                  (<span class="tab_language">French</span>)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="origin_fr"
+                                  id="origin_fr"
+                                  class="text"
+                                  value=""
+                                  lang="fr"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="note">
+                                  &rarr; Packaging mentions that indicate the
+                                  manufacturing place and/or the origins of the
+                                  ingredients
+                                </p>
+
+                                <p class="example">
+                                  Examples: Made in France. Tomatoes from Italy.
+                                  Origin of the rice: India, Thailand.
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_ingredients_image_new_lc"
+                              >
+                                <label for="ingredients_new_lc"
+                                  >Ingredients picture (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)</label
+                                >
+                                <p class="note">
+                                  &rarr; If the picture is neat enough, the
+                                  ingredients can be extracted automatically
+                                </p>
+                                <div
+                                  class="select_crop"
+                                  id="ingredients_new_lc"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_imgid"
+                                  id="ingredients_new_lc_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_x1"
+                                  id="ingredients_new_lc_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_y1"
+                                  id="ingredients_new_lc_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_x2"
+                                  id="ingredients_new_lc_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_y2"
+                                  id="ingredients_new_lc_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="ingredients_new_lc_display_url"
+                                  id="ingredients_new_lc_display_url"
+                                  value=""
+                                />
+
+                                <div id="ingredients_new_lc_image_full"></div>
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="ingredients_text_new_lc">
+                                  Ingredients list (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="ingredients_text_new_lc"
+                                  id="ingredients_text_new_lc"
+                                  lang="new_lc"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; Keep the order, indicate the % when
+                                  specified, separate with a comma or - , use (
+                                  ) for ingredients of an ingredient, surround
+                                  allergens with _ e.g. _milk_
+                                </p>
+
+                                <p class="example">
+                                  Examples: Cereals 85.5% (_wheat_ flour,
+                                  whole-_wheat_ flour 11%), malt extract, cocoa
+                                  4,8%, ascorbic acid
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="origin_new_lc">
+                                  Origin of the product and/or its ingredients
+                                  (<span class="tab_language"></span>)
+                                </label>
+
+                                <input
+                                  type="text"
+                                  name="origin_new_lc"
+                                  id="origin_new_lc"
+                                  class="text"
+                                  value=""
+                                  lang="new_lc"
+                                  data-autocomplete=""
+                                />
+
+                                <p class="note">
+                                  &rarr; Packaging mentions that indicate the
+                                  manufacturing place and/or the origins of the
+                                  ingredients
+                                </p>
+
+                                <p class="example">
+                                  Examples: Made in France. Tomatoes from Italy.
+                                  Origin of the rice: India, Thailand.
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="allergens">
+                              Substances or products causing allergies or
+                              intolerances
+                            </label>
+
+                            <input
+                              type="text"
+                              name="allergens"
+                              id="allergens"
+                              class="text tagify-me"
+                              value="Apple, Eggs, Gluten, Milk"
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=allergens"
+                            />
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="traces"> Traces </label>
+
+                            <input
+                              type="text"
+                              name="traces"
+                              id="traces"
+                              class="text tagify-me"
+                              value=""
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=traces"
+                            />
+
+                            <p class="note">
+                              &rarr; Indicate ingredients from mentions like
+                              "May contain traces of", "Made in a factory that
+                              also uses" etc.
+                            </p>
+
+                            <p class="example">Examples: Milk, Gluten, Nuts</p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                            <label for="origins"> Origin of ingredients </label>
+
+                            <input
+                              type="text"
+                              name="origins"
+                              id="origins"
+                              class="text tagify-me"
+                              value=""
+                              lang="en"
+                              data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=origins"
+                            />
+
+                            <p class="example">Examples: California, USA</p>
+
+                            <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                          </div>
+                        </section>
+
+                        <!--nutrient fieldset-->
+                        <section class="card fieldset" id="nutrition">
+                          <div class="card-section">
+                            <legend>Nutrition facts</legend>
+                            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                            <input
+                              type="hidden"
+                              name="no_nutrition_data_displayed"
+                              value="1"
+                            />
+                            <input
+                              type="checkbox"
+                              id="no_nutrition_data"
+                              name="no_nutrition_data"
+                            />
+                            <label
+                              for="no_nutrition_data"
+                              class="checkbox_label"
+                              >Nutrition facts are not specified on the
+                              product.</label
+                            ><br />
+                            <div id="nutrition_data_div">
+                              <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                              <!--html tab header starts-->
+                              <ul
+                                id="tabs_nutrition_image"
+                                class="tabs"
+                                data-tab
+                              >
+                                <li
+                                  class="tabs tab-title active tabs_en"
+                                  id="tabs_nutrition_image_en_tab"
+                                  data-language="en"
+                                >
+                                  <a
+                                    href="#tabs_nutrition_image_en"
+                                    class="tab_language"
+                                    >English</a
+                                  >
+                                </li>
+
+                                <li
+                                  class="tabs tab-title tabs_fr"
+                                  id="tabs_nutrition_image_fr_tab"
+                                  data-language="fr"
+                                >
+                                  <a
+                                    href="#tabs_nutrition_image_fr"
+                                    class="tab_language"
+                                    >French</a
+                                  >
+                                </li>
+
+                                <li
+                                  class="tabs tab-title new_lc hide tabs_new_lc"
+                                  id="tabs_nutrition_image_new_lc_tab"
+                                  data-language="new_lc"
+                                >
+                                  <a
+                                    href="#tabs_nutrition_image_new_lc"
+                                    class="tab_language"
+                                  ></a>
+                                </li>
+
+                                <li class="tabs tab-title new tabs_new">
+                                  <select
+                                    class="select_add_language"
+                                    style="width: 100%"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </li>
+                              </ul>
+                              <!--html tab header ends-->
+
+                              <!--The content tab starts-->
+                              <div
+                                id="tabs_content_nutrition_image"
+                                class="tabs-content"
+                              >
+                                <div
+                                  class="tabs content active tabs_en"
+                                  id="tabs_nutrition_image_en"
+                                >
+                                  <label for="nutrition_en"
+                                    >Nutrition facts picture (<span
+                                      class="tab_language"
+                                      >English</span
+                                    >)</label
+                                  >
+
+                                  <div
+                                    class="select_crop"
+                                    id="nutrition_en"
+                                  ></div>
+                                  <hr class="floatclear" />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_imgid"
+                                    id="nutrition_en_imgid"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_x1"
+                                    id="nutrition_en_x1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_y1"
+                                    id="nutrition_en_y1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_x2"
+                                    id="nutrition_en_x2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_y2"
+                                    id="nutrition_en_y2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_en_display_url"
+                                    id="nutrition_en_display_url"
+                                    value=""
+                                  />
+                                </div>
+
+                                <div
+                                  class="tabs content tabs_fr"
+                                  id="tabs_nutrition_image_fr"
+                                >
+                                  <label for="nutrition_fr"
+                                    >Nutrition facts picture (<span
+                                      class="tab_language"
+                                      >French</span
+                                    >)</label
+                                  >
+
+                                  <div
+                                    class="select_crop"
+                                    id="nutrition_fr"
+                                  ></div>
+                                  <hr class="floatclear" />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_imgid"
+                                    id="nutrition_fr_imgid"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_x1"
+                                    id="nutrition_fr_x1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_y1"
+                                    id="nutrition_fr_y1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_x2"
+                                    id="nutrition_fr_x2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_y2"
+                                    id="nutrition_fr_y2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_fr_display_url"
+                                    id="nutrition_fr_display_url"
+                                    value=""
+                                  />
+                                </div>
+
+                                <div
+                                  class="tabs content new_lc hide tabs_new_lc"
+                                  id="tabs_nutrition_image_new_lc"
+                                >
+                                  <label for="nutrition_new_lc"
+                                    >Nutrition facts picture (<span
+                                      class="tab_language"
+                                    ></span
+                                    >)</label
+                                  >
+
+                                  <div
+                                    class="select_crop"
+                                    id="nutrition_new_lc"
+                                  ></div>
+                                  <hr class="floatclear" />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_imgid"
+                                    id="nutrition_new_lc_imgid"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_x1"
+                                    id="nutrition_new_lc_x1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_y1"
+                                    id="nutrition_new_lc_y1"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_x2"
+                                    id="nutrition_new_lc_x2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_y2"
+                                    id="nutrition_new_lc_y2"
+                                    value=""
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name="nutrition_new_lc_display_url"
+                                    id="nutrition_new_lc_display_url"
+                                    value=""
+                                  />
+                                </div>
+                              </div>
+                              <!--The content tab ends-->
+
+                              <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+                              <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                              <label for="serving_size"> Serving size </label>
+
+                              <input
+                                type="text"
+                                name="serving_size"
+                                id="serving_size"
+                                class="text"
+                                value="10 g"
+                                lang="en"
+                                data-autocomplete=""
+                              />
+
+                              <p class="note">
+                                &rarr; If the nutrition facts table contains
+                                values for the prepared product, indicate the
+                                total serving size of the prepared product
+                                (including added water or milk).
+                              </p>
+
+                              <p class="example">
+                                Examples: 60 g, 12 oz, 20cl, 2 fl oz
+                              </p>
+
+                              <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+
+                              <!-- petfood nutriment are as sold only -->
+
+                              <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                              <input
+                                type="hidden"
+                                name="nutrition_data_displayed"
+                                value="1"
+                              />
+                              <input
+                                type="checkbox"
+                                id="nutrition_data"
+                                name="nutrition_data"
+                                checked="checked"
+                              />
+                              <label for="nutrition_data" class="checkbox_label"
+                                >Nutrition facts are specified for the product
+                                as sold.</label
+                              >
+                              &nbsp;
+                              <input
+                                type="radio"
+                                id="nutrition_data_per_100g"
+                                value="100g"
+                                name="nutrition_data_per"
+                                checked="checked"
+                              />
+                              <label for="nutrition_data_per_100g"
+                                >for 100 g / 100 ml</label
+                              >
+                              <input
+                                type="radio"
+                                id="nutrition_data_per_serving"
+                                value="serving"
+                                name="nutrition_data_per"
+                              />
+                              <label for="nutrition_data_per_serving"
+                                >per serving</label
+                              ><br />
+
+                              <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                              <input
+                                type="hidden"
+                                name="nutrition_data_prepared_displayed"
+                                value="1"
+                              />
+                              <input
+                                type="checkbox"
+                                id="nutrition_data_prepared"
+                                name="nutrition_data_prepared"
+                              />
+                              <label
+                                for="nutrition_data_prepared"
+                                class="checkbox_label"
+                                >Nutrition facts are specified for the prepared
+                                product.</label
+                              >
+                              &nbsp;
+                              <input
+                                type="radio"
+                                id="nutrition_data_prepared_per_100g"
+                                value="100g"
+                                name="nutrition_data_prepared_per"
+                                checked="checked"
+                              />
+                              <label for="nutrition_data_prepared_per_100g"
+                                >for 100 g / 100 ml</label
+                              >
+                              <input
+                                type="radio"
+                                id="nutrition_data_prepared_per_serving"
+                                value="serving"
+                                name="nutrition_data_prepared_per"
+                              />
+                              <label for="nutrition_data_prepared_per_serving"
+                                >per serving</label
+                              ><br />
+
+                              <div style="position: relative">
+                                <table
+                                  id="nutrition_data_table"
+                                  class="data_table"
+                                  style="display: table"
+                                  aria-label="nutrition table"
+                                >
+                                  <thead class="nutriment_header">
+                                    <th id="col_1">Nutrition facts</th>
+                                    <th id="col_2" class="nutriment_col">
+                                      As sold<br />
+
+                                      <span id="nutrition_data_100g"
+                                        >for 100 g / 100 ml</span
+                                      >
+                                      <span
+                                        id="nutrition_data_serving"
+                                        style="display: none"
+                                        >per serving</span
+                                      >
+                                    </th>
+                                    <th
+                                      id="col_3"
+                                      class="nutriment_col_prepared"
+                                      style="display: none"
+                                    >
+                                      Prepared<br />
+                                      <span id="nutrition_data_prepared_100g"
+                                        >for 100 g / 100 ml</span
+                                      >
+                                      <span
+                                        id="nutrition_data_prepared_serving"
+                                        style="display: none"
+                                        >per serving</span
+                                      >
+                                    </th>
+                                    <th id="col_4">Unit</th>
+                                  </thead>
+
+                                  <tbody>
+                                    <tr
+                                      id="nutriment_energy-kj_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_energy-kj"
+                                        >
+                                          Energy (kJ) *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_energy-kj"
+                                          name="nutriment_energy-kj"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_energy-kj"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_energy-kj"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_energy-kj_prepared"
+                                          name="nutriment_energy-kj_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span class="nutriment_unit">kJ</span>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_energy-kcal_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_energy-kcal"
+                                        >
+                                          Energy (kcal)
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_energy-kcal"
+                                          name="nutriment_energy-kcal"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_energy-kcal"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_energy-kcal"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_energy-kcal_prepared"
+                                          name="nutriment_energy-kcal_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span class="nutriment_unit">kcal</span>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_fat_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_fat"
+                                        >
+                                          Fat *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_fat"
+                                          name="nutriment_fat"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_fat"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_fat"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_fat_prepared"
+                                          name="nutriment_fat_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_fat_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_fat_unit"
+                                          name="nutriment_fat_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_saturated-fat_tr"
+                                      class="nutriment_sub"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_saturated-fat"
+                                        >
+                                          Saturated fat *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_saturated-fat"
+                                          name="nutriment_saturated-fat"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_saturated-fat"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_saturated-fat"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_saturated-fat_prepared"
+                                          name="nutriment_saturated-fat_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_saturated-fat_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_saturated-fat_unit"
+                                          name="nutriment_saturated-fat_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_carbohydrates_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_carbohydrates"
+                                        >
+                                          Carbohydrates
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_carbohydrates"
+                                          name="nutriment_carbohydrates"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_carbohydrates"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_carbohydrates"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_carbohydrates_prepared"
+                                          name="nutriment_carbohydrates_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_carbohydrates_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_carbohydrates_unit"
+                                          name="nutriment_carbohydrates_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_sugars_tr"
+                                      class="nutriment_sub"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_sugars"
+                                        >
+                                          Sugars *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_sugars"
+                                          name="nutriment_sugars"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_sugars"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_sugars"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_sugars_prepared"
+                                          name="nutriment_sugars_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_sugars_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_sugars_unit"
+                                          name="nutriment_sugars_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_fiber_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_fiber"
+                                        >
+                                          Fiber *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_fiber"
+                                          name="nutriment_fiber"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_fiber"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_fiber"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_fiber_prepared"
+                                          name="nutriment_fiber_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_fiber_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_fiber_unit"
+                                          name="nutriment_fiber_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_proteins_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_proteins"
+                                        >
+                                          Proteins *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_proteins"
+                                          name="nutriment_proteins"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_proteins"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_proteins"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_proteins_prepared"
+                                          name="nutriment_proteins_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_proteins_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_proteins_unit"
+                                          name="nutriment_proteins_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_salt_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_salt"
+                                        >
+                                          Salt *
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_salt"
+                                          name="nutriment_salt"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_salt"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_salt"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_salt_prepared"
+                                          name="nutriment_salt_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_salt_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_salt_unit"
+                                          name="nutriment_salt_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_sodium_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_sodium"
+                                        >
+                                          Sodium
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_sodium"
+                                          name="nutriment_sodium"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_sodium"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_sodium"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_sodium_prepared"
+                                          name="nutriment_sodium_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_sodium_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_sodium_unit"
+                                          name="nutriment_sodium_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_alcohol_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <label
+                                          class="nutriment_label"
+                                          for="nutriment_alcohol"
+                                        >
+                                          Alcohol
+                                        </label>
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_alcohol"
+                                          name="nutriment_alcohol"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_alcohol"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_alcohol"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_alcohol_prepared"
+                                          name="nutriment_alcohol_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span class="nutriment_unit"
+                                          >% vol / °</span
+                                        >
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_new_0_tr"
+                                      class="nutriment_main"
+                                      style="display: none"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <input
+                                          class="nutriment_label"
+                                          id="nutriment_new_0_label"
+                                          name="nutriment_new_0_label"
+                                          placeholder="Add a nutrient"
+                                        />
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_new_0"
+                                          name="nutriment_new_0"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_new_0"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_new_0"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_new_0_prepared"
+                                          name="nutriment_new_0_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_new_0_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_new_0_unit"
+                                          name="nutriment_new_0_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+
+                                          <option value="% DV">% DV</option>
+
+                                          <option value="IU">IU</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+
+                                    <tr
+                                      id="nutriment_new_1_tr"
+                                      class="nutriment_main"
+                                    >
+                                      <td>
+                                        <!--label starts-->
+
+                                        <input
+                                          class="nutriment_label"
+                                          id="nutriment_new_1_label"
+                                          name="nutriment_new_1_label"
+                                          placeholder="Add a nutrient"
+                                        />
+
+                                        <!--label ends-->
+                                      </td>
+
+                                      <td class="nutriment_col">
+                                        <input
+                                          class="nutriment_value nutriment_value_as_sold soft-background"
+                                          id="nutriment_new_1"
+                                          name="nutriment_new_1"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                        <span
+                                          id="nutriment_question_mark_new_1"
+                                          class="question_mark"
+                                          >?</span
+                                        >
+                                        <span
+                                          id="nutriment_sugars_warning_new_1"
+                                          class="sugars_warning"
+                                          >Please enter a valid value.</span
+                                        >
+                                      </td>
+                                      <td
+                                        class="nutriment_col_prepared"
+                                        style="display: none"
+                                      >
+                                        <input
+                                          class="nutriment_value nutriment_value_prepared"
+                                          id="nutriment_new_1_prepared"
+                                          name="nutriment_new_1_prepared"
+                                          value=""
+                                          autocomplete="off"
+                                        />
+                                      </td>
+
+                                      <!-- food -->
+                                      <!-- petfood -->
+
+                                      <td>
+                                        <span
+                                          class="nutriment_unit_percent"
+                                          id="nutriment_new_1_unit_percent"
+                                          style="display: none"
+                                          >%</span
+                                        >
+                                        <select
+                                          class="nutriment_unit"
+                                          id="nutriment_new_1_unit"
+                                          name="nutriment_new_1_unit"
+                                        >
+                                          <option value="g" selected="selected">
+                                            g
+                                          </option>
+
+                                          <option value="mg">mg</option>
+
+                                          <option value="µg">mcg/µg</option>
+
+                                          <option value="% DV">% DV</option>
+
+                                          <option value="IU">IU</option>
+                                        </select>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+
+                                <input
+                                  type="hidden"
+                                  name="new_max"
+                                  id="new_max"
+                                  value="1"
+                                />
+                                <div
+                                  id="nutrition_image_copy"
+                                  style="position: absolute; bottom: 0"
+                                ></div>
+                              </div>
+
+                              <p class="asterisk">
+                                &rarr;*:Essential nutrients to calculate the
+                                Nutri-Score.
+                              </p>
+
+                              <p class="note">
+                                &rarr; The table lists by default nutriments
+                                that are often specified. Leave the field blank
+                                if it's not on the label.<br />You can add extra
+                                nutriments (vitamins, minerals, cholesterol
+                                etc.) by typing the first letters of their name
+                                in the last row of the table.
+                              </p>
+                            </div>
+                          </div>
+                        </section>
+                        <!--nutrient field set-->
+
+                        <!--packaging field-->
+                        <section id="packaging_section" class="card fieldset">
+                          <div class="card-section">
+                            <legend>Packaging</legend>
+                            <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!--html tab header starts-->
+                            <ul id="tabs_packaging_image" class="tabs" data-tab>
+                              <li
+                                class="tabs tab-title active tabs_en"
+                                id="tabs_packaging_image_en_tab"
+                                data-language="en"
+                              >
+                                <a
+                                  href="#tabs_packaging_image_en"
+                                  class="tab_language"
+                                  >English</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title tabs_fr"
+                                id="tabs_packaging_image_fr_tab"
+                                data-language="fr"
+                              >
+                                <a
+                                  href="#tabs_packaging_image_fr"
+                                  class="tab_language"
+                                  >French</a
+                                >
+                              </li>
+
+                              <li
+                                class="tabs tab-title new_lc hide tabs_new_lc"
+                                id="tabs_packaging_image_new_lc_tab"
+                                data-language="new_lc"
+                              >
+                                <a
+                                  href="#tabs_packaging_image_new_lc"
+                                  class="tab_language"
+                                ></a>
+                              </li>
+
+                              <li class="tabs tab-title new tabs_new">
+                                <select
+                                  class="select_add_language"
+                                  style="width: 100%"
+                                >
+                                  <option></option>
+                                </select>
+                              </li>
+                            </ul>
+                            <!--html tab header ends-->
+
+                            <!--The content tab starts-->
+                            <div
+                              id="tabs_content_packaging_image"
+                              class="tabs-content"
+                            >
+                              <div
+                                class="tabs content active tabs_en"
+                                id="tabs_packaging_image_en"
+                              >
+                                <label for="packaging_en"
+                                  >Recycling instructions and/or packaging
+                                  information picture (<span
+                                    class="tab_language"
+                                    >English</span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="packaging_en"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_imgid"
+                                  id="packaging_en_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_x1"
+                                  id="packaging_en_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_y1"
+                                  id="packaging_en_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_x2"
+                                  id="packaging_en_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_y2"
+                                  id="packaging_en_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_en_display_url"
+                                  id="packaging_en_display_url"
+                                  value=""
+                                />
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="packaging_text_en">
+                                  Recycling instructions and/or packaging
+                                  information (<span class="tab_language"
+                                    >English</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="packaging_text_en"
+                                  id="packaging_text_en"
+                                  lang="en"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; List all packaging parts separated by a
+                                  comma or line feed, with their amount (e.g. 1
+                                  or 6) type (e.g. bottle, box, can), material
+                                  (e.g. plastic, metal, aluminium) and if
+                                  available their size (e.g. 33cl) and recycling
+                                  instructions.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Try to be as specific as possible. For
+                                  plastic, please indicate if it is opaque or
+                                  transparent, colored, PET or PEHD.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Data from this field will be combined
+                                  with any data provided for each packaging
+                                  part. It is possible to provide one or the
+                                  other, or both.
+                                </p>
+
+                                <p class="example">
+                                  Examples: 1 plastic film to discard, 1 FSC
+                                  carboard box to recycle, 6 1.5L transparent
+                                  PET plastic bottles to recycle, 6 colored
+                                  opaque plastic caps, 12 33cl aluminium cans
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content tabs_fr"
+                                id="tabs_packaging_image_fr"
+                              >
+                                <label for="packaging_fr"
+                                  >Recycling instructions and/or packaging
+                                  information picture (<span
+                                    class="tab_language"
+                                    >French</span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="packaging_fr"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_imgid"
+                                  id="packaging_fr_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_x1"
+                                  id="packaging_fr_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_y1"
+                                  id="packaging_fr_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_x2"
+                                  id="packaging_fr_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_y2"
+                                  id="packaging_fr_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_fr_display_url"
+                                  id="packaging_fr_display_url"
+                                  value=""
+                                />
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="packaging_text_fr">
+                                  Recycling instructions and/or packaging
+                                  information (<span class="tab_language"
+                                    >French</span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="packaging_text_fr"
+                                  id="packaging_text_fr"
+                                  lang="fr"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; List all packaging parts separated by a
+                                  comma or line feed, with their amount (e.g. 1
+                                  or 6) type (e.g. bottle, box, can), material
+                                  (e.g. plastic, metal, aluminium) and if
+                                  available their size (e.g. 33cl) and recycling
+                                  instructions.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Try to be as specific as possible. For
+                                  plastic, please indicate if it is opaque or
+                                  transparent, colored, PET or PEHD.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Data from this field will be combined
+                                  with any data provided for each packaging
+                                  part. It is possible to provide one or the
+                                  other, or both.
+                                </p>
+
+                                <p class="example">
+                                  Examples: 1 plastic film to discard, 1 FSC
+                                  carboard box to recycle, 6 1.5L transparent
+                                  PET plastic bottles to recycle, 6 colored
+                                  opaque plastic caps, 12 33cl aluminium cans
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+
+                              <div
+                                class="tabs content new_lc hide tabs_new_lc"
+                                id="tabs_packaging_image_new_lc"
+                              >
+                                <label for="packaging_new_lc"
+                                  >Recycling instructions and/or packaging
+                                  information picture (<span
+                                    class="tab_language"
+                                  ></span
+                                  >)</label
+                                >
+
+                                <div
+                                  class="select_crop"
+                                  id="packaging_new_lc"
+                                ></div>
+                                <hr class="floatclear" />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_imgid"
+                                  id="packaging_new_lc_imgid"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_x1"
+                                  id="packaging_new_lc_x1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_y1"
+                                  id="packaging_new_lc_y1"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_x2"
+                                  id="packaging_new_lc_x2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_y2"
+                                  id="packaging_new_lc_y2"
+                                  value=""
+                                />
+                                <input
+                                  type="hidden"
+                                  name="packaging_new_lc_display_url"
+                                  id="packaging_new_lc_display_url"
+                                  value=""
+                                />
+
+                                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
+                                <label for="packaging_text_new_lc">
+                                  Recycling instructions and/or packaging
+                                  information (<span class="tab_language"></span
+                                  >)
+                                </label>
+
+                                <textarea
+                                  name="packaging_text_new_lc"
+                                  id="packaging_text_new_lc"
+                                  lang="new_lc"
+                                ></textarea>
+
+                                <p class="note">
+                                  &rarr; List all packaging parts separated by a
+                                  comma or line feed, with their amount (e.g. 1
+                                  or 6) type (e.g. bottle, box, can), material
+                                  (e.g. plastic, metal, aluminium) and if
+                                  available their size (e.g. 33cl) and recycling
+                                  instructions.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Try to be as specific as possible. For
+                                  plastic, please indicate if it is opaque or
+                                  transparent, colored, PET or PEHD.
+                                </p>
+
+                                <p class="note">
+                                  &rarr; Data from this field will be combined
+                                  with any data provided for each packaging
+                                  part. It is possible to provide one or the
+                                  other, or both.
+                                </p>
+
+                                <p class="example">
+                                  Examples: 1 plastic film to discard, 1 FSC
+                                  carboard box to recycle, 6 1.5L transparent
+                                  PET plastic bottles to recycle, 6 colored
+                                  opaque plastic caps, 12 33cl aluminium cans
+                                </p>
+
+                                <!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
+                              </div>
+                            </div>
+                            <!--The content tab ends-->
+
+                            <!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
+
+                            <!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+                            <p>Packaging parts</p>
+
+                            <div id="packagings_components_edit">
+                              <ul>
+                                <li>
+                                  <b>Number of units:</b> Enter the number of
+                                  packaging units of the same shape and material
+                                  contained in the product.
+                                </li>
+                                <li>
+                                  <b>Shape:</b> Enter the shape name listed in
+                                  the recycling instructions if they are
+                                  available, or select a shape.
+                                </li>
+                                <li>
+                                  <b>Material:</b> Enter the specific material
+                                  if it can be determined (a material code
+                                  inside a triangle can often be found on
+                                  packaging parts), or a generic material (for
+                                  instance plastic or metal) if you are unsure.
+                                </li>
+                                <li>
+                                  <b>Recycling:</b> Enter recycling instructions
+                                  only if they are listed on the product.
+                                </li>
+                                <li>
+                                  <b>Weight of one empty unit:</b> Remove any
+                                  remaining food and wash and dry the packaging
+                                  part before weighting. If possible, use a
+                                  scale with 0.1g or 0.01g precision.
+                                </li>
+                                <li>
+                                  <b>Quantity of product contained per unit:</b>
+                                  Enter the net weight or net volume and
+                                  indicate the unit (for example g or ml).
+                                </li>
+                              </ul>
+
+                              <!-- header row for large display -->
+                              <div
+                                class="row show-for-large-up"
+                                id="packagings_components_edit_header"
+                              >
+                                <div class="large-1 columns">
+                                  Number of units
+                                </div>
+                                <div class="large-3 columns">Shape</div>
+                                <div class="large-3 columns">Material</div>
+                                <div class="large-3 columns">Recycling</div>
+                                <div class="large-1 columns">
+                                  Weight of one empty unit (g)
+                                </div>
+                                <div class="large-1 columns">
+                                  Quantity of product contained per unit
+                                </div>
+                              </div>
+
+                              <div
+                                class="row packagings_components_edit_row"
+                                id="packaging_0_row"
+                              >
+                                <div class="small-12 large-1 columns">
+                                  <!-- label for small displays -->
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_number_of_units"
+                                    >Number of units</label
+                                  >
+
+                                  <div class="row">
+                                    <div
+                                      class="small-12 large-4 columns delete_packaging_column"
+                                    >
+                                      <a
+                                        class="delete_packaging"
+                                        id="packaging_0_delete"
+                                      >
+                                        <span class="material-icons">
+                                          delete
+                                        </span>
+                                      </a>
+                                    </div>
+
+                                    <div class="small-12 large-8 columns">
+                                      <input
+                                        id="packaging_0_number_of_units"
+                                        name="packaging_0_number_of_units"
+                                        type="text"
+                                        value=""
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_shape"
+                                    >Shape</label
+                                  >
+                                  <select
+                                    id="packaging_0_shape"
+                                    name="packaging_0_shape"
+                                    class="form-control packaging_shapes_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_material"
+                                    >Material</label
+                                  >
+                                  <select
+                                    id="packaging_0_material"
+                                    name="packaging_0_material"
+                                    class="form-control packaging_materials_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_recycling"
+                                    >Recycling</label
+                                  >
+                                  <select
+                                    id="packaging_0_recycling"
+                                    name="packaging_0_recycling"
+                                    class="form-control packaging_recycling_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_weight_measured"
+                                    >Weight of one empty unit (g)</label
+                                  >
+
+                                  <input id="packaging_0_weight_measured"
+                                  name="packaging_0_weight_measured" type="text"
+                                  value="" %]">
+                                </div>
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_0_quantity_per_unit"
+                                    >Quantity of product contained per
+                                    unit</label
+                                  >
+                                  <input id="packaging_0_quantity_per_unit"
+                                  name="packaging_0_quantity_per_unit"
+                                  type="text" value="" %]">
+                                </div>
+                              </div>
+
+                              <div
+                                class="row packagings_components_edit_row"
+                                id="packaging_1_row"
+                              >
+                                <div class="small-12 large-1 columns">
+                                  <!-- label for small displays -->
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_number_of_units"
+                                    >Number of units</label
+                                  >
+
+                                  <div class="row">
+                                    <div
+                                      class="small-12 large-4 columns delete_packaging_column"
+                                    >
+                                      <a
+                                        class="delete_packaging"
+                                        id="packaging_1_delete"
+                                      >
+                                        <span class="material-icons">
+                                          delete
+                                        </span>
+                                      </a>
+                                    </div>
+
+                                    <div class="small-12 large-8 columns">
+                                      <input
+                                        id="packaging_1_number_of_units"
+                                        name="packaging_1_number_of_units"
+                                        type="text"
+                                        value=""
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_shape"
+                                    >Shape</label
+                                  >
+                                  <select
+                                    id="packaging_1_shape"
+                                    name="packaging_1_shape"
+                                    class="form-control packaging_shapes_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_material"
+                                    >Material</label
+                                  >
+                                  <select
+                                    id="packaging_1_material"
+                                    name="packaging_1_material"
+                                    class="form-control packaging_materials_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-3 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_recycling"
+                                    >Recycling</label
+                                  >
+                                  <select
+                                    id="packaging_1_recycling"
+                                    name="packaging_1_recycling"
+                                    class="form-control packaging_recycling_select2"
+                                  >
+                                    <option></option>
+                                  </select>
+                                </div>
+
+                                <!-- row 0 is a template for new row, we do not populate it -->
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_weight_measured"
+                                    >Weight of one empty unit (g)</label
+                                  >
+
+                                  <input id="packaging_1_weight_measured"
+                                  name="packaging_1_weight_measured" type="text"
+                                  value="" %]">
+                                </div>
+
+                                <div class="small-12 large-1 columns">
+                                  <label
+                                    class="hide-for-large-up"
+                                    for="packaging_1_quantity_per_unit"
+                                    >Quantity of product contained per
+                                    unit</label
+                                  >
+                                  <input id="packaging_1_quantity_per_unit"
+                                  name="packaging_1_quantity_per_unit"
+                                  type="text" value="" %]">
+                                </div>
+                              </div>
+
+                              <input
+                                type="hidden"
+                                name="packaging_max"
+                                value="1"
+                              />
+                            </div>
+
+                            <input
+                              type="checkbox"
+                              id="packagings_complete"
+                              name="packagings_complete"
+                            />
+                            <label
+                              for="packagings_complete"
+                              class="checkbox_label"
+                              >All the packaging parts of the product are
+                              listed.</label
+                            ><br />
+
+                            <!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+                          </div>
+                        </section>
+
+                        <input type="hidden" name="type" value="edit" />
+                        <input
+                          type="hidden"
+                          id="code"
+                          name="code"
+                          value="3300000000001"
+                        />
+                        <input type="hidden" name="action" value="process" />
+
+                        <div id="fixed_bar" class="bottom-validation">
+                          <div class="row">
+                            <div
+                              class="small-12 medium-12 large-8 xlarge-8 columns"
+                              style="margin-bottom: 0.5rem"
+                            >
+                              <input
+                                id="comment"
+                                name="comment"
+                                placeholder="Changes summary"
+                                value=""
+                                type="text"
+                                class="text"
+                                style="margin: 0"
+                              />
+                            </div>
+                            <div
+                              class="small-6 medium-6 large-2 xlarge-2 columns"
+                            >
+                              <button
+                                type="submit"
+                                id="save"
+                                name=".submit"
+                                class="button postfix success small"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                  <path
+                                    d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                  />
+                                </svg>
+                                Save
+                              </button>
+                            </div>
+                            <div
+                              class="small-6 medium-6 large-2 xlarge-2 columns"
+                            >
+                              <button
+                                type="button"
+                                id="back-btn"
+                                class="button postfix small secondary"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+
+                        <!-- start templates/web/pages/product/includes/edit_history.tt.html -->
+
+                        <h2 id="history">Changes history</h2>
+                        <ul id="history_list">
+                          <li>
+                            <time datetime="--ignore--">--ignore--</time> -
+                            <a href="/facets/editors/tests" lang="no_language"
+                              >tests</a
+                            >
+                            Data (Added: product_type, code, lang, product_name,
+                            generic_name, quantity, brands, categories, labels,
+                            link, countries, origin, nutrition_data_per,
+                            nutrition_data_prepared_per, serving_size,
+                            ingredients_text, generic_name_en,
+                            ingredients_text_en, origin_en, product_name_en,
+                            ingredients_text_fr) -- Nutriments (Added:
+                            nutrition-score-fr) - (app) &nbsp;
+                            <a
+                              href="/product/3300000000001/apple-pie-bob-s-pies?rev=1"
+                              class="button tiny"
+                              >View this revision</a
+                            >
+                          </li>
+                        </ul>
+
+                        <script>
+                          var revert_confirm_message =
+                            "Revert to this product revision?";
+                        </script>
+
+                        <!-- end templates/web/pages/product/includes/edit_history.tt.html -->
+                      </div>
+                    </div>
+                  </div>
+                </form>
+
+                <style>
+                  .question_mark {
+                    display: none;
+                    position: relative;
+                    width: 20px;
+                    height: 20px;
+                    border-radius: 50%;
+                    background-color: #999;
+                    color: #fff;
+                    text-align: center;
+                    font-weight: bold;
+                    cursor: help;
+                  }
+
+                  .sugars_warning {
+                    display: none;
+                    position: absolute;
+                    left: 16%;
+                    transform: translateX(50%);
+                    padding: 0.5em;
+                    background-color: #333;
+                    color: #fff;
+                    font-size: 0.8em;
+                    white-space: nowrap;
+                    margin-top: 1%;
+                    z-index: 1;
+                  }
+
+                  .soft-background {
+                    background-color: #f5f5f5;
+                  }
+
+                  .question_mark:hover + .sugars_warning {
+                    display: inline-block;
+                  }
+
+                  .question_mark:hover {
+                    opacity: 0.7;
+                  }
+                </style>
+
+                <!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
+              </div>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div id="prodInfos">
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-            <div class="row">
-                <div class="small-12 columns">
+        <!-- Donation banner @ footer -->
 
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
-        <section id="misc" class="card fieldset">
-            <div class="card-section">
-                <p id="barcode_paragraph"> Barcode:
-                    <span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">3300000000001</span>
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
                 </p>
-
-
-        
-        
-        
-            <label for="product_type" id="label_product_type">Product type</label>
-            <select name="product_type" id="product_type">
-                
-                    <option value="food"  selected="selected" >Food</option>
-                
-                    <option value="petfood" >Pet food</option>
-                
-                    <option value="beauty" >Beauty</option>
-                
-                    <option value="product" >Product</option>
-                
-            </select>
-        
-
-        
-
-        
-        
-        <div data-alert class="alert-box info store-state" id="warning_3rd_party_content" style="display:none;">
-            <span>Information and data must come from the product package and label (and not from other sites or the manufacturer's site), and you must have taken the pictures yourself.<br/>
-→ <a href="//support.openfoodfacts.org/help/en-gb/9/27">Why it matters</a></span>
-             <a href="#" class="close">&times;</a>
-        </div>
-        
-
-        <div data-alert class="alert-box secondary store-state" id="licence_accept" style="display:none;">
-            <span>By adding information, data and/or images, you accept to place irrevocably your contribution under the <a href="//opendatacommons.org/licenses/dbcl/1.0/">Database Contents Licence 1.0</a> licence
-for information and data, and under the <a href="//creativecommons.org/licenses/by-sa/3.0/deed.en">Creative Commons Attribution - ShareAlike 3.0</a> licence for images.
-You accept to be credited by re-users by a link to the product your are contributing to.</span>
-             <a href="#" class="close">&times;</a>
-        </div>
-
-        
-
-        
-
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
             </div>
+          </div>
         </section>
 
-        <section id="product_image" class="card fieldset">
-            <div class="card-section">
-                <legend>Product picture</legend>
-                <input type="hidden" id="sorted_langs" name="sorted_langs" value="en,fr"/>
-
-                <label for="lang"> Main language </label>
-                <select name="lang" id="lang">
-                    
-                        <option value="ab" >Abkhaz</option>
-                    
-                        <option value="aa" >Afar</option>
-                    
-                        <option value="af" >Afrikaans</option>
-                    
-                        <option value="ak" >Akan</option>
-                    
-                        <option value="sq" >Albanian</option>
-                    
-                        <option value="am" >Amharic</option>
-                    
-                        <option value="ar" >Arabic</option>
-                    
-                        <option value="an" >Aragonese</option>
-                    
-                        <option value="hy" >Armenian</option>
-                    
-                        <option value="as" >Assamese</option>
-                    
-                        <option value="av" >Avar</option>
-                    
-                        <option value="ae" >Avestan</option>
-                    
-                        <option value="ay" >Aymara</option>
-                    
-                        <option value="az" >Azerbaijani</option>
-                    
-                        <option value="bm" >Bambara</option>
-                    
-                        <option value="ba" >Bashkir</option>
-                    
-                        <option value="eu" >Basque</option>
-                    
-                        <option value="be" >Belarusian</option>
-                    
-                        <option value="bn" >Bengali</option>
-                    
-                        <option value="bh" >Bihari languages</option>
-                    
-                        <option value="bi" >Bislama</option>
-                    
-                        <option value="nb" >Bokmål</option>
-                    
-                        <option value="bs" >Bosnian</option>
-                    
-                        <option value="br" >Breton</option>
-                    
-                        <option value="bg" >Bulgarian</option>
-                    
-                        <option value="my" >Burmese</option>
-                    
-                        <option value="ca" >Catalan</option>
-                    
-                        <option value="ch" >Chamorro</option>
-                    
-                        <option value="ce" >Chechen</option>
-                    
-                        <option value="ny" >Chewa</option>
-                    
-                        <option value="zh" >Chinese</option>
-                    
-                        <option value="cu" >Church Slavonic</option>
-                    
-                        <option value="cv" >Chuvash</option>
-                    
-                        <option value="kw" >Cornish</option>
-                    
-                        <option value="co" >Corsican</option>
-                    
-                        <option value="cr" >Cree</option>
-                    
-                        <option value="hr" >Croatian</option>
-                    
-                        <option value="cs" >Czech</option>
-                    
-                        <option value="da" >Danish</option>
-                    
-                        <option value="nl" >Dutch</option>
-                    
-                        <option value="dz" >Dzongkha language</option>
-                    
-                        <option value="en"  selected="selected" >English</option>
-                    
-                        <option value="eo" >Esperanto</option>
-                    
-                        <option value="et" >Estonian</option>
-                    
-                        <option value="ee" >Ewe</option>
-                    
-                        <option value="fo" >Faroese</option>
-                    
-                        <option value="fj" >Fijian language</option>
-                    
-                        <option value="fi" >Finnish</option>
-                    
-                        <option value="fr" >French</option>
-                    
-                        <option value="ff" >Fula language</option>
-                    
-                        <option value="gl" >Galician</option>
-                    
-                        <option value="ka" >Georgian</option>
-                    
-                        <option value="de" >German</option>
-                    
-                        <option value="ki" >Gikuyu</option>
-                    
-                        <option value="el" >Greek</option>
-                    
-                        <option value="kl" >Greenlandic</option>
-                    
-                        <option value="gn" >Guarani</option>
-                    
-                        <option value="gu" >Gujarati</option>
-                    
-                        <option value="ht" >Haitian Creole</option>
-                    
-                        <option value="ha" >Hausa</option>
-                    
-                        <option value="he" >Hebrew</option>
-                    
-                        <option value="hz" >Herero</option>
-                    
-                        <option value="hi" >Hindi</option>
-                    
-                        <option value="ho" >Hiri Motu</option>
-                    
-                        <option value="hu" >Hungarian</option>
-                    
-                        <option value="is" >Icelandic</option>
-                    
-                        <option value="io" >Ido</option>
-                    
-                        <option value="ig" >Igbo language</option>
-                    
-                        <option value="id" >Indonesian</option>
-                    
-                        <option value="ia" >Interlingua</option>
-                    
-                        <option value="ie" >Interlingue</option>
-                    
-                        <option value="iu" >Inuktitut</option>
-                    
-                        <option value="ik" >Inupiat language</option>
-                    
-                        <option value="ga" >Irish</option>
-                    
-                        <option value="it" >Italian</option>
-                    
-                        <option value="ja" >Japanese</option>
-                    
-                        <option value="jv" >Javanese</option>
-                    
-                        <option value="kn" >Kannada</option>
-                    
-                        <option value="kr" >Kanuri</option>
-                    
-                        <option value="ks" >Kashmiri</option>
-                    
-                        <option value="kk" >Kazakh</option>
-                    
-                        <option value="km" >Khmer</option>
-                    
-                        <option value="rw" >Kinyarwanda</option>
-                    
-                        <option value="rn" >Kirundi</option>
-                    
-                        <option value="kv" >Komi</option>
-                    
-                        <option value="kg" >Kongo language</option>
-                    
-                        <option value="ko" >Korean</option>
-                    
-                        <option value="ku" >Kurdish</option>
-                    
-                        <option value="kj" >Kwanyama</option>
-                    
-                        <option value="ky" >Kyrgyz</option>
-                    
-                        <option value="lo" >Lao</option>
-                    
-                        <option value="la" >Latin</option>
-                    
-                        <option value="lv" >Latvian</option>
-                    
-                        <option value="li" >Limburgish language</option>
-                    
-                        <option value="ln" >Lingala language</option>
-                    
-                        <option value="lt" >Lithuanian</option>
-                    
-                        <option value="lu" >Luba-Katanga language</option>
-                    
-                        <option value="lg" >Luganda</option>
-                    
-                        <option value="lb" >Luxembourgish</option>
-                    
-                        <option value="mk" >Macedonian</option>
-                    
-                        <option value="mg" >Malagasy</option>
-                    
-                        <option value="ms" >Malay</option>
-                    
-                        <option value="ml" >Malayalam</option>
-                    
-                        <option value="dv" >Maldivian language</option>
-                    
-                        <option value="mt" >Maltese</option>
-                    
-                        <option value="gv" >Manx</option>
-                    
-                        <option value="mi" >Māori</option>
-                    
-                        <option value="mr" >Marathi</option>
-                    
-                        <option value="mh" >Marshallese</option>
-                    
-                        <option value="mo" >Moldovan</option>
-                    
-                        <option value="mn" >Mongolian</option>
-                    
-                        <option value="me" >Montenegrin</option>
-                    
-                        <option value="na" >Nauruan</option>
-                    
-                        <option value="nv" >Navajo</option>
-                    
-                        <option value="ng" >Ndonga dialect</option>
-                    
-                        <option value="ne" >Nepali</option>
-                    
-                        <option value="nd" >Northern Ndebele language</option>
-                    
-                        <option value="se" >Northern Sami</option>
-                    
-                        <option value="no" >Norwegian</option>
-                    
-                        <option value="ii" >Nuosu language</option>
-                    
-                        <option value="nn" >Nynorsk</option>
-                    
-                        <option value="oc" >Occitan</option>
-                    
-                        <option value="or" >Odia</option>
-                    
-                        <option value="oj" >Ojibwe</option>
-                    
-                        <option value="om" >Oromo</option>
-                    
-                        <option value="os" >Ossetian</option>
-                    
-                        <option value="pi" >Pali</option>
-                    
-                        <option value="ps" >Pashto</option>
-                    
-                        <option value="fa" >Persian</option>
-                    
-                        <option value="pl" >Polish</option>
-                    
-                        <option value="pt" >Portuguese</option>
-                    
-                        <option value="pa" >Punjabi</option>
-                    
-                        <option value="qu" >Quechua languages</option>
-                    
-                        <option value="ro" >Romanian</option>
-                    
-                        <option value="rm" >Romansh</option>
-                    
-                        <option value="ru" >Russian</option>
-                    
-                        <option value="ry" >Rusyn</option>
-                    
-                        <option value="sm" >Samoan</option>
-                    
-                        <option value="sg" >Sango</option>
-                    
-                        <option value="sa" >Sanskrit</option>
-                    
-                        <option value="sc" >Sardinian language</option>
-                    
-                        <option value="gd" >Scottish Gaelic</option>
-                    
-                        <option value="sr" >Serbian</option>
-                    
-                        <option value="sh" >Serbo-Croatian</option>
-                    
-                        <option value="sn" >Shona</option>
-                    
-                        <option value="sd" >Sindhi</option>
-                    
-                        <option value="si" >Sinhala</option>
-                    
-                        <option value="sk" >Slovak</option>
-                    
-                        <option value="sl" >Slovene</option>
-                    
-                        <option value="so" >Somali</option>
-                    
-                        <option value="st" >Sotho</option>
-                    
-                        <option value="nr" >Southern Ndebele</option>
-                    
-                        <option value="es" >Spanish</option>
-                    
-                        <option value="su" >Sundanese language</option>
-                    
-                        <option value="sw" >Swahili</option>
-                    
-                        <option value="ss" >Swazi</option>
-                    
-                        <option value="sv" >Swedish</option>
-                    
-                        <option value="tl" >Tagalog</option>
-                    
-                        <option value="ty" >Tahitian</option>
-                    
-                        <option value="tg" >Tajik</option>
-                    
-                        <option value="ta" >Tamil</option>
-                    
-                        <option value="tt" >Tatar</option>
-                    
-                        <option value="te" >Telugu</option>
-                    
-                        <option value="th" >Thai</option>
-                    
-                        <option value="bo" >Tibetan language</option>
-                    
-                        <option value="ti" >Tigrinya</option>
-                    
-                        <option value="to" >Tongan language</option>
-                    
-                        <option value="ts" >Tsonga</option>
-                    
-                        <option value="tn" >Tswana</option>
-                    
-                        <option value="tr" >Turkish</option>
-                    
-                        <option value="tk" >Turkmen</option>
-                    
-                        <option value="tw" >Twi</option>
-                    
-                        <option value="uk" >Ukrainian</option>
-                    
-                        <option value="xx" >Unknown language</option>
-                    
-                        <option value="ur" >Urdu</option>
-                    
-                        <option value="ug" >Uyghur</option>
-                    
-                        <option value="uz" >Uzbek</option>
-                    
-                        <option value="ve" >Venda</option>
-                    
-                        <option value="vi" >Vietnamese</option>
-                    
-                        <option value="vo" >Volapük</option>
-                    
-                        <option value="wa" >Walloon</option>
-                    
-                        <option value="cy" >Welsh</option>
-                    
-                        <option value="fy" >West Frisian</option>
-                    
-                        <option value="wo" >Wolof</option>
-                    
-                        <option value="xh" >Xhosa</option>
-                    
-                        <option value="yi" >Yiddish</option>
-                    
-                        <option value="yo" >Yoruba</option>
-                    
-                        <option value="za" >Zhuang languages</option>
-                    
-                        <option value="zu" >Zulu</option>
-                    
-                </select>
-
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_front_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_en" id="tabs_front_image_en_tab" data-language="en"><a href="#tabs_front_image_en" class="tab_language">English</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_fr" id="tabs_front_image_fr_tab" data-language="fr"><a href="#tabs_front_image_fr" class="tab_language">French</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_front_image_new_lc_tab" data-language="new_lc"><a href="#tabs_front_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_front_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_en" id="tabs_front_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="front_en">Front picture (<span class="tab_language">English</span>)</label>
-
-<div class="select_crop" id="front_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="front_en_imgid" id="front_en_imgid" value="" />
-<input type="hidden" name="front_en_x1" id="front_en_x1" value="" />
-<input type="hidden" name="front_en_y1" id="front_en_y1" value="" />
-<input type="hidden" name="front_en_x2" id="front_en_x2" value="" />
-<input type="hidden" name="front_en_y2" id="front_en_y2" value="" />
-<input type="hidden" name="front_en_display_url" id="front_en_display_url" value="" />
-
-                
-
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
             </div>
-        
-    
-        
-            <div class="tabs content tabs_fr" id="tabs_front_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="front_fr">Front picture (<span class="tab_language">French</span>)</label>
-
-<div class="select_crop" id="front_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="front_fr_imgid" id="front_fr_imgid" value="" />
-<input type="hidden" name="front_fr_x1" id="front_fr_x1" value="" />
-<input type="hidden" name="front_fr_y1" id="front_fr_y1" value="" />
-<input type="hidden" name="front_fr_x2" id="front_fr_x2" value="" />
-<input type="hidden" name="front_fr_y2" id="front_fr_y2" value="" />
-<input type="hidden" name="front_fr_display_url" id="front_fr_display_url" value="" />
-
-                
-
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
             </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_front_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="front_new_lc">Front picture (<span class="tab_language"></span>)</label>
-
-<div class="select_crop" id="front_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="front_new_lc_imgid" id="front_new_lc_imgid" value="" />
-<input type="hidden" name="front_new_lc_x1" id="front_new_lc_x1" value="" />
-<input type="hidden" name="front_new_lc_y1" id="front_new_lc_y1" value="" />
-<input type="hidden" name="front_new_lc_x2" id="front_new_lc_x2" value="" />
-<input type="hidden" name="front_new_lc_y2" id="front_new_lc_y2" value="" />
-<input type="hidden" name="front_new_lc_display_url" id="front_new_lc_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-            </div>
-        </section>
-
-        <section id="product_characteristics" class="fieldset card">
-            <div class="card-section">
-                <legend>Product characteristics</legend>
-
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_product" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_en" id="tabs_product_en_tab" data-language="en"><a href="#tabs_product_en" class="tab_language">English</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_fr" id="tabs_product_fr_tab" data-language="fr"><a href="#tabs_product_fr" class="tab_language">French</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_product_new_lc_tab" data-language="new_lc"><a href="#tabs_product_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_product" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_en" id="tabs_product_en">
-                
-                                 
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="product_name_en">
-    Product name
-    
-        (<span class="tab_language">English</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="product_name_en" id="product_name_en" class="text " value="Apple pie" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Example: Kinder Bueno White</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="generic_name_en">
-    Common name
-    
-        (<span class="tab_language">English</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="generic_name_en" id="generic_name_en" class="text " value="default_name" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Example: Chocolate bar with milk and hazelnuts</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_fr" id="tabs_product_fr">
-                
-                                 
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="product_name_fr">
-    Product name
-    
-        (<span class="tab_language">French</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="product_name_fr" id="product_name_fr" class="text " value="" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Example: Kinder Bueno White</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="generic_name_fr">
-    Common name
-    
-        (<span class="tab_language">French</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="generic_name_fr" id="generic_name_fr" class="text " value="" lang="fr" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Example: Chocolate bar with milk and hazelnuts</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_product_new_lc">
-                
-                                 
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="product_name_new_lc">
-    Product name
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <input type="text" name="product_name_new_lc" id="product_name_new_lc" class="text " value="" lang="new_lc" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Example: Kinder Bueno White</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="generic_name_new_lc">
-    Common name
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <input type="text" name="generic_name_new_lc" id="generic_name_new_lc" class="text " value="" lang="new_lc" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Example: Chocolate bar with milk and hazelnuts</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="quantity">
-    Quantity
-    
-    
-</label>
-
-
-    <input type="text" name="quantity" id="quantity" class="text " value="100 g" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Examples: 2 l, 250 g, 1 kg, 25 cl, 6 fl oz, 1 pound</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="brands">
-    Brands
-    
-    
-</label>
-
-
-    <input type="text" name="brands" id="brands" class="text tagify-me" value="Bob's pies" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=brands" />
-
-
-
-
-
-
-    <p class="example">Examples: Kinder Bueno White, Kinder Bueno, Kinder, Ferrero</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="categories">
-    Categories
-    
-    
-</label>
-
-
-    <input type="text" name="categories" id="categories" class="text tagify-me" value="Desserts, Pies, Sweet pies, Apple pies" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=categories" />
-
-
-
-
-    
-        <p class="note">&rarr; Indicate only the most specific category. "Parents" categories will be automatically added.</p>
-    
-
-
-
-    <p class="example">Examples: Sardines in olive oil, Orange juice from concentrate</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="labels">
-    Labels, certifications, awards
-    
-    
-</label>
-
-
-    <input type="text" name="labels" id="labels" class="text tagify-me" value="Fair trade" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=labels" />
-
-
-
-
-    
-        <p class="note">&rarr; Indicate only the most specific labels. "Parents" labels will be added automatically.</p>
-    
-
-
-
-    <p class="example">Example: Organic</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="manufacturing_places">
-    Manufacturing or processing places
-    
-    
-</label>
-
-
-    <input type="text" name="manufacturing_places" id="manufacturing_places" class="text tagify-me" value="" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-    <p class="example">Examples: Montana, USA</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="emb_codes">
-    Traceability code
-    
-    
-</label>
-
-
-    <input type="text" name="emb_codes" id="emb_codes" class="text tagify-me" value="" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=emb_codes" />
-
-
-
-
-    
-        <p class="note">&rarr; In Europe, the code is in an ellipse with the 2 country initials followed by a number and CE.</p>
-    
-
-
-
-    <p class="example">Examples: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="link">
-    Link to the product page on the official site of the producer
-    
-    
-</label>
-
-
-    <input type="text" name="link" id="link" class="text " value="//world.openfoodfacts.org/" lang="en" data-autocomplete="" />
-
-
-
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="expiration_date">
-    Best before date
-    
-    
-</label>
-
-
-    <input type="text" name="expiration_date" id="expiration_date" class="text " value="" lang="en" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; The expiration date is a way to track product changes over time and to identify the most recent version.</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="purchase_places">
-    City, state and country where purchased
-    
-    
-</label>
-
-
-    <input type="text" name="purchase_places" id="purchase_places" class="text tagify-me" value="" lang="en" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Indicate where you bought or saw the product (at least the country)</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="stores">
-    Stores
-    
-    
-</label>
-
-
-    <input type="text" name="stores" id="stores" class="text tagify-me" value="" lang="en" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Name of the shop or supermarket chain</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="countries">
-    Countries where sold
-    
-    
-</label>
-
-
-    <input type="text" name="countries" id="countries" class="text tagify-me" value="India, Japan, United States" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=countries" />
-
-
-
-
-    
-        <p class="note">&rarr; Countries where the product is widely available (not including stores specialising in foreign products)</p>
-    
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-            </div>
-        </section>
-
-        <section id="ingredients" class="card fieldset">
-            <div class="card-section">
-                <legend>Ingredients</legend>
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_ingredients_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_en" id="tabs_ingredients_image_en_tab" data-language="en"><a href="#tabs_ingredients_image_en" class="tab_language">English</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_fr" id="tabs_ingredients_image_fr_tab" data-language="fr"><a href="#tabs_ingredients_image_fr" class="tab_language">French</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_ingredients_image_new_lc_tab" data-language="new_lc"><a href="#tabs_ingredients_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_ingredients_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_en" id="tabs_ingredients_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="ingredients_en">Ingredients picture (<span class="tab_language">English</span>)</label>
-<p class="note">&rarr; If the picture is neat enough, the ingredients can be extracted automatically</p>
-<div class="select_crop" id="ingredients_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="ingredients_en_imgid" id="ingredients_en_imgid" value="" />
-<input type="hidden" name="ingredients_en_x1" id="ingredients_en_x1" value="" />
-<input type="hidden" name="ingredients_en_y1" id="ingredients_en_y1" value="" />
-<input type="hidden" name="ingredients_en_x2" id="ingredients_en_x2" value="" />
-<input type="hidden" name="ingredients_en_y2" id="ingredients_en_y2" value="" />
-<input type="hidden" name="ingredients_en_display_url" id="ingredients_en_display_url" value="" />
-
-                
-                    
-                        <div id="ingredients_en_image_full"></div>
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="ingredients_text_en">
-    Ingredients list
-    
-        (<span class="tab_language">English</span>)
-    
-    
-</label>
-
-
-    <textarea  name="ingredients_text_en" id="ingredients_text_en" lang="en">Wheat flour, apples, sugar, butter, eggs, salt, palm oil, acidifier: citric acid, raising agent: sodium bicarbonate</textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Keep the order, indicate the % when specified, separate with a comma or - , use ( ) for ingredients of an ingredient, surround allergens with _ e.g. _milk_</p>
-    
-
-
-
-    <p class="example">Examples: Cereals 85.5% (_wheat_ flour, whole-_wheat_ flour 11%), malt extract, cocoa 4,8%, ascorbic acid</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origin_en">
-    Origin of the product and/or its ingredients
-    
-        (<span class="tab_language">English</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="origin_en" id="origin_en" class="text " value="Germany" lang="en" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients</p>
-    
-
-
-
-    <p class="example">Examples: Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand.</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_fr" id="tabs_ingredients_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="ingredients_fr">Ingredients picture (<span class="tab_language">French</span>)</label>
-<p class="note">&rarr; If the picture is neat enough, the ingredients can be extracted automatically</p>
-<div class="select_crop" id="ingredients_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="ingredients_fr_imgid" id="ingredients_fr_imgid" value="" />
-<input type="hidden" name="ingredients_fr_x1" id="ingredients_fr_x1" value="" />
-<input type="hidden" name="ingredients_fr_y1" id="ingredients_fr_y1" value="" />
-<input type="hidden" name="ingredients_fr_x2" id="ingredients_fr_x2" value="" />
-<input type="hidden" name="ingredients_fr_y2" id="ingredients_fr_y2" value="" />
-<input type="hidden" name="ingredients_fr_display_url" id="ingredients_fr_display_url" value="" />
-
-                
-                    
-                        <div id="ingredients_fr_image_full"></div>
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="ingredients_text_fr">
-    Ingredients list
-    
-        (<span class="tab_language">French</span>)
-    
-    
-</label>
-
-
-    <textarea  name="ingredients_text_fr" id="ingredients_text_fr" lang="fr">Farine de blé, pommes, sucre, beurre, oeufs, sel, huile de palme, acidifiant: acide citrique, agent levant: bicarbonate de sodium</textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Keep the order, indicate the % when specified, separate with a comma or - , use ( ) for ingredients of an ingredient, surround allergens with _ e.g. _milk_</p>
-    
-
-
-
-    <p class="example">Examples: Cereals 85.5% (_wheat_ flour, whole-_wheat_ flour 11%), malt extract, cocoa 4,8%, ascorbic acid</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origin_fr">
-    Origin of the product and/or its ingredients
-    
-        (<span class="tab_language">French</span>)
-    
-    
-</label>
-
-
-    <input type="text" name="origin_fr" id="origin_fr" class="text " value="" lang="fr" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients</p>
-    
-
-
-
-    <p class="example">Examples: Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand.</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_ingredients_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="ingredients_new_lc">Ingredients picture (<span class="tab_language"></span>)</label>
-<p class="note">&rarr; If the picture is neat enough, the ingredients can be extracted automatically</p>
-<div class="select_crop" id="ingredients_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="ingredients_new_lc_imgid" id="ingredients_new_lc_imgid" value="" />
-<input type="hidden" name="ingredients_new_lc_x1" id="ingredients_new_lc_x1" value="" />
-<input type="hidden" name="ingredients_new_lc_y1" id="ingredients_new_lc_y1" value="" />
-<input type="hidden" name="ingredients_new_lc_x2" id="ingredients_new_lc_x2" value="" />
-<input type="hidden" name="ingredients_new_lc_y2" id="ingredients_new_lc_y2" value="" />
-<input type="hidden" name="ingredients_new_lc_display_url" id="ingredients_new_lc_display_url" value="" />
-
-                
-                    
-                        <div id="ingredients_new_lc_image_full"></div>
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="ingredients_text_new_lc">
-    Ingredients list
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <textarea  name="ingredients_text_new_lc" id="ingredients_text_new_lc" lang="new_lc"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; Keep the order, indicate the % when specified, separate with a comma or - , use ( ) for ingredients of an ingredient, surround allergens with _ e.g. _milk_</p>
-    
-
-
-
-    <p class="example">Examples: Cereals 85.5% (_wheat_ flour, whole-_wheat_ flour 11%), malt extract, cocoa 4,8%, ascorbic acid</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origin_new_lc">
-    Origin of the product and/or its ingredients
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <input type="text" name="origin_new_lc" id="origin_new_lc" class="text " value="" lang="new_lc" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients</p>
-    
-
-
-
-    <p class="example">Examples: Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand.</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="allergens">
-    Substances or products causing allergies or intolerances
-    
-    
-</label>
-
-
-    <input type="text" name="allergens" id="allergens" class="text tagify-me" value="Apple, Eggs, Gluten, Milk" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=allergens" />
-
-
-
-
-
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="traces">
-    Traces
-    
-    
-</label>
-
-
-    <input type="text" name="traces" id="traces" class="text tagify-me" value="" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=traces" />
-
-
-
-
-    
-        <p class="note">&rarr; Indicate ingredients from mentions like "May contain traces of", "Made in a factory that also uses" etc.</p>
-    
-
-
-
-    <p class="example">Examples: Milk, Gluten, Nuts</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="origins">
-    Origin of ingredients
-    
-    
-</label>
-
-
-    <input type="text" name="origins" id="origins" class="text tagify-me" value="" lang="en" data-autocomplete="//world.openfoodfacts.localhost/api/v3/taxonomy_suggestions?tagtype=origins" />
-
-
-
-
-
-
-    <p class="example">Examples: California, USA</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-            </div>
-        </section>
-
-        <!--nutrient fieldset-->
-        <section class="card fieldset" id="nutrition">
-            <div class="card-section">
-                <legend>Nutrition facts</legend>
-                <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                <input type="hidden" name="no_nutrition_data_displayed" value="1" />
-                <input type="checkbox" id="no_nutrition_data" name="no_nutrition_data"  />
-                <label for="no_nutrition_data" class="checkbox_label">Nutrition facts are not specified on the product.</label><br/>
-                <div id="nutrition_data_div">
-                    <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_nutrition_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_en" id="tabs_nutrition_image_en_tab" data-language="en"><a href="#tabs_nutrition_image_en" class="tab_language">English</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_fr" id="tabs_nutrition_image_fr_tab" data-language="fr"><a href="#tabs_nutrition_image_fr" class="tab_language">French</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_nutrition_image_new_lc_tab" data-language="new_lc"><a href="#tabs_nutrition_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_nutrition_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_en" id="tabs_nutrition_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="nutrition_en">Nutrition facts picture (<span class="tab_language">English</span>)</label>
-
-<div class="select_crop" id="nutrition_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="nutrition_en_imgid" id="nutrition_en_imgid" value="" />
-<input type="hidden" name="nutrition_en_x1" id="nutrition_en_x1" value="" />
-<input type="hidden" name="nutrition_en_y1" id="nutrition_en_y1" value="" />
-<input type="hidden" name="nutrition_en_x2" id="nutrition_en_x2" value="" />
-<input type="hidden" name="nutrition_en_y2" id="nutrition_en_y2" value="" />
-<input type="hidden" name="nutrition_en_display_url" id="nutrition_en_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_fr" id="tabs_nutrition_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="nutrition_fr">Nutrition facts picture (<span class="tab_language">French</span>)</label>
-
-<div class="select_crop" id="nutrition_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="nutrition_fr_imgid" id="nutrition_fr_imgid" value="" />
-<input type="hidden" name="nutrition_fr_x1" id="nutrition_fr_x1" value="" />
-<input type="hidden" name="nutrition_fr_y1" id="nutrition_fr_y1" value="" />
-<input type="hidden" name="nutrition_fr_x2" id="nutrition_fr_x2" value="" />
-<input type="hidden" name="nutrition_fr_y2" id="nutrition_fr_y2" value="" />
-<input type="hidden" name="nutrition_fr_display_url" id="nutrition_fr_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_nutrition_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="nutrition_new_lc">Nutrition facts picture (<span class="tab_language"></span>)</label>
-
-<div class="select_crop" id="nutrition_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="nutrition_new_lc_imgid" id="nutrition_new_lc_imgid" value="" />
-<input type="hidden" name="nutrition_new_lc_x1" id="nutrition_new_lc_x1" value="" />
-<input type="hidden" name="nutrition_new_lc_y1" id="nutrition_new_lc_y1" value="" />
-<input type="hidden" name="nutrition_new_lc_x2" id="nutrition_new_lc_x2" value="" />
-<input type="hidden" name="nutrition_new_lc_y2" id="nutrition_new_lc_y2" value="" />
-<input type="hidden" name="nutrition_new_lc_display_url" id="nutrition_new_lc_display_url" value="" />
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="serving_size">
-    Serving size
-    
-    
-</label>
-
-
-    <input type="text" name="serving_size" id="serving_size" class="text " value="10 g" lang="en" data-autocomplete="" />
-
-
-
-
-    
-        <p class="note">&rarr; If the nutrition facts table contains values for the prepared product, indicate the total serving size of the prepared product (including added water or milk).</p>
-    
-
-
-
-    <p class="example">Examples: 60 g, 12 oz, 20cl, 2 fl oz</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-
-                    <!-- petfood nutriment are as sold only -->
-                    
-                        
-                            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                            <input type="hidden" name="nutrition_data_displayed" value="1" />
-                            <input type="checkbox" id="nutrition_data" name="nutrition_data" checked="checked" />
-                            <label for="nutrition_data" class="checkbox_label">Nutrition facts are specified for the product as sold.</label> &nbsp;
-                            <input type="radio" id="nutrition_data_per_100g" value="100g" name="nutrition_data_per" checked="checked" />
-                            <label for="nutrition_data_per_100g">for 100 g / 100 ml</label>
-                            <input type="radio" id="nutrition_data_per_serving" value="serving" name="nutrition_data_per"  />
-                            <label for="nutrition_data_per_serving">per serving</label><br/>
-
-                            
-                        
-                            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                            <input type="hidden" name="nutrition_data_prepared_displayed" value="1" />
-                            <input type="checkbox" id="nutrition_data_prepared" name="nutrition_data_prepared"  />
-                            <label for="nutrition_data_prepared" class="checkbox_label">Nutrition facts are specified for the prepared product.</label> &nbsp;
-                            <input type="radio" id="nutrition_data_prepared_per_100g" value="100g" name="nutrition_data_prepared_per" checked="checked" />
-                            <label for="nutrition_data_prepared_per_100g">for 100 g / 100 ml</label>
-                            <input type="radio" id="nutrition_data_prepared_per_serving" value="serving" name="nutrition_data_prepared_per"  />
-                            <label for="nutrition_data_prepared_per_serving">per serving</label><br/>
-
-                            
-                        
-                    
-
-                    <div style="position:relative">
-
-                        <table id="nutrition_data_table" class="data_table" style="display: table;" aria-label="nutrition table">
-                            <thead class="nutriment_header">
-                                <th id="col_1">
-                                    
-                                        Nutrition facts
-                                    
-                                </th>
-                                <th id="col_2" class="nutriment_col" >
-                                    As sold<br/>
-                                    
-                                        <span id="nutrition_data_100g" >for 100 g / 100 ml</span>
-                                        <span id="nutrition_data_serving"  style="display:none">per serving</span>
-                                    
-                                </th>
-                                <th id="col_3" class="nutriment_col_prepared" style="display:none">
-                                    Prepared<br/>
-                                    <span id="nutrition_data_prepared_100g" >for 100 g / 100 ml</span>
-                                    <span id="nutrition_data_prepared_serving"  style="display:none">per serving</span>
-                                </th>
-                                <th id="col_4">
-                                    Unit
-                                </th>
-                            </thead>
-
-                            <tbody>
-
-                                
-
-                                    
-                                        <tr id="nutriment_energy-kj_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_energy-kj">
-                                                Energy (kJ)
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_energy-kj" name="nutriment_energy-kj" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_energy-kj" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_energy-kj" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_energy-kj_prepared" name="nutriment_energy-kj_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit">kJ</span>
-
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_energy-kcal_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_energy-kcal">
-                                                Energy (kcal)
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_energy-kcal" name="nutriment_energy-kcal" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_energy-kcal" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_energy-kcal" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_energy-kcal_prepared" name="nutriment_energy-kcal_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit">kcal</span>
-
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_fat_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_fat">
-                                                Fat
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_fat" name="nutriment_fat" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_fat" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_fat" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_fat_prepared" name="nutriment_fat_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_fat_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_fat_unit" name="nutriment_fat_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_saturated-fat_tr" class="nutriment_sub">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_saturated-fat">
-                                                Saturated fat
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_saturated-fat" name="nutriment_saturated-fat" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_saturated-fat" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_saturated-fat" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_saturated-fat_prepared" name="nutriment_saturated-fat_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_saturated-fat_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_saturated-fat_unit" name="nutriment_saturated-fat_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_carbohydrates_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_carbohydrates">
-                                                Carbohydrates
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_carbohydrates" name="nutriment_carbohydrates" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_carbohydrates" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_carbohydrates" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_carbohydrates_prepared" name="nutriment_carbohydrates_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_carbohydrates_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_carbohydrates_unit" name="nutriment_carbohydrates_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_sugars_tr" class="nutriment_sub">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_sugars">
-                                                Sugars
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_sugars" name="nutriment_sugars" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_sugars" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_sugars" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_sugars_prepared" name="nutriment_sugars_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_sugars_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_sugars_unit" name="nutriment_sugars_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_fiber_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_fiber">
-                                                Fiber
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_fiber" name="nutriment_fiber" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_fiber" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_fiber" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_fiber_prepared" name="nutriment_fiber_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_fiber_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_fiber_unit" name="nutriment_fiber_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_proteins_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_proteins">
-                                                Proteins
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_proteins" name="nutriment_proteins" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_proteins" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_proteins" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_proteins_prepared" name="nutriment_proteins_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_proteins_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_proteins_unit" name="nutriment_proteins_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_salt_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_salt">
-                                                Salt
-                                                
-                                                *
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_salt" name="nutriment_salt" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_salt" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_salt" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_salt_prepared" name="nutriment_salt_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_salt_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_salt_unit" name="nutriment_salt_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_sodium_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_sodium">
-                                                Sodium
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_sodium" name="nutriment_sodium" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_sodium" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_sodium" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_sodium_prepared" name="nutriment_sodium_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_sodium_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_sodium_unit" name="nutriment_sodium_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_alcohol_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <label class="nutriment_label" for="nutriment_alcohol">
-                                                Alcohol
-                                                
-                                                
-                                            </label>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_alcohol" name="nutriment_alcohol" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_alcohol" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_alcohol" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_alcohol_prepared" name="nutriment_alcohol_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit">% vol / °</span>
-
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_new_0_tr" class="nutriment_main" style="display:none">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <input class="nutriment_label" id="nutriment_new_0_label" name="nutriment_new_0_label" placeholder="Add a nutrient"/>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_new_0" name="nutriment_new_0" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_new_0" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_new_0" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_new_0_prepared" name="nutriment_new_0_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_new_0_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_new_0_unit" name="nutriment_new_0_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                            <option value="% DV" >% DV</option>
-                                                        
-                                                            <option value="IU" >IU</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                                    
-                                        <tr id="nutriment_new_1_tr" class="nutriment_main">
-
-                                    <td>
-                                        <!--label starts-->
-                                        
-                                            <input class="nutriment_label" id="nutriment_new_1_label" name="nutriment_new_1_label" placeholder="Add a nutrient"/>
-                                        
-                                        <!--label ends-->
-                                    </td>
-
-                                            <td class="nutriment_col" >
-                                                <input  class="nutriment_value nutriment_value_as_sold soft-background" id="nutriment_new_1" name="nutriment_new_1" value=""  autocomplete="off"/>
-                                                <span id="nutriment_question_mark_new_1" class="question_mark">?</span>
-                                                <span id="nutriment_sugars_warning_new_1" class="sugars_warning">Please enter a valid value.</span>
-                                            </td>
-                                            <td class="nutriment_col_prepared" style="display:none">
-                                                <input  class="nutriment_value nutriment_value_prepared" id="nutriment_new_1_prepared" name="nutriment_new_1_prepared" value=""  autocomplete="off"/>
-                                            </td>
-
-                                            <!-- food -->
-                                            <!-- petfood -->
-                                            
-                                                <td>
-                                                    <span class="nutriment_unit_percent" id="nutriment_new_1_unit_percent" style="display:none">%</span>
-                                                    <select class="nutriment_unit" id="nutriment_new_1_unit" name="nutriment_new_1_unit" >
-                                                        
-                                                            <option value="g" selected="selected" >g</option>
-                                                        
-                                                            <option value="mg" >mg</option>
-                                                        
-                                                            <option value="µg" >mcg/µg</option>
-                                                        
-                                                            <option value="% DV" >% DV</option>
-                                                        
-                                                            <option value="IU" >IU</option>
-                                                        
-                                                        </select>
-                                            
-                                                    </td>
-                                            </tr>
-
-                                    
-
-                                
-
-                            </tbody>
-                        </table>
-
-                        <input type="hidden" name="new_max" id="new_max" value="1" />
-                        <div id="nutrition_image_copy" style="position:absolute;bottom:0;"></div>
-                    </div>
-
-                
-
-                
-                    <p class="asterisk">&rarr;*:Essential nutrients to calculate the Nutri-Score.</p>
-                
-                <p class="note">&rarr; The table lists by default nutriments that are often specified. Leave the field blank if it's not on the label.<br/>You can add extra nutriments (vitamins, minerals, cholesterol etc.)
-by typing the first letters of their name in the last row of the table.</p>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
                 </div>
-
+              </div>
             </div>
-    </section><!--nutrient field set-->
-
-        <!--packaging field-->
-        <section id="packaging_section" class="card fieldset">
-            <div class="card-section">
-                <legend>Packaging</legend>
-                <!-- start templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-<!--html tab header starts-->
-<ul id="tabs_packaging_image" class="tabs" data-tab>
-    
-        
-            <li class="tabs tab-title active tabs_en" id="tabs_packaging_image_en_tab" data-language="en"><a href="#tabs_packaging_image_en" class="tab_language">English</a></li>
-        
-    
-        
-            <li class="tabs tab-title tabs_fr" id="tabs_packaging_image_fr_tab" data-language="fr"><a href="#tabs_packaging_image_fr" class="tab_language">French</a></li>
-        
-    
-        
-            <li class="tabs tab-title new_lc hide tabs_new_lc" id="tabs_packaging_image_new_lc_tab" data-language="new_lc"><a href="#tabs_packaging_image_new_lc" class="tab_language"></a></li>
-        
-    
-        
-            <li class="tabs tab-title new tabs_new">
-                <select class="select_add_language" style="width:100%">
-                    <option></option>
-                </select>
-            </li>
-        
-    
-</ul>
-<!--html tab header ends-->
-
-<!--The content tab starts-->
-<div id="tabs_content_packaging_image" class="tabs-content">
-    
-        
-            <div class="tabs content active tabs_en" id="tabs_packaging_image_en">
-                
-                                 
-
-                
-                    
-                    	<label for="packaging_en">Recycling instructions and/or packaging information picture (<span class="tab_language">English</span>)</label>
-
-<div class="select_crop" id="packaging_en"></div>
-<hr class="floatclear" />
-<input type="hidden" name="packaging_en_imgid" id="packaging_en_imgid" value="" />
-<input type="hidden" name="packaging_en_x1" id="packaging_en_x1" value="" />
-<input type="hidden" name="packaging_en_y1" id="packaging_en_y1" value="" />
-<input type="hidden" name="packaging_en_x2" id="packaging_en_x2" value="" />
-<input type="hidden" name="packaging_en_y2" id="packaging_en_y2" value="" />
-<input type="hidden" name="packaging_en_display_url" id="packaging_en_display_url" value="" />
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="packaging_text_en">
-    Recycling instructions and/or packaging information
-    
-        (<span class="tab_language">English</span>)
-    
-    
-</label>
-
-
-    <textarea  name="packaging_text_en" id="packaging_text_en" lang="en"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.</p>
-    
-
-    
-        <p class="note">&rarr; Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD.</p>
-    
-
-    
-        <p class="note">&rarr; Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both.</p>
-    
-
-
-
-    <p class="example">Examples: 1 plastic film to discard, 1 FSC carboard box to recycle, 6 1.5L transparent PET plastic bottles to recycle, 6 colored opaque plastic caps, 12 33cl aluminium cans</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content tabs_fr" id="tabs_packaging_image_fr">
-                
-                                 
-
-                
-                    
-                    	<label for="packaging_fr">Recycling instructions and/or packaging information picture (<span class="tab_language">French</span>)</label>
-
-<div class="select_crop" id="packaging_fr"></div>
-<hr class="floatclear" />
-<input type="hidden" name="packaging_fr_imgid" id="packaging_fr_imgid" value="" />
-<input type="hidden" name="packaging_fr_x1" id="packaging_fr_x1" value="" />
-<input type="hidden" name="packaging_fr_y1" id="packaging_fr_y1" value="" />
-<input type="hidden" name="packaging_fr_x2" id="packaging_fr_x2" value="" />
-<input type="hidden" name="packaging_fr_y2" id="packaging_fr_y2" value="" />
-<input type="hidden" name="packaging_fr_display_url" id="packaging_fr_display_url" value="" />
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="packaging_text_fr">
-    Recycling instructions and/or packaging information
-    
-        (<span class="tab_language">French</span>)
-    
-    
-</label>
-
-
-    <textarea  name="packaging_text_fr" id="packaging_text_fr" lang="fr"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.</p>
-    
-
-    
-        <p class="note">&rarr; Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD.</p>
-    
-
-    
-        <p class="note">&rarr; Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both.</p>
-    
-
-
-
-    <p class="example">Examples: 1 plastic film to discard, 1 FSC carboard box to recycle, 6 1.5L transparent PET plastic bottles to recycle, 6 colored opaque plastic caps, 12 33cl aluminium cans</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-            <div class="tabs content new_lc hide tabs_new_lc" id="tabs_packaging_image_new_lc">
-                
-                                 
-
-                
-                    
-                    	<label for="packaging_new_lc">Recycling instructions and/or packaging information picture (<span class="tab_language"></span>)</label>
-
-<div class="select_crop" id="packaging_new_lc"></div>
-<hr class="floatclear" />
-<input type="hidden" name="packaging_new_lc_imgid" id="packaging_new_lc_imgid" value="" />
-<input type="hidden" name="packaging_new_lc_x1" id="packaging_new_lc_x1" value="" />
-<input type="hidden" name="packaging_new_lc_y1" id="packaging_new_lc_y1" value="" />
-<input type="hidden" name="packaging_new_lc_x2" id="packaging_new_lc_x2" value="" />
-<input type="hidden" name="packaging_new_lc_y2" id="packaging_new_lc_y2" value="" />
-<input type="hidden" name="packaging_new_lc_display_url" id="packaging_new_lc_display_url" value="" />
-
-                
-                    
-                    <!-- start templates/web/pages/product_edit/display_input_field.tt.html -->
-<label for="packaging_text_new_lc">
-    Recycling instructions and/or packaging information
-    
-        (<span class="tab_language"></span>)
-    
-    
-</label>
-
-
-    <textarea  name="packaging_text_new_lc" id="packaging_text_new_lc" lang="new_lc"></textarea>
-
-
-
-
-    
-        <p class="note">&rarr; List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.</p>
-    
-
-    
-        <p class="note">&rarr; Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD.</p>
-    
-
-    
-        <p class="note">&rarr; Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both.</p>
-    
-
-
-
-    <p class="example">Examples: 1 plastic film to discard, 1 FSC carboard box to recycle, 6 1.5L transparent PET plastic bottles to recycle, 6 colored opaque plastic caps, 12 33cl aluminium cans</p>
-
-
-<!-- end templates/web/pages/product_edit/display_input_field.tt.html -->
-
-
-                
-
-            </div>
-        
-    
-        
-    
-</div>
-<!--The content tab ends-->
-
-<!-- end templates/web/pages/product_edit/display_input_tabs.tt.html -->
-
-                <!-- start templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-<p>Packaging parts</p>
-    
-<div id="packagings_components_edit">
-
-    <ul>
-        <li><b>Number of units:</b> Enter the number of packaging units of the same shape and material contained in the product.</li>
-        <li><b>Shape:</b> Enter the shape name listed in the recycling instructions if they are available, or select a shape.</li>
-        <li><b>Material:</b> Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.</li>
-        <li><b>Recycling:</b> Enter recycling instructions only if they are listed on the product.</li>
-        <li><b>Weight of one empty unit:</b> Remove any remaining food and wash and dry the packaging part before weighting. If possible, use a scale with 0.1g or 0.01g precision.</li>
-        <li><b>Quantity of product contained per unit:</b> Enter the net weight or net volume and indicate the unit (for example g or ml).</li>
-    </ul>
-
-    <!-- header row for large display -->
-    <div class="row show-for-large-up" id="packagings_components_edit_header">
-        <div class="large-1 columns">Number of units</div>
-        <div class="large-3 columns">Shape</div>
-        <div class="large-3 columns">Material</div>
-        <div class="large-3 columns">Recycling</div>
-        <div class="large-1 columns">Weight of one empty unit (g)</div>
-        <div class="large-1 columns">Quantity of product contained per unit</div>
+          </div>
+        </div>
+      </footer>
     </div>
 
-
-    
-    <div class="row packagings_components_edit_row" id="packaging_0_row">
-        <div class="small-12 large-1 columns">
-
-            <!-- label for small displays -->
-            <label class="hide-for-large-up" for="packaging_0_number_of_units">Number of units</label>
-
-            <div class="row">
-                <div class="small-12 large-4 columns delete_packaging_column">
-                    <a class="delete_packaging" id="packaging_0_delete">
-                        <span class="material-icons">
-                            delete
-                        </span>
-                    </a>
-                </div>
-
-                <div class="small-12 large-8 columns">
-                    <input id="packaging_0_number_of_units" name="packaging_0_number_of_units" type="text" value="">
-                </div>
-            </div>
-        </div>
-
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_0_shape">Shape</label>
-                <select id="packaging_0_shape" name="packaging_0_shape" class="form-control packaging_shapes_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_0_material">Material</label>
-                <select id="packaging_0_material" name="packaging_0_material" class="form-control packaging_materials_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_0_recycling">Recycling</label>
-                <select id="packaging_0_recycling" name="packaging_0_recycling" class="form-control packaging_recycling_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-        
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_0_weight_measured">Weight of one empty unit (g)</label>
-            
-            
-                <input id="packaging_0_weight_measured" name="packaging_0_weight_measured" type="text" value="" %]">
-            
-        </div>
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_0_quantity_per_unit">Quantity of product contained per unit</label>
-            <input id="packaging_0_quantity_per_unit" name="packaging_0_quantity_per_unit" type="text" value="" %]">
-        </div>        
-
-    </div>
-
-    
-
-    
-    <div class="row packagings_components_edit_row" id="packaging_1_row">
-        <div class="small-12 large-1 columns">
-
-            <!-- label for small displays -->
-            <label class="hide-for-large-up" for="packaging_1_number_of_units">Number of units</label>
-
-            <div class="row">
-                <div class="small-12 large-4 columns delete_packaging_column">
-                    <a class="delete_packaging" id="packaging_1_delete">
-                        <span class="material-icons">
-                            delete
-                        </span>
-                    </a>
-                </div>
-
-                <div class="small-12 large-8 columns">
-                    <input id="packaging_1_number_of_units" name="packaging_1_number_of_units" type="text" value="">
-                </div>
-            </div>
-        </div>
-
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_1_shape">Shape</label>
-                <select id="packaging_1_shape" name="packaging_1_shape" class="form-control packaging_shapes_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_1_material">Material</label>
-                <select id="packaging_1_material" name="packaging_1_material" class="form-control packaging_materials_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-            
-                
-        
-
-            
-                
-            
-
-            
-
-            <div class="small-12 large-3 columns">
-                <label class="hide-for-large-up" for="packaging_1_recycling">Recycling</label>
-                <select id="packaging_1_recycling" name="packaging_1_recycling" class="form-control packaging_recycling_select2">
-                    <option></option>
-                </select>
-            </div>
-
-            <!-- row 0 is a template for new row, we do not populate it -->
-            
-                
-            
-                
-        
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_1_weight_measured">Weight of one empty unit (g)</label>
-            
-            
-                <input id="packaging_1_weight_measured" name="packaging_1_weight_measured" type="text" value="" %]">
-            
-        </div>
-
-        <div class="small-12 large-1 columns">
-            <label class="hide-for-large-up" for="packaging_1_quantity_per_unit">Quantity of product contained per unit</label>
-            <input id="packaging_1_quantity_per_unit" name="packaging_1_quantity_per_unit" type="text" value="" %]">
-        </div>        
-
-    </div>
-
-    
-
-
-<input type="hidden" name="packaging_max" value="1">
-
-
-
-</div>
-
-<input type="checkbox" id="packagings_complete" name="packagings_complete"  />
-<label for="packagings_complete" class="checkbox_label">All the packaging parts of the product are listed.</label><br/>
-    
-<!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-
-            </div>
-        </section>
-
-        
-
-        
-
-        <input type="hidden" name="type" value="edit">
-        <input type="hidden" id="code" name="code" value="3300000000001">
-        <input type="hidden" name="action" value="process">
-
-        <div id="fixed_bar" class="bottom-validation">
-            
-
-                <div class="row">
-                    
-                        
-                        
-                    
-                    <div class="small-12 medium-12 large-8 xlarge-8 columns" style="margin-bottom:0.5rem;">
-                        <input id="comment" name="comment" placeholder="Changes summary" value="" type="text" class="text" style="margin:0" />
-                    </div>
-                    <div class="small-6 medium-6 large-2 xlarge-2 columns">
-                        <button type="submit" id="save" name=".submit" class="button postfix success small">
-                            <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg> Save
-                        </button>
-                    </div>
-                    <div class="small-6 medium-6 large-2 xlarge-2 columns">
-                        <button type="button" id="back-btn" class="button postfix small secondary">
-                            <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/><path d="M0 0h24v24H0z" fill="none"/></svg> Cancel
-                        </button>
-                    </div>
-                    
-                </div>
-
-            
-        </div>
-
-        <!-- start templates/web/pages/product/includes/edit_history.tt.html -->
-
-
-
-<h2 id="history">Changes history</h2>
-<ul id="history_list">
-  
-  <li>
-    <time datetime="--ignore--">--ignore--</time> - <a href="/facets/editors/tests" lang="no_language">tests</a> Data (Added: product_type, code, lang, product_name, generic_name, quantity, brands, categories, labels, link, countries, origin, nutrition_data_per, nutrition_data_prepared_per, serving_size, ingredients_text, generic_name_en, ingredients_text_en, origin_en, product_name_en, ingredients_text_fr) -- Nutriments (Added: nutrition-score-fr)   - (app)  &nbsp;
-    <a href="/product/3300000000001/apple-pie-bob-s-pies?rev=1" class="button tiny">View this revision</a>
-    
-  </li>
-  
-</ul>
-
-<script>var revert_confirm_message = "Revert to this product revision?";</script>
-
-<!-- end templates/web/pages/product/includes/edit_history.tt.html -->
-
-
-        </div>
-
-        </div>
-
-        </div>
-
-    </form>
-
-
-<style>
-.question_mark {
-    display: none;
-    position: relative;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background-color: #999;
-    color: #fff;
-    text-align: center;
-    font-weight: bold;
-    cursor: help;
-}
-
-.sugars_warning {
-  display: none;
-  position: absolute;
-  left: 16%;
-  transform: translateX(50%);
-  padding: 0.5em;
-  background-color: #333;
-  color: #fff;
-  font-size: 0.8em;
-  white-space: nowrap;
-  margin-top: 1%;
-  z-index: 1;
-}
-
-.soft-background {
-    background-color: #f5f5f5;
-}
-
-.question_mark:hover + .sugars_warning {
-    display: inline-block;
-}
-
-.question_mark:hover {
-    opacity: 0.7;
-}
-</style>
-
-<!-- end templates/web/pages/product_edit/product_edit_form_display.tt.html -->
-
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-
-	$([]).selectcrop('init_images', [
-		
-	]);
-	$(".select_crop").selectcrop('init', {img_path : "//images.openfoodfacts.localhost/images/products/330/000/000/0001/"});
-	$(".select_crop").selectcrop('show');
-
-
-                    configure_packaging_select2("packaging_1_shape", "packaging_shapes", "Shape" )
-
-                    
-
-                    $("#packaging_1_delete").click(function(event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        $("#packaging_1_row").remove();
-                    });
-                
-                    configure_packaging_select2("packaging_1_material", "packaging_materials", "Material" )
-
-                    
-
-                    $("#packaging_1_delete").click(function(event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        $("#packaging_1_row").remove();
-                    });
-                
-                    configure_packaging_select2("packaging_1_recycling", "packaging_recycling", "Recycling" )
-
-                    
-
-                    $("#packaging_1_delete").click(function(event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        $("#packaging_1_row").remove();
-                    });
-                
-// defined by the FOREACH loop above
-var packaging_max = 1;
-
-/**
- * Configure the select2 dropdown with autocomplete for shape, material and recycling
- */
-function configure_packaging_select2(select2_id, taxonomy, placeholder) {
-    
-    $("#" + select2_id).select2({
-        placeholder: placeholder,
-        allowClear:true,
-        tags: true,
-        ajax: {
-            url: '/api/v3/taxonomy_suggestions?limit=400&tagtype=' + taxonomy,
-            data: function (params) {
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
+
+    <script>
+      $(function () {
+        $([]).selectcrop("init_images", []);
+        $(".select_crop").selectcrop("init", {
+          img_path:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0001/",
+        });
+        $(".select_crop").selectcrop("show");
+
+        configure_packaging_select2(
+          "packaging_1_shape",
+          "packaging_shapes",
+          "Shape"
+        );
+
+        $("#packaging_1_delete").click(function (event) {
+          event.stopPropagation();
+          event.preventDefault();
+          $("#packaging_1_row").remove();
+        });
+
+        configure_packaging_select2(
+          "packaging_1_material",
+          "packaging_materials",
+          "Material"
+        );
+
+        $("#packaging_1_delete").click(function (event) {
+          event.stopPropagation();
+          event.preventDefault();
+          $("#packaging_1_row").remove();
+        });
+
+        configure_packaging_select2(
+          "packaging_1_recycling",
+          "packaging_recycling",
+          "Recycling"
+        );
+
+        $("#packaging_1_delete").click(function (event) {
+          event.stopPropagation();
+          event.preventDefault();
+          $("#packaging_1_row").remove();
+        });
+
+        // defined by the FOREACH loop above
+        var packaging_max = 1;
+
+        /**
+         * Configure the select2 dropdown with autocomplete for shape, material and recycling
+         */
+        function configure_packaging_select2(
+          select2_id,
+          taxonomy,
+          placeholder
+        ) {
+          $("#" + select2_id).select2({
+            placeholder: placeholder,
+            allowClear: true,
+            tags: true,
+            ajax: {
+              url: "/api/v3/taxonomy_suggestions?limit=400&tagtype=" + taxonomy,
+              data: function (params) {
                 // tagify has values in a JSON array, parse it and convert it to a commas separated list
-                var categories_json = $("#categories").val()
-                
+                var categories_json = $("#categories").val();
+
                 var query = {
-                    string: params.term,
-                }
+                  string: params.term,
+                };
                 // If the product has categories, pass them to get better suggestions
                 if (categories_json) {
-                    var categories_array = JSON.parse(categories_json);
-                    query.categories = categories_array.map(item => item.value).join(',');
+                  var categories_array = JSON.parse(categories_json);
+                  query.categories = categories_array
+                    .map((item) => item.value)
+                    .join(",");
                 }
                 // If the select2 is for the material, send the corresponding selected shape
                 if (taxonomy == "packaging_materials") {
-                    
-                    var shape_select2_id = select2_id.replace('_material', '_shape');
-                    query.shape = $("#" + shape_select2_id).val();
+                  var shape_select2_id = select2_id.replace(
+                    "_material",
+                    "_shape"
+                  );
+                  query.shape = $("#" + shape_select2_id).val();
                 }
                 return query;
-            },
-            processResults: function (data) {
+              },
+              processResults: function (data) {
                 if (data.suggestions) {
-                    return {
-                        // transform the simple array of suggestions in array of objects expected by select2
-                        results: Array.from(data.suggestions, function (element) { return {"id": element, "text": element}; }) 
-                    };
+                  return {
+                    // transform the simple array of suggestions in array of objects expected by select2
+                    results: Array.from(data.suggestions, function (element) {
+                      return { id: element, text: element };
+                    }),
+                  };
                 }
-            }
+              },
+            },
+          });
         }
-    });
-}
 
-/**
- * Add a new row of packaging data
- */
-function add_packaging() {
+        /**
+         * Add a new row of packaging data
+         */
+        function add_packaging() {
+          // row that triggers new row addition is no more the last row
+          // remove events and let it be removed
+          $(this).unbind("select2:select");
+          $("#packaging_" + packaging_max + "_delete").show();
 
-    // row that triggers new row addition is no more the last row
-    // remove events and let it be removed
-    $(this).unbind("select2:select");
-    $("#packaging_" + packaging_max + "_delete").show();
+          packaging_max = packaging_max + 1;
+          $('input[name="packaging_max"]').val(packaging_max);
 
-    packaging_max = packaging_max + 1;
-    $('input[name="packaging_max"]').val(packaging_max);
+          var new_packaging_id = "packaging_" + packaging_max;
+          // row 0 is our template row
+          var new_packaging_html = $("#packaging_0_row")[0].outerHTML;
+          new_packaging_html = new_packaging_html.replaceAll(
+            "packaging_0",
+            new_packaging_id
+          );
 
-    var new_packaging_id = "packaging_" + packaging_max;
-    // row 0 is our template row
-    var new_packaging_html = $("#packaging_0_row")[0].outerHTML;
-    new_packaging_html = new_packaging_html.replaceAll("packaging_0", new_packaging_id);
-    
-    $("#packagings_components_edit").append(new_packaging_html);
+          $("#packagings_components_edit").append(new_packaging_html);
 
-    
+          configure_packaging_select2(
+            new_packaging_id + "_shape",
+            "packaging_shapes",
+            "Shape"
+          );
 
-        
-            
-        
-        
-         configure_packaging_select2(new_packaging_id + "_shape", "packaging_shapes", "Shape");
+          configure_packaging_select2(
+            new_packaging_id + "_material",
+            "packaging_materials",
+            "Material"
+          );
 
-    
+          configure_packaging_select2(
+            new_packaging_id + "_recycling",
+            "packaging_recycling",
+            "Recycling"
+          );
 
-        
-            
-        
-        
-         configure_packaging_select2(new_packaging_id + "_material", "packaging_materials", "Material");
+          $("#" + new_packaging_id + "_delete")
+            .click(function (event) {
+              event.stopPropagation();
+              event.preventDefault();
+              $("#" + new_packaging_id + "_row").remove();
+            })
+            .hide();
 
-    
+          $("#" + new_packaging_id + "_shape").on(
+            "select2:select",
+            add_packaging
+          );
+        }
 
-        
-            
-        
-        
-         configure_packaging_select2(new_packaging_id + "_recycling", "packaging_recycling", "Recycling");
+        // last row triggers addition of a new row
+        $("#packaging_1_shape").on("select2:select", add_packaging);
+        // disable removal of last row
+        $("#packaging_1_delete").hide();
 
-    
-
-    $("#" + new_packaging_id + "_delete").click(function(event) {
-        event.stopPropagation();
-        event.preventDefault();
-        $("#" + new_packaging_id + "_row").remove();
-    }).hide();    
-
-    $("#" + new_packaging_id + "_shape").on('select2:select', add_packaging);
-}
-
-
-// last row triggers addition of a new row
-$("#packaging_1_shape").on('select2:select', add_packaging);
-// disable removal of last row
-$("#packaging_1_delete").hide()
-
-
-/**
- * select2 auto-open options
- */
-$(document).on("focus", ".select2", function (e) {
-    if (e.originalEvent) {
-      var s2element = $(this).siblings("select:enabled");
-      s2element.select2("open");
-      // Set focus back to select2 element on closing.
-      s2element.on("select2:closing", function () {
-        if (s2element.val()) s2element.select2("focus");
+        /**
+         * select2 auto-open options
+         */
+        $(document).on("focus", ".select2", function (e) {
+          if (e.originalEvent) {
+            var s2element = $(this).siblings("select:enabled");
+            s2element.select2("open");
+            // Set focus back to select2 element on closing.
+            s2element.on("select2:closing", function () {
+              if (s2element.val()) s2element.select2("focus");
+            });
+          }
+        });
       });
-    }
-  });
+    </script>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/cropper.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/tagify.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/load-image.all.min.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/canvas-to-blob.js"
+    ></script>
+    <script type="text/javascript">
+      var admin = 0;
+    </script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/product-multilingual.js?v=--ignore--"
+    ></script>
+    <script
+      type="text/javascript"
+      src="//static.openfoodfacts.localhost/js/dist/product-history.js"
+    ></script>
 
+    <script type="text/javascript">
+      var nutriments = {
+        Energy: "energy",
+        "Energy from fat": "energy-from-fat",
+        "Butyric acid": "butyric-acid",
+        "Caproic acid": "caproic-acid",
+        "Caprylic acid": "caprylic-acid",
+        "Capric acid": "capric-acid",
+        "Lauric acid": "lauric-acid",
+        "Myristic acid": "myristic-acid",
+        "Palmitic acid": "palmitic-acid",
+        "Stearic acid": "stearic-acid",
+        "Arachidic acid": "arachidic-acid",
+        "Behenic acid": "behenic-acid",
+        "Lignoceric acid": "lignoceric-acid",
+        "Cerotic acid": "cerotic-acid",
+        "Montanic acid": "montanic-acid",
+        "Melissic acid": "melissic-acid",
+        "Unsaturated fat": "unsaturated-fat",
+        "Monounsaturated fat": "monounsaturated-fat",
+        "Omega 9 fat": "omega-9-fat",
+        "Polyunsaturated fat": "polyunsaturated-fat",
+        "Omega 3 fat": "omega-3-fat",
+        "Omega 6 fat": "omega-6-fat",
+        "Alpha-linolenic acid": "alpha-linolenic-acid",
+        "Eicosapentaenoic acid": "eicosapentaenoic-acid",
+        "Docosahexaenoic acid": "docosahexaenoic-acid",
+        "Linoleic acid": "linoleic-acid",
+        "Arachidonic acid": "arachidonic-acid",
+        "Gamma-linolenic acid": "gamma-linolenic-acid",
+        "Dihomo-gamma-linolenic acid": "dihomo-gamma-linolenic-acid",
+        "Oleic acid": "oleic-acid",
+        "Elaidic acid": "elaidic-acid",
+        "Gondoic acid": "gondoic-acid",
+        "Mead acid": "mead-acid",
+        "Erucic acid": "erucic-acid",
+        "Nervonic acid": "nervonic-acid",
+        "Trans fat": "trans-fat",
+        Cholesterol: "cholesterol",
+        "Added sugars": "added-sugars",
+        Sucrose: "sucrose",
+        Glucose: "glucose",
+        Fructose: "fructose",
+        Lactose: "lactose",
+        Maltose: "maltose",
+        Maltodextrins: "maltodextrins",
+        Starch: "starch",
+        "Polyols (sugar alcohols)": "polyols",
+        Erythritol: "erythritol",
+        "Soluble fiber": "soluble-fiber",
+        "Insoluble fiber": "insoluble-fiber",
+        Casein: "casein",
+        "Serum proteins": "serum-proteins",
+        Nucleotides: "nucleotides",
+        "Added salt": "added-salt",
+        "Vitamin A": "vitamin-a",
+        "Beta carotene": "beta-carotene",
+        "Vitamin D (D3)": "vitamin-d",
+        "Vitamin E": "vitamin-e",
+        "Vitamin K": "vitamin-k",
+        "Vitamin C (ascorbic acid)": "vitamin-c",
+        "Vitamin B1 (Thiamin)": "vitamin-b1",
+        "Vitamin B2 (Riboflavin)": "vitamin-b2",
+        "Vitamin B3/PP (Niacin)": "vitamin-pp",
+        "Vitamin B6 (Pyridoxin)": "vitamin-b6",
+        "Vitamin B9 (Folic acid)": "vitamin-b9",
+        "Folates (total folates)": "folates",
+        "Vitamin B12 (cobalamin)": "vitamin-b12",
+        Biotin: "biotin",
+        "Vitamin B5 (Pantothenic acid)": "pantothenic-acid",
+        Silica: "silica",
+        Bicarbonate: "bicarbonate",
+        Potassium: "potassium",
+        Chloride: "chloride",
+        Calcium: "calcium",
+        Phosphorus: "phosphorus",
+        Iron: "iron",
+        Magnesium: "magnesium",
+        Zinc: "zinc",
+        Copper: "copper",
+        Manganese: "manganese",
+        Fluoride: "fluoride",
+        Selenium: "selenium",
+        Chromium: "chromium",
+        Molybdenum: "molybdenum",
+        Iodine: "iodine",
+        Caffeine: "caffeine",
+        Taurine: "taurine",
+        PH: "ph",
+        "Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils":
+          "fruits-vegetables-nuts",
+        "Fruits‚ vegetables and nuts - dried": "fruits-vegetables-nuts-dried",
+        "Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils (manual estimate from ingredients list)":
+          "fruits-vegetables-nuts-estimate",
+        "Collagen/Meat protein ratio (maximum)": "collagen-meat-protein-ratio",
+        "Cocoa (minimum)": "cocoa",
+        Chlorophyl: "chlorophyl",
+        "Carbon footprint": "carbon-footprint",
+        "Glycemic Index": "glycemic-index",
+        "Water hardness": "water-hardness",
+        Choline: "choline",
+        "Vitamin K1 (Phylloquinone)": "phylloquinone",
+        "Beta-glucan": "beta-glucan",
+        Inositol: "inositol",
+        Carnitine: "carnitine",
+        Sulphate: "sulphate",
+        Nitrate: "nitrate",
+        Acidity: "acidity",
+      };
 
-});
-</script>
+      var otherNutriments = [
+        { value: "Energy", unit: "kj", iu: false },
+        { value: "Energy from fat", unit: "kj", iu: false },
+        { value: "Butyric acid", unit: "g", iu: false },
+        { value: "Caproic acid", unit: "g", iu: false },
+        { value: "Caprylic acid", unit: "g", iu: false },
+        { value: "Capric acid", unit: "g", iu: false },
+        { value: "Lauric acid", unit: "g", iu: false },
+        { value: "Myristic acid", unit: "g", iu: false },
+        { value: "Palmitic acid", unit: "g", iu: false },
+        { value: "Stearic acid", unit: "g", iu: false },
+        { value: "Arachidic acid", unit: "g", iu: false },
+        { value: "Behenic acid", unit: "g", iu: false },
+        { value: "Lignoceric acid", unit: "g", iu: false },
+        { value: "Cerotic acid", unit: "g", iu: false },
+        { value: "Montanic acid", unit: "g", iu: false },
+        { value: "Melissic acid", unit: "g", iu: false },
+        { value: "Unsaturated fat", unit: "g", iu: false },
+        { value: "Monounsaturated fat", unit: "g", iu: false },
+        { value: "Omega 9 fat", unit: "mg", iu: false },
+        { value: "Polyunsaturated fat", unit: "g", iu: false },
+        { value: "Omega 3 fat", unit: "mg", iu: false },
+        { value: "Omega 6 fat", unit: "mg", iu: false },
+        { value: "Alpha-linolenic acid", unit: "g", iu: false },
+        { value: "Eicosapentaenoic acid", unit: "g", iu: false },
+        { value: "Docosahexaenoic acid", unit: "g", iu: false },
+        { value: "Linoleic acid", unit: "g", iu: false },
+        { value: "Arachidonic acid", unit: "g", iu: false },
+        { value: "Gamma-linolenic acid", unit: "g", iu: false },
+        { value: "Dihomo-gamma-linolenic acid", unit: "g", iu: false },
+        { value: "Oleic acid", unit: "g", iu: false },
+        { value: "Elaidic acid", unit: "g", iu: false },
+        { value: "Gondoic acid", unit: "g", iu: false },
+        { value: "Mead acid", unit: "g", iu: false },
+        { value: "Erucic acid", unit: "g", iu: false },
+        { value: "Nervonic acid", unit: "g", iu: false },
+        { value: "Trans fat", unit: "g", iu: false },
+        { value: "Cholesterol", unit: "mg", iu: false },
+        { value: "Added sugars", unit: "g", iu: false },
+        { value: "Sucrose", unit: "g", iu: false },
+        { value: "Glucose", unit: "g", iu: false },
+        { value: "Fructose", unit: "g", iu: false },
+        { value: "Lactose", unit: "g", iu: false },
+        { value: "Maltose", unit: "g", iu: false },
+        { value: "Maltodextrins", unit: "g", iu: false },
+        { value: "Starch", unit: "g", iu: false },
+        { value: "Polyols (sugar alcohols)", unit: "g", iu: false },
+        { value: "Erythritol", unit: "g", iu: false },
+        { value: "Soluble fiber", unit: "g", iu: false },
+        { value: "Insoluble fiber", unit: "g", iu: false },
+        { value: "Casein", unit: "g", iu: false },
+        { value: "Serum proteins", unit: "g", iu: false },
+        { value: "Nucleotides", unit: "g", iu: false },
+        { value: "Added salt", unit: "g", iu: false },
+        { value: "Vitamin A", unit: "µg", iu: true },
+        { value: "Beta carotene", unit: "g", iu: false },
+        { value: "Vitamin D (D3)", unit: "µg", iu: true },
+        { value: "Vitamin E", unit: "mg", iu: true },
+        { value: "Vitamin K", unit: "µg", iu: false },
+        { value: "Vitamin C (ascorbic acid)", unit: "mg", iu: true },
+        { value: "Vitamin B1 (Thiamin)", unit: "mg", iu: false },
+        { value: "Vitamin B2 (Riboflavin)", unit: "mg", iu: false },
+        { value: "Vitamin B3/PP (Niacin)", unit: "mg", iu: false },
+        { value: "Vitamin B6 (Pyridoxin)", unit: "mg", iu: false },
+        { value: "Vitamin B9 (Folic acid)", unit: "µg", iu: false },
+        { value: "Folates (total folates)", unit: "µg", iu: false },
+        { value: "Vitamin B12 (cobalamin)", unit: "µg", iu: false },
+        { value: "Biotin", unit: "µg", iu: false },
+        { value: "Vitamin B5 (Pantothenic acid)", unit: "mg", iu: false },
+        { value: "Silica", unit: "mg", iu: false },
+        { value: "Bicarbonate", unit: "mg", iu: false },
+        { value: "Potassium", unit: "mg", iu: false },
+        { value: "Chloride", unit: "mg", iu: false },
+        { value: "Calcium", unit: "mg", iu: false },
+        { value: "Phosphorus", unit: "mg", iu: false },
+        { value: "Iron", unit: "mg", iu: false },
+        { value: "Magnesium", unit: "mg", iu: false },
+        { value: "Zinc", unit: "mg", iu: false },
+        { value: "Copper", unit: "mg", iu: false },
+        { value: "Manganese", unit: "mg", iu: false },
+        { value: "Fluoride", unit: "mg", iu: false },
+        { value: "Selenium", unit: "µg", iu: false },
+        { value: "Chromium", unit: "µg", iu: false },
+        { value: "Molybdenum", unit: "µg", iu: false },
+        { value: "Iodine", unit: "µg", iu: false },
+        { value: "Caffeine", unit: "mg", iu: false },
+        { value: "Taurine", unit: "g", iu: false },
+        { value: "PH", unit: "", iu: false },
+        {
+          value: "Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils",
+          unit: "%",
+          iu: false,
+        },
+        { value: "Fruits‚ vegetables and nuts - dried", unit: "%", iu: false },
+        {
+          value:
+            "Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils (manual estimate from ingredients list)",
+          unit: "%",
+          iu: false,
+        },
+        {
+          value: "Collagen/Meat protein ratio (maximum)",
+          unit: "%",
+          iu: false,
+        },
+        { value: "Cocoa (minimum)", unit: "%", iu: false },
+        { value: "Chlorophyl", unit: "g", iu: false },
+        { value: "Carbon footprint", unit: "g", iu: false },
+        { value: "Glycemic Index", unit: "", iu: false },
+        { value: "Water hardness", unit: "mmol/l", iu: false },
+        { value: "Choline", unit: "g", iu: false },
+        { value: "Vitamin K1 (Phylloquinone)", unit: "g", iu: false },
+        { value: "Beta-glucan", unit: "g", iu: false },
+        { value: "Inositol", unit: "g", iu: false },
+        { value: "Carnitine", unit: "g", iu: false },
+        { value: "Sulphate", unit: "mg", iu: false },
+        { value: "Nitrate", unit: "mg", iu: false },
+        { value: "Acidity", unit: "% vol", iu: false },
+      ];
+    </script>
 
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/load-image.all.min.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/canvas-to-blob.js"></script>
-<script type="text/javascript">
-var admin = 0;
-</script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/product-multilingual.js?v=--ignore--"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
-
-<script type="text/javascript">
-var nutriments = {
-"Energy" : "energy",
-"Energy from fat" : "energy-from-fat",
-"Butyric acid" : "butyric-acid",
-"Caproic acid" : "caproic-acid",
-"Caprylic acid" : "caprylic-acid",
-"Capric acid" : "capric-acid",
-"Lauric acid" : "lauric-acid",
-"Myristic acid" : "myristic-acid",
-"Palmitic acid" : "palmitic-acid",
-"Stearic acid" : "stearic-acid",
-"Arachidic acid" : "arachidic-acid",
-"Behenic acid" : "behenic-acid",
-"Lignoceric acid" : "lignoceric-acid",
-"Cerotic acid" : "cerotic-acid",
-"Montanic acid" : "montanic-acid",
-"Melissic acid" : "melissic-acid",
-"Unsaturated fat" : "unsaturated-fat",
-"Monounsaturated fat" : "monounsaturated-fat",
-"Omega 9 fat" : "omega-9-fat",
-"Polyunsaturated fat" : "polyunsaturated-fat",
-"Omega 3 fat" : "omega-3-fat",
-"Omega 6 fat" : "omega-6-fat",
-"Alpha-linolenic acid" : "alpha-linolenic-acid",
-"Eicosapentaenoic acid" : "eicosapentaenoic-acid",
-"Docosahexaenoic acid" : "docosahexaenoic-acid",
-"Linoleic acid" : "linoleic-acid",
-"Arachidonic acid" : "arachidonic-acid",
-"Gamma-linolenic acid" : "gamma-linolenic-acid",
-"Dihomo-gamma-linolenic acid" : "dihomo-gamma-linolenic-acid",
-"Oleic acid" : "oleic-acid",
-"Elaidic acid" : "elaidic-acid",
-"Gondoic acid" : "gondoic-acid",
-"Mead acid" : "mead-acid",
-"Erucic acid" : "erucic-acid",
-"Nervonic acid" : "nervonic-acid",
-"Trans fat" : "trans-fat",
-"Cholesterol" : "cholesterol",
-"Added sugars" : "added-sugars",
-"Sucrose" : "sucrose",
-"Glucose" : "glucose",
-"Fructose" : "fructose",
-"Lactose" : "lactose",
-"Maltose" : "maltose",
-"Maltodextrins" : "maltodextrins",
-"Starch" : "starch",
-"Polyols (sugar alcohols)" : "polyols",
-"Erythritol" : "erythritol",
-"Soluble fiber" : "soluble-fiber",
-"Insoluble fiber" : "insoluble-fiber",
-"Casein" : "casein",
-"Serum proteins" : "serum-proteins",
-"Nucleotides" : "nucleotides",
-"Added salt" : "added-salt",
-"Vitamin A" : "vitamin-a",
-"Beta carotene" : "beta-carotene",
-"Vitamin D (D3)" : "vitamin-d",
-"Vitamin E" : "vitamin-e",
-"Vitamin K" : "vitamin-k",
-"Vitamin C (ascorbic acid)" : "vitamin-c",
-"Vitamin B1 (Thiamin)" : "vitamin-b1",
-"Vitamin B2 (Riboflavin)" : "vitamin-b2",
-"Vitamin B3/PP (Niacin)" : "vitamin-pp",
-"Vitamin B6 (Pyridoxin)" : "vitamin-b6",
-"Vitamin B9 (Folic acid)" : "vitamin-b9",
-"Folates (total folates)" : "folates",
-"Vitamin B12 (cobalamin)" : "vitamin-b12",
-"Biotin" : "biotin",
-"Vitamin B5 (Pantothenic acid)" : "pantothenic-acid",
-"Silica" : "silica",
-"Bicarbonate" : "bicarbonate",
-"Potassium" : "potassium",
-"Chloride" : "chloride",
-"Calcium" : "calcium",
-"Phosphorus" : "phosphorus",
-"Iron" : "iron",
-"Magnesium" : "magnesium",
-"Zinc" : "zinc",
-"Copper" : "copper",
-"Manganese" : "manganese",
-"Fluoride" : "fluoride",
-"Selenium" : "selenium",
-"Chromium" : "chromium",
-"Molybdenum" : "molybdenum",
-"Iodine" : "iodine",
-"Caffeine" : "caffeine",
-"Taurine" : "taurine",
-"PH" : "ph",
-"Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils" : "fruits-vegetables-nuts",
-"Fruits‚ vegetables and nuts - dried" : "fruits-vegetables-nuts-dried",
-"Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils (manual estimate from ingredients list)" : "fruits-vegetables-nuts-estimate",
-"Collagen/Meat protein ratio (maximum)" : "collagen-meat-protein-ratio",
-"Cocoa (minimum)" : "cocoa",
-"Chlorophyl" : "chlorophyl",
-"Carbon footprint" : "carbon-footprint",
-"Glycemic Index" : "glycemic-index",
-"Water hardness" : "water-hardness",
-"Choline" : "choline",
-"Vitamin K1 (Phylloquinone)" : "phylloquinone",
-"Beta-glucan" : "beta-glucan",
-"Inositol" : "inositol",
-"Carnitine" : "carnitine",
-"Sulphate" : "sulphate",
-"Nitrate" : "nitrate",
-"Acidity" : "acidity"
-};
-
-var otherNutriments = [
-{ "value" : "Energy", "unit" : "kj", "iu": false  },
-{ "value" : "Energy from fat", "unit" : "kj", "iu": false  },
-{ "value" : "Butyric acid", "unit" : "g", "iu": false  },
-{ "value" : "Caproic acid", "unit" : "g", "iu": false  },
-{ "value" : "Caprylic acid", "unit" : "g", "iu": false  },
-{ "value" : "Capric acid", "unit" : "g", "iu": false  },
-{ "value" : "Lauric acid", "unit" : "g", "iu": false  },
-{ "value" : "Myristic acid", "unit" : "g", "iu": false  },
-{ "value" : "Palmitic acid", "unit" : "g", "iu": false  },
-{ "value" : "Stearic acid", "unit" : "g", "iu": false  },
-{ "value" : "Arachidic acid", "unit" : "g", "iu": false  },
-{ "value" : "Behenic acid", "unit" : "g", "iu": false  },
-{ "value" : "Lignoceric acid", "unit" : "g", "iu": false  },
-{ "value" : "Cerotic acid", "unit" : "g", "iu": false  },
-{ "value" : "Montanic acid", "unit" : "g", "iu": false  },
-{ "value" : "Melissic acid", "unit" : "g", "iu": false  },
-{ "value" : "Unsaturated fat", "unit" : "g", "iu": false  },
-{ "value" : "Monounsaturated fat", "unit" : "g", "iu": false  },
-{ "value" : "Omega 9 fat", "unit" : "mg", "iu": false  },
-{ "value" : "Polyunsaturated fat", "unit" : "g", "iu": false  },
-{ "value" : "Omega 3 fat", "unit" : "mg", "iu": false  },
-{ "value" : "Omega 6 fat", "unit" : "mg", "iu": false  },
-{ "value" : "Alpha-linolenic acid", "unit" : "g", "iu": false  },
-{ "value" : "Eicosapentaenoic acid", "unit" : "g", "iu": false  },
-{ "value" : "Docosahexaenoic acid", "unit" : "g", "iu": false  },
-{ "value" : "Linoleic acid", "unit" : "g", "iu": false  },
-{ "value" : "Arachidonic acid", "unit" : "g", "iu": false  },
-{ "value" : "Gamma-linolenic acid", "unit" : "g", "iu": false  },
-{ "value" : "Dihomo-gamma-linolenic acid", "unit" : "g", "iu": false  },
-{ "value" : "Oleic acid", "unit" : "g", "iu": false  },
-{ "value" : "Elaidic acid", "unit" : "g", "iu": false  },
-{ "value" : "Gondoic acid", "unit" : "g", "iu": false  },
-{ "value" : "Mead acid", "unit" : "g", "iu": false  },
-{ "value" : "Erucic acid", "unit" : "g", "iu": false  },
-{ "value" : "Nervonic acid", "unit" : "g", "iu": false  },
-{ "value" : "Trans fat", "unit" : "g", "iu": false  },
-{ "value" : "Cholesterol", "unit" : "mg", "iu": false  },
-{ "value" : "Added sugars", "unit" : "g", "iu": false  },
-{ "value" : "Sucrose", "unit" : "g", "iu": false  },
-{ "value" : "Glucose", "unit" : "g", "iu": false  },
-{ "value" : "Fructose", "unit" : "g", "iu": false  },
-{ "value" : "Lactose", "unit" : "g", "iu": false  },
-{ "value" : "Maltose", "unit" : "g", "iu": false  },
-{ "value" : "Maltodextrins", "unit" : "g", "iu": false  },
-{ "value" : "Starch", "unit" : "g", "iu": false  },
-{ "value" : "Polyols (sugar alcohols)", "unit" : "g", "iu": false  },
-{ "value" : "Erythritol", "unit" : "g", "iu": false  },
-{ "value" : "Soluble fiber", "unit" : "g", "iu": false  },
-{ "value" : "Insoluble fiber", "unit" : "g", "iu": false  },
-{ "value" : "Casein", "unit" : "g", "iu": false  },
-{ "value" : "Serum proteins", "unit" : "g", "iu": false  },
-{ "value" : "Nucleotides", "unit" : "g", "iu": false  },
-{ "value" : "Added salt", "unit" : "g", "iu": false  },
-{ "value" : "Vitamin A", "unit" : "µg", "iu": true  },
-{ "value" : "Beta carotene", "unit" : "g", "iu": false  },
-{ "value" : "Vitamin D (D3)", "unit" : "µg", "iu": true  },
-{ "value" : "Vitamin E", "unit" : "mg", "iu": true  },
-{ "value" : "Vitamin K", "unit" : "µg", "iu": false  },
-{ "value" : "Vitamin C (ascorbic acid)", "unit" : "mg", "iu": true  },
-{ "value" : "Vitamin B1 (Thiamin)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamin B2 (Riboflavin)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamin B3/PP (Niacin)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamin B6 (Pyridoxin)", "unit" : "mg", "iu": false  },
-{ "value" : "Vitamin B9 (Folic acid)", "unit" : "µg", "iu": false  },
-{ "value" : "Folates (total folates)", "unit" : "µg", "iu": false  },
-{ "value" : "Vitamin B12 (cobalamin)", "unit" : "µg", "iu": false  },
-{ "value" : "Biotin", "unit" : "µg", "iu": false  },
-{ "value" : "Vitamin B5 (Pantothenic acid)", "unit" : "mg", "iu": false  },
-{ "value" : "Silica", "unit" : "mg", "iu": false  },
-{ "value" : "Bicarbonate", "unit" : "mg", "iu": false  },
-{ "value" : "Potassium", "unit" : "mg", "iu": false  },
-{ "value" : "Chloride", "unit" : "mg", "iu": false  },
-{ "value" : "Calcium", "unit" : "mg", "iu": false  },
-{ "value" : "Phosphorus", "unit" : "mg", "iu": false  },
-{ "value" : "Iron", "unit" : "mg", "iu": false  },
-{ "value" : "Magnesium", "unit" : "mg", "iu": false  },
-{ "value" : "Zinc", "unit" : "mg", "iu": false  },
-{ "value" : "Copper", "unit" : "mg", "iu": false  },
-{ "value" : "Manganese", "unit" : "mg", "iu": false  },
-{ "value" : "Fluoride", "unit" : "mg", "iu": false  },
-{ "value" : "Selenium", "unit" : "µg", "iu": false  },
-{ "value" : "Chromium", "unit" : "µg", "iu": false  },
-{ "value" : "Molybdenum", "unit" : "µg", "iu": false  },
-{ "value" : "Iodine", "unit" : "µg", "iu": false  },
-{ "value" : "Caffeine", "unit" : "mg", "iu": false  },
-{ "value" : "Taurine", "unit" : "g", "iu": false  },
-{ "value" : "PH", "unit" : "", "iu": false  },
-{ "value" : "Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils", "unit" : "%", "iu": false  },
-{ "value" : "Fruits‚ vegetables and nuts - dried", "unit" : "%", "iu": false  },
-{ "value" : "Fruits‚ vegetables‚ nuts and rapeseed‚ walnut and olive oils (manual estimate from ingredients list)", "unit" : "%", "iu": false  },
-{ "value" : "Collagen/Meat protein ratio (maximum)", "unit" : "%", "iu": false  },
-{ "value" : "Cocoa (minimum)", "unit" : "%", "iu": false  },
-{ "value" : "Chlorophyl", "unit" : "g", "iu": false  },
-{ "value" : "Carbon footprint", "unit" : "g", "iu": false  },
-{ "value" : "Glycemic Index", "unit" : "", "iu": false  },
-{ "value" : "Water hardness", "unit" : "mmol/l", "iu": false  },
-{ "value" : "Choline", "unit" : "g", "iu": false  },
-{ "value" : "Vitamin K1 (Phylloquinone)", "unit" : "g", "iu": false  },
-{ "value" : "Beta-glucan", "unit" : "g", "iu": false  },
-{ "value" : "Inositol", "unit" : "g", "iu": false  },
-{ "value" : "Carnitine", "unit" : "g", "iu": false  },
-{ "value" : "Sulphate", "unit" : "mg", "iu": false  },
-{ "value" : "Nitrate", "unit" : "mg", "iu": false  },
-{ "value" : "Acidity", "unit" : "% vol", "iu": false  }
-];
-</script>
-
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -1,5244 +1,6058 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Open Food Facts - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.hide-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .hide-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="has-dropdown">
-								<a href="#" class="userlink h-space-tiny">
-									<span class="material-icons">
-										account_circle
-									</span>
-									Test
-								</a>
-								<ul class="dropdown">
-									<li><a href="/cgi/user.pl?type=edit&userid=tests"><span class="material-icons">settings</span> Account parameters</a></li>
-
-									
-
-									
-									
-									<li class="divider"></li>			
-									<li><label>Your contributions</label></li>
-									<li><a href="/facets/contributors/tests">Products added</a></li>
-									<li><a href="/facets/editors/tests">Products edited</a></li>
-									<li><a href="/facets/photographers/tests">Products photographed</a></li>
-									
-									<li class="divider"></li>			
-									<li class="has-form">
-										<form method="post" action="/cgi/session.pl">
-											<input type="hidden" name="length" value="logout">
-											<input type="submit" name=".submit" value="Sign out" class="button small">
-										</form>
-									</li>
-								</ul>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix loggedin">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="has-dropdown">
+                <a href="#" class="userlink h-space-tiny">
+                  <span class="material-icons"> account_circle </span>
+                  Test
+                </a>
+                <ul class="dropdown">
+                  <li>
+                    <a href="/cgi/user.pl?type=edit&userid=tests"
+                      ><span class="material-icons">settings</span> Account
+                      parameters</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Your contributions</label></li>
+                  <li>
+                    <a href="/facets/contributors/tests">Products added</a>
+                  </li>
+                  <li><a href="/facets/editors/tests">Products edited</a></li>
+                  <li>
+                    <a href="/facets/photographers/tests"
+                      >Products photographed</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li class="has-form">
+                    <form method="post" action="/cgi/session.pl">
+                      <input type="hidden" name="length" value="logout" />
+                      <input
+                        type="submit"
+                        name=".submit"
+                        value="Sign out"
+                        class="button small"
+                      />
+                    </form>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Open Food Facts - World</h1>
-									</div>
-								</div>
-								
-<div class="hide-when-logged-in homepage-greeter-wrapper">
-<div class="homepage-greeter">
-	<div class="homepage-greeter__discover">
-    <div class="homepage-greeter__discover--content">
-      <div>
-        <h2>Discover</h2>
-        <p>Open Food Facts is a food products database made by everyone, for everyone. You can use it to make better food choices, and as it is open data, anyone can re-use it for any purpose.</p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/discover"><span class="material-icons">auto_stories</span>Learn more about Open Food Facts</a>
-    </div>
-    <div class="homepage-greeter__discover--image">
-      <img src="images/illustrations/globe.svg" alt="Discover Open Food Facts." />
-    </div>
-	</div>
-	<div class="homepage-greeter__contribute">
-    <div class="homepage-greeter__contribute--content"> 
-      <div>
-        <h2>Contribute</h2>
-        <p>
-        Open Food Facts is a non-profit project developed by thousands of volunteers from around the world.
-        You can start contributing by <a href="/open-food-facts-mobile-app">adding a product from your kitchen with our app for iPhone or Android</a>, and we have lots of
-        exciting projects you can contribute to in many different ways.
-        </p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/contribute"><span class="material-icons">add_task</span>Learn more about how you can join us</a>
-    </div>
-    <div class="homepage-greeter__contribute--image">
-      <img src="images/illustrations/puzzle-big.svg" alt="Contribute to Open Food Facts." />
-    </div>
-	</div>
-</div>
-</div>
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          13 products
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            Recently modified products
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        <div>
-          <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">sort</span>
-            Explore products by...
-          </button>
-          <ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/countries">Countries</a>
-            </li>
-          
-            <li>
-              <a href="/nutrition-grades">Nutrition grades</a>
-            </li>
-          
-            <li>
-              <a href="/nova-groups">NOVA groups</a>
-            </li>
-          
-            <li>
-              <a href="/environmental-score">Green-Score</a>
-            </li>
-          
-            <li>
-              <a href="/brands">Brands</a>
-            </li>
-          
-            <li>
-              <a href="/categories">Categories</a>
-            </li>
-          
-            <li>
-              <a href="/labels">Labels</a>
-            </li>
-          
-            <li>
-              <a href="/packaging">Packaging</a>
-            </li>
-          
-            <li>
-              <a href="/origins">Origins of ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/manufacturing-places">Manufacturing or processing places</a>
-            </li>
-          
-            <li>
-              <a href="/packager-codes">Traceability codes</a>
-            </li>
-          
-            <li>
-              <a href="/ingredients">Ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/additives">Additives</a>
-            </li>
-          
-            <li>
-              <a href="/vitamins">Added vitamins</a>
-            </li>
-          
-            <li>
-              <a href="/minerals">Added minerals</a>
-            </li>
-          
-            <li>
-              <a href="/amino-acids">Added amino acids</a>
-            </li>
-          
-            <li>
-              <a href="/nucleotides">Added nucleotides</a>
-            </li>
-          
-            <li>
-              <a href="/other-nutritional-substances">Other nutritional substances added</a>
-            </li>
-          
-            <li>
-              <a href="/allergens">Allergens</a>
-            </li>
-          
-            <li>
-              <a href="/traces">Traces</a>
-            </li>
-          
-            <li>
-              <a href="/misc">Miscellaneous</a>
-            </li>
-          
-            <li>
-              <a href="/languages">Languages</a>
-            </li>
-          
-            <li>
-              <a href="/contributors">Contributors</a>
-            </li>
-          
-            <li>
-              <a href="/states">States</a>
-            </li>
-          
-            <li>
-              <a href="/data-sources">Data sources</a>
-            </li>
-          
-            <li>
-              <a href="/entry-dates">Entry dates</a>
-            </li>
-          
-            <li>
-              <a href="/last-edit-dates">Last edit dates</a>
-            </li>
-          
-            <li>
-              <a href="/last-check-dates">Last check dates</a>
-            </li>
-          
-            <li>
-              <a href="/teams">Teams</a>
-            </li>
-          
-          </ul>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix loggedin"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Open Food Facts - World</h1>
+                  </div>
+                </div>
+
+                <div class="hide-when-logged-in homepage-greeter-wrapper">
+                  <div class="homepage-greeter">
+                    <div class="homepage-greeter__discover">
+                      <div class="homepage-greeter__discover--content">
+                        <div>
+                          <h2>Discover</h2>
+                          <p>
+                            Open Food Facts is a food products database made by
+                            everyone, for everyone. You can use it to make
+                            better food choices, and as it is open data, anyone
+                            can re-use it for any purpose.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/discover"
+                          ><span class="material-icons">auto_stories</span>Learn
+                          more about Open Food Facts</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__discover--image">
+                        <img
+                          src="images/illustrations/globe.svg"
+                          alt="Discover Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                    <div class="homepage-greeter__contribute">
+                      <div class="homepage-greeter__contribute--content">
+                        <div>
+                          <h2>Contribute</h2>
+                          <p>
+                            Open Food Facts is a non-profit project developed by
+                            thousands of volunteers from around the world. You
+                            can start contributing by
+                            <a href="/open-food-facts-mobile-app"
+                              >adding a product from your kitchen with our app
+                              for iPhone or Android</a
+                            >, and we have lots of exciting projects you can
+                            contribute to in many different ways.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/contribute"
+                          ><span class="material-icons">add_task</span>Learn
+                          more about how you can join us</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__contribute--image">
+                        <img
+                          src="images/illustrations/puzzle-big.svg"
+                          alt="Contribute to Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          13 products
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                            Recently modified products
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Most scanned products</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Products with the best Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Products with the best Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Recently added products</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Recently modified products</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop1"
+                            aria-controls="drop1"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">sort</span>
+                            Explore products by...
+                          </button>
+                          <ul
+                            id="drop1"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a href="/countries">Countries</a>
+                            </li>
+
+                            <li>
+                              <a href="/nutrition-grades">Nutrition grades</a>
+                            </li>
+
+                            <li>
+                              <a href="/nova-groups">NOVA groups</a>
+                            </li>
+
+                            <li>
+                              <a href="/environmental-score">Green-Score</a>
+                            </li>
+
+                            <li>
+                              <a href="/brands">Brands</a>
+                            </li>
+
+                            <li>
+                              <a href="/categories">Categories</a>
+                            </li>
+
+                            <li>
+                              <a href="/labels">Labels</a>
+                            </li>
+
+                            <li>
+                              <a href="/packaging">Packaging</a>
+                            </li>
+
+                            <li>
+                              <a href="/origins">Origins of ingredients</a>
+                            </li>
+
+                            <li>
+                              <a href="/manufacturing-places"
+                                >Manufacturing or processing places</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/packager-codes">Traceability codes</a>
+                            </li>
+
+                            <li>
+                              <a href="/ingredients">Ingredients</a>
+                            </li>
+
+                            <li>
+                              <a href="/additives">Additives</a>
+                            </li>
+
+                            <li>
+                              <a href="/vitamins">Added vitamins</a>
+                            </li>
+
+                            <li>
+                              <a href="/minerals">Added minerals</a>
+                            </li>
+
+                            <li>
+                              <a href="/amino-acids">Added amino acids</a>
+                            </li>
+
+                            <li>
+                              <a href="/nucleotides">Added nucleotides</a>
+                            </li>
+
+                            <li>
+                              <a href="/other-nutritional-substances"
+                                >Other nutritional substances added</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/allergens">Allergens</a>
+                            </li>
+
+                            <li>
+                              <a href="/traces">Traces</a>
+                            </li>
+
+                            <li>
+                              <a href="/misc">Miscellaneous</a>
+                            </li>
+
+                            <li>
+                              <a href="/languages">Languages</a>
+                            </li>
+
+                            <li>
+                              <a href="/contributors">Contributors</a>
+                            </li>
+
+                            <li>
+                              <a href="/states">States</a>
+                            </li>
+
+                            <li>
+                              <a href="/data-sources">Data sources</a>
+                            </li>
+
+                            <li>
+                              <a href="/entry-dates">Entry dates</a>
+                            </li>
+
+                            <li>
+                              <a href="/last-edit-dates">Last edit dates</a>
+                            </li>
+
+                            <li>
+                              <a href="/last-check-dates">Last check dates</a>
+                            </li>
+
+                            <li>
+                              <a href="/teams">Teams</a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+              </div>
+            </div>
+          </div>
         </div>
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 13 products below according to your preferences";
+      var contributor_prefs = { display_barcode: "", edit_link: "" };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-e-new-en.svg",
+                  id: "nutriscore",
+                  match: 18.2727272727273,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score E",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000012",
+          product_display_name: "Olio d'oliva - Mario's olive oils - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000012/olio-d-oliva-mario-s-olive-oils",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "en:nuts in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 0,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Contains: Nuts",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "en:soybeans in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 0,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Contains: Soybeans",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/1-additives.svg",
+                  id: "additives",
+                  match: 80,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "1 additive",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000011",
+          product_display_name: "Crema di nocciole - Bob's creme - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000011/crema-di-nocciole-bob-s-creme",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegan.svg",
+                  id: "vegan",
+                  match: 50,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:maybe-vegan",
+                  status: "known",
+                  title: "Maybe vegan",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 50,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:maybe-vegetarian",
+                  status: "known",
+                  title: "Maybe vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description_short:
+                    "Not yet applicable for the category: Sodas",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-not-applicable.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not applicable",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000010",
+          product_display_name: "ラムネレモネード - ラムネ - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000010/%E3%83%A9%E3%83%A0%E3%83%8D%E3%83%AC%E3%83%A2%E3%83%8D%E3%83%BC%E3%83%89-%E3%83%A9%E3%83%A0%E3%83%8D",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000009",
+          product_display_name: "Tarta de manzana - Pablo's tartas - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000009/tarta-de-manzana-pablo-s-tartas",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 41,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000008",
+          product_display_name:
+            "Organic apple and raspberry juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 35.25,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000007",
+          product_display_name: "Organic apple juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 57.8888888888889,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "en:soybeans in traces",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/may-contain-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 20,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "May contain: Soybeans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 41,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000006",
+          product_display_name:
+            "Vegan pizza with basil and oregano - Bob's pizzas - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000006/vegan-pizza-with-basil-and-oregano-bob-s-pizzas",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000005",
+          product_display_name:
+            "Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 50,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:maybe-vegetarian",
+                  status: "known",
+                  title: "Maybe vegetarian",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/may-contain-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 50,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:may-contain-palm-oil",
+                  status: "known",
+                  title: "May contain palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/6-additives.svg",
+                  id: "additives",
+                  match: 0,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "6 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000004",
+          product_display_name:
+            "Very bad vanilla ice cream with lots of sugar and additives - Bob's ice creams - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000004/very-bad-vanilla-ice-cream-with-lots-of-sugar-and-additives-bob-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 0,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:non-vegetarian",
+                  status: "known",
+                  title: "Non-vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000003",
+          product_display_name: "test_default - Bob's salads - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000003/test-default-bob-s-salads",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Organic apple and raspberry pie - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000001",
+          product_display_name: "Apple pie - Bob's pies - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 13 products below according to your preferences";
-var contributor_prefs = {"display_barcode":"","edit_link":""};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-e-new-en.svg",
-                  "id":"nutriscore",
-                  "match":18.2727272727273,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score E"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000012",
-      "product_display_name":"Olio d'oliva - Mario's olive oils - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000012/olio-d-oliva-mario-s-olive-oils"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"en:nuts in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":0,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Contains: Nuts"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"en:soybeans in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":0,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Contains: Soybeans"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/1-additives.svg",
-                  "id":"additives",
-                  "match":80,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"1 additive"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000011",
-      "product_display_name":"Crema di nocciole - Bob's creme - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000011/crema-di-nocciole-bob-s-creme"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegan.svg",
-                  "id":"vegan",
-                  "match":50,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:maybe-vegan",
-                  "status":"known",
-                  "title":"Maybe vegan"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":50,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:maybe-vegetarian",
-                  "status":"known",
-                  "title":"Maybe vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description_short":"Not yet applicable for the category: Sodas",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-not-applicable.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not applicable"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000010",
-      "product_display_name":"ラムネレモネード - ラムネ - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000010/%E3%83%A9%E3%83%A0%E3%83%8D%E3%83%AC%E3%83%A2%E3%83%8D%E3%83%BC%E3%83%89-%E3%83%A9%E3%83%A0%E3%83%8D"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000009",
-      "product_display_name":"Tarta de manzana - Pablo's tartas - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000009/tarta-de-manzana-pablo-s-tartas"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":41,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000008",
-      "product_display_name":"Organic apple and raspberry juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":35.25,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000007",
-      "product_display_name":"Organic apple juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":57.8888888888889,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"en:soybeans in traces",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/may-contain-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":20,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"May contain: Soybeans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":41,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000006",
-      "product_display_name":"Vegan pizza with basil and oregano - Bob's pizzas - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000006/vegan-pizza-with-basil-and-oregano-bob-s-pizzas"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000005",
-      "product_display_name":"Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":50,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:maybe-vegetarian",
-                  "status":"known",
-                  "title":"Maybe vegetarian"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/may-contain-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":50,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:may-contain-palm-oil",
-                  "status":"known",
-                  "title":"May contain palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/6-additives.svg",
-                  "id":"additives",
-                  "match":0,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"6 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000004",
-      "product_display_name":"Very bad vanilla ice cream with lots of sugar and additives - Bob's ice creams - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000004/very-bad-vanilla-ice-cream-with-lots-of-sugar-and-additives-bob-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":0,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:non-vegetarian",
-                  "status":"known",
-                  "title":"Non-vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000003",
-      "product_display_name":"test_default - Bob's salads - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000003/test-default-bob-s-salads"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Organic apple and raspberry pie - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000001",
-      "product_display_name":"Apple pie - Bob's pies - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -1,5221 +1,6027 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Open Food Facts - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Open Food Facts - World</h1>
-									</div>
-								</div>
-								
-<div class="hide-when-logged-in homepage-greeter-wrapper">
-<div class="homepage-greeter">
-	<div class="homepage-greeter__discover">
-    <div class="homepage-greeter__discover--content">
-      <div>
-        <h2>Discover</h2>
-        <p>Open Food Facts is a food products database made by everyone, for everyone. You can use it to make better food choices, and as it is open data, anyone can re-use it for any purpose.</p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/discover"><span class="material-icons">auto_stories</span>Learn more about Open Food Facts</a>
-    </div>
-    <div class="homepage-greeter__discover--image">
-      <img src="images/illustrations/globe.svg" alt="Discover Open Food Facts." />
-    </div>
-	</div>
-	<div class="homepage-greeter__contribute">
-    <div class="homepage-greeter__contribute--content"> 
-      <div>
-        <h2>Contribute</h2>
-        <p>
-        Open Food Facts is a non-profit project developed by thousands of volunteers from around the world.
-        You can start contributing by <a href="/open-food-facts-mobile-app">adding a product from your kitchen with our app for iPhone or Android</a>, and we have lots of
-        exciting projects you can contribute to in many different ways.
-        </p>
-      </div>
-      <a class="button round secondary small homepage-greeter__button" href="/contribute"><span class="material-icons">add_task</span>Learn more about how you can join us</a>
-    </div>
-    <div class="homepage-greeter__contribute--image">
-      <img src="images/illustrations/puzzle-big.svg" alt="Contribute to Open Food Facts." />
-    </div>
-	</div>
-</div>
-</div>
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          13 products
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            Recently modified products
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        <div>
-          <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">sort</span>
-            Explore products by...
-          </button>
-          <ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/countries">Countries</a>
-            </li>
-          
-            <li>
-              <a href="/nutrition-grades">Nutrition grades</a>
-            </li>
-          
-            <li>
-              <a href="/nova-groups">NOVA groups</a>
-            </li>
-          
-            <li>
-              <a href="/environmental-score">Green-Score</a>
-            </li>
-          
-            <li>
-              <a href="/brands">Brands</a>
-            </li>
-          
-            <li>
-              <a href="/categories">Categories</a>
-            </li>
-          
-            <li>
-              <a href="/labels">Labels</a>
-            </li>
-          
-            <li>
-              <a href="/packaging">Packaging</a>
-            </li>
-          
-            <li>
-              <a href="/origins">Origins of ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/manufacturing-places">Manufacturing or processing places</a>
-            </li>
-          
-            <li>
-              <a href="/packager-codes">Traceability codes</a>
-            </li>
-          
-            <li>
-              <a href="/ingredients">Ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/additives">Additives</a>
-            </li>
-          
-            <li>
-              <a href="/vitamins">Added vitamins</a>
-            </li>
-          
-            <li>
-              <a href="/minerals">Added minerals</a>
-            </li>
-          
-            <li>
-              <a href="/amino-acids">Added amino acids</a>
-            </li>
-          
-            <li>
-              <a href="/nucleotides">Added nucleotides</a>
-            </li>
-          
-            <li>
-              <a href="/other-nutritional-substances">Other nutritional substances added</a>
-            </li>
-          
-            <li>
-              <a href="/allergens">Allergens</a>
-            </li>
-          
-            <li>
-              <a href="/traces">Traces</a>
-            </li>
-          
-            <li>
-              <a href="/misc">Miscellaneous</a>
-            </li>
-          
-            <li>
-              <a href="/languages">Languages</a>
-            </li>
-          
-            <li>
-              <a href="/contributors">Contributors</a>
-            </li>
-          
-            <li>
-              <a href="/states">States</a>
-            </li>
-          
-            <li>
-              <a href="/data-sources">Data sources</a>
-            </li>
-          
-            <li>
-              <a href="/entry-dates">Entry dates</a>
-            </li>
-          
-            <li>
-              <a href="/last-edit-dates">Last edit dates</a>
-            </li>
-          
-            <li>
-              <a href="/last-check-dates">Last check dates</a>
-            </li>
-          
-            <li>
-              <a href="/teams">Teams</a>
-            </li>
-          
-          </ul>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Open Food Facts - World</h1>
+                  </div>
+                </div>
+
+                <div class="hide-when-logged-in homepage-greeter-wrapper">
+                  <div class="homepage-greeter">
+                    <div class="homepage-greeter__discover">
+                      <div class="homepage-greeter__discover--content">
+                        <div>
+                          <h2>Discover</h2>
+                          <p>
+                            Open Food Facts is a food products database made by
+                            everyone, for everyone. You can use it to make
+                            better food choices, and as it is open data, anyone
+                            can re-use it for any purpose.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/discover"
+                          ><span class="material-icons">auto_stories</span>Learn
+                          more about Open Food Facts</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__discover--image">
+                        <img
+                          src="images/illustrations/globe.svg"
+                          alt="Discover Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                    <div class="homepage-greeter__contribute">
+                      <div class="homepage-greeter__contribute--content">
+                        <div>
+                          <h2>Contribute</h2>
+                          <p>
+                            Open Food Facts is a non-profit project developed by
+                            thousands of volunteers from around the world. You
+                            can start contributing by
+                            <a href="/open-food-facts-mobile-app"
+                              >adding a product from your kitchen with our app
+                              for iPhone or Android</a
+                            >, and we have lots of exciting projects you can
+                            contribute to in many different ways.
+                          </p>
+                        </div>
+                        <a
+                          class="button round secondary small homepage-greeter__button"
+                          href="/contribute"
+                          ><span class="material-icons">add_task</span>Learn
+                          more about how you can join us</a
+                        >
+                      </div>
+                      <div class="homepage-greeter__contribute--image">
+                        <img
+                          src="images/illustrations/puzzle-big.svg"
+                          alt="Contribute to Open Food Facts."
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          13 products
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                            Recently modified products
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Most scanned products</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Products with the best Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Products with the best Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Recently added products</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Recently modified products</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop1"
+                            aria-controls="drop1"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">sort</span>
+                            Explore products by...
+                          </button>
+                          <ul
+                            id="drop1"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a href="/countries">Countries</a>
+                            </li>
+
+                            <li>
+                              <a href="/nutrition-grades">Nutrition grades</a>
+                            </li>
+
+                            <li>
+                              <a href="/nova-groups">NOVA groups</a>
+                            </li>
+
+                            <li>
+                              <a href="/environmental-score">Green-Score</a>
+                            </li>
+
+                            <li>
+                              <a href="/brands">Brands</a>
+                            </li>
+
+                            <li>
+                              <a href="/categories">Categories</a>
+                            </li>
+
+                            <li>
+                              <a href="/labels">Labels</a>
+                            </li>
+
+                            <li>
+                              <a href="/packaging">Packaging</a>
+                            </li>
+
+                            <li>
+                              <a href="/origins">Origins of ingredients</a>
+                            </li>
+
+                            <li>
+                              <a href="/manufacturing-places"
+                                >Manufacturing or processing places</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/packager-codes">Traceability codes</a>
+                            </li>
+
+                            <li>
+                              <a href="/ingredients">Ingredients</a>
+                            </li>
+
+                            <li>
+                              <a href="/additives">Additives</a>
+                            </li>
+
+                            <li>
+                              <a href="/vitamins">Added vitamins</a>
+                            </li>
+
+                            <li>
+                              <a href="/minerals">Added minerals</a>
+                            </li>
+
+                            <li>
+                              <a href="/amino-acids">Added amino acids</a>
+                            </li>
+
+                            <li>
+                              <a href="/nucleotides">Added nucleotides</a>
+                            </li>
+
+                            <li>
+                              <a href="/other-nutritional-substances"
+                                >Other nutritional substances added</a
+                              >
+                            </li>
+
+                            <li>
+                              <a href="/allergens">Allergens</a>
+                            </li>
+
+                            <li>
+                              <a href="/traces">Traces</a>
+                            </li>
+
+                            <li>
+                              <a href="/misc">Miscellaneous</a>
+                            </li>
+
+                            <li>
+                              <a href="/languages">Languages</a>
+                            </li>
+
+                            <li>
+                              <a href="/contributors">Contributors</a>
+                            </li>
+
+                            <li>
+                              <a href="/states">States</a>
+                            </li>
+
+                            <li>
+                              <a href="/data-sources">Data sources</a>
+                            </li>
+
+                            <li>
+                              <a href="/entry-dates">Entry dates</a>
+                            </li>
+
+                            <li>
+                              <a href="/last-edit-dates">Last edit dates</a>
+                            </li>
+
+                            <li>
+                              <a href="/last-check-dates">Last check dates</a>
+                            </li>
+
+                            <li>
+                              <a href="/teams">Teams</a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+              </div>
+            </div>
+          </div>
         </div>
-        
-        
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 13 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-e-new-en.svg",
+                  id: "nutriscore",
+                  match: 18.2727272727273,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score E",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000012",
+          product_display_name: "Olio d'oliva - Mario's olive oils - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000012/olio-d-oliva-mario-s-olive-oils",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "en:nuts in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 0,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Contains: Nuts",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "en:soybeans in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 0,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Contains: Soybeans",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "8 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/1-additives.svg",
+                  id: "additives",
+                  match: 80,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "1 additive",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000011",
+          product_display_name: "Crema di nocciole - Bob's creme - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000011/crema-di-nocciole-bob-s-creme",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "5 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegan.svg",
+                  id: "vegan",
+                  match: 50,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:maybe-vegan",
+                  status: "known",
+                  title: "Maybe vegan",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 50,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:maybe-vegetarian",
+                  status: "known",
+                  title: "Maybe vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description_short:
+                    "Not yet applicable for the category: Sodas",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-not-applicable.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not applicable",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000010",
+          product_display_name: "ラムネレモネード - ラムネ - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000010/%E3%83%A9%E3%83%A0%E3%83%8D%E3%83%AC%E3%83%A2%E3%83%8D%E3%83%BC%E3%83%89-%E3%83%A9%E3%83%A0%E3%83%8D",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000009",
+          product_display_name: "Tarta de manzana - Pablo's tartas - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000009/tarta-de-manzana-pablo-s-tartas",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 41,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000008",
+          product_display_name:
+            "Organic apple and raspberry juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 35.25,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000007",
+          product_display_name: "Organic apple juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 57.8888888888889,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "en:soybeans in traces",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/may-contain-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 20,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "May contain: Soybeans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "High environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
+                  id: "ecoscore",
+                  match: 41,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score D",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000006",
+          product_display_name:
+            "Vegan pizza with basil and oregano - Bob's pizzas - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000006/vegan-pizza-with-basil-and-oregano-bob-s-pizzas",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "3 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000005",
+          product_display_name:
+            "Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "13 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 50,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:maybe-vegetarian",
+                  status: "known",
+                  title: "Maybe vegetarian",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/may-contain-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 50,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:may-contain-palm-oil",
+                  status: "known",
+                  title: "May contain palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
+                  id: "nova",
+                  match: 0,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Ultra-processed foods",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/6-additives.svg",
+                  id: "additives",
+                  match: 0,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "6 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 67,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000004",
+          product_display_name:
+            "Very bad vanilla ice cream with lots of sugar and additives - Bob's ice creams - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000004/very-bad-vanilla-ice-cream-with-lots-of-sugar-and-additives-bob-s-ice-creams",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Missing data to compute the Nutri-Score",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                  id: "nutriscore",
+                  match: 0,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "unknown",
+                  title: "Nutri-Score unknown",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "7 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegetarian.svg",
+                  id: "vegetarian",
+                  match: 0,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:non-vegetarian",
+                  status: "known",
+                  title: "Non-vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000003",
+          product_display_name: "test_default - Bob's salads - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000003/test-default-bob-s-salads",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Organic apple and raspberry pie - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000001",
+          product_display_name: "Apple pie - Bob's pies - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 13 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-e-new-en.svg",
-                  "id":"nutriscore",
-                  "match":18.2727272727273,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score E"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000012",
-      "product_display_name":"Olio d'oliva - Mario's olive oils - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000012/olio-d-oliva-mario-s-olive-oils"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"en:nuts in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":0,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Contains: Nuts"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"en:soybeans in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":0,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Contains: Soybeans"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"8 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/1-additives.svg",
-                  "id":"additives",
-                  "match":80,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"1 additive"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000011",
-      "product_display_name":"Crema di nocciole - Bob's creme - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000011/crema-di-nocciole-bob-s-creme"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"5 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegan.svg",
-                  "id":"vegan",
-                  "match":50,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:maybe-vegan",
-                  "status":"known",
-                  "title":"Maybe vegan"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":50,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:maybe-vegetarian",
-                  "status":"known",
-                  "title":"Maybe vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description_short":"Not yet applicable for the category: Sodas",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-not-applicable.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not applicable"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000010",
-      "product_display_name":"ラムネレモネード - ラムネ - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000010/%E3%83%A9%E3%83%A0%E3%83%8D%E3%83%AC%E3%83%A2%E3%83%8D%E3%83%BC%E3%83%89-%E3%83%A9%E3%83%A0%E3%83%8D"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000009",
-      "product_display_name":"Tarta de manzana - Pablo's tartas - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000009/tarta-de-manzana-pablo-s-tartas"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":41,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000008",
-      "product_display_name":"Organic apple and raspberry juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":35.25,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000007",
-      "product_display_name":"Organic apple juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":57.8888888888889,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"en:soybeans in traces",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/may-contain-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":20,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"May contain: Soybeans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"High environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-d.svg",
-                  "id":"ecoscore",
-                  "match":41,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score D"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000006",
-      "product_display_name":"Vegan pizza with basil and oregano - Bob's pizzas - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000006/vegan-pizza-with-basil-and-oregano-bob-s-pizzas"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"3 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000005",
-      "product_display_name":"Very good vanilla ice cream with no sugar and no additives - Alice's ice creams - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000005/very-good-vanilla-ice-cream-with-no-sugar-and-no-additives-alice-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"13 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/maybe-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":50,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:maybe-vegetarian",
-                  "status":"known",
-                  "title":"Maybe vegetarian"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/may-contain-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":50,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:may-contain-palm-oil",
-                  "status":"known",
-                  "title":"May contain palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-4.svg",
-                  "id":"nova",
-                  "match":0,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Ultra-processed foods"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/6-additives.svg",
-                  "id":"additives",
-                  "match":0,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"6 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":67,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000004",
-      "product_display_name":"Very bad vanilla ice cream with lots of sugar and additives - Bob's ice creams - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000004/very-bad-vanilla-ice-cream-with-lots-of-sugar-and-additives-bob-s-ice-creams"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Missing data to compute the Nutri-Score",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
-                  "id":"nutriscore",
-                  "match":0,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"unknown",
-                  "title":"Nutri-Score unknown"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"7 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":0,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:non-vegetarian",
-                  "status":"known",
-                  "title":"Non-vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000003",
-      "product_display_name":"test_default - Bob's salads - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000003/test-default-bob-s-salads"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Organic apple and raspberry pie - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000001",
-      "product_display_name":"Apple pie - Bob's pies - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -1,2687 +1,3586 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Organic</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/labels/en:organic/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/labels/en:organic/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/labels/en:organic/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/labels/en:organic/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<!-- some lists of products for facets (e.g. brands) have microformats data -->
-								<div itemscope itemtype="//schema.org/Thing">
-									<div class="row">
-										<div class="small-12 column v-space-short">
-											<h1 itemprop="name">Organic</h1>
-										</div>
-									</div>
-								  <!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-                    <a href="/facets/labels">Label</a>:
-                    <a href="/facets/labels/organic">Organic</a>
-                    
-                
-            </div>
-
-            
-
-                
-
-                
-
-                
-
-                
-                <div class="parents_and_children">
-                    <p>Contains:</p><ul>
-<li><a href="/facets/labels/de:bio-7-initiative" class="tag user_defined" lang="de">de:Bio 7 Initiative</a></li>
-<li><a href="/facets/labels/austria-bio-garantie" class="tag well_known">Austria Bio Garantie</a></li>
-<li><a href="/facets/labels/bio-austria" class="tag well_known">Bio Austria</a></li>
-<li><a href="/facets/labels/bio-suisse" class="tag well_known">Bio Suisse</a></li>
-<li><a href="/facets/labels/biodynamic-agriculture" class="tag well_known">Biodynamic agriculture</a></li>
-<li><a href="/facets/labels/biogarantie" class="tag well_known">Biogarantie</a></li>
-<li><a href="/facets/labels/biokreis" class="tag well_known">Biokreis</a></li>
-<li><a href="/facets/labels/bioland" class="tag well_known">Bioland</a></li>
-<li><a href="/facets/labels/canada-organic" class="tag well_known">Canada Organic</a></li>
-<li><a href="/facets/labels/catalan-council-of-organic-production" class="tag well_known">Catalan Council of Organic Production</a></li>
-<li><a href="/facets/labels/danish-state-controlled-organic" class="tag well_known">Danish state-controlled organic</a></li>
-<li><a href="/facets/labels/debio-organic" class="tag well_known">Debio organic</a></li>
-<li><a href="/facets/labels/ecoveg" class="tag well_known">EcoVeg</a></li>
-<li><a href="/facets/labels/eu-organic" class="tag well_known">EU Organic</a></li>
-<li><a href="/facets/labels/fair-trade-organic" class="tag well_known">Fair-Trade Organic</a></li>
-<li><a href="/facets/labels/farm-verified-organic" class="tag well_known">Farm Verified Organic</a></li>
-<li><a href="/facets/labels/finnish-organic-association" class="tag well_known">Finnish organic association</a></li>
-<li><a href="/facets/labels/india-organic" class="tag well_known">India Organic</a></li>
-<li><a href="/facets/labels/luomu-controlled-organic-production" class="tag well_known">Luomu - controlled organic production</a></li>
-<li><a href="/facets/labels/migros-bio" class="tag well_known">Migros Bio</a></li>
-<li><a href="/facets/labels/naturaplan" class="tag well_known">Naturaplan</a></li>
-<li><a href="/facets/labels/naturland" class="tag well_known">Naturland</a></li>
-<li><a href="/facets/labels/soil-association-organic" class="tag well_known">Soil Association Organic</a></li>
-<li><a href="/facets/labels/tun-certified-organic" class="tag well_known">Tún certified organic</a></li>
-<li><a href="/facets/labels/usda-organic" class="tag well_known">USDA Organic</a></li>
-<li><a href="/facets/labels/es:comite-aragones-de-agricultura-ecologica" class="tag user_defined" lang="es">es:Comité Aragonés de Agricultura Ecologica</a></li>
-<li><a href="/facets/labels/es:comite-de-agricultura-ecologica" class="tag user_defined" lang="es">es:Comité de Agricultura Ecologica</a></li>
-<li><a href="/facets/labels/es:comite-de-agricultura-ecologica-de-la-comunidad-de-madrid" class="tag user_defined" lang="es">es:Comité de Agricultura Ecologica de la Comunidad de Madrid</a></li>
-<li><a href="/facets/labels/es:comite-de-agricultura-ecologica-de-la-comunitat-valenciana" class="tag user_defined" lang="es">es:Comité de Agricultura Ecológica de la Comunitat Valenciana</a></li>
-<li><a href="/facets/labels/es:consejo-de-agricultura-ecologica-de-la-region-de-murcia" class="tag user_defined" lang="es">es:Consejo de Agricultura Ecologica de la Región de Murcia</a></li>
-<li><a href="/facets/labels/es:organico-argentina" class="tag user_defined" lang="es">es:Orgánico Argentina</a></li>
-<li><a href="/facets/labels/fr:bio-coherence" class="tag user_defined" lang="fr">fr:Bio-Cohérence</a></li>
-<li><a href="/facets/labels/fr:bio-equitable" class="tag user_defined" lang="fr">fr:Bio-équitable</a></li>
-<li><a href="/facets/labels/fr:bio-equitable-en-france" class="tag user_defined" lang="fr">fr:Bio équitable en France</a></li>
-<li><a href="/facets/labels/fr:bio-solidaire" class="tag user_defined" lang="fr">fr:Bio-Solidaire</a></li>
-<li><a href="/facets/labels/biopartenaire" class="tag well_known">Biopartenaire</a></li>
-<li><a href="/facets/labels/fr:nature-et-progres" class="tag user_defined" lang="fr">fr:Nature et Progrès</a></li>
-<li><a href="/facets/labels/icea-bio-vegan" class="tag well_known">ICEA Bio Vegan</a></li>
-<li><a href="/facets/labels/icea-bio-vegetariano" class="tag well_known">ICEA Bio Vegetariano</a></li>
-<li><a href="/facets/labels/icea-biologico" class="tag well_known">ICEA Biologico</a></li>
-<li><a href="/facets/labels/pt:produto-organico-brasil" class="tag user_defined" lang="pt">pt:Produto Orgânico Brasil</a></li>
-<li><a href="/facets/labels/krav" class="tag well_known">KRAV</a></li>
-</ul>
-
-                </div>
-                
-
-                
-                <div class="description">
-                    <div class="row">
-
-	<div id="tag_description" class="large-12 columns">
-		<p>Organic food is food produced by methods complying with the standards of organic farming and features practices that cycle resources, promote ecological balance, and conserve biodiversity.</p>
-	</div>
-	<div id="tag_map" class="large-9 columns" style="display: none;">
-		<div id="container" style="height: 300px"></div>
-	</div>
-
-</div>
-<!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-<link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/leaflet.css" />
-<script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    displayMap([], ["Q380778"]);
-  });
-</script>
-
-<!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
-
-                </div>
-                
-
-                
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-            
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-            <div class="large-6 column">                
-            <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
-                <h2 id="facet_panels_title"></h2>
-                <div id="facet_panels_content"></div>
-            </div>
-            <!-- Fetching facet knowledge panel -->                
-            <script>
-                    let facet_kp = "//facets-kp.openfoodfacts.org/render-to-html";
-                    let params = "?facet_tag=labels&value_tag=en:organic";
-                    if ("") {
-                        params += "&sec_facet_tag=&sec_value_tag="
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
                     }
 
-                    // Adding language code to get translated data
-                    params += "&lang_code=en&country=world";
+                    return "";
+                  }
 
-                    fetch(facet_kp + params)
-                        .then((response) => {
-                            if (response.ok) {
-                                return response.text();
-                            }
-                            else {
-                                throw new Error("Network Response Error while fetching facet kp");
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
 
-                            }
-                        })
-                        .then(data => {
-                            let title = document.getElementById("facet_panels_title");
-                            title.innerHTML = "Facet knowledge panel";
-                            let knowledgepanel = document.getElementById("facet_panels_content");
-                            knowledgepanel.innerHTML = data;
-                            // Keeping Hungergames and Lastedits panel open by default
-                            jQuery("#HungerGames").attr("open", true);
-                            jQuery("#LastEdits").attr("open", true);
-
-                        })
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
                 </script>
+
+                <!-- some lists of products for facets (e.g. brands) have microformats data -->
+                <div itemscope itemtype="//schema.org/Thing">
+                  <div class="row">
+                    <div class="small-12 column v-space-short">
+                      <h1 itemprop="name">Organic</h1>
+                    </div>
+                  </div>
+                  <!-- start templates/web/pages/tag/tag.tt.html -->
+                  <div class="tag">
+                    <div class="row">
+                      <div class="large-6 column">
+                        <div class="tag_navigation">
+                          <a href="/facets/labels">Label</a>:
+                          <a href="/facets/labels/organic">Organic</a>
+                        </div>
+
+                        <div class="parents_and_children">
+                          <p>Contains:</p>
+                          <ul>
+                            <li>
+                              <a
+                                href="/facets/labels/de:bio-7-initiative"
+                                class="tag user_defined"
+                                lang="de"
+                                >de:Bio 7 Initiative</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/austria-bio-garantie"
+                                class="tag well_known"
+                                >Austria Bio Garantie</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/bio-austria"
+                                class="tag well_known"
+                                >Bio Austria</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/bio-suisse"
+                                class="tag well_known"
+                                >Bio Suisse</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/biodynamic-agriculture"
+                                class="tag well_known"
+                                >Biodynamic agriculture</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/biogarantie"
+                                class="tag well_known"
+                                >Biogarantie</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/biokreis"
+                                class="tag well_known"
+                                >Biokreis</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/bioland"
+                                class="tag well_known"
+                                >Bioland</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/canada-organic"
+                                class="tag well_known"
+                                >Canada Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/catalan-council-of-organic-production"
+                                class="tag well_known"
+                                >Catalan Council of Organic Production</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/danish-state-controlled-organic"
+                                class="tag well_known"
+                                >Danish state-controlled organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/debio-organic"
+                                class="tag well_known"
+                                >Debio organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/ecoveg"
+                                class="tag well_known"
+                                >EcoVeg</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/eu-organic"
+                                class="tag well_known"
+                                >EU Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/fair-trade-organic"
+                                class="tag well_known"
+                                >Fair-Trade Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/farm-verified-organic"
+                                class="tag well_known"
+                                >Farm Verified Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/finnish-organic-association"
+                                class="tag well_known"
+                                >Finnish organic association</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/india-organic"
+                                class="tag well_known"
+                                >India Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/luomu-controlled-organic-production"
+                                class="tag well_known"
+                                >Luomu - controlled organic production</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/migros-bio"
+                                class="tag well_known"
+                                >Migros Bio</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/naturaplan"
+                                class="tag well_known"
+                                >Naturaplan</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/naturland"
+                                class="tag well_known"
+                                >Naturland</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/soil-association-organic"
+                                class="tag well_known"
+                                >Soil Association Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/tun-certified-organic"
+                                class="tag well_known"
+                                >Tún certified organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/usda-organic"
+                                class="tag well_known"
+                                >USDA Organic</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/es:comite-aragones-de-agricultura-ecologica"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Comité Aragonés de Agricultura Ecologica</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/es:comite-de-agricultura-ecologica"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Comité de Agricultura Ecologica</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/es:comite-de-agricultura-ecologica-de-la-comunidad-de-madrid"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Comité de Agricultura Ecologica de la
+                                Comunidad de Madrid</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/es:comite-de-agricultura-ecologica-de-la-comunitat-valenciana"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Comité de Agricultura Ecológica de la
+                                Comunitat Valenciana</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/es:consejo-de-agricultura-ecologica-de-la-region-de-murcia"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Consejo de Agricultura Ecologica de la
+                                Región de Murcia</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/es:organico-argentina"
+                                class="tag user_defined"
+                                lang="es"
+                                >es:Orgánico Argentina</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/fr:bio-coherence"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Bio-Cohérence</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/fr:bio-equitable"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Bio-équitable</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/fr:bio-equitable-en-france"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Bio équitable en France</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/fr:bio-solidaire"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Bio-Solidaire</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/biopartenaire"
+                                class="tag well_known"
+                                >Biopartenaire</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/fr:nature-et-progres"
+                                class="tag user_defined"
+                                lang="fr"
+                                >fr:Nature et Progrès</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/icea-bio-vegan"
+                                class="tag well_known"
+                                >ICEA Bio Vegan</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/icea-bio-vegetariano"
+                                class="tag well_known"
+                                >ICEA Bio Vegetariano</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/icea-biologico"
+                                class="tag well_known"
+                                >ICEA Biologico</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/pt:produto-organico-brasil"
+                                class="tag user_defined"
+                                lang="pt"
+                                >pt:Produto Orgânico Brasil</a
+                              >
+                            </li>
+                            <li>
+                              <a
+                                href="/facets/labels/krav"
+                                class="tag well_known"
+                                >KRAV</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+
+                        <div class="description">
+                          <div class="row">
+                            <div id="tag_description" class="large-12 columns">
+                              <p>
+                                Organic food is food produced by methods
+                                complying with the standards of organic farming
+                                and features practices that cycle resources,
+                                promote ecological balance, and conserve
+                                biodiversity.
+                              </p>
+                            </div>
+                            <div
+                              id="tag_map"
+                              class="large-9 columns"
+                              style="display: none"
+                            >
+                              <div id="container" style="height: 300px"></div>
+                            </div>
+                          </div>
+                          <!-- start templates/web/pages/tags_map/map_of_tags.tt.html -->
+
+                          <link
+                            rel="stylesheet"
+                            href="//static.openfoodfacts.localhost/css/dist/leaflet.css"
+                          />
+                          <script src="//static.openfoodfacts.localhost/js/dist/leaflet.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/osmtogeojson.js"></script>
+                          <script src="//static.openfoodfacts.localhost/js/dist/display-tag.js"></script>
+
+                          <script>
+                            document.addEventListener(
+                              "DOMContentLoaded",
+                              function () {
+                                displayMap([], ["Q380778"]);
+                              }
+                            );
+                          </script>
+
+                          <!-- end templates/web/pages/tags_map/map_of_tags.tt.html -->
+                        </div>
+                      </div>
+
+                      <div class="large-6 column">
+                        <!-- injecting facet-knowledge-panel -->
+                        <div
+                          id="facet-knowledge-panel"
+                          style="margin-left: 70px; z-index: 1"
+                        >
+                          <h2 id="facet_panels_title"></h2>
+                          <div id="facet_panels_content"></div>
+                        </div>
+                        <!-- Fetching facet knowledge panel -->
+                        <script>
+                          let facet_kp =
+                            "//facets-kp.openfoodfacts.org/render-to-html";
+                          let params = "?facet_tag=labels&value_tag=en:organic";
+                          if ("") {
+                            params += "&sec_facet_tag=&sec_value_tag=";
+                          }
+
+                          // Adding language code to get translated data
+                          params += "&lang_code=en&country=world";
+
+                          fetch(facet_kp + params)
+                            .then((response) => {
+                              if (response.ok) {
+                                return response.text();
+                              } else {
+                                throw new Error(
+                                  "Network Response Error while fetching facet kp"
+                                );
+                              }
+                            })
+                            .then((data) => {
+                              let title =
+                                document.getElementById("facet_panels_title");
+                              title.innerHTML = "Facet knowledge panel";
+                              let knowledgepanel = document.getElementById(
+                                "facet_panels_content"
+                              );
+                              knowledgepanel.innerHTML = data;
+                              // Keeping Hungergames and Lastedits panel open by default
+                              jQuery("#HungerGames").attr("open", true);
+                              jQuery("#LastEdits").attr("open", true);
+                            });
+                        </script>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/pages/tag/tag.tt.html -->
+                  <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <!-- display a permalink if the url is for a script that may have POST parameters -->
+                    </div>
+                  </div>
+
+                  <div class="block short block_ristreto">
+                    <div class="row">
+                      <div class="small-12 columns filterProducts">
+                        <div>
+                          <span class="filterProducts__results">
+                            <span class="material-icons" aria-hidden="true"
+                              >search</span
+                            >
+                            5 products
+                          </span>
+                        </div>
+                        <div class="filterProducts__buttons">
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop_sort"
+                              aria-controls="drop_sort"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">swap_vert</span>
+                            </button>
+                            <ul
+                              id="drop_sort"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/labels/organic?sort_by=popularity"
+                                  onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                  >Most scanned products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic?sort_by=nutriscore_score"
+                                  onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                  >Products with the best Nutri-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic?sort_by=environmental_score_score"
+                                  onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                  >Products with the best Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic?sort_by=created_t"
+                                  onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                  >Recently added products</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic?sort_by=last_modified_t"
+                                  onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                  >Recently modified products</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+
+                          <div>
+                            <button
+                              href="#"
+                              data-dropdown="drop1"
+                              aria-controls="drop1"
+                              aria-expanded="false"
+                              class="button round dropdown small secondary unmarged"
+                            >
+                              <span class="material-icons">sort</span>
+                              Explore products by...
+                            </button>
+                            <ul
+                              id="drop1"
+                              data-dropdown-content
+                              class="f-dropdown"
+                              aria-hidden="true"
+                            >
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/countries"
+                                  rel="nofollow"
+                                  >Countries</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/nutrition-grades"
+                                  rel="nofollow"
+                                  >Nutrition grades</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/nova-groups"
+                                  rel="nofollow"
+                                  >NOVA groups</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/environmental-score"
+                                  rel="nofollow"
+                                  >Green-Score</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/brands"
+                                  rel="nofollow"
+                                  >Brands</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/categories"
+                                  rel="nofollow"
+                                  >Categories</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/labels"
+                                  rel="nofollow"
+                                  >Labels</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/packaging"
+                                  rel="nofollow"
+                                  >Packaging</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/origins"
+                                  rel="nofollow"
+                                  >Origins of ingredients</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/manufacturing-places"
+                                  rel="nofollow"
+                                  >Manufacturing or processing places</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/packager-codes"
+                                  rel="nofollow"
+                                  >Traceability codes</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/ingredients"
+                                  rel="nofollow"
+                                  >Ingredients</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/additives"
+                                  rel="nofollow"
+                                  >Additives</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/vitamins"
+                                  rel="nofollow"
+                                  >Added vitamins</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/minerals"
+                                  rel="nofollow"
+                                  >Added minerals</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/amino-acids"
+                                  rel="nofollow"
+                                  >Added amino acids</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/nucleotides"
+                                  rel="nofollow"
+                                  >Added nucleotides</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/other-nutritional-substances"
+                                  rel="nofollow"
+                                  >Other nutritional substances added</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/allergens"
+                                  rel="nofollow"
+                                  >Allergens</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/traces"
+                                  rel="nofollow"
+                                  >Traces</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/misc"
+                                  rel="nofollow"
+                                  >Miscellaneous</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/languages"
+                                  rel="nofollow"
+                                  >Languages</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/contributors"
+                                  rel="nofollow"
+                                  >Contributors</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/states"
+                                  rel="nofollow"
+                                  >States</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/data-sources"
+                                  rel="nofollow"
+                                  >Data sources</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/entry-dates"
+                                  rel="nofollow"
+                                  >Entry dates</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/last-edit-dates"
+                                  rel="nofollow"
+                                  >Last edit dates</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/last-check-dates"
+                                  rel="nofollow"
+                                  >Last check dates</a
+                                >
+                              </li>
+
+                              <li>
+                                <a
+                                  href="/facets/labels/organic/teams"
+                                  rel="nofollow"
+                                  >Teams</a
+                                >
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="small-12 columns">
+                      <div
+                        id="preferences_selected"
+                        class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                      ></div>
+                      <div
+                        id="preferences_selection_form"
+                        style="display: none"
+                      ></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="large-12 columns">
+                      <div id="search_results" style="clear: left">
+                        <ul class="products"></ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                </div>
+              </div>
             </div>
-            
-        
-    </div>
-</div>
-
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-    
-    
-  </div>
-</div>
-
- 
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          5 products
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/labels/organic?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/labels/organic?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/labels/organic?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/facets/labels/organic?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/facets/labels/organic?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+          </div>
         </div>
-        
-        
-        <div>
-          <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">sort</span>
-            Explore products by...
-          </button>
-          <ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/facets/labels/organic/countries" rel="nofollow">Countries</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/nutrition-grades" rel="nofollow">Nutrition grades</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/nova-groups" rel="nofollow">NOVA groups</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/environmental-score" rel="nofollow">Green-Score</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/brands" rel="nofollow">Brands</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/categories" rel="nofollow">Categories</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/labels" rel="nofollow">Labels</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/packaging" rel="nofollow">Packaging</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/origins" rel="nofollow">Origins of ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/manufacturing-places" rel="nofollow">Manufacturing or processing places</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/packager-codes" rel="nofollow">Traceability codes</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/ingredients" rel="nofollow">Ingredients</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/additives" rel="nofollow">Additives</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/vitamins" rel="nofollow">Added vitamins</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/minerals" rel="nofollow">Added minerals</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/amino-acids" rel="nofollow">Added amino acids</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/nucleotides" rel="nofollow">Added nucleotides</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/other-nutritional-substances" rel="nofollow">Other nutritional substances added</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/allergens" rel="nofollow">Allergens</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/traces" rel="nofollow">Traces</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/misc" rel="nofollow">Miscellaneous</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/languages" rel="nofollow">Languages</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/contributors" rel="nofollow">Contributors</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/states" rel="nofollow">States</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/data-sources" rel="nofollow">Data sources</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/entry-dates" rel="nofollow">Entry dates</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/last-edit-dates" rel="nofollow">Last edit dates</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/last-check-dates" rel="nofollow">Last check dates</a>
-            </li>
-          
-            <li>
-              <a href="/facets/labels/organic/teams" rel="nofollow">Teams</a>
-            </li>
-          
-          </ul>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        
-        
-      </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 5 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Organic apple and raspberry pie - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 35.25,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000007",
+          product_display_name: "Organic apple juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 41,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000008",
+          product_display_name:
+            "Organic apple and raspberry juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-e-new-en.svg",
+                  id: "nutriscore",
+                  match: 18.2727272727273,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score E",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Unknown environmental impact",
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                  id: "ecoscore",
+                  match: 0,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "unknown",
+                  title: "Green-Score not computed",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short:
+                    "Fair trade products help producers in developing countries.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 0,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Not a fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000012",
+          product_display_name: "Olio d'oliva - Mario's olive oils - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000012/olio-d-oliva-mario-s-olive-oils",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-
-								</div>
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 5 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Organic apple and raspberry pie - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":35.25,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000007",
-      "product_display_name":"Organic apple juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":41,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000008",
-      "product_display_name":"Organic apple and raspberry juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-e-new-en.svg",
-                  "id":"nutriscore",
-                  "match":18.2727272727273,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score E"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Unknown environmental impact",
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-                  "id":"ecoscore",
-                  "match":0,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"unknown",
-                  "title":"Green-Score not computed"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Fair trade products help producers in developing countries.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":0,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Not a fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000012",
-      "product_display_name":"Olio d'oliva - Mario's olive oils - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000012/olio-d-oliva-mario-s-olive-oils"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -1,682 +1,1142 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>List of labels - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/facets/labels/1">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/facets/labels/1">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/facets/labels/1"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/facets/labels/1"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/js/datatables.min.css"
+    />
 
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="list_of_tags_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="list_of_tags_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">List of labels - World</h1>
-									<!-- start templates/web/pages/tag/tag.tt.html -->
-<div class="tag">
-    <div class="row">
-        <div class="large-6 column">
-
-            <div class="tag_navigation">
-                
-            </div>
-
-            
-
-            
-
-            
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
 
-        
-    </div>
-</div>
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
 
-<!-- end templates/web/pages/tag/tag.tt.html -->
-<p>9 labels:</p><div style="max-width:600px;"><table id="tagstable">
-<thead><tr><th>Label</th><th>Products</th><th>*</th></tr></thead>
-<tbody>
-<tr><td><a href="/facets/labels/fair-trade" class="tag known">Fair trade</a></td>
-<td style="text-align:right"><a href="/facets/labels/fair-trade" class="tag known">6</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/organic" class="tag known">Organic</a></td>
-<td style="text-align:right"><a href="/facets/labels/organic" class="tag known">5</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/free-range-duck" class="tag user_defined">Free-range-duck</a></td>
-<td style="text-align:right"><a href="/facets/labels/free-range-duck" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/labels/no-palm-oil" class="tag known">No palm oil</a></td>
-<td style="text-align:right"><a href="/facets/labels/no-palm-oil" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/vegan" class="tag known">Vegan</a></td>
-<td style="text-align:right"><a href="/facets/labels/vegan" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/vegetarian" class="tag known">Vegetarian</a></td>
-<td style="text-align:right"><a href="/facets/labels/vegetarian" class="tag known">1</a></td><td></td></tr>
-<tr><td><a href="/facets/labels/very-bad" class="tag user_defined">Very-bad</a></td>
-<td style="text-align:right"><a href="/facets/labels/very-bad" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/labels/very-good" class="tag user_defined">Very-good</a></td>
-<td style="text-align:right"><a href="/facets/labels/very-good" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-<tr><td><a href="/facets/labels/ja:%E3%83%95%E3%82%A7%E3%82%A2%E3%83%88%E3%83%AC%E3%83%BC%E3%83%89" class="tag user_defined">ja:フェアトレード</a></td>
-<td style="text-align:right"><a href="/facets/labels/ja:%E3%83%95%E3%82%A7%E3%82%A2%E3%83%88%E3%83%AC%E3%83%BC%E3%83%89" class="tag user_defined">1</a></td><td style="text-align:center">*</td></tr>
-</tbody></table></div>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
 
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
+            <!-- full width banner on mobile -->
 
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
 
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+                <!-- Donation banner @ footer -->
 
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
 
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
 
-<!-- Donation banner @ footer -->
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
 
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
 
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
 
-				
+                    return "";
+                  }
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">List of labels - World</h1>
+                    <!-- start templates/web/pages/tag/tag.tt.html -->
+                    <div class="tag">
+                      <div class="row">
+                        <div class="large-6 column">
+                          <div class="tag_navigation"></div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- end templates/web/pages/tag/tag.tt.html -->
+                    <p>9 labels:</p>
+                    <div style="max-width: 600px">
+                      <table id="tagstable">
+                        <thead>
+                          <tr>
+                            <th>Label</th>
+                            <th>Products</th>
+                            <th>*</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/fair-trade"
+                                class="tag known"
+                                >Fair trade</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/fair-trade"
+                                class="tag known"
+                                >6</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/labels/organic" class="tag known"
+                                >Organic</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/labels/organic" class="tag known"
+                                >5</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/free-range-duck"
+                                class="tag user_defined"
+                                >Free-range-duck</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/free-range-duck"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/no-palm-oil"
+                                class="tag known"
+                                >No palm oil</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/no-palm-oil"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a href="/facets/labels/vegan" class="tag known"
+                                >Vegan</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a href="/facets/labels/vegan" class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/vegetarian"
+                                class="tag known"
+                                >Vegetarian</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/vegetarian"
+                                class="tag known"
+                                >1</a
+                              >
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/very-bad"
+                                class="tag user_defined"
+                                >Very-bad</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/very-bad"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/very-good"
+                                class="tag user_defined"
+                                >Very-good</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/very-good"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <a
+                                href="/facets/labels/ja:%E3%83%95%E3%82%A7%E3%82%A2%E3%83%88%E3%83%AC%E3%83%BC%E3%83%89"
+                                class="tag user_defined"
+                                >ja:フェアトレード</a
+                              >
+                            </td>
+                            <td style="text-align: right">
+                              <a
+                                href="/facets/labels/ja:%E3%83%95%E3%82%A7%E3%82%A2%E3%83%88%E3%83%AC%E3%83%BC%E3%83%89"
+                                class="tag user_defined"
+                                >1</a
+                              >
+                            </td>
+                            <td style="text-align: center">*</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+    <script>
+      $(function () {
+        let oTable = $("#tagstable").DataTable({
+          language: {
+            search: "Search:",
+            info: "_TOTAL_ labels",
+            infoFiltered: " - out of _MAX_",
+          },
+          paging: false,
+          order: [[1, "desc"]],
+          columns: [null, { searchable: false }, { searchable: false }],
+        });
+      });
+    </script>
 
-			<div class="block_off block_dark block_ristreto" id="footer_block">
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
 
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-let oTable = $('#tagstable').DataTable({
-	language: {
-		search: "Search:",
-		info: "_TOTAL_ labels",
-		infoFiltered: " - out of _MAX_"
-	},
-	paging: false,
-	order: [[ 1, "desc" ]],
-	columns: [
-		null,
-		{"searchable": false} , {"searchable": false}
-	]
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start

--- a/tests/integration/expected_test_results/web_html/world-product-content-only.html
+++ b/tests/integration/expected_test_results/web_html/world-product-content-only.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -1,637 +1,966 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Error</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="error_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="error_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Error</h1>
+                    <p>No product listed for barcode 1000000000001.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        $(".f-dropdown").on("opened.fndtn.dropdown", function () {
+          $(document).foundation("equalizer", "reflow");
+        });
+        $(".f-dropdown").on("closed.fndtn.dropdown", function () {
+          $(document).foundation("equalizer", "reflow");
+        });
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/off-webcomponents-utils.js"></script>
+    <script
+      type="module"
+      src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"
+    ></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							<div class="row">
-								<div class="small-12 column">
-									<h1 class="if-empty-dnone">Error</h1>
-									<p>No product listed for barcode 1000000000001.</p>
-								</div>
-							</div>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-$('.f-dropdown').on('opened.fndtn.dropdown', function() {
-   $(document).foundation('equalizer', 'reflow');
-});
-$('.f-dropdown').on('closed.fndtn.dropdown', function() {
-   $(document).foundation('equalizer', 'reflow');
-});
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/product-history.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/off-webcomponents-utils.js"></script>
-<script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/world-product-smoothie.html
+++ b/tests/integration/expected_test_results/web_html/world-product-smoothie.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -1,650 +1,989 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Search results - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta property="og:url" content="//world.openfoodfacts.localhost" />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link rel="canonical" href="//world.openfoodfacts.localhost" />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
+
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
+
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value=""
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
+        </div>
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Search results - World</h1>
+                  </div>
+                </div>
+                <!-- start templates/web/pages/search_results/search_results.tt.html -->
+
+                <div id="search_results" style="clear: left">
+                  Products are being loaded, please wait.
+                </div>
+
+                <!-- end templates/web/pages/search_results/search_results.tt.html -->
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        search_products(
+          "#search_results",
+          products,
+          "//world.openfoodfacts.localhost/api/v0/search?code=3300000000001%2C3300000000002&fields=code,product_display_name,url,image_front_small_url,attribute_groups&page_size=50",
+          contributor_prefs
+        );
+      });
+    </script>
 
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text = "Classify products according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Search results - World</h1>
-									</div>
-								</div>
-								<!-- start templates/web/pages/search_results/search_results.tt.html -->
-
-
-	
-<div id="search_results" style="clear:left">
-Products are being loaded, please wait.
-</div>
-
-<!-- end templates/web/pages/search_results/search_results.tt.html -->
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-search_products("#search_results", products, "//world.openfoodfacts.localhost/api/v0/search?code=3300000000001%2C3300000000002&fields=code,product_display_name,url,image_front_small_url,attribute_groups&page_size=50", contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify products according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [];
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
-
-
 
 <!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta property="fb:app_id" content="219331381518041">
     <meta property="og:type" content="food">
-    <meta property="og:title" content="">
+    <meta property="og:title" content="Open Food Facts - World">
     <meta property="og:url" content="//world.openfoodfacts.localhost">
     
     <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Food transparency at your fingertips!">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -1,2427 +1,2990 @@
 <!-- start templates/web/common/site_layout.tt.html -->
 
-<!doctype html>
-<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
-<head>
-    <meta charset="utf-8">
+<!DOCTYPE html>
+<html
+  class="no-js"
+  lang="en"
+  data-serverdomain="openfoodfacts.localhost"
+  dir="ltr"
+>
+  <head>
+    <meta charset="utf-8" />
     <title>Search results - World</title>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="fb:app_id" content="219331381518041">
-    <meta property="og:type" content="food">
-    <meta property="og:title" content="">
-    <meta property="og:url" content="//world.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50">
-    
-    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
-    <meta property="og:description" content="">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/off/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/off/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/off/favicon-16x16.png">
-<link rel="manifest" href="/images/favicon/off/site.webmanifest">
-<link rel="mask-icon" href="/images/favicon/off/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/images/favicon/off/favicon.ico">
-<meta name="msapplication-TileColor" content="#00aba9">
-<meta name="msapplication-config" content="/images/favicon/off/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
 
-	<meta name="apple-itunes-app" content="app-id=588797948">
-    <link rel="canonical" href="//world.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
-    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
-    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
-	
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="fb:app_id" content="219331381518041" />
+    <meta property="og:type" content="food" />
+    <meta property="og:title" content="Open Food Facts - World" />
+    <meta
+      property="og:url"
+      content="//world.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50"
+    />
+
+    <meta
+      property="og:image"
+      content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png"
+    />
+    <meta property="og:description" content="" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/images/favicon/off/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon/off/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon/off/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/images/favicon/off/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/images/favicon/off/safari-pinned-tab.svg"
+      color="#5bbad5"
+    />
+    <link rel="shortcut icon" href="/images/favicon/off/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta
+      name="msapplication-config"
+      content="/images/favicon/off/browserconfig.xml"
+    />
+    <meta name="theme-color" content="#ffffff" />
+
+    <meta name="apple-itunes-app" content="app-id=588797948" />
+    <link
+      rel="canonical"
+      href="//world.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css"
+      data-base-layout="true"
+    />
+    <link
+      rel="stylesheet"
+      href="//static.openfoodfacts.localhost/css/dist/select2.min.css"
+    />
+    <link
+      rel="search"
+      href="//world.openfoodfacts.localhost/cgi/opensearch.pl"
+      type="application/opensearchdescription+xml"
+      title="Open Food Facts"
+    />
+
     <style media="all">
-        
-        .show-when-no-access-to-producers-platform {display:none}
-.show-when-logged-in {display:none}
+      .show-when-no-access-to-producers-platform {
+        display: none;
+      }
+      .show-when-logged-in {
+        display: none;
+      }
 
-		
-		.badge-container{
-			margin: 0 auto;
-		}
+      .badge-container {
+        margin: 0 auto;
+      }
 
-		.badge-container img{
-			margin: 5px;
-		}
-		@media only screen and (max-width: 537px ) and (min-width: 280px) {
-			.badge-container{
-				width: 280px;
-			}
-		}
-		@media only screen and (max-width: 279px ){
-			.badge-container{
-				width: 130px;
-			}
-		}
+      .badge-container img {
+        margin: 5px;
+      }
+      @media only screen and (max-width: 537px) and (min-width: 280px) {
+        .badge-container {
+          width: 280px;
+        }
+      }
+      @media only screen and (max-width: 279px) {
+        .badge-container {
+          width: 130px;
+        }
+      }
     </style>
-</head>
-<body class="products_page">
-
-	<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
-  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
-  _paq.push(["setDoNotTrack", true]);
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.openfoodfacts.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '5']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-
-
-
-	
-	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
-	
-
-	<div id="page">
-		
-		<div class="upper-nav contain-to-grid"  id="upNav">
-			<nav class="top-bar " data-topbar role="navigation">
-				
-				<section class="top-bar-section">
-					
-					<!-- Left Nav Section -->
-					<ul class="left">
-
-						<li class="has-dropdown">
-							<a id="menu_link">
-								<span class="material-icons">
-									menu
-								</span>
-							</a>
-							<ul class="dropdown">				
-								
-									<li><a href="/discover">Discover</a></li>
-									<li><a href="/contribute">Contribute</a></li>
-									<li class="divider"></li>
-									<li><label>Add products</label></li>
-                <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
-									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
-								
-
-								<li class="divider"></li>
-								<li><label>Search and analyze products</label></li>
-
-								<li>
-									<a href="/cgi/search.pl">Advanced search</a>
-								</li>
-								<li>
-									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
-								</li>
-								
-							</ul>
-						</li>
-						
-						<li>
-							<ul class="country_language_selection">
-								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="Country">
-										<option></option>
-									</select>
-								</li>
-								<li class="has-dropdown">
-									<a href="//world.openfoodfacts.localhost/">English</a>
-
-									<ul class="dropdown">
-										
-									</ul>
-								</li>
-							</ul>
-						</li>
-					</ul>
-
-
-					<!-- Right Nav Section -->
-					
-					<ul class="right">
-						
-							<li class="h-space-tiny has-form">
-								<a href="/cgi/session.pl" class="round button secondary">
-									<span class="material-icons material-symbols-button">account_circle</span>
-									Sign in
-								</a>
-							</li>
-						
-					</ul>
-				</section>
-			</nav>
-		</div>
-		
-
-		<div id="main_container" style="position:relative" class="block_latte">
-		
-		
-		<div class="topbarsticky">
-			<div class="contain-to-grid " id="offNav" >
-				<nav class="top-bar" data-topbar role="navigation" >
-
-					<ul class="title-area">
-						<li class="name">
-							<div style="position:relative;max-width:292px;">
-								<a href="/">
-								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
-								
-							</a>
-							</div>
-						</li>
-					</ul>
-
-					
-					
-					<section class="top-bar-section">
-					
-						<ul class="left small-4" style="margin-right:2rem;">
-							<li class="search-li">
-							
-								<form action="/cgi/search.pl">
-								<div class="row"><div class="small-12">
-								<div class="row collapse postfix-round">
-									<div class="columns">
-									<input type="text" placeholder="Search for a product" name="search_terms" value="apple" style="background-color:white">
-									<input name="search_simple" value="1" type="hidden">
-									<input name="action" value="process" type="hidden">
-									</div>
-									<div class="columns">
-									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-									</div>
-								</div>
-								</div></div>
-								</form>
-							</li>
-						</ul>
-					<ul class="search_and_links">
-						<li><a href="/discover" class="top-bar-links">Discover</a></li>
-						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
-						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
-						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
-				<!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
-          </ul>
-					</section>
-					
-				</nav>
-			</div>
-		</div>
-
-	
-	
-		<nav class="tab-bar hide">
-			<div class="left-small">
-				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
-				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
-				</a>
-			</div>
-			<div class="middle tab-bar-section">
-				<form action="/cgi/search.pl">
-					<div class="row collapse">
-						<div class="small-8 columns">
-							<input type="text" placeholder="Search for a product" name="search_terms">
-							<input name="search_simple" value="1" type="hidden">
-							<input name="action" value="process" type="hidden">
-						</div>
-						<div class="small-2 columns">
-							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
-						</div>
-						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
-						</div>
-					</div>
-				</form>
-			</div>
-		</nav>
-		
-
-		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
-			<div class="inner-wrap">
-			
-				<a class="exit-off-canvas"></a>
-
-				
-				
-				<!-- full width banner on mobile -->
-				
-				
-
-				
-
-				<div class="main block_light">
-					<div id="main_column">
-
-						
-						
-							
-							
-								<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-								
-
-<section id="donation-banner-top" class="donation-banner row">
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
+  </head>
+  <body class="products_page">
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+      _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+        var u = "//analytics.openfoodfacts.org/";
+        _paq.push(["setTrackerUrl", u + "matomo.php"]);
+        _paq.push(["setSiteId", "5"]);
+        var d = document,
+          g = d.createElement("script"),
+          s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = u + "matomo.js";
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <noscript
+      ><p>
         <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-        <ul>
-          <li>
-            keeping our database open & available to all,
-            <ul>
-              <li>technical infrastructure (website/mobile app) & a small permanent team</li>
+          src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1"
+          style="border: 0"
+          alt=""
+        /></p
+    ></noscript>
+    <!-- End Matomo Code -->
+
+    <div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+    <div id="page">
+      <div class="upper-nav contain-to-grid" id="upNav">
+        <nav class="top-bar" data-topbar role="navigation">
+          <section class="top-bar-section">
+            <!-- Left Nav Section -->
+            <ul class="left">
+              <li class="has-dropdown">
+                <a id="menu_link">
+                  <span class="material-icons"> menu </span>
+                </a>
+                <ul class="dropdown">
+                  <li><a href="/discover">Discover</a></li>
+                  <li><a href="/contribute">Contribute</a></li>
+                  <li class="divider"></li>
+                  <li><label>Add products</label></li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                  <li>
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en"
+                      >Install the app to add products</a
+                    >
+                  </li>
+                  <li>
+                    <a href="/cgi/product.pl?type=search_or_add&action=display"
+                      >Add a product</a
+                    >
+                  </li>
+
+                  <li class="divider"></li>
+                  <li><label>Search and analyze products</label></li>
+
+                  <li>
+                    <a href="/cgi/search.pl">Advanced search</a>
+                  </li>
+                  <li>
+                    <a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <ul class="country_language_selection">
+                  <li class="has-form has-dropdown" id="select_country_li">
+                    <select
+                      id="select_country"
+                      style="width: 100%"
+                      data-placeholder="Country"
+                    >
+                      <option></option>
+                    </select>
+                  </li>
+                  <li class="has-dropdown">
+                    <a href="//world.openfoodfacts.localhost/">English</a>
+
+                    <ul class="dropdown"></ul>
+                  </li>
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>engage a community of committed citizens,</p>
-          </li>
-          <li>
-            <p>support the advancement of public health research.</p>
-          </li>
-        </ul>
+
+            <!-- Right Nav Section -->
+
+            <ul class="right">
+              <li class="h-space-tiny has-form">
+                <a href="/cgi/session.pl" class="round button secondary">
+                  <span class="material-icons material-symbols-button"
+                    >account_circle</span
+                  >
+                  Sign in
+                </a>
+              </li>
+            </ul>
+          </section>
+        </nav>
       </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.  
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="donation-banner__close">
-    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
-  </div>
-</section>
 
-<script>
-  let d = new Date();
-  let bannerID = document.getElementById('donation-banner-top');
-  let getDomain = window.location.origin.split('.');
+      <div id="main_container" style="position: relative" class="block_latte">
+        <div class="topbarsticky">
+          <div class="contain-to-grid" id="offNav">
+            <nav class="top-bar" data-topbar role="navigation">
+              <ul class="title-area">
+                <li class="name">
+                  <div style="position: relative; max-width: 292px">
+                    <a href="/">
+                      <img
+                        id="logo"
+                        src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg"
+                        alt="Open Food Facts"
+                        style="margin: 8px; height: 48px; width: auto"
+                      />
+                    </a>
+                  </div>
+                </li>
+              </ul>
 
-  function setBannerCookie(bcname, bcval, bcexdays) {
-    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
-    let expires = 'expires=' + d.toUTCString();
-    // Apply cookie for every domain contains open...facts
-    let domain = 'domain=.' + getDomain.slice(1).join('.');
-    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
-  }
-  
-  function getBannerCookie(bcname) {
-    const name = bcname + '=';
-    const decodedCookies = decodeURIComponent(document.cookie);
-    const cookies = decodedCookies.split(';');
-    for (const cookie of cookies) {
-      let c = cookie;
-      while (c.charAt(0) == ' ') { c = c.substring(1); }
-      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
-    }
-    
-    return '';
-  }
-
-  function DonationButton() {
-    setBannerCookie('off_donation_banner_2024_a', 1, 180);
-    bannerID.style.display = 'none';
-  }
-
-  if (getBannerCookie('off_donation_banner_2024_a') !== '') {
-    bannerID.style.display = 'none';
-  } else { 
-    bannerID.style.display = 'flex';
-  }
-</script>
-
-
-							
-						
-						
-            			
-						
-							
-								<div class="row">
-                  <div class="small-12 column"> 
-										<h1 class="if-empty-dnone">Search results - World</h1>
-									</div>
-								</div>
-								<!-- start templates/web/common/includes/list_of_products.tt.html --> 
-
-<div class="row">
-  <div class="small-12 columns"> 
-    
-    
-      
-      
-      
-      <!-- display a permalink if the url is for a script that may have POST parameters -->
-      
-        <p>&rarr; <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50">Permanent link to these results, shareable by e-mail and on social networks</a></p>
-      
-    
-    
-      <p>&rarr; <a href="/cgi/search.pl?action=display&search_terms=apple&sort_by=unique_scans_n&page_size=50">Change search criteria</a></p>
-    
-  </div>
-</div>
-
- 
-  <div class="row">
-    <div class="small-12 columns"> 
-      <p>&rarr;Download results in XLSX or CSV format. Please note that for performance reasons, you can download up to 10.000 results only.</p>
-      
-      <ul>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx">XLSX format</a>
-          (Excel or LibreOffice)
-        </li>
-        <li>
-          <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50&download=on&format=csv">CSV format</a>
-          (Character set: Unicode (UTF-8) - Separator: tabulation (tab))
-        </li>
-      </ul>
-      
-    </div>
-  </div>
-
-
-<div class="block short block_ristreto">
-  <div class="row">
-    <div class="small-12 columns filterProducts">
-      <div>
-        <span class="filterProducts__results">
-          <span class="material-icons" aria-hidden="true">search</span>
-          5 products
-        </span>
-      </div>
-      <div class="filterProducts__buttons">
-        <div>
-          <button href="#" data-dropdown="drop_sort" aria-controls="drop_sort" aria-expanded="false" class="button round dropdown small secondary unmarged">
-            <span class="material-icons">swap_vert</span>
-            
-          </button>
-          <ul id="drop_sort" data-dropdown-content class="f-dropdown" aria-hidden="true">
-          
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=popularity" onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });">Most scanned products</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score" onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });">Products with the best Nutri-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score" onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });">Products with the best Green-Score</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=created_t" onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });">Recently added products</a>
-            </li>
-        
-            <li>
-              <a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t" onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });">Recently modified products</a>
-            </li>
-        
-          </ul>
+              <section class="top-bar-section">
+                <ul class="left small-4" style="margin-right: 2rem">
+                  <li class="search-li">
+                    <form action="/cgi/search.pl">
+                      <div class="row">
+                        <div class="small-12">
+                          <div class="row collapse postfix-round">
+                            <div class="columns">
+                              <input
+                                type="text"
+                                placeholder="Search for a product"
+                                name="search_terms"
+                                value="apple"
+                                style="background-color: white"
+                              />
+                              <input
+                                name="search_simple"
+                                value="1"
+                                type="hidden"
+                              />
+                              <input
+                                name="action"
+                                value="process"
+                                type="hidden"
+                              />
+                            </div>
+                            <div class="columns">
+                              <button
+                                type="submit"
+                                title="Search"
+                                class="button postfix"
+                                style="line-height: normal"
+                              >
+                                <svg
+                                  xmlns="//www.w3.org/2000/svg"
+                                  viewBox="0 0 24 24"
+                                  class="icon"
+                                  aria-hidden="true"
+                                  focusable="false"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                  />
+                                  <path d="M0 0h24v24H0z" fill="none" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </li>
+                </ul>
+                <ul class="search_and_links">
+                  <li>
+                    <a href="/discover" class="top-bar-links">Discover</a>
+                  </li>
+                  <li>
+                    <a href="/contribute" class="top-bar-links">Contribute</a>
+                  </li>
+                  <li class="show-for-xlarge-up">
+                    <a
+                      href="//world.pro.openfoodfacts.org/"
+                      class="top-bar-links"
+                      >Producers</a
+                    >
+                  </li>
+                  <li class="flex-grid getapp">
+                    <a
+                      href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en"
+                      class="buttonbar button"
+                      style="top: 0"
+                      ><svg
+                        xmlns="//www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        class="icon"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path
+                          d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"
+                        />
+                        <path d="M0 0h24v24H0z" fill="none" />
+                      </svg>
+                      <span class="bt-text">Get the app</span></a
+                    >
+                  </li>
+                  <!-- For reference: get_the_app_link_off" = /open-food-facts-mobile-app" -->
+                </ul>
+              </section>
+            </nav>
+          </div>
         </div>
-        
-        
-        
+
+        <nav class="tab-bar hide">
+          <div class="left-small">
+            <a
+              href="#idOfLeftMenu"
+              role="button"
+              aria-controls="idOfLeftMenu"
+              aria-expanded="false"
+              class="left-off-canvas-toggle button postfix anonymous"
+            >
+              <svg
+                xmlns="//www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="icon"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+              </svg>
+            </a>
+          </div>
+          <div class="middle tab-bar-section">
+            <form action="/cgi/search.pl">
+              <div class="row collapse">
+                <div class="small-8 columns">
+                  <input
+                    type="text"
+                    placeholder="Search for a product"
+                    name="search_terms"
+                  />
+                  <input name="search_simple" value="1" type="hidden" />
+                  <input name="action" value="process" type="hidden" />
+                </div>
+                <div class="small-2 columns">
+                  <button type="submit" class="button postfix">
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="small-2 columns">
+                  <a href="/cgi/search.pl" title="Advanced search"
+                    ><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                      />
+                      <path d="M0 0h24v24H0z" fill="none" />
+                    </svg>
+                    <svg
+                      xmlns="//www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                      <path d="M0 0h24v24H0z" fill="none" /></svg
+                  ></a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </nav>
+
+        <div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+          <div class="inner-wrap">
+            <a class="exit-off-canvas"></a>
+
+            <!-- full width banner on mobile -->
+
+            <div class="main block_light">
+              <div id="main_column">
+                <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+                <!-- Donation banner @ footer -->
+
+                <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+                <section id="donation-banner-top" class="donation-banner row">
+                  <div class="donation-banner__left-aside">
+                    <div class="donation-banner__hook-section">
+                      <p>
+                        Help us inform millions of consumers around the world
+                        about what they eat
+                      </p>
+                    </div>
+                    <img
+                      src="/images/misc/donation-banners/donation-banner-group-photo.png"
+                      alt="group photo donation 2024"
+                    />
+                  </div>
+                  <div>
+                    <div class="donation-banner__aside">
+                      <div class="donation-banner__main-section">
+                        <img
+                          width="50"
+                          height="50"
+                          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                          alt="open food facts logo"
+                        />
+                        <h3 class="donation-banner__main-title">
+                          Please give to our 2024 Fundraiser
+                        </h3>
+                      </div>
+                      <div style="padding: 1rem">
+                        <p>
+                          Your donations fund the day-to-day operations of our
+                          non-profit association:
+                        </p>
+                        <ul>
+                          <li>
+                            keeping our database open & available to all,
+                            <ul>
+                              <li>
+                                technical infrastructure (website/mobile app) &
+                                a small permanent team
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>remain independent of the food industry,</p>
+                          </li>
+                          <li>
+                            <p>engage a community of committed citizens,</p>
+                          </li>
+                          <li>
+                            <p>
+                              support the advancement of public health research.
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="donation-banner__actions-section">
+                      <div class="donation-banner__actions-section__financial">
+                        <p>
+                          Each donation counts! We appreciate your support in
+                          bringing further food transparency in the world.
+                        </p>
+                      </div>
+                      <div
+                        class="donation-banner__actions-section__donate-button"
+                      >
+                        <a
+                          href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                        >
+                          <button>I SUPPORT</button>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="donation-banner__close">
+                    <button
+                      id="hide-donate-banner"
+                      class="material-icons modest"
+                      onclick="DonationButton();"
+                      onkeypress="DonationButton();"
+                    >
+                      close
+                    </button>
+                  </div>
+                </section>
+
+                <script>
+                  let d = new Date();
+                  let bannerID = document.getElementById("donation-banner-top");
+                  let getDomain = window.location.origin.split(".");
+
+                  function setBannerCookie(bcname, bcval, bcexdays) {
+                    d.setTime(d.getTime() + bcexdays * 60 * 60 * 24 * 1000);
+                    let expires = "expires=" + d.toUTCString();
+                    // Apply cookie for every domain contains open...facts
+                    let domain = "domain=." + getDomain.slice(1).join(".");
+                    document.cookie =
+                      bcname +
+                      "=" +
+                      bcval +
+                      ";" +
+                      expires +
+                      ";" +
+                      domain +
+                      ";SameSite=None;Secure;path=/";
+                  }
+
+                  function getBannerCookie(bcname) {
+                    const name = bcname + "=";
+                    const decodedCookies = decodeURIComponent(document.cookie);
+                    const cookies = decodedCookies.split(";");
+                    for (const cookie of cookies) {
+                      let c = cookie;
+                      while (c.charAt(0) == " ") {
+                        c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                      }
+                    }
+
+                    return "";
+                  }
+
+                  function DonationButton() {
+                    setBannerCookie("off_donation_banner_2024_a", 1, 180);
+                    bannerID.style.display = "none";
+                  }
+
+                  if (getBannerCookie("off_donation_banner_2024_a") !== "") {
+                    bannerID.style.display = "none";
+                  } else {
+                    bannerID.style.display = "flex";
+                  }
+                </script>
+
+                <div class="row">
+                  <div class="small-12 column">
+                    <h1 class="if-empty-dnone">Search results - World</h1>
+                  </div>
+                </div>
+                <!-- start templates/web/common/includes/list_of_products.tt.html -->
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <!-- display a permalink if the url is for a script that may have POST parameters -->
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50"
+                        >Permanent link to these results, shareable by e-mail
+                        and on social networks</a
+                      >
+                    </p>
+
+                    <p>
+                      &rarr;
+                      <a
+                        href="/cgi/search.pl?action=display&search_terms=apple&sort_by=unique_scans_n&page_size=50"
+                        >Change search criteria</a
+                      >
+                    </p>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <p>
+                      &rarr;Download results in XLSX or CSV format. Please note
+                      that for performance reasons, you can download up to
+                      10.000 results only.
+                    </p>
+
+                    <ul>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50&download=on&format=xlsx"
+                          >XLSX format</a
+                        >
+                        (Excel or LibreOffice)
+                      </li>
+                      <li>
+                        <a
+                          href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50&download=on&format=csv"
+                          >CSV format</a
+                        >
+                        (Character set: Unicode (UTF-8) - Separator: tabulation
+                        (tab))
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="block short block_ristreto">
+                  <div class="row">
+                    <div class="small-12 columns filterProducts">
+                      <div>
+                        <span class="filterProducts__results">
+                          <span class="material-icons" aria-hidden="true"
+                            >search</span
+                          >
+                          5 products
+                        </span>
+                      </div>
+                      <div class="filterProducts__buttons">
+                        <div>
+                          <button
+                            href="#"
+                            data-dropdown="drop_sort"
+                            aria-controls="drop_sort"
+                            aria-expanded="false"
+                            class="button round dropdown small secondary unmarged"
+                          >
+                            <span class="material-icons">swap_vert</span>
+                          </button>
+                          <ul
+                            id="drop_sort"
+                            data-dropdown-content
+                            class="f-dropdown"
+                            aria-hidden="true"
+                          >
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=popularity"
+                                onclick="$.cookie('last_sort_by', 'popularity', { expires: 180, path: '/' });"
+                                >Most scanned products</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=nutriscore_score"
+                                onclick="$.cookie('last_sort_by', 'nutriscore_score', { expires: 180, path: '/' });"
+                                >Products with the best Nutri-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=environmental_score_score"
+                                onclick="$.cookie('last_sort_by', 'environmental_score_score', { expires: 180, path: '/' });"
+                                >Products with the best Green-Score</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=created_t"
+                                onclick="$.cookie('last_sort_by', 'created_t', { expires: 180, path: '/' });"
+                                >Recently added products</a
+                              >
+                            </li>
+
+                            <li>
+                              <a
+                                href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50?sort_by=last_modified_t"
+                                onclick="$.cookie('last_sort_by', 'last_modified_t', { expires: 180, path: '/' });"
+                                >Recently modified products</a
+                              >
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="small-12 columns">
+                    <div
+                      id="preferences_selected"
+                      class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"
+                    ></div>
+                    <div
+                      id="preferences_selection_form"
+                      style="display: none"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="large-12 columns">
+                    <div id="search_results" style="clear: left">
+                      <ul class="products"></ul>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- end templates/web/common/includes/list_of_products.tt.html -->
+                <div
+                  class="share_button right"
+                  style="float: right; margin-top: -10px; display: none"
+                >
+                  <a
+                    href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50"
+                    class="button small"
+                    title="Search results - World"
+                  >
+                    <?xml version="1.0" standalone="no"?><svg
+                      xmlns="//www.w3.org/2000/svg"
+                      xmlns:xlink="//www.w3.org/1999/xlink"
+                      viewBox="0 0 1000 1000"
+                      class="icon"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <metadata>IcoFont Icons</metadata>
+                      <title>share</title>
+                      <glyph
+                        glyph-name="share"
+                        unicode="î¿¥"
+                        horiz-adv-x="1000"
+                      />
+                      <path
+                        d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"
+                      />
+                    </svg>
+                    <span class="show-for-large-up"> Share</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
+
+      <footer>
+        <div class="block_light bg-white" id="install_the_app_block">
+          <div class="row">
+            <div
+              class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny"
+            >
+              <div
+                class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row"
+              >
+                <img
+                  class="cell small-50 v-align-center"
+                  src="/images/illustrations/app-icon-in-the-clouds.svg"
+                  alt="The Open Food Facts logo in the cloud"
+                  style="height: 120px"
+                />
+                <div
+                  class="cell small-50 v-align-center"
+                  id="footer_scan"
+                  style="display: block"
+                >
+                  <div id="footer_install_the_app">Install the app!</div>
+                  Scan your <span id="everyday">everyday</span>
+                  <span id="foods">foods</span>
+                </div>
+              </div>
+              <div class="row">
+                <div
+                  class="small-12 medium-12 large-12 v-space-normal column badge-container"
+                >
+                  <!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
+                  <a
+                    href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"
+                    ><img
+                      src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg"
+                      alt="Get It On Google Play"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <a
+                    href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
+                    ><img
+                      src="/images/misc/f-droid/svg/get-it-on-en.svg"
+                      alt="Available on F-Droid"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
+                  <a
+                    href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"
+                    ><img
+                      src="/images/misc/app-landing-page/download-apk/download-apk_en.svg"
+                      alt="Android APK"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+
+                  <!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
+                  <a
+                    href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"
+                    ><img
+                      src="/images/misc/appstore/black/appstore_US.svg"
+                      alt="Download on the App Store"
+                      loading="lazy"
+                      height="40"
+                      width="120"
+                  /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+        <!-- Donation banner @ footer -->
+
+        <!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+        <section class="donation-banner-footer row">
+          <div class="donation-banner-footer__left-aside">
+            <div class="donation-banner-footer__hook-section">
+              <p>
+                Help us inform millions of consumers around the world about what
+                they eat
+              </p>
+            </div>
+            <img
+              src="/images/misc/donation-banners/donation-banner-group-photo.png"
+              alt="group photo donation 2024"
+            />
+          </div>
+          <div>
+            <div>
+              <div class="donation-banner-footer__main-section">
+                <img
+                  width="50"
+                  height="50"
+                  src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
+                  alt="open food facts logo"
+                />
+                <h3 class="donation-banner-footer__main-title">
+                  Please give to our 2024 Fundraiser
+                </h3>
+              </div>
+              <p>
+                Your donations fund the day-to-day operations of our non-profit
+                association:
+              </p>
+              <ul>
+                <li>
+                  keeping our database open & available to all,
+                  <ul>
+                    <li>
+                      technical infrastructure (website/mobile app) & a small
+                      permanent team
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p>remain independent of the food industry,</p>
+                </li>
+                <li>
+                  <p>engage a community of committed citizens,</p>
+                </li>
+                <li>
+                  <p>support the advancement of public health research.</p>
+                </li>
+              </ul>
+            </div>
+            <div class="donation-banner-footer__actions-section">
+              <div class="donation-banner-footer__actions-section__financial">
+                <p>
+                  Each donation counts! We appreciate your support in bringing
+                  further food transparency in the world.
+                </p>
+              </div>
+              <div
+                class="donation-banner-footer__actions-section__donate-button"
+              >
+                <a
+                  href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button"
+                >
+                  <button>I SUPPORT</button>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="block_light block_cappucino"
+          id="contribute_and_discover_links_block"
+        >
+          <div class="row">
+            <div class="small-12 large-6 columns v-space-normal block_off">
+              <h3 class="title-5 text-medium">Join the community</h3>
+              <p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+              <p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+              <p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+              <p id="footer_social_icons">
+                Follow us:
+                <a href="//x.com/OpenFoodFacts"
+                  ><img
+                    src="/images/icons/dist/x.svg"
+                    class="footer_social_icon"
+                    alt="x"
+                /></a>
+                <a
+                  href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"
+                  ><img
+                    src="/images/icons/dist/facebook.svg"
+                    class="footer_social_icon"
+                    alt="Facebook"
+                /></a>
+                <a href="//www.instagram.com/open.food.facts/"
+                  ><img
+                    src="/images/icons/dist/instagram.svg"
+                    class="footer_social_icon"
+                    alt="Instagram"
+                /></a>
+              </p>
+              <p>
+                <a href="//link.openfoodfacts.org/newsletter-en"
+                  >Subscribe to our newsletter</a
+                >
+              </p>
+            </div>
+            <div class="small-12 large-6 columns project v-space-normal">
+              <h3 class="title-5 text-medium">Discover the project</h3>
+              <ul class="inline-list tags_links v-space-tiny h-space-tiny">
+                <li>
+                  <a class="button small white-button radius" href="/who-we-are"
+                    >Who we are</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs"
+                    >Vision, Mission, Values and Programs</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//support.openfoodfacts.org/help/en-gb"
+                    >Frequently asked questions</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//blog.openfoodfacts.org/en/"
+                    >Open Food Facts blog</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/press"
+                    >Press</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//wiki.openfoodfacts.org"
+                    >Open Food Facts wiki (en)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="/cgi/top_translators.pl"
+                    >Translators</a
+                  >
+                </li>
+                <li>
+                  <a class="button small white-button radius" href="/partners"
+                    >Partners</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.openbeautyfacts.org"
+                    >Open Beauty Facts - Cosmetics</a
+                  >
+                </li>
+                <li>
+                  <a
+                    class="button small white-button radius"
+                    href="//world.pro.openfoodfacts.localhost/"
+                    >Open Food Facts for Producers</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="block_off block_dark block_ristreto" id="footer_block">
+          <div id="footer_block_image_banner_outside">
+            <div id="footer_block_image_banner_outside2">
+              <div class="row">
+                <div class="small-12 text-center v-space-short h-space-large">
+                  <a href="/" style="font-size: 1rem"
+                    ><img
+                      id="logo"
+                      src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg"
+                      alt="Open Food Facts"
+                      style="margin: 8px; height: 48px; width: auto"
+                  /></a>
+
+                  <p>
+                    A collaborative, free and open database of food products
+                    from around the world.
+                  </p>
+
+                  <ul class="inline-list text-center text-small">
+                    <li><a href="/legal">Legal</a></li>
+                    <li><a href="/privacy">Privacy</a></li>
+                    <li><a href="/terms-of-use">Terms of use</a></li>
+                    <li><a href="/data">Data, API and SDKs</a></li>
+                    <li>
+                      <a
+                        href="//world.openfoodfacts.org/donate-to-open-food-facts"
+                        >Donate to Open Food Facts</a
+                      >
+                    </li>
+                    <li>
+                      <a href="//world.pro.openfoodfacts.org/">Producers</a>
+                    </li>
+                    <li>
+                      <a href="//link.openfoodfacts.org/newsletter-en"
+                        >Subscribe to our newsletter</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-  </div>
-</div>
 
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/modernizr.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery.js"
+      data-base-layout="true"
+    ></script>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
 
-<div class="row">
-	<div class="small-12 columns">
-    <div id="preferences_selected" class="small-12 flex-grid v-space-short v-align-center direction-row full-width v-align-between"></div>
-    <div id="preferences_selection_form" style="display:none"></div>
-  </div>
-</div>
+    <script>
+      $(function () {
+        display_user_product_preferences(
+          "#preferences_selected",
+          "#preferences_selection_form",
+          function () {
+            rank_and_display_products(
+              "#search_results",
+              products,
+              contributor_prefs
+            );
+          }
+        );
+        rank_and_display_products(
+          "#search_results",
+          products,
+          contributor_prefs
+        );
+      });
+    </script>
 
-	 
-<div class="row">
-<div class="large-12 columns">
-    
-    <div id="search_results" style="clear:left;">
-        <ul class="products">
-    
-    
-    
-      
-    
-      
-    
-      
-    
-      
-    
-      
-    
-    
-		</ul>
-  </div>
-      
-    
-	
-  </div>
-</div>
+    <script
+      src="//static.openfoodfacts.localhost/js/dist/foundation.js"
+      data-base-layout="true"
+    ></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+    <script type="text/javascript">
+      var page_type = "products";
+      var default_preferences = {
+        ecoscore: "important",
+        nova: "important",
+        nutriscore: "very_important",
+      };
+      var preferences_text =
+        "Classify the 5 products below according to your preferences";
+      var contributor_prefs = { display_barcode: null, edit_link: null };
+      var products = [
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "11 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9118518518518,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Organic products promote ecological sustainability and biodiversity.",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
+                  id: "labels_organic",
+                  match: 0,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Not an organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000001",
+          product_display_name: "Apple pie - Bob's pies - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 27.3333333333333,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                  id: "palm_oil_free",
+                  match: 0,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil",
+                  status: "known",
+                  title: "Palm oil",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 60,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000002",
+          product_display_name:
+            "Organic apple and raspberry pie - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 35.25,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "1 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000007",
+          product_display_name: "Organic apple juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Average nutritional quality",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                  id: "nutriscore",
+                  match: 41,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score C",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 100,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Does not contain: Gluten",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 100,
+                  name: "Milk",
+                  status: "known",
+                  title: "Does not contain: Milk",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 100,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Does not contain: Eggs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "2 ingredients (0 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                  id: "vegan",
+                  match: 100,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:vegan",
+                  status: "known",
+                  title: "Vegan",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                  id: "vegetarian",
+                  match: 100,
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian",
+                  status: "known",
+                  title: "Vegetarian",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                  id: "nova",
+                  match: 100,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Unprocessed or minimally processed foods",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                  id: "additives",
+                  match: 100,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "Without additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Moderate environmental impact",
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
+                  id: "ecoscore",
+                  match: 50,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score C",
+                },
+                {
+                  description: "",
+                  description_short:
+                    "Currently only for products with chicken or eggs",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                  id: "forest_footprint",
+                  match: 0,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Forest footprint not computed",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000008",
+          product_display_name:
+            "Organic apple and raspberry juice - Bob's juices - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices",
+        },
+        {
+          attribute_groups: [
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Lower nutritional quality",
+                  grade: "d",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
+                  id: "nutriscore",
+                  match: 29.4444444444444,
+                  name: "Nutri-Score",
+                  panel_id: "nutriscore_2023",
+                  status: "known",
+                  title: "Nutri-Score D",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                  id: "low_salt",
+                  missing: "Missing nutrition facts",
+                  name: "Salt",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Salt in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                  id: "low_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Fat in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                  id: "low_sugars",
+                  missing: "Missing nutrition facts",
+                  name: "Sugars",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Sugars in unknown quantity",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                  id: "low_saturated_fat",
+                  missing: "Missing nutrition facts",
+                  name: "Saturated fat",
+                  panel_id: "nutrition_facts_table",
+                  status: "unknown",
+                  title: "Saturated fat in unknown quantity",
+                },
+              ],
+              id: "nutritional_quality",
+              name: "Nutritional quality",
+            },
+            {
+              attributes: [
+                {
+                  debug: "en:gluten in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
+                  id: "allergens_no_gluten",
+                  match: 0,
+                  name: "Gluten",
+                  status: "known",
+                  title: "Contains: Gluten",
+                },
+                {
+                  debug: "en:milk in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                  id: "allergens_no_milk",
+                  match: 0,
+                  name: "Milk",
+                  status: "known",
+                  title: "Contains: Milk",
+                },
+                {
+                  debug: "en:eggs in allergens",
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                  id: "allergens_no_eggs",
+                  match: 0,
+                  name: "Eggs",
+                  status: "known",
+                  title: "Contains: Eggs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                  id: "allergens_no_nuts",
+                  match: 100,
+                  name: "Nuts",
+                  status: "known",
+                  title: "Does not contain: Nuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                  id: "allergens_no_peanuts",
+                  match: 100,
+                  name: "Peanuts",
+                  status: "known",
+                  title: "Does not contain: Peanuts",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                  id: "allergens_no_sesame_seeds",
+                  match: 100,
+                  name: "Sesame seeds",
+                  status: "known",
+                  title: "Does not contain: Sesame seeds",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                  id: "allergens_no_soybeans",
+                  match: 100,
+                  name: "Soybeans",
+                  status: "known",
+                  title: "Does not contain: Soybeans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                  id: "allergens_no_celery",
+                  match: 100,
+                  name: "Celery",
+                  status: "known",
+                  title: "Does not contain: Celery",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                  id: "allergens_no_mustard",
+                  match: 100,
+                  name: "Mustard",
+                  status: "known",
+                  title: "Does not contain: Mustard",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                  id: "allergens_no_lupin",
+                  match: 100,
+                  name: "Lupin",
+                  status: "known",
+                  title: "Does not contain: Lupin",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                  id: "allergens_no_fish",
+                  match: 100,
+                  name: "Fish",
+                  status: "known",
+                  title: "Does not contain: Fish",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                  id: "allergens_no_crustaceans",
+                  match: 100,
+                  name: "Crustaceans",
+                  status: "known",
+                  title: "Does not contain: Crustaceans",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                  id: "allergens_no_molluscs",
+                  match: 100,
+                  name: "Molluscs",
+                  status: "known",
+                  title: "Does not contain: Molluscs",
+                },
+                {
+                  debug: "12 ingredients (1 unknown)",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                  id: "allergens_no_sulphur_dioxide_and_sulphites",
+                  match: 100,
+                  name: "Sulphur dioxide and sulphites",
+                  status: "known",
+                  title: "Does not contain: Sulphur dioxide and sulphites",
+                },
+              ],
+              id: "allergens",
+              name: "Allergens",
+              warning:
+                "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging.",
+            },
+            {
+              attributes: [
+                {
+                  grade: "e",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                  id: "vegan",
+                  match: 0,
+                  name: "Vegan",
+                  panel_id: "ingredients_analysis_en:non-vegan",
+                  status: "known",
+                  title: "Non-vegan",
+                },
+                {
+                  grade: "unknown",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
+                  id: "vegetarian",
+                  name: "Vegetarian",
+                  panel_id: "ingredients_analysis_en:vegetarian-status-unknown",
+                  status: "unknown",
+                  title: "Vegetarian status unknown",
+                },
+                {
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                  id: "palm_oil_free",
+                  match: 100,
+                  name: "Palm oil free",
+                  panel_id: "ingredients_analysis_en:palm-oil-free",
+                  status: "known",
+                  title: "Palm oil free",
+                },
+              ],
+              id: "ingredients_analysis",
+              name: "Ingredients",
+            },
+            {
+              attributes: [
+                {
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
+                  id: "nova",
+                  match: 75,
+                  name: "NOVA group",
+                  panel_id: "nova",
+                  status: "known",
+                  title: "Processed foods",
+                },
+                {
+                  grade: "c",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
+                  id: "additives",
+                  match: 60,
+                  name: "Additives",
+                  panel_id: "additives",
+                  status: "known",
+                  title: "2 additives",
+                },
+              ],
+              id: "processing",
+              name: "Food processing",
+            },
+            {
+              attributes: [
+                {
+                  description: "",
+                  description_short: "Low environmental impact",
+                  grade: "b",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
+                  id: "ecoscore",
+                  match: 70,
+                  name: "Green-Score",
+                  panel_id: "environmental_score",
+                  status: "known",
+                  title: "Green-Score B",
+                },
+                {
+                  description: "",
+                  description_short: "Almost no risk of deforestation",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                  id: "forest_footprint",
+                  match: 99.9766666666667,
+                  name: "Forest footprint",
+                  status: "known",
+                  title: "Very small forest footprint",
+                },
+              ],
+              id: "environment",
+              name: "Environment",
+            },
+            {
+              attributes: [
+                {
+                  description:
+                    "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                  description_short:
+                    "Promotes ecological sustainability and biodiversity.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
+                  id: "labels_organic",
+                  match: 100,
+                  name: "Organic farming",
+                  status: "known",
+                  title: "Organic product",
+                },
+                {
+                  description:
+                    "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                  description_short: "Helps producers in developing countries.",
+                  grade: "a",
+                  icon_url:
+                    "//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
+                  id: "labels_fair_trade",
+                  match: 100,
+                  name: "Fair trade",
+                  status: "known",
+                  title: "Fair trade product",
+                },
+              ],
+              id: "labels",
+              name: "Labels",
+            },
+          ],
+          code: "3300000000013",
+          image_front_small_url:
+            "//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
+          product_display_name:
+            "Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
+          url: "//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert",
+        },
+      ];
+    </script>
+    <script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+    <script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
 
-
-<!-- end templates/web/common/includes/list_of_products.tt.html -->
-<div class="share_button right" style="float:right;margin-top:-10px;display:none;">
-<a href="/cgi/search.pl?action=process&search_terms=apple&sort_by=unique_scans_n&page_size=50" class="button small" title="Search results - World">
-	<?xml version="1.0" standalone="no"?><svg xmlns="//www.w3.org/2000/svg" xmlns:xlink="//www.w3.org/1999/xlink" viewBox="0 0 1000 1000" class="icon" aria-hidden="true" focusable="false"><metadata>IcoFont Icons</metadata><title>share</title><glyph glyph-name="share" unicode="î¿¥" horiz-adv-x="1000"/><path d="M752 598.7c-58.200000000000045 0-109.60000000000002 29.59999999999991-140.20000000000005 74.39999999999998l-214.29999999999995-118.80000000000007c12.399999999999977-23.5 19.5-50.19999999999993 19.5-78.69999999999993 0-27.700000000000045-6.800000000000011-53.60000000000002-18.600000000000023-76.70000000000005l162.70000000000005-70.79999999999995c30.600000000000023 44.099999999999966 81.60000000000002 73.09999999999997 139.19999999999993 73.09999999999997 93.5 0 169.4000000000001-76 169.4000000000001-169.39999999999998s-76-169.3-169.4000000000001-169.3-169.39999999999998 76-169.39999999999998 169.4c0 19.19999999999999 3.300000000000068 37.49999999999997 9.300000000000068 54.79999999999998l-169.00000000000006 73.5c-31-33.099999999999966-74.80000000000001-53.89999999999998-123.6-53.89999999999998-93.5 0-169.39999999999998 76-169.39999999999998 169.39999999999998-1.4210854715202004e-14 93.50000000000006 75.99999999999997 169.40000000000003 169.39999999999998 169.40000000000003 48.20000000000002 0 91.70000000000002-20.399999999999977 122.6-52.80000000000007l221.09999999999997 122.40000000000009c-5.599999999999909 16.799999999999955-8.799999999999955 34.69999999999993-8.799999999999955 53.299999999999955 0 93.5 76 169.39999999999998 169.39999999999998 169.39999999999998s169.39999999999998-76 169.39999999999998-169.39999999999998-75.79999999999995-169.29999999999995-169.29999999999995-169.29999999999995z"/></svg>
-	<span class="show-for-large-up"> Share</span>
-</a></div>
-
-							
-						
-					</div>
-				</div>
-			</div>
-		</div>
-		</div>
-
-		
-		<footer>
-			<div class="block_light bg-white" id="install_the_app_block">
-				<div class="row">
-					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
-						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
-							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
-								<div id="footer_install_the_app">
-									Install the app!
-								</div>
-								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
-							</div>
-						</div>
-						<div class="row">
-							<div class="small-12 medium-12 large-12 v-space-normal column badge-container">
-								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
-								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get It On Google Play" loading="lazy" height="40" width="120"></a>
-								
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Available on F-Droid" loading="lazy" height="40" width="120"></a>
-
-								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
-								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>
-								
-								<!-- msgid "//apps.apple.com/app/open-beauty-facts/id1122926380" -->
-								<a href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" height="40" width="120"></a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			
-      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
-
-
-
-<!-- Donation banner @ footer -->
-
-
-<!-- end templates/web/common/includes/donate_banner.tt.html -->
-
-				
-
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Help us inform millions of consumers around the world about what they eat</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="open food facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Please give to our 2024 Fundraiser</h3>
-      </div>
-      <p>Your donations fund the day-to-day operations of our non-profit association:</p>
-      <ul>
-        <li>
-          keeping our database open & available to all,
-          <ul>
-            <li>technical infrastructure (website/mobile app) & a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>engage a community of committed citizens,</p>
-        </li>
-        <li>
-          <p>support the advancement of public health research.</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Each donation counts! We appreciate your support in bringing further food transparency in the world.
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2024-a&utm_term=en-text-button">
-          <button>I SUPPORT</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-			
-      		
-			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
-				<div class="row">
-					<div class="small-12 large-6 columns v-space-normal block_off">
-						<h3 class="title-5 text-medium">Join the community</h3>
-						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
-						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
-						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
-						<p id="footer_social_icons">Follow us: 
-							<a href="//x.com/OpenFoodFacts"><img src="/images/icons/dist/x.svg" class="footer_social_icon" alt="x"></a>
-							<a href="//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
-							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							
-						</p>
-						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
-					</div>
-					<div class="small-12 large-6 columns project v-space-normal">
-						<h3 class="title-5 text-medium">Discover the project</h3>
-						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
-							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
-							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
-							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
-							<li><a class="button small white-button radius" href="/press">Press</a></li>
-							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
-							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
-							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
-							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-
-			<div class="block_off block_dark block_ristreto" id="footer_block">
-
-				<div id="footer_block_image_banner_outside">
-					<div id="footer_block_image_banner_outside2">
-
-						<div class="row">
-
-							<div class="small-12 text-center v-space-short h-space-large">
-								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
-
-								<p>A collaborative, free and open database of food products from around the world.</p>
-								
-								<ul class="inline-list text-center text-small">
-									<li><a href="/legal">Legal</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Terms of use</a></li>
-									<li><a href="/data">Data, API and SDKs</a></li>
-									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
-									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
-									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</footer>
-		
-
-	</div>
-
-<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
-  
-
-<script>
-$(function() {
-display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
-	rank_and_display_products("#search_results", products, contributor_prefs);
-});
-rank_and_display_products("#search_results", products, contributor_prefs);
-
-
-});
-</script>
-
-
-
-<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
-<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
-<script type="text/javascript">
-var page_type = "products";
-var default_preferences = {"ecoscore":"important","nova":"important","nutriscore":"very_important"};
-var preferences_text = "Classify the 5 products below according to your preferences";
-var contributor_prefs = {"display_barcode":null,"edit_link":null};
-var products = [
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"11 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9118518518518,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Organic products promote ecological sustainability and biodiversity.",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/not-organic.svg",
-                  "id":"labels_organic",
-                  "match":0,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Not an organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000001",
-      "product_display_name":"Apple pie - Bob's pies - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000001/apple-pie-bob-s-pies"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":27.3333333333333,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
-                  "id":"palm_oil_free",
-                  "match":0,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil",
-                  "status":"known",
-                  "title":"Palm oil"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":60,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000002",
-      "product_display_name":"Organic apple and raspberry pie - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":35.25,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"1 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000007",
-      "product_display_name":"Organic apple juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000007/organic-apple-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Average nutritional quality",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
-                  "id":"nutriscore",
-                  "match":41,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score C"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":100,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Does not contain: Gluten"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":100,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Does not contain: Milk"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":100,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Does not contain: Eggs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"2 ingredients (0 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
-                  "id":"vegan",
-                  "match":100,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:vegan",
-                  "status":"known",
-                  "title":"Vegan"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
-                  "id":"vegetarian",
-                  "match":100,
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian",
-                  "status":"known",
-                  "title":"Vegetarian"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
-                  "id":"nova",
-                  "match":100,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Unprocessed or minimally processed foods"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
-                  "id":"additives",
-                  "match":100,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"Without additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Moderate environmental impact",
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
-                  "id":"ecoscore",
-                  "match":50,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score C"
-               },
-               {
-                  "description":"",
-                  "description_short":"Currently only for products with chicken or eggs",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
-                  "id":"forest_footprint",
-                  "match":0,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Forest footprint not computed"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000008",
-      "product_display_name":"Organic apple and raspberry juice - Bob's juices - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000008/organic-apple-and-raspberry-juice-bob-s-juices"
-   },
-   {
-      "attribute_groups":[
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Lower nutritional quality",
-                  "grade":"d",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutriscore-d-new-en.svg",
-                  "id":"nutriscore",
-                  "match":29.4444444444444,
-                  "name":"Nutri-Score",
-                  "panel_id":"nutriscore_2023",
-                  "status":"known",
-                  "title":"Nutri-Score D"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
-                  "id":"low_salt",
-                  "missing":"Missing nutrition facts",
-                  "name":"Salt",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Salt in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
-                  "id":"low_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Fat in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
-                  "id":"low_sugars",
-                  "missing":"Missing nutrition facts",
-                  "name":"Sugars",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Sugars in unknown quantity"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
-                  "id":"low_saturated_fat",
-                  "missing":"Missing nutrition facts",
-                  "name":"Saturated fat",
-                  "panel_id":"nutrition_facts_table",
-                  "status":"unknown",
-                  "title":"Saturated fat in unknown quantity"
-               }
-            ],
-            "id":"nutritional_quality",
-            "name":"Nutritional quality"
-         },
-         {
-            "attributes":[
-               {
-                  "debug":"en:gluten in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-gluten.svg",
-                  "id":"allergens_no_gluten",
-                  "match":0,
-                  "name":"Gluten",
-                  "status":"known",
-                  "title":"Contains: Gluten"
-               },
-               {
-                  "debug":"en:milk in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
-                  "id":"allergens_no_milk",
-                  "match":0,
-                  "name":"Milk",
-                  "status":"known",
-                  "title":"Contains: Milk"
-               },
-               {
-                  "debug":"en:eggs in allergens",
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
-                  "id":"allergens_no_eggs",
-                  "match":0,
-                  "name":"Eggs",
-                  "status":"known",
-                  "title":"Contains: Eggs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
-                  "id":"allergens_no_nuts",
-                  "match":100,
-                  "name":"Nuts",
-                  "status":"known",
-                  "title":"Does not contain: Nuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
-                  "id":"allergens_no_peanuts",
-                  "match":100,
-                  "name":"Peanuts",
-                  "status":"known",
-                  "title":"Does not contain: Peanuts"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
-                  "id":"allergens_no_sesame_seeds",
-                  "match":100,
-                  "name":"Sesame seeds",
-                  "status":"known",
-                  "title":"Does not contain: Sesame seeds"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
-                  "id":"allergens_no_soybeans",
-                  "match":100,
-                  "name":"Soybeans",
-                  "status":"known",
-                  "title":"Does not contain: Soybeans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
-                  "id":"allergens_no_celery",
-                  "match":100,
-                  "name":"Celery",
-                  "status":"known",
-                  "title":"Does not contain: Celery"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
-                  "id":"allergens_no_mustard",
-                  "match":100,
-                  "name":"Mustard",
-                  "status":"known",
-                  "title":"Does not contain: Mustard"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
-                  "id":"allergens_no_lupin",
-                  "match":100,
-                  "name":"Lupin",
-                  "status":"known",
-                  "title":"Does not contain: Lupin"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
-                  "id":"allergens_no_fish",
-                  "match":100,
-                  "name":"Fish",
-                  "status":"known",
-                  "title":"Does not contain: Fish"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
-                  "id":"allergens_no_crustaceans",
-                  "match":100,
-                  "name":"Crustaceans",
-                  "status":"known",
-                  "title":"Does not contain: Crustaceans"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
-                  "id":"allergens_no_molluscs",
-                  "match":100,
-                  "name":"Molluscs",
-                  "status":"known",
-                  "title":"Does not contain: Molluscs"
-               },
-               {
-                  "debug":"12 ingredients (1 unknown)",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
-                  "id":"allergens_no_sulphur_dioxide_and_sulphites",
-                  "match":100,
-                  "name":"Sulphur dioxide and sulphites",
-                  "status":"known",
-                  "title":"Does not contain: Sulphur dioxide and sulphites"
-               }
-            ],
-            "id":"allergens",
-            "name":"Allergens",
-            "warning":"There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"e",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
-                  "id":"vegan",
-                  "match":0,
-                  "name":"Vegan",
-                  "panel_id":"ingredients_analysis_en:non-vegan",
-                  "status":"known",
-                  "title":"Non-vegan"
-               },
-               {
-                  "grade":"unknown",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/vegetarian-status-unknown.svg",
-                  "id":"vegetarian",
-                  "name":"Vegetarian",
-                  "panel_id":"ingredients_analysis_en:vegetarian-status-unknown",
-                  "status":"unknown",
-                  "title":"Vegetarian status unknown"
-               },
-               {
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
-                  "id":"palm_oil_free",
-                  "match":100,
-                  "name":"Palm oil free",
-                  "panel_id":"ingredients_analysis_en:palm-oil-free",
-                  "status":"known",
-                  "title":"Palm oil free"
-               }
-            ],
-            "id":"ingredients_analysis",
-            "name":"Ingredients"
-         },
-         {
-            "attributes":[
-               {
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/nova-group-3.svg",
-                  "id":"nova",
-                  "match":75,
-                  "name":"NOVA group",
-                  "panel_id":"nova",
-                  "status":"known",
-                  "title":"Processed foods"
-               },
-               {
-                  "grade":"c",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/2-additives.svg",
-                  "id":"additives",
-                  "match":60,
-                  "name":"Additives",
-                  "panel_id":"additives",
-                  "status":"known",
-                  "title":"2 additives"
-               }
-            ],
-            "id":"processing",
-            "name":"Food processing"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"",
-                  "description_short":"Low environmental impact",
-                  "grade":"b",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-b.svg",
-                  "id":"ecoscore",
-                  "match":70,
-                  "name":"Green-Score",
-                  "panel_id":"environmental_score",
-                  "status":"known",
-                  "title":"Green-Score B"
-               },
-               {
-                  "description":"",
-                  "description_short":"Almost no risk of deforestation",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
-                  "id":"forest_footprint",
-                  "match":99.9766666666667,
-                  "name":"Forest footprint",
-                  "status":"known",
-                  "title":"Very small forest footprint"
-               }
-            ],
-            "id":"environment",
-            "name":"Environment"
-         },
-         {
-            "attributes":[
-               {
-                  "description":"Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
-                  "description_short":"Promotes ecological sustainability and biodiversity.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/organic.svg",
-                  "id":"labels_organic",
-                  "match":100,
-                  "name":"Organic farming",
-                  "status":"known",
-                  "title":"Organic product"
-               },
-               {
-                  "description":"When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
-                  "description_short":"Helps producers in developing countries.",
-                  "grade":"a",
-                  "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/fair-trade.svg",
-                  "id":"labels_fair_trade",
-                  "match":100,
-                  "name":"Fair trade",
-                  "status":"known",
-                  "title":"Fair trade product"
-               }
-            ],
-            "id":"labels",
-            "name":"Labels"
-         }
-      ],
-      "code":"3300000000013",
-      "image_front_small_url":"//images.openfoodfacts.localhost/images/products/330/000/000/0013/front_fr.3.200.jpg",
-      "product_display_name":"Organic apple and raspberry pie with a picture - Les tartes de Robert - 100 g",
-      "url":"//world.openfoodfacts.localhost/product/3300000000013/organic-apple-and-raspberry-pie-with-a-picture-les-tartes-de-robert"
-   }
-]
-;
-</script>
-<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
-<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
-
-<script>
-$(document).foundation({
-	equalizer : {
-		equalize_on_stack: true
-	},
-	accordion: {
-		callback : function (accordion) {
-			$(document).foundation('equalizer', 'reflow');
-		}
-	}
-});
-
-</script>
-<script type="application/ld+json">
-{
-	"@context" : "//schema.org",
-	"@type" : "WebSite",
-	"name" : "Open Food Facts",
-	"url" : "//world.openfoodfacts.localhost",
-	"potentialAction": {
-		"@type": "SearchAction",
-		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
-		"query-input": "required name=search_term_string"
-	}
-}
-</script>
-<script type="application/ld+json">
-{
-	"@context": "//schema.org/",
-	"@type": "Organization",
-	"url": "//world.openfoodfacts.localhost",
-	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
-	"name": "Open Food Facts",
-	"sameAs" : ["//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web", "//x.com/OpenFoodFacts"]
-}
-</script>
-
-
-
-
-
-</body>
+    <script>
+      $(document).foundation({
+        equalizer: {
+          equalize_on_stack: true,
+        },
+        accordion: {
+          callback: function (accordion) {
+            $(document).foundation("equalizer", "reflow");
+          },
+        },
+      });
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org",
+        "@type": "WebSite",
+        "name": "Open Food Facts",
+        "url": "//world.openfoodfacts.localhost",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "//schema.org/",
+        "@type": "Organization",
+        "url": "//world.openfoodfacts.localhost",
+        "logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+        "name": "Open Food Facts",
+        "sameAs": [
+          "//www.facebook.com/OpenFoodFacts?utm_source=off&utf_medium=web",
+          "//x.com/OpenFoodFacts"
+        ]
+      }
+    </script>
+  </body>
 </html>
 
 <!-- data_debug: data_debug start


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### PR Title: Fix

### What

<!-- Describe the changes made and why they were made instead of how they were made. -->
Solved Issue number #10143 and #11633 about link previews.

This issue only occurred on static HTML pages and not dynamic generated pages. Some pages has blank descriptions which are done for good and mostly on products page.

Added appropriate title and description for Link preview, the Image is kept the same which is Open Food Facts Logo.

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]
#10143 , #11633 
