### PR TITLE
fix: update session handling titles for sign in/out actions

### DIFF
--- a/cgi/session.pl
+++ b/cgi/session.pl
@@ -100,25 +100,30 @@ if (single_param('jqm')) {
 }
 else {
 	my $template;
+	my $action = param('length');
 
-	if ((defined param('length')) and (param('length') eq 'logout')) {
+	if ((defined $action) and ($action eq 'logout')) {
 		# The user is signing out
 		$template = "signed_out";
+		# Set a specific title for sign out
+		$request_ref->{title} = lang('sign_out');
 	}
 	elsif (defined $User_id) {
 		# The user is signed in
 		$template = "signed_in";
+		# Set an empty title to prevent "Sign in" from showing when already signed in
+		$request_ref->{title} = '';
 	}
 	else {
-		# The user is signing in: display the login form
+		# The user is signing in: display the login form
 		$template = "sign_in_form";
+		# Set sign in title only when actually signing in
+		$request_ref->{title} = lang('sign_in');
 	}
 
 	process_template("web/pages/session/$template.tt.html", $template_data_ref, \$html)
 		or $html = "<p>" . $tt->error() . "</p>";
 
-	$request_ref->{title} = lang('session_title');
 	$request_ref->{content_ref} = \$html;
 	display_page($request_ref);
 }
-


### PR DESCRIPTION
**Signed-off-by:** Areeb Ahmed ([areebshariff@acm.org](mailto:areebshariff@acm.org))

## Summary of Changes

1. Set conditional page titles based on login state:  
   - Empty title when the user is signed in  
   - "Sign out" when logging out  
   - "Sign in" only on the login form  

2. Removed the generic title previously used for all states  

## Related Issues  
Closes #11723