### PR TITLE
ci: GitHub Actions: prefer tags/commit IDs instead of branch names

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -52,7 +52,7 @@ jobs:
         false
 
     - name: Check for an eventual NO_DEPLOY file to put deployment on hold
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -100,7 +100,7 @@ jobs:
       run: echo Timeout && false # fail if build time out
 
     - name: Checkout git repository
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -126,7 +126,7 @@ jobs:
           git checkout -qf ${{ github.sha }}
 
     - name: Set environment variables
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -186,7 +186,7 @@ jobs:
           sed -i.bak "s/productopener.localhost/${{ env.PRODUCT_OPENER_DOMAIN }}/g" ./conf/nginx-docker/nginx.conf
 
     - name: Create Docker volumes and network
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -202,7 +202,7 @@ jobs:
 
     - name: wait for docker images to be available
       # we sometimes have the images not ready immediately after build, so we prefer to wait for it
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -231,7 +231,7 @@ jobs:
           done
 
     - name: initialize the backend
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -247,7 +247,7 @@ jobs:
 
     # NOTE: the mongodb and redis containers are deployed by openfoodfacts-shared-services 
     - name: Start services
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
@@ -264,7 +264,7 @@ jobs:
           make prod_up
 
     - name: Check services are up
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       if: ${{ always() }}
       with:
         host: ${{ env.SSH_HOST }}
@@ -279,7 +279,7 @@ jobs:
           make livecheck
 
     - name: Cleanup obsolete Docker objects
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.2
       if: ${{ always() }}
       with:
         host: ${{ env.SSH_HOST }}

--- a/.github/workflows/github-projects-ventilation.yml
+++ b/.github/workflows/github-projects-ventilation.yml
@@ -44,108 +44,108 @@ jobs:
     name: Ventilate issues to the right GitHub projects
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/12 # add to openfoodfacts-server
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           label-operator: AND
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/11 # Add issue to the openfoodfacts-design project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🎨 Mockup available, 🎨 Mockup required
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/36 # Add issue to the open pet food facts project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🐾 Open Pet Food Facts
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/43 # Add issue to the open products facts project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📸 Open Products Facts
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/37 # Add issue to the open beauty facts project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🧴 Open Beauty Facts
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/4 # Add issue to the packaging project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📦 Packaging
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/25 # Add issue to the documentation project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📚 Documentation
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/5 # Add issue to the folksonomy project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🏷️ Folksonomy Project
           label-operator: OR         
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/44 # Add issue to the data quality project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🧽 Data quality
           label-operator: OR    
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/82 # Add issue to the search project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🔎 Search
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/41 # Add issue to the producer platform project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🏭 Producers Platform
           label-operator: OR    
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/19 # Add issue to the infrastructure project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: infrastructure
           label-operator: OR   
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/92 # Add issue to the Nutri-Score project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🚦 Nutri-Score
           label-operator: OR   
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/132 # Add issue to the Top upvoted issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ⭐ top issue, 👍 Top 10 Issue!
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/57 # Add issue to the Most impactful issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🎯 P0, 🎯 P1
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/60 # Add issue to the API issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: API, API READ, API WRITE, 🔐 API auth, API v3, API tests, API Refactor, 🧽 API - Quality, API Read - Product, OpenAPI, 📚 OpenAPI
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/136 # Add issue to the Translations project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🌐 Translations, translations, i18n, Translations
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/84 # Add issue to the Metrics project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -12,7 +12,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@master
+      - uses: mschilde/auto-label-merge-conflicts@5981f8933e92b78098af86b9e33fe0871cc7a3be  # v2.0 (2020-01-27)
         with:
           CONFLICT_LABEL_NAME: "💥 Merge Conflicts"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Three of the GitHub Actions that we use in our GitHub Actions CI workflows (via the `uses: ...` clause in the YAML files) refer to those actions based on a branch name, instead of a conventional tagged release number or fixed commit ID.

The three relevant actions are:

  * `actions/add-to-project` (used to add issues/PRs to our GitHub Project boards)
  * `appleboy/ssh-action` (used during some of our deployment workflows)
  * `mschilde/auto-label-merge-conflicts` (used to annotate PRs that currently have merge conflicts)

I noticed this during some auditing of our GitHub Actions references during [Slack discussion](https://openfoodfacts.slack.com/archives/C02LDQDDD/p1744723461030369) of the possible merits and disadvantages of [`ratchet`](https://github.com/sethvargo/ratchet/) and how it relates to our existing use of GitHub's [Dependabot](https://github.com/dependabot).

Regardless of whether we use Ratchet and/or Dependabot, I think it is better to use versioned tags or commit IDs instead of branch names when referring to actions modules, because the contents of branches can vary and may sometimes contain code that is not release-ready.

:spiral_notepad: **Detail notes**

* As an exception in the case of `mschilde/auto-label-merge-conflicts`, I chose to pin to a commit ID instead of a tag name.  This is because the functionality seems very stable, and upstream has not released a version since Y2020.  So I would expect that for minimal disruption and workload we could continue to use this precise version.

* Technically `appleboy/ssh-action` downloads the latest-known version of another project, [`appleboy/drone-ssh`](https://github.com/appleboy/drone-ssh) when it runs.  I decided _not_ to pin to a specific version -- something that is possible using the [`version` option](https://github.com/appleboy/ssh-action/blob/master/README.md?plain=1#L53) -- because I doubt that Dependabot would detect updates to that and to recommend upgrades, meaning that we might unintentionally miss important updates.

### Related issue(s) and discussion
- [Slack thread](https://openfoodfacts.slack.com/archives/C02LDQDDD/p1744723461030369) related to Ratchet for GitHub Actions version management.