### PR TITLE
taxonomy: Untangle un/pickled cucumbers/gherkins

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -106671,10 +106671,19 @@ ja: きゅうりのピクルス
 nl: Ingemaakte komkommer
 ru: Маринованые огурцы
 tr: Salatalık turşusu, Hıyar turşusu
-wikidata:en: Q1211297
+wikidata:en: Q1365891
 
-< en:Pickled cucumbers
+< en:Cucumbers
+en: Small cucumbers, Gherkins (non-pickled)
+sv: Smågurkor
+
+< en:Small cucumbers
 en: Gherkins
+comment:en: “Gherkins” can refer to both non-pickled and pickled small cucumbers
+
+< en:Gherkins
+< en:Pickled cucumbers
+en: Pickled gherkins, Gherkins (pickled), Pickled small cucumbers
 bg: Кисели краставички
 de: Essiggurken
 es: Pepinillos, Pepinillos encurtidos
@@ -106684,18 +106693,22 @@ hr: Kiseli krastavci
 hu: Csemegeuborka
 it: Cetriolini
 nl: Ingemaakte Augurken
-ciqual_proxy_food_code:en: 11004
-ciqual_proxy_food_name:en: Gherkin, pickled in vinegar
-ciqual_proxy_food_name:fr: Cornichon, au vinaigre
+comment:en: Pickled small cucumbers (gherkins) regardless of the method used to pickle them.
 intake24_category_code:en: GHRK
 intake24_category_code:fr: GHRK
-wikidata:en: Q1365891
+
+< en:Pickled gherkins
+en: Gherkins pickled in brine, Salzgurke, Small cucumbers pickled in brine
+de: Salzgurke
+nb: Saltagurk
+sv: Saltgurkor
+wikidata:en: Q1211297
 
 # agribalyse_food_code:en:99999
 # TODO Curious code not present in official Agribalyse file. Not sure who added this
 
-< en:Gherkins
-en: Pickled gherkins, Gherkins pickled in vinegar
+< en:Pickled gherkins
+en: Gherkins pickled in vinegar
 bg: Кисели краставички с оцет
 de: Gewürzgurken, Cornichons
 fr: Cornichons au vinaigre
@@ -106709,7 +106722,7 @@ ciqual_food_name:fr: Cornichon, au vinaigre
 < en:Gherkins
 en: Extra-fine gherkins
 de: Extra-feine Cornichons
-fi: hienoja suolakurkkuja
+fi: Hienoja suolakurkkuja
 fr: Cornichons extra-fins
 hr: Ekstra-fini kornišoni
 nl: Zeer fijne augurken
@@ -106724,7 +106737,7 @@ hr: Fini kornišoni
 nl: Fijne augurken
 
 < en:Gherkins
-en: semi-fine gherkins
+en: Semi-fine gherkins
 fr: Cornichons mi-fins
 
 < en:Gherkins
@@ -106739,15 +106752,15 @@ ciqual_food_code:en: 11097
 ciqual_food_name:en: Gherkin, in sweet and sour sauce
 ciqual_food_name:fr: Cornichon, aigre-doux
 
-< en:Gherkins
+< en:Pickled gherkins
 en: dill pickles
 fr: Cornichons à l'aneth
 
-< en:Gherkins
+< en:Pickled gherkins
 en: Polish pickles
 fr: Cornichons à la polonaise
 
-< en:Gherkins
+< en:Pickled gherkins
 en: Russian pickles
 fr: Cornichons à la russe
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -51,7 +51,7 @@
 # Synonyms must be separated with an empty line.
 # If a term is also in the taxonomy, it must come first. e.g. "en:hydrolysed"
 
-# comment:en:These are words that occur inside the name of one ingredient, that can be considered as synonyms 
+# comment:en:These are words that occur inside the name of one ingredient, that can be considered as synonyms
 # for matching the ingredient with entries in the taxonomy
 # note: synonyms should not be ingredients themselves, if we have an ingredient entry with synonyms, they should not be listed in the synonyms below as well
 # for example, zumo, jugo (juice) cannot be listed here
@@ -17543,10 +17543,10 @@ it: olio di sansa di oliva raffinato
 pl: rafinowana oliwa z wytłoczyn z oliwek, rafinowana oliwa z wytłoczyn oliwek
 
 
-#  comment:en:Beware of a confusion between the generic name (rapeseed oil) and more specific oil varieties: colza oil and canola oil. 
-#    Not all languages distinguish between the two. Probably where rapeseed is given, colza is meant. 
-#    The difference between the two oils is important due to different levels of erucic acid. 
-#    It seems that only the oils with a low erucic acid percentage are fit for humans. So the naming difference between rapeseed, 
+#  comment:en:Beware of a confusion between the generic name (rapeseed oil) and more specific oil varieties: colza oil and canola oil.
+#    Not all languages distinguish between the two. Probably where rapeseed is given, colza is meant.
+#    The difference between the two oils is important due to different levels of erucic acid.
+#    It seems that only the oils with a low erucic acid percentage are fit for humans. So the naming difference between rapeseed,
 #    colza and canola might just be a language issue.
 
 < en:vegetable oil and fat
@@ -85318,7 +85318,7 @@ vegetarian:en: yes
 
 #category/cucumbers
 < en:fruit vegetable
-en: cucumber, cucumbers, baby cucumbers, pickle
+en: cucumber, cucumbers
 ar: الخيار
 bg: краставица, краставици
 ca: cogombre
