### PR TITLE
fix: templates: string-quoting audit / fixups

### DIFF
--- a/templates/api/knowledge-panels/health/ingredients/ingredient.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredient.tt.json
@@ -35,8 +35,8 @@
             "element_type": "text",
             "text_element": {
                 "html": "<strong>[% edq(panel.wikipedia_title) %][% sep %]:</strong> [% edq(panel.wikipedia_abstract) %]",
-                "source_text": `Wikipedia`,
-                "source_url": `[% panel.wikipedia_url %]`,
+                "source_text": "Wikipedia",
+                "source_url": "[% panel.wikipedia_url %]",
                 "source_lc": "[% panel.wikipedia_url_lc %]",
                 "source_language": "[% panel.wikipedia_url_language %]"
             }

--- a/templates/api/knowledge-panels/health/ingredients/ingredient.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredient.tt.json
@@ -34,7 +34,7 @@
         {
             "element_type": "text",
             "text_element": {
-                "html": `<strong>[% edq(panel.wikipedia_title) %][% sep %]:</strong> [% edq(panel.wikipedia_abstract) %]`,
+                "html": "<strong>[% edq(panel.wikipedia_title) %][% sep %]:</strong> [% edq(panel.wikipedia_abstract) %]",
                 "source_text": `Wikipedia`,
                 "source_url": `[% panel.wikipedia_url %]`,
                 "source_lc": "[% panel.wikipedia_url_lc %]",

--- a/templates/api/knowledge-panels/health/ingredients/ingredients_list.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients_list.tt.json
@@ -5,7 +5,7 @@
     ],
     "expanded": true,
     "title_element": {
-        "title":"[% lang("ingredient_information") %]",
+        "title":"[% edq(lang("ingredient_information")) %]",
     },
     "elements": [
         [% FOREACH ingredient_panel_id IN panel.ingredients_panels_ids %]

--- a/templates/api/knowledge-panels/health/ingredients/ingredients_rare_crops.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients_rare_crops.tt.json
@@ -6,8 +6,8 @@
     "expanded": false,
     "evaluation": "good",
     "title_element": {
-        "title":"[% lang("knowledge_panels_ingredients_rare_crops_title") %]",
-        "subtitle": "[% lang("knowledge_panels_ingredients_rare_crops_subtitle") %] [% display_taxonomy_tags_list("ingredients", panel.ingredients_rare_crops) %]",
+        "title":"[% edq(lang("knowledge_panels_ingredients_rare_crops_title")) %]",
+        "subtitle": "[% edq(lang("knowledge_panels_ingredients_rare_crops_subtitle")) %] [% display_taxonomy_tags_list("ingredients", panel.ingredients_rare_crops) %]",
         "icon_url": "[% static_subdomain %]/images/panels/divinfood/divinfood.png",
     },
     "elements": [

--- a/templates/api/knowledge-panels/secondhand/used_products.tt.json
+++ b/templates/api/knowledge-panels/secondhand/used_products.tt.json
@@ -5,8 +5,8 @@
     ],
     "expand_for": "large",
     "title_element": {
-        "title": "[% lang('used_products_title') %]",
-        "subtitle": "[% lang('used_products_subtitle') %]",
+        "title": "[% edq(lang('used_products_title')) %]",
+        "subtitle": "[% edq(lang('used_products_subtitle')) %]",
         //"icon_url": "[% static_subdomain %]/images/panels/report_problem/signalconso.png",
     },
     "elements": [

--- a/templates/web/pages/import_file_select_format/import_file_select_format.tt.js
+++ b/templates/web/pages/import_file_select_format/import_file_select_format.tt.js
@@ -97,7 +97,7 @@ function init_select_field_option(col) {
 
 			if (field.match(/^energy/)) {
 				select += "<option value='value_in_kj'>[% edq(lang('value_in_kj')) %]</option>"
-				+ "<option value='value_in_kcal'>[% lang('value_in_kcal') %]</option>";
+				+ "<option value='value_in_kcal'>[% edq(lang('value_in_kcal')) %]</option>";
 			}
 			else if (field.match(/weight/)) {
 				select += "<option value='value_in_g'>[% edq(lang('value_in_g')) %]</option>";
@@ -146,10 +146,10 @@ function init_select_field_option(col) {
 
 			instructions += "<p>[% edq(lang('value_unit_dropdown')) %]'</p>"
 			+ "<ul>"
-			+ "<li>[% lang('value_unit_dropdown_value_specific_unit') %]</li>"
-			+ "<li>[% lang('value_unit_dropdown_value_unit') %]</li>"
-			+ "<li>[% lang('value_unit_dropdown_value') %]</li>"
-			+ "<li>[% lang('value_unit_dropdown_unit') %]</li>"
+			+ "<li>[% edq(lang('value_unit_dropdown_value_specific_unit')) %]</li>"
+			+ "<li>[% edq(lang('value_unit_dropdown_value_unit')) %]</li>"
+			+ "<li>[% edq(lang('value_unit_dropdown_value')) %]</li>"
+			+ "<li>[% edq(lang('value_unit_dropdown_unit')) %]</li>"
 			+ "</ul>";
 		}
 	}

--- a/templates/web/pages/product/includes/edit_history.tt.html
+++ b/templates/web/pages/product/includes/edit_history.tt.html
@@ -17,6 +17,6 @@
   [% END %]
 </ul>
 
-<script>var revert_confirm_message = "[% lang("product_js_product_revert_confirm") %]";</script>
+<script>var revert_confirm_message = "[% edq(lang("product_js_product_revert_confirm")) %]";</script>
 
 <!-- end templates/[% component.name %] -->

--- a/templates/web/pages/product_edit/product_edit_form_packagings.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_packagings.tt.html
@@ -67,7 +67,7 @@
             <!-- row 0 is a template for new row, we do not populate it -->
             [% IF packaging_max.defined && packaging_max > 0 %]
                 <initjs>
-                    configure_packaging_select2("[% select2_id %]", "[% taxonomy %]", "[% lang("packaging_$property") %]" )
+                    configure_packaging_select2("[% select2_id %]", "[% taxonomy %]", "[% edq(lang("packaging_$property")) %]" )
 
                     [% IF packaging.$property.defined %]
                     // Set the value, creating a new option if necessary (for non taxonomy values)
@@ -193,7 +193,7 @@ function add_packaging() {
             [% SET taxonomy = "packaging_recycling" %]
         [% END %]
         
-         configure_packaging_select2(new_packaging_id + "_$property", "$taxonomy", "[% lang("packaging_$property") %]");
+         configure_packaging_select2(new_packaging_id + "_$property", "$taxonomy", "[% edq(lang("packaging_$property")) %]");
 
     [% END %]
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
From manually auditing the templates directory (searching for the literal string ` lang(`, basically), I think there are a few places where the templates should be updated to wrap the inputs in `edq(...)` (escape-double-quotes) because the results are interpolated inside double-quotes.

E.g. where a template contains `x = "[% lang('something') %]";` we should instead use `x = "[% edq(lang('something')) %]";`

Tests are likely going to fail here initially; I'll update the test expectations soon.

### Related issue(s) and discussion
- Follow-up to #9822.