### PR TITLE
taxonomy: add UK recycle-at-supermarket packaging recycling option

### DIFF
--- a/taxonomies/packaging_recycling.txt
+++ b/taxonomies/packaging_recycling.txt
@@ -139,3 +139,6 @@ it: non riciclabile, indifferenziata
 nl: restafval, bij restafval, niet PMD
 pt: descartar, a descartar, para descartar, não-reciclável, não recicláel
 
+# In the UK, some packaging is accepted for recycling by supermarkets despite not being recyclable in home bins
+< en:recycle
+en: recycle with bags at large supermarket, recycle at store, don't recycle at home


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Some packaging in the UK can be recycled at supermarkets, despite not being acceptable for recycling in at-home bins.

These are frequently lightweight plastic packaging, and some common examples include store-bought bean/ground coffee packaging, crisp packets, frozen fries, and packaging for some styles of flavoured bread (e.g. garlic bread).

This seems _similar_ to an [existing entry](https://github.com/openfoodfacts/openfoodfacts-server/blob/e1e5811acb8cc8e804809988d1e091f8f886bb35/taxonomies/packaging_recycling.txt#L92-L97) -- `return to store` -- but in this case I do not believe that there is any requirement for the returned supermarket to be the one where the item was (or could be) purchased, and also there is no financial incentive.

To clarify that, I would hope that `en:recycle-with-bags-at-large-supermarkets` could be the primary identifier/prompt text for this.

Sometimes the composition of the text on the labels varies; so far I have encountered:

  * Recycle with bags at large supermarket
  * Recycle at store
    * e.g. https://world.openfoodfacts.org/product/5000328270548/walkers-grab-bag

Sometimes with additional / accompanying text:

  * Don't recycle at home
  * UK only

### Screenshot
After learning about PR #9240, I took and uploaded a supporting example photo of some coffee grounds in some packaging that exhibit this type of recycling information:

![recycle-at-store](https://github.com/user-attachments/assets/cf9e0d3c-ab60-4db5-b9c9-53a0063eaa67)

### Related issue(s) and discussion
- Continues-from / completes #9240.