@@ -85349,10 +85349,11 @@ ru: огурец, огурцы
 sd: کيرو
 sk: uhorka
 sl: Kumara
-sv: Gurka
+sv: gurka, gurkor
 tr: salatalık, hıyar
 za: lwgbieng
 zh: 黄瓜
+# ang:hwerhwette
 #carbon_footprint_fr_foodges_ingredient:fr:Concombre
 #carbon_footprint_fr_foodges_value:fr:1.7
 carbon_footprint_fr_foodges_ingredient:fr: Concombre serre chauffée
@@ -85374,7 +85375,7 @@ ecobalyse_origins_en_european_union:en:
 ecobalyse_origins_en_france:en: cucumber-fr-offseason
 # 6546 products in 22 @2021-09-02
 eurocode_2_group_3:en: 8.40.30
-# ang:hwerhwette
+nutriscore_fruits_vegetables_nuts:en: yes
 wikidata:en: Q2735883
 wikipedia:en: https://en.wikipedia.org/wiki/Cucumber
 
@@ -85393,12 +85394,20 @@ ciqual_food_code:en: 20210
 ciqual_food_name:en: Cucumber, pulp, raw
 ciqual_food_name:fr: Concombre, pulpe, cru
 
-
-
 # comment:en:From wikidata it is not clear if a language differentiates between cucumber and gherkin
 
 < en:cucumber
-en: gherkin
+en: baby cucumber, baby cucumbers, small cucumber, raw gherkin, unpickled gherkin
+sv: smågurka, smågurkor, smågurk
+
+< en:cucumber
+en: pickled cucumber
+da: syltet agurk, syltede agurker
+wikidata:en: Q1365891
+
+< en:baby cucumber
+< en:pickled cucumber
+en: pickled gherkin, pickle
 bg: корнишон, кисела краставичка, кисели краставички, краставички, корнишони
 da: cornichon
 de: Cornichons
@@ -85410,17 +85419,17 @@ it: cetriolini
 nl: augurken, augurk
 pl: korniszon, korniszony, ogórek konserwowy, ogórki konserwowe
 ro: castraveți murați
-sv: inläggningsgurka
-ciqual_proxy_food_code:en: 11004
-ciqual_proxy_food_name:en: Gherkin, pickled in vinegar
-description:en: A GHERKIN is a variety of cucumber
-#wikidata:en:Q1365891
-# ingredient/gherkin has 1006 products in 8 languages @2018-12-01
-nutriscore_fruits_vegetables_nuts:en: yes
-wikidata:en: Q23425
 
-< en:gherkin
-en: vinegar gherkin, pickled gherkin, pickled cucumber
+# this is done in the style of other "X or Y" ingredients
+< en: baby cucumber
+< en: pickled gherkin
+en: gherkin, pickled or unpickled gherkin
+sv: inläggningsgurka
+description:en: GHERKIN can refer to either a pickled small cucumber (esp. in Ireland and the UK) or an unpickled small cucumber
+# ingredient/gherkin has 1006 products in 8 languages @2018-12-01
+
+< en:pickled gherkin
+en: vinegar gherkin
 de: kleine Essiggurken, Essiggurke, Gewürzgurke
 fr: cornichon au vinaigre, cornichons au vinaigre
 hr: ocat kornišon
@@ -85433,6 +85442,14 @@ ciqual_food_name:en: Gherkin, pickled in vinegar
 eurocode_2_group_2:en: 8.70
 eurocode_2_group_3:en: 8.70.40
 
+< en:pickled gherkin
+cs: kvašáky
+de: Salzgurke
+pl: ogórki kiszone, ogórek kiszony, ogórki kwaszone, ogórek kwaszony
+ru: cолёные огурцы
+sv: saltgurka, saltgurkor
+wikidata:en: Q1211297
+
 # <en:compound
 < en:cucumber
 en: vinegar cucumbers
@@ -85442,7 +85459,6 @@ fr: concombres au vinaigre
 hr: ocat krastavci
 it: cetrioli all'aceto
 # ingredient/fr:concombres-au-vinaigre has 19 products in 4 languages @2019-05-15
-
 
 # <en:cucumber
 # fr:Concombre produit sous serre chauffée
@@ -85488,13 +85504,6 @@ hr: sok od krastavca iz koncentrata
 it: succo di cetriolo da concentrato
 nl: komkommersap uit concentraat
 # ingredient/cucumber-juice-from-concentrate has 1 product @2019-05-15
-
-< en:cucumber
-# processing:en: en:fermented
-cs: kvašáky
-de: Salzgurke
-pl: ogórki kiszone, ogórek kiszony, ogórki kwaszone, ogórek kwaszony
-ru: cолёные огурцы
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -95012,7 +95021,7 @@ it: gambero, gamberi
 
 < en:cucumber
 < en:gherkin
-en: cumcumber or gherkin
+en: cucumber or gherkin, cumcumber or gherkin
 de: Gurke
 
 < en: bell pepper


### PR DESCRIPTION
Right now pickled and non-pickled cucumbers and gherkins seem to be mixed together with no clear purpose or clear separation of what should go where.

This is an attempt at starting to unravel this.

See:
https://openfoodfacts.slack.com/archives/C06A7LENM/p1744912951211729
https://en.wikipedia.org/wiki/Pickled_cucumber
https://www.wikidata.org/wiki/Q1211297
https://www.wikidata.org/wiki/Q1365891

Related (but not addressed here) issue:
https://github.com/openfoodfacts/openfoodfacts-server/issues/11798