### PR TITLE
feat: add webcredentials in off-apple-app-site-association for the iOS app

### DIFF
--- a/conf/well-known/off-apple-app-site-association
+++ b/conf/well-known/off-apple-app-site-association
@@ -6,5 +6,8 @@
         "paths": ["*"]
       }
     ]
-  }
+  },
+  "webcredentials": {
+      "apps": [ "ZC9CYWD334.org.openfoodfacts.scanner" ]
+   }
 }


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->
The change that was made was adding a few lines of JSON to enable credential sharing on the iOS app. We will still need to modify the iOS app a bit to enable the credential sharing.

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Related to https://github.com/openfoodfacts/smooth-app/issues/6416, but for iOS app and not the Android app; we will still need an app-side pull request to close this issue out.

