### PR TITLE
taxonomy: Update L. plantarum ingredient

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -1492,19 +1492,6 @@ it: Lactobacillus lactis, L. lactis
 wikidata:en: Q62877111
 wikipedia:en: https://en.wikipedia.org/wiki/Lactobacillus_delbrueckii
 
-# description:en:LACTOBACILLUS PLANTARUM is a widespread member of the genus Lactobacillus, commonly found in many fermented food products
-
-< en:Lactobacillus
-en: Lactobacillus plantarum, L. plantarum
-xx: Lactobacillus plantarum
-bg: Lactobacillus plantarum, L. plantarum
-it: Lactobacillus plantarum, L. plantarum
-pl: żywe kultury bakterii Lactobacillus plantarum
-zh: 植物乳桿菌
-# zh-tw:胚芽乳酸菌
-wikidata:en: Q1756682
-wikipedia:en: https://en.wikipedia.org/wiki/Lactobacillus_plantarum
-
 # description:en:LACTOBACILLUS REUTERI is a Gram-positive bacterium that naturally inhabits the gut of mammals and birds. Although L. reuteri occurs naturally in humans, it is not found in all individuals. Dietary supplementation can sustain high levels of it in those with deficiencies.
 
 < en:Lactobacillus
@@ -1534,6 +1521,25 @@ en: Lactobacillus rhamnosus GG
 xx: Lactobacillus rhamnosus GG, LGG
 hr: kultura Lactobacillus rhamnosus LGG, Lactobacillus rhamnosus Gorbach & Goldin ATCC 53103, Lactobacillus rhamnosus gorbach i goldin ATCC 53103
 # ingredient/fi:Lactobacillus-rhamnosus-GG has 1 product in 2 languages @2020-06-08
+
+# description:en:LACTIPLANTIBACILLUS is a genus of lactic acid bacteria
+
+< en:lactic ferments
+en: Lactiplantibacillus
+xx: Lactiplantibacillus
+wikidata:en: Q107536944
+wikipedia:en: https://en.wikipedia.org/wiki/Lactiplantibacillus
+
+# description:en:LACTIPLANTIBACILLUS PLANTARUM is a widespread member of the genus Lactiplantibacillus, commonly found in many fermented food products
+
+< en:Lactiplantibacillus
+en: Lactiplantibacillus plantarum, Lactobacillus arabinosus, Lactobacillus plantarum, L. plantarum
+xx: Lactiplantibacillus plantarum, Lactobacillus arabinosus, Lactobacillus plantarum, L. plantarum
+pl: żywe kultury bakterii Lactiplantibacillus plantarum, żywe kultury bakterii Lactobacillus plantarum
+zh: 植物乳桿菌
+# zh-tw:胚芽乳酸菌
+wikidata:en: Q1756682
+wikipedia:en: https://en.wikipedia.org/wiki/Lactiplantibacillus_plantarum
 
 # description:en:BACILLUS COAGULANS is a lactic acid-forming bacterial species. B. coagulans is often marketed as Lactobacillus sporogenes or a 'sporeforming lactic acid bacterium' probiotic, but this is an outdated name due to taxonomic changes in 1939.
 


### PR DESCRIPTION
Several lactic acid bacteria were recategorised in 2020, including Lactobacillus plantarum being reassigned to the “new” genus Lactiplantibacillus, thus becoming Lactiplantibacillus plantarum.

See
https://en.wikipedia.org/wiki/Lactobacillaceae
https://en.wikipedia.org/wiki/Lactiplantibacillus
https://en.wikipedia.org/wiki/Lactiplantibacillus_plantarum