### PR TITLE
fix: include user_form.tt.js only in display mode

### DIFF
--- a/templates/web/pages/user_form/user_form.tt.js
+++ b/templates/web/pages/user_form/user_form.tt.js
@@ -1,5 +1,4 @@
-[% IF action == 'display' %]
-
+[%- IF action == 'display' -%]
 function checkboxChange(checkbox) {
 	if (checkbox.checked) {
 		\$('.pro_org_display').show();
@@ -20,5 +19,4 @@ checkboxChange(proCheckbox);
 proCheckbox.addEventListener('change', function() {
 	checkboxChange(this);
 });
-
-[% END %]
+[%- END -%]

--- a/templates/web/pages/user_form/user_form.tt.js
+++ b/templates/web/pages/user_form/user_form.tt.js
@@ -1,3 +1,4 @@
+[% IF action == 'display' %]
 
 function checkboxChange(checkbox) {
 	if (checkbox.checked) {
@@ -19,3 +20,5 @@ checkboxChange(proCheckbox);
 proCheckbox.addEventListener('change', function() {
 	checkboxChange(this);
 });
+
+[% END %]

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -1773,7 +1773,6 @@ function togglePasswordVisibility(FieldID) {
 
 <script>
 $(function() {
-
 function checkboxChange(checkbox) {
 	if (checkbox.checked) {
 		$('.pro_org_display').show();


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
The user registration process uses the `cgi-bin/user.pl` script in two modes: `display` mode to present an input form where the user enters their details, and confirms items such as whether they are creating a producer account, and secondly a `process` mode where the user's input is processed.

The browser scripting found in the `user_form.tt.js` template is only relevant for the `display` mode, and causes a browser-side error on the welcome page because an element it expects to find does not appear in the HTML of that page.

This changeset filters `user_form.tt.js` so that the relevant scripting is only included on the page in `display` mode -- retaining the functionality while also preventing the error.

### Related issue(s) and discussion
- Resolves #11721