### PR TITLE
fix: keep query parameters in facet redirect URLs

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -134,7 +134,7 @@ BEGIN {
 use vars @EXPORT_OK;
 
 use ProductOpener::HTTP
-	qw(write_cors_headers set_http_response_header write_http_response_headers get_http_request_header redirect_to_url single_param request_param);
+	qw(write_cors_headers set_http_response_header write_http_response_headers get_http_request_header add_extension_and_query_parameters_to_redirect_url redirect_to_url single_param request_param);
 use ProductOpener::Store qw(get_string_id_for_lang retrieve);
 use ProductOpener::Config qw(:all);
 use ProductOpener::Paths qw/%BASE_DIRS/;
@@ -148,7 +148,7 @@ use ProductOpener::Ingredients qw(flatten_sub_ingredients);
 use ProductOpener::Products qw(:all);
 use ProductOpener::Missions qw(:all);
 use ProductOpener::MissionsConfig qw(:all);
-use ProductOpener::URL qw(format_subdomain get_owner_pretty_path extension_based_on_parameter);
+use ProductOpener::URL qw(format_subdomain get_owner_pretty_path);
 use ProductOpener::Data qw(:all);
 use ProductOpener::Text
 	qw(escape_char escape_single_quote_and_newlines get_decimal_formatter get_percent_formatter remove_tags_and_quote);
@@ -3124,7 +3124,8 @@ sub canonicalize_request_tags_and_redirect_to_canonical_url ($request_ref) {
 	# The redirect is temporary (302), as the canonicalization could change if the corresponding taxonomies change
 	if ($redirect_to_canonical_url) {
 		$request_ref->{redirect} = $formatted_subdomain . $request_ref->{current_link};
-		$request_ref->{redirect} .= extension_based_on_parameter($request_ref);
+		add_extension_and_query_parameters_to_redirect_url($request_ref);
+
 		$log->debug("one or more tagids mismatch, redirecting to correct url", {redirect => $request_ref->{redirect}})
 			if $log->is_debug();
 		redirect_to_url($request_ref, 302, $request_ref->{redirect});

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -134,7 +134,7 @@ BEGIN {
 use vars @EXPORT_OK;
 
 use ProductOpener::HTTP
-	qw(write_cors_headers set_http_response_header write_http_response_headers get_http_request_header add_extension_and_query_parameters_to_redirect_url redirect_to_url single_param request_param);
+	qw(write_cors_headers set_http_response_header write_http_response_headers get_http_request_header redirect_to_url single_param request_param);
 use ProductOpener::Store qw(get_string_id_for_lang retrieve);
 use ProductOpener::Config qw(:all);
 use ProductOpener::Paths qw/%BASE_DIRS/;
@@ -3124,7 +3124,7 @@ sub canonicalize_request_tags_and_redirect_to_canonical_url ($request_ref) {
 	# The redirect is temporary (302), as the canonicalization could change if the corresponding taxonomies change
 	if ($redirect_to_canonical_url) {
 		$request_ref->{redirect} = $formatted_subdomain . $request_ref->{current_link};
-		add_extension_and_query_parameters_to_redirect_url($request_ref);
+		$request_ref->{redirect} .= extension_and_query_parameters_to_redirect_url($request_ref);
 
 		$log->debug("one or more tagids mismatch, redirecting to correct url", {redirect => $request_ref->{redirect}})
 			if $log->is_debug();

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -134,7 +134,7 @@ BEGIN {
 use vars @EXPORT_OK;
 
 use ProductOpener::HTTP
-	qw(write_cors_headers set_http_response_header write_http_response_headers get_http_request_header redirect_to_url single_param request_param);
+	qw(write_cors_headers set_http_response_header write_http_response_headers get_http_request_header extension_and_query_parameters_to_redirect_url redirect_to_url single_param request_param);
 use ProductOpener::Store qw(get_string_id_for_lang retrieve);
 use ProductOpener::Config qw(:all);
 use ProductOpener::Paths qw/%BASE_DIRS/;

--- a/lib/ProductOpener/HTTP.pm
+++ b/lib/ProductOpener/HTTP.pm
@@ -49,7 +49,7 @@ BEGIN {
 		&get_http_request_headers
 		&set_http_response_header
 		&write_http_response_headers
-		&add_extension_and_query_parameters_to_redirect_url
+		&extension_and_query_parameters_to_redirect_url
 		&redirect_to_url
 		&single_param
 		&request_param
@@ -219,30 +219,35 @@ sub get_http_request_header($header_name) {
 	return;
 }
 
-=head2 add_extension_and_query_parameters_to_redirect_url($request_ref)
+=head2 extension_and_query_parameters_to_redirect_url($request_ref)
 
-This function adds the extension and query parameters to the redirect URL.
+This function returns the extension and query parameters that can be added to a redirect URL.
 e.g. if the URL is /ingredients.json?filter=strawberry
-we get a redirect_url /facets/ingredients and we need to add back .json and ?filter=strawberry
+we get a .json?filter=strawberry
 
 =head3 Parameters
 
 =head4 $request_ref - Reference to the request object.
 
+=head3 Return value
+
+A string with the extension and query parameters that can be added to a redirect URL.
+
 =cut
 
-sub add_extension_and_query_parameters_to_redirect_url($request_ref) {
+sub extension_and_query_parameters_to_redirect_url($request_ref) {
 	# Add the extension to the redirect URL
+	my $add_to_url = '';
 
 	if ($request_ref->{extension}) {
-		$request_ref->{redirect} .= '.' . $request_ref->{extension};
+		$add_to_url .= '.' . $request_ref->{extension};
 	}
 	# Add the query parameters to the redirect URL
 	if ($request_ref->{query_parameters}) {
-		$request_ref->{redirect} .= '?' . $request_ref->{query_parameters};
+		$add_to_url .= '?' . $request_ref->{query_parameters};
 	}
 
-	return;
+	return $add_to_url;
 }
 
 =head2 redirect_to_url($request_ref, $status_code, $redirect_url)

--- a/lib/ProductOpener/HTTP.pm
+++ b/lib/ProductOpener/HTTP.pm
@@ -49,6 +49,7 @@ BEGIN {
 		&get_http_request_headers
 		&set_http_response_header
 		&write_http_response_headers
+		&add_extension_and_query_parameters_to_redirect_url
 		&redirect_to_url
 		&single_param
 		&request_param
@@ -215,6 +216,32 @@ sub get_http_request_header($header_name) {
 
 	}
 	$log->error("get_http_request_header: request object does not have headers_in method (not in mod_perl?)");
+	return;
+}
+
+=head2 add_extension_and_query_parameters_to_redirect_url($request_ref)
+
+This function adds the extension and query parameters to the redirect URL.
+e.g. if the URL is /ingredients.json?filter=strawberry
+we get a redirect_url /facets/ingredients and we need to add back .json and ?filter=strawberry
+
+=head3 Parameters
+
+=head4 $request_ref - Reference to the request object.
+
+=cut
+
+sub add_extension_and_query_parameters_to_redirect_url($request_ref) {
+	# Add the extension to the redirect URL
+
+	if ($request_ref->{extension}) {
+		$request_ref->{redirect} .= '.' . $request_ref->{extension};
+	}
+	# Add the query parameters to the redirect URL
+	if ($request_ref->{query_parameters}) {
+		$request_ref->{redirect} .= '?' . $request_ref->{query_parameters};
+	}
+
 	return;
 }
 

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -47,7 +47,7 @@ use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/:all/;
 use ProductOpener::Products qw/is_valid_code normalize_code product_url/;
 use ProductOpener::Display qw/$formatted_subdomain %index_tag_types_set display_robots_txt_and_exit init_request/;
-use ProductOpener::HTTP qw/add_extension_and_query_parameters_to_redirect_url redirect_to_url single_param/;
+use ProductOpener::HTTP qw/extension_and_query_parameters_to_redirect_url redirect_to_url single_param/;
 use ProductOpener::Users qw/:all/;
 use ProductOpener::Lang qw/%tag_type_from_plural %tag_type_from_singular %tag_type_plural %tag_type_singular lang/;
 use ProductOpener::API qw/:all/;
@@ -598,7 +598,7 @@ sub facets_route($request_ref) {
 		$redirect_url =~ s!/${target_lc}:!/!g;
 		$redirect_url =~ s!/1$!!;
 		$request_ref->{redirect} = $redirect_url;
-		add_extension_and_query_parameters_to_redirect_url($request_ref);
+		$request_ref->{redirect} .= extension_and_query_parameters_to_redirect_url($request_ref);
 		$request_ref->{redirect_status} = 301;
 	}
 

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -47,7 +47,7 @@ use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/:all/;
 use ProductOpener::Products qw/is_valid_code normalize_code product_url/;
 use ProductOpener::Display qw/$formatted_subdomain %index_tag_types_set display_robots_txt_and_exit init_request/;
-use ProductOpener::HTTP qw/redirect_to_url single_param/;
+use ProductOpener::HTTP qw/add_extension_and_query_parameters_to_redirect_url redirect_to_url single_param/;
 use ProductOpener::Users qw/:all/;
 use ProductOpener::Lang qw/%tag_type_from_plural %tag_type_from_singular %tag_type_plural %tag_type_singular lang/;
 use ProductOpener::API qw/:all/;
@@ -58,7 +58,7 @@ use ProductOpener::Index qw/%texts/;
 use ProductOpener::Store qw/get_string_id_for_lang/;
 use ProductOpener::Redis qw/:all/;
 use ProductOpener::RequestStats qw/:all/;
-use ProductOpener::URL qw/get_owner_pretty_path extension_based_on_parameter/;
+use ProductOpener::URL qw/get_owner_pretty_path/;
 
 use Encode;
 use CGI qw/:cgi :form escapeHTML/;
@@ -598,7 +598,7 @@ sub facets_route($request_ref) {
 		$redirect_url =~ s!/${target_lc}:!/!g;
 		$redirect_url =~ s!/1$!!;
 		$request_ref->{redirect} = $redirect_url;
-		$request_ref->{redirect} .= extension_based_on_parameter($request_ref);
+		add_extension_and_query_parameters_to_redirect_url($request_ref);
 		$request_ref->{redirect_status} = 301;
 	}
 
@@ -780,7 +780,7 @@ sub sanitize_request($request_ref) {
 
 			param($parameter, 1);
 			$request_ref->{query_string} =~ s/\.$parameter(\b|$)//;
-			$request_ref->{response_type_as_extension} = 1;
+			$request_ref->{extension} = $parameter;
 
 			$log->debug("parameter was set from extension in URL path",
 				{parameter => $parameter, value => $request_ref->{$parameter}})
@@ -795,7 +795,8 @@ sub sanitize_request($request_ref) {
 	# some sites like FB can add query parameters, remove all of them
 	# make sure that all query parameters of interest have already been consumed above
 
-	$request_ref->{query_string} =~ s/(\&|\?).*//;
+	$request_ref->{query_string} =~ s/(?:\&|\?)(.*)//;
+	$request_ref->{query_parameters} = $1;
 
 	$log->debug("analyzing query_string, step 3 - removed all query parameters",
 		{query_string => $request_ref->{query_string}})

--- a/lib/ProductOpener/URL.pm
+++ b/lib/ProductOpener/URL.pm
@@ -49,7 +49,6 @@ use Exporter qw< import >;
 BEGIN {
 	use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
-		&extension_based_on_parameter
 		&format_subdomain
 		&get_owner_pretty_path
 	);    # symbols to export on request
@@ -60,7 +59,6 @@ use vars @EXPORT_OK;
 
 use experimental 'smartmatch';
 
-use ProductOpener::HTTP qw/single_param/;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS/;
 
@@ -144,27 +142,6 @@ or an empty string if not on the producers platform.
 
 sub get_owner_pretty_path ($owner_id) {
 	return ($server_options{producers_platform} and defined $owner_id) ? "/org/$owner_id" : "";
-}
-
-=head2 extension_based_on_parameter($request_ref)
-
-Add back a file extension based on json/jsonp/xml etc. parameters
-
-Particularly useful on redirects
-
-see https://github.com/openfoodfacts/openfoodfacts-server/issues/894
-
-=cut
-
-sub extension_based_on_parameter($request_ref) {
-	# this is set by sanitize_request in Routing.pm
-	if ($request_ref->{response_type_as_extension} // undef) {
-		return '.json' if single_param("json");
-		return '.jsonp' if single_param("jsonp");
-		return '.xml' if single_param("xml");
-		return '.jqm' if single_param("jqm");
-	}
-	return "";
 }
 
 1;

--- a/tests/integration/expected_test_results/facets/brand_-brand1.json
+++ b/tests/integration/expected_test_results/facets/brand_-brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 9,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 9,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_-unknown.json
+++ b/tests/integration/expected_test_results/facets/brand_-unknown.json
@@ -1,6 +1,6 @@
 {
    "count" : 8,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 8,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_brand1.json
+++ b/tests/integration/expected_test_results/facets/brand_brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 5,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 5,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_brand2_brand_-brand1.json
+++ b/tests/integration/expected_test_results/facets/brand_brand2_brand_-brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 2,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 2,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_unknown.json
+++ b/tests/integration/expected_test_results/facets/brand_unknown.json
@@ -1,6 +1,6 @@
 {
    "count" : 6,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 6,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category-vitamins.json
+++ b/tests/integration/expected_test_results/facets/category-vitamins.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_-apples.json
+++ b/tests/integration/expected_test_results/facets/category_-apples.json
@@ -1,6 +1,6 @@
 {
    "count" : 11,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 11,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_-apples_label_-organic.json
+++ b/tests/integration/expected_test_results/facets/category_-apples_label_-organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 3,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 3,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_-apples_label_organic.json
+++ b/tests/integration/expected_test_results/facets/category_-apples_label_organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 8,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 8,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_apples.json
+++ b/tests/integration/expected_test_results/facets/category_apples.json
@@ -1,6 +1,6 @@
 {
    "count" : 3,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 3,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_apples_label_organic.json
+++ b/tests/integration/expected_test_results/facets/category_apples_label_organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 3,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 3,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_-brand1.json
+++ b/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_-brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_brand1.json
+++ b/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/contributor-alice-label_organic.json
+++ b/tests/integration/expected_test_results/facets/contributor-alice-label_organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 10,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 10,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/contributor-alice.json
+++ b/tests/integration/expected_test_results/facets/contributor-alice.json
@@ -1,6 +1,6 @@
 {
    "count" : 13,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 13,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/contributor-bob.json
+++ b/tests/integration/expected_test_results/facets/contributor-bob.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/de-accented-cafe-label.json
+++ b/tests/integration/expected_test_results/facets/de-accented-cafe-label.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/label_fair-trade_label_-organic.json
+++ b/tests/integration/expected_test_results/facets/label_fair-trade_label_-organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 2,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 2,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/packager-code_fr-85-222-003-ce.json
+++ b/tests/integration/expected_test_results/facets/packager-code_fr-85-222-003-ce.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : 1,
+   "page" : "1",
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/redirect-facets-search-with-json-and-query-parameter.html
+++ b/tests/integration/expected_test_results/facets/redirect-facets-search-with-json-and-query-parameter.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>301 Moved Permanently</title>
+</head><body>
+<h1>Moved Permanently</h1>
+<p>The document has moved <a href="/facets/categories/vitamins.json?no_cache=1">here</a>.</p>
+<hr>
+<address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
+</body></html>

--- a/tests/integration/expected_test_results/facets/redirect-facets-search-with-json-query-parameter.html
+++ b/tests/integration/expected_test_results/facets/redirect-facets-search-with-json-query-parameter.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>301 Moved Permanently</title>
+</head><body>
+<h1>Moved Permanently</h1>
+<p>The document has moved <a href="/facets/categories/vitamins?json=1">here</a>.</p>
+<hr>
+<address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
+</body></html>

--- a/tests/integration/expected_test_results/facets/redirect-facets-with-multiple-query-parameters.html
+++ b/tests/integration/expected_test_results/facets/redirect-facets-with-multiple-query-parameters.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>301 Moved Permanently</title>
+</head><body>
+<h1>Moved Permanently</h1>
+<p>The document has moved <a href="/facets/ingredients?filter=bon&amp;status=unknown">here</a>.</p>
+<hr>
+<address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
+</body></html>

--- a/tests/integration/facets.t
+++ b/tests/integration/facets.t
@@ -372,6 +372,36 @@ my $tests_ref = [
 		expected_type => 'html',    # the redirect itself is html
 	},
 	{
+		test_case => 'redirect-facets-search-with-json-and-query-parameter',
+		method => 'GET',
+		path => '/categories/vitamins.json?no_cache=1',
+		expected_status_code => 301,
+		headers => {
+			Location => '/facets/categories/vitamins.json?no_cache=1',
+		},
+		expected_type => 'html',    # the redirect itself is html
+	},
+	{
+		test_case => 'redirect-facets-search-with-json-query-parameter',
+		method => 'GET',
+		path => '/categories/vitamins?json=1',
+		expected_status_code => 301,
+		headers => {
+			Location => '/facets/categories/vitamins?json=1',
+		},
+		expected_type => 'html',    # the redirect itself is html
+	},
+	{
+		test_case => 'redirect-facets-with-multiple-query-parameters',
+		method => 'GET',
+		path => '/ingredients?filter=bon&status=unknown',
+		expected_status_code => 301,
+		headers => {
+			Location => '/facets/ingredients?filter=bon&status=unknown',
+		},
+		expected_type => 'html',    # the redirect itself is html
+	},
+	{
 		test_case => 'redirect-facets-agg-with-json',
 		method => 'GET',
 		path => '/categories.json',

--- a/tests/unit/expected_test_results/routing/api-v0-attribute-groups.json
+++ b/tests/unit/expected_test_results/routing/api-v0-attribute-groups.json
@@ -14,6 +14,7 @@
    "no_index" : "0",
    "original_query_string" : "api/v0/attribute_groups",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "api/v0/attribute_groups",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,

--- a/tests/unit/expected_test_results/routing/api-v3-product-code.json
+++ b/tests/unit/expected_test_results/routing/api-v3-product-code.json
@@ -16,6 +16,7 @@
    "no_index" : "0",
    "original_query_string" : "api/v3/product/03564703999971",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "api/v3/product/03564703999971",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "product",

--- a/tests/unit/expected_test_results/routing/api-v3-product-gs1-data-uri.json
+++ b/tests/unit/expected_test_results/routing/api-v3-product-gs1-data-uri.json
@@ -16,6 +16,7 @@
    "no_index" : "0",
    "original_query_string" : "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "product",

--- a/tests/unit/expected_test_results/routing/facet-url-group-by-in-english.json
+++ b/tests/unit/expected_test_results/routing/facet-url-group-by-in-english.json
@@ -9,6 +9,7 @@
    "no_index" : 1,
    "original_query_string" : "facets/categories/breads/ingredients",
    "page" : "1",
+   "query_parameters" : null,
    "query_string" : "facets/categories/breads/ingredients",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_tags",

--- a/tests/unit/expected_test_results/routing/facet-url-group-by.json
+++ b/tests/unit/expected_test_results/routing/facet-url-group-by.json
@@ -9,6 +9,7 @@
    "no_index" : 1,
    "original_query_string" : "facets/categories/breads/ingredients",
    "page" : "1",
+   "query_parameters" : null,
    "query_string" : "facets/categories/breads/ingredients",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_tags",

--- a/tests/unit/expected_test_results/routing/facet-url-with-page-number.json
+++ b/tests/unit/expected_test_results/routing/facet-url-with-page-number.json
@@ -8,6 +8,7 @@
    "no_index" : 1,
    "original_query_string" : "facets/categories/breads/4",
    "page" : "4",
+   "query_parameters" : null,
    "query_string" : "facets/categories/breads/4",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_products",

--- a/tests/unit/expected_test_results/routing/facet-url-with-synonym-and-page-number.json
+++ b/tests/unit/expected_test_results/routing/facet-url-with-synonym-and-page-number.json
@@ -8,6 +8,7 @@
    "no_index" : "0",
    "original_query_string" : "facets/categories/bread/4",
    "page" : "4",
+   "query_parameters" : null,
    "query_string" : "facets/categories/bread/4",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_products",

--- a/tests/unit/expected_test_results/routing/facet-url.json
+++ b/tests/unit/expected_test_results/routing/facet-url.json
@@ -8,6 +8,7 @@
    "no_index" : "0",
    "original_query_string" : "facets/categories/breads",
    "page" : "1",
+   "query_parameters" : null,
    "query_string" : "facets/categories/breads",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_products",

--- a/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv4-us.json
+++ b/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv4-us.json
@@ -15,6 +15,7 @@
    "no_index" : "0",
    "original_query_string" : "api/v3/geopip/12.45.23.45",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "api/v3/geopip/12.45.23.45",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,

--- a/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv6-fr.json
+++ b/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv6-fr.json
@@ -15,6 +15,7 @@
    "no_index" : "0",
    "original_query_string" : "api/v3/geopip/2001:ac8:25:3b::e01d",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "api/v3/geopip/2001:ac8:25:3b::e01d",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,

--- a/tests/unit/expected_test_results/routing/invalid-last-url-component.json
+++ b/tests/unit/expected_test_results/routing/invalid-last-url-component.json
@@ -10,6 +10,7 @@
    "no_index" : "0",
    "original_query_string" : "facets/categories/breads/no-nutrition-data",
    "page" : "1",
+   "query_parameters" : null,
    "query_string" : "facets/categories/breads/no-nutrition-data",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,

--- a/tests/unit/expected_test_results/routing/product-french.json
+++ b/tests/unit/expected_test_results/routing/product-french.json
@@ -12,6 +12,7 @@
    "original_query_string" : "produit/3564703999971",
    "page" : 1,
    "product" : 1,
+   "query_parameters" : null,
    "query_string" : "produit/3564703999971",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "product",

--- a/tests/unit/expected_test_results/routing/products-code.json
+++ b/tests/unit/expected_test_results/routing/products-code.json
@@ -10,6 +10,7 @@
    "no_index" : "0",
    "original_query_string" : "products/3564703999971",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "products/3564703999971",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,

--- a/tests/unit/expected_test_results/routing/products-codes.json
+++ b/tests/unit/expected_test_results/routing/products-codes.json
@@ -10,6 +10,7 @@
    "no_index" : "0",
    "original_query_string" : "products/3564703999971,3564703999972",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "products/3564703999971,3564703999972",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,

--- a/tests/unit/expected_test_results/routing/rate-limit-on-facet-registered-user.json
+++ b/tests/unit/expected_test_results/routing/rate-limit-on-facet-registered-user.json
@@ -8,6 +8,7 @@
    "no_index" : "0",
    "original_query_string" : "facets/categories/breads",
    "page" : "1",
+   "query_parameters" : null,
    "query_string" : "facets/categories/breads",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_products",

--- a/tests/unit/expected_test_results/routing/redirect-to-facets-prefix-and-plural.json
+++ b/tests/unit/expected_test_results/routing/redirect-to-facets-prefix-and-plural.json
@@ -9,6 +9,7 @@
    "original_query_string" : "categories/pain/brand/lidl",
    "page" : "1",
    "param" : {},
+   "query_parameters" : null,
    "query_string" : "categories/pain/brand/lidl",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_products",

--- a/tests/unit/expected_test_results/routing/redirect-to-facets-prefix.json
+++ b/tests/unit/expected_test_results/routing/redirect-to-facets-prefix.json
@@ -10,6 +10,7 @@
    "original_query_string" : "categories",
    "page" : "1",
    "param" : {},
+   "query_parameters" : null,
    "query_string" : "categories",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_tags",

--- a/tests/unit/expected_test_results/routing/redirect-to-plural-tagtype.json
+++ b/tests/unit/expected_test_results/routing/redirect-to-plural-tagtype.json
@@ -8,6 +8,7 @@
    "no_index" : "0",
    "original_query_string" : "facets/category/breads/brand/lidl",
    "page" : "1",
+   "query_parameters" : null,
    "query_string" : "facets/category/breads/brand/lidl",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : "facet_products",

--- a/tests/unit/expected_test_results/routing/redirect-to-product-normalized-code.json
+++ b/tests/unit/expected_test_results/routing/redirect-to-product-normalized-code.json
@@ -10,6 +10,7 @@
    "no_index" : "0",
    "original_query_string" : "product/012345678",
    "page" : 1,
+   "query_parameters" : null,
    "query_string" : "product/012345678",
    "rate_limiter_blocking" : 0,
    "rate_limiter_bucket" : null,


### PR DESCRIPTION
Continuation of https://github.com/openfoodfacts/openfoodfacts-server/pull/11794 to fix ?json=1 and add support for all other query parameters.