### PR TITLE
fix: Fix GitHub Actions workflow to properly fetch pull request branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,7 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        persist-credentials: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: true
     - name: crowdin action
       uses: crowdin/github-action@v2.6.1
       with:

--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -37,6 +37,7 @@ jobs:
         # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # So this is a personal access token
         token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        persist-credentials: true
     # we need origin/main to have comparison linting work !
     - name: Fetch origin/main
       run: |
@@ -88,6 +89,7 @@ jobs:
         # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # So this is a personal access token
         token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        persist-credentials: true
     - name: Run update tests results
       run: make update_tests_results
     - name: Push changes if needed

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: true
 
       - name: Get changed files
         uses: step-security/changed-files@v45
@@ -45,6 +47,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: true
     - uses: actions/setup-node@v4
       with:
         node-version: '22.x'
@@ -71,6 +74,7 @@ jobs:
       with:
         # needs depth to run git log below
         fetch-depth: 50
+        persist-credentials: true
     - uses: actions/cache@v4
       id: cache
       with:
@@ -109,6 +113,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: true
     - name: Setup Git and Restore Taxonomies
       run: ./.github/scripts/setup_git.sh
     - uses: actions/cache/restore@v4
@@ -149,6 +154,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: true
     - uses: actions/cache/restore@v4
       id: cache
       with:
@@ -201,6 +207,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: true
     - uses: actions/cache/restore@v4
       id: cache
       with:
@@ -242,6 +249,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: true
     - name: verify apache2 envvars is correct
       run: |
         env/setenv.sh off;


### PR DESCRIPTION
### What
This PR fixes an issue with GitHub Actions workflows where the action was failing to fetch pull request branches. The error was happening because the `persist-credentials` flag was not set to `true` in the checkout action.

**Changes**
- Added `persist-credentials: true` to all `actions/checkout@v4` usages in workflow files
- This ensures GitHub token credentials are properly maintained between steps
- Affected workflows: pull_request.yml, pr_actions.yml, container-build.yml, codeql-analysis.yml, and crowdin.yml

**Related Issues**
Fixes the error: "Unable to fetch pull request branch because 'persist-credentials' is not set to 'true'"