### PR TITLE
chore: remove unused CSS localization

### DIFF
--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -24,7 +24,6 @@
     <script type="module" src="[% static_subdomain %]/js/dist/off-webcomponents.bundled.js"></script>
 	[% header %]
     <style media="all">
-        [% lang("css") %]
         [% styles %]
 		
 		.badge-container{

--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -34,7 +34,6 @@
 	
     <style media="all">
         
-        
 		
 		.badge-container{
 			margin: 0 auto;

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -34,7 +34,6 @@
 	
     <style media="all">
         
-        
 		
 		.badge-container{
 			margin: 0 auto;

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -42,7 +42,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .hide-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .hide-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .hide-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
+++ b/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -35,7 +35,6 @@
 <link rel="stylesheet" type="text/css" href="/css/dist/tagify.css" />
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .hide-when-logged-in {display:none}
 .ui-selectable li {

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 .select2-container--default .select2-results > .select2-results__options {

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -35,7 +35,6 @@
 <link rel="stylesheet" type="text/css" href="/css/dist/tagify.css" />
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .hide-when-logged-in {display:none}
 .ui-selectable li {

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .hide-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -34,7 +34,6 @@
 	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-product-content-only.html
+++ b/tests/integration/expected_test_results/web_html/world-product-content-only.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-product-smoothie.html
+++ b/tests/integration/expected_test_results/web_html/world-product-smoothie.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -44,7 +44,6 @@
 
 
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 .select2-container--default .select2-results > .select2-results__options {

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -33,7 +33,6 @@
     <script type="module" src="//static.openfoodfacts.localhost/js/dist/off-webcomponents.bundled.js"></script>
 	
     <style media="all">
-        
         .show-when-no-access-to-producers-platform {display:none}
 .show-when-logged-in {display:none}
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [x] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Removes unused CSS localization (`lang("css")`) from the web templates.

### Related issue(s) and discussion
- Fixes #11764.
- Ref also a [`productopener` discussion thread on Slack](https://openfoodfacts.slack.com/archives/C02LDQDDD/p1744038417726459?thread_ts=1744037784.677939&cid=C02LDQDDD).