### PR TITLE
taxonomy: Move vitamins out of ingredients.txt

### DIFF
--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -1770,31 +1770,34 @@ sv: naturligt förtjockningsmedel
 en: enriching substances, enriching additives, enriching substance
 pl: substancje wzbogacające, substancja wzbogacająca
 
-en: Vitamins
-bg: Витамини
-cs: Vitaminy
-de: Vitamine
-el: Βιταμίνες
-es: Vitaminas
-et: Vitamiinid
-fi: Vitamiinit, Vitamiineja
-fr: Vitamines
+en: vitamins
+bg: витамини
+cs: vitaminy
+da: vitaminer
+de: vitamine
+el: βιταμίνες
+es: vitaminas
+et: vitamiinid
+fi: vitamiinit, vitamiineja
+fr: vitamines
 hr: vitamini, vitamins, vitamin complex, kompleks vitamina
-hu: Vitaminok
-it: Vitamine
+hu: vitaminok
+it: vitamine
 ja: ビタミン
-lt: Vitaminai
-lv: Vitamīni
-mt: Vitamini
-nl: Vitaminen
-pl: Witaminy, kompleks witamin, premiks witaminowy, kompleks witaminowy
-pt: Vitaminas
-ro: Vitamine
+lt: vitaminai
+lv: vitamīni
+mt: vitamini
+nl: vitaminen
+pl: witaminy, kompleks witamin, premiks witaminowy, kompleks witaminowy
+pt: vitaminas
+ro: vitamine
 ru: витамины
-sk: Vitamíny
-sl: Vitamini
-sv: Vitaminer
-#wikidata:en:
+sk: vitamíny
+sl: vitamini
+sv: vitaminer
+vegan:en: yes
+vegetarian:en: yes
+wikidata:en: Q34956
 
 en: Minerals
 bg: Минерали

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -51,7 +51,7 @@
 # Synonyms must be separated with an empty line.
 # If a term is also in the taxonomy, it must come first. e.g. "en:hydrolysed"
 
-# comment:en:These are words that occur inside the name of one ingredient, that can be considered as synonyms 
+# comment:en:These are words that occur inside the name of one ingredient, that can be considered as synonyms
 # for matching the ingredient with entries in the taxonomy
 # note: synonyms should not be ingredients themselves, if we have an ingredient entry with synonyms, they should not be listed in the synonyms below as well
 # for example, zumo, jugo (juice) cannot be listed here
@@ -9606,784 +9606,137 @@ wikipedia:en: https://en.wikipedia.org/wiki/American_cheese
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+# Note that individual vitamins should generally be added to taxonomy/vitamins.txt rather than added here.
+
 # description:en: A vitamin is an organic molecule (or related set of molecules) which is an essential micronutrient that an organism needs in small quantities for the proper functioning of its metabolism. This ingredient is written in plural
 
-en: Vitamins, vitamin, vit.
-af: Vitamien, vit.
+en: vitamins, vitamin, vit.
+af: vitamien, vit.
 ar: فيتامين
 as: ভিটামিন
-az: Vitaminlər, vit.
-ba: Витаминдар
-be: Вітаміны, Вітамін
-bg: Витамини, Витамин, vitamins, vit.
+az: vitaminlər, vit.
+ba: витаминдар
+be: вітаміны, вітамін
+bg: витамини, витамин, vitamins, vit.
 bn: ভিটামিন
-bs: Vitamini, Vitamin, vit.
+bs: vitamini, vitamin, vit.
 ca: vitamina, vitamines, vit.
-cs: Vitaminy, vitamín, vit.
-cv: Витамин
-cy: Fitaminau, Fitamin
-da: Vitaminer, Vitamin, vit.
-de: Vitamine, Vitamin, Vitaminmischung, vit.
+cs: vitaminy, vitamín, vit.
+cv: витамин
+cy: fitaminau, fitamin
+da: vitaminer, vitamin, vit.
+de: Vitamine, Vitamin, Vitaminmischung, Vit.
 dv: ވިޓަމިން
-el: Βιταμίνες, Βιταμίνη
+el: βιταμίνες, βιταμίνη
 eo: vitamino
-es: Vitaminas, vitamina, vit.
-et: Vitamiin, Vitamiinid, vit.
-eu: Bitamina
+es: vitaminas, vitamina, vit.
+et: vitamiin, vitamiinid, vit.
+eu: bitamina
 fa: ویتامین
-fi: Vitamiinit, vitamiini, vit.
-fo: Vitamin
-fr: Vitamines, vitamine, mélange de vitamines, vit.
-ga: Vitimín, vit.
-gl: Vitamina, vit.
+fi: vitamiinit, vitamiini, vit.
+fo: vitamin
+fr: vitamines, vitamine, mélange de vitamines, vit.
+ga: vitimín, vit.
+gl: vitamina, vit.
 he: ויטמין
 hi: विटामिन
 hr: vitamin, vitamini, vitaminska mješavina, vit.
-ht: Vitamin, vit.
-hu: Vitaminok, vitamin, vit.
-hy: Վիտամին
-ia: Vitamina, vit.
-id: Vitamin, vit.
-is: Vítamín, vit.
-it: Vitamine, vit.
+ht: vitamin, vit.
+hu: vitaminok, vitamin, vit.
+hy: վիտամին
+ia: vitamina, vit.
+id: vitamin, vit.
+is: vítamín, vit.
+it: vitamine, vit.
 ja: ビタミン
-jv: Vitamin, vit.
+jv: vitamin, vit.
 ka: ვიტამინი
-kk: Дәрумен
+kk: дәрумен
 km: វីតាមីន
 kn: ಜೀವಸತ್ವಗಳು
 ko: 비타민
-ky: Витаминдер
-la: Vitaminum, vit.
-lb: Vitamin, vit.
-lg: Vitamin, vit.
+ky: витаминдер
+la: vitaminum, vit.
+lb: vitamin, vit.
+lg: vitamin, vit.
 lo: ວິຕາມິນ
-lt: Vitaminai, Vitaminas, vit.
-lv: Vitamīni, vit.
-mk: Витамин
+lt: vitaminai, vitaminas, vit.
+lv: vitamīni, vit.
+mk: витамин
 ml: ജീവകം
 mr: जीवनसत्त्व
-ms: Vitamin, vit.
-mt: Vitamini, vit.
+ms: vitamin, vit.
+mt: vitamini, vit.
 my: ဗီတာမင်
-nb: Vitaminer, vitamin, vit.
+nb: vitaminer, vitamin, vit.
 ne: भिटामिन
-nl: Vitamines, vitaminen, Vitamine, vit.
-nn: Vitaminer, vitamin, vit.
+nl: vitamines, vitaminen, vitamine, vit.
+nn: vitaminer, vitamin, vit.
 no: vitaminer, vitamin, vit.
-nv: Vitamine, vit.
-oc: Vitamina, vit.
+nv: vitamine, vit.
+oc: vitamina, vit.
 or: ଜୀବସାର
 pa: ਵਿਟਾਮਿਨ
-pl: Witamina, Witaminy
+pl: witamina, witaminy
 ps: ويټامين
-pt: Vitaminas, vitamina, Premezcla de Vitaminas, vit.
-ro: Vitamine, Vitamină, vit.
+pt: vitaminas, vitamina, premezcla de vitaminas, vit.
+ro: vitamine, vitamină, vit.
 ru: витамин
-sh: Vitamini, Vitamin, vit.
+sh: vitamini, vitamin, vit.
 si: විටමින්
-sk: Vitamíny, vitamín, vit.
-sl: Vitamini, Vitamin, vit.
-so: Fiitamiin
-sq: Vitamina, Vitaminat, vit.
-sr: Витамини, витамин
-su: Vitamin, vit.
-sv: Vitaminer, Vitamin, vit.
-sw: Vitamini, vit.
+sk: vitamíny, vitamín, vit.
+sl: vitamini, vitamin, vit.
+so: fiitamiin
+sq: vitamina, vitaminat, vit.
+sr: витамини, витамин
+su: vitamin, vit.
+sv: vitaminer, vitamin, vit.
+sw: vitamini, vit.
 ta: உயிர்ச்சத்து
 te: విటమిన్
-tg: Витамин
+tg: витамин
 th: วิตามิน
-tk: Witamin
-tl: Bitamina
-tr: Vitamin, vit.
-tt: Витамин
-uk: Вітаміни
+tk: witamin
+tl: bitamina
+tr: vitamin, vit.
+tt: витамин
+uk: вітаміни
 ur: حیاتین
-uz: Vitaminlar, vit.
+uz: vitaminlar, vit.
 vi: vitamin, vit.
-wa: Vitamene, vit.
+wa: vitamene, vit.
 yi: וויטאמין
-yo: Àmínìamáralókun
+yo: àmínìamáralókun
 zh: 维生素
 vegan:en: yes
 vegetarian:en: yes
-# ast:Vitamina
-# be-tarask:Вітаміны
-# cdo:Mì-sĕng-só
+# ast:vitamina
+# be-tarask:вітаміны
+# cdo:mì-sĕng-só
 # ckb:ڤیتامین
 # de-ch:Vitamin
 # dty:भिटामिन
-# en-ca:Vitamin
-# en-gb:Vitamin
-# frr:Vitamiin
-# hak:Ví-ta-mìn
-# kaa:Vitamin
+# en-ca:vitamin
+# en-gb:vitamin
+# frr:vitamiin
+# hak:ví-ta-mìn
+# kaa:vitamin
 # koi:витамин
-# lmo:Vitamina
-# nan:Bî-tá-mín
+# lmo:vitamina
+# nan:bî-tá-mín
 # pnb:ਵਿਟਾਮਿਨ
 # pt-br:vitamina
-# rue:Витамин
-# scn:Vitamini, Vitamina
+# rue:витамин
+# scn:vitamini, vitamina
 # sco:vitamin
-# sr-ec:Витамини, витамин
+# sr-ec:витамини, витамин
 # sr-el:vitamin
-# tyv:Витаминнер
-# war:Bitamina
+# tyv:витаминнер
+# war:bitamina
 # xmf:ვიტამინეფი
 # yue:維他命
-#wikidata:en:Q34956
+wikidata:en: Q34956
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin
-
-
-# description:en:Vitamin A is a group of unsaturated nutritional organic compounds that includes retinol, retinal, retinoic acid
-# and several provitamin A carotenoids (most notably beta-carotene).
-
-< en:vitamins
-en: vitamin A
-af: Vitamien A
-ar: فيتامين ألف
-az: A vitamini
-bg: витамин А, vitamin A
-bs: Vitamin A
-ca: Vitamina A, Vitamina A (Retinol)
-cs: vitamín A
-cy: Fitamin A
-da: Vitamin A
-de: Vitamin A, Vitamin A (Retinol)
-dv: ވިޓަމިން އޭ
-eo: Vitamino A
-es: vitamina A, Vitamina A (Retinol)
-et: A-vitamiin
-eu: A bitamina
-fa: ویتامین آ
-fi: A-vitamiini
-fo: A vitamin
-fr: vitamine A, Vitamine A (rétinol)
-gl: Vitamina A
-he: A ויטמין
-hi: विटामिन ए
-hr: vitamin A
-hu: A-vitamin
-id: Vitamin A
-is: A-vítamín
-it: vitamina A, Vitamina A (Retinolo)
-ja: ビタミンA
-jv: Vitamin A
-ka: ვიტამინი A
-kn: ಎ ಜೀವಸತ್ವ
-ko: 비타민 A
-lt: Vitaminas A
-lv: A vitamīns
-mk: Витамин А
-ml: ജീവകം എ
-mn: Витамин А
-mr: अ-जीवनसत्त्व
-ms: Vitamin A
-nb: Vitamin A
-ne: भिटामिन ए
-nl: vitamine A
-nn: vitamin A, A-vitamin
-oc: Vitamina A
-or: ଜୀବସାର କ
-pa: ਵਿਟਾਮਿਨ ਏ
-pl: witamina A
-ps: ويټامين اې
-pt: vitamina A
-ro: vitamine A
-ru: витамин А
-rw: Vitamini A
-sh: Vitamin A
-si: විටමින් A
-sl: Vitamin A
-sq: Vitamina A
-sr: vitamin A
-sv: vitamin A
-sw: Vitamini A
-ta: உயிர்ச்சத்து ஏ
-te: విటమిన్ ఎ
-th: วิตามินเอ
-tr: A vitamini
-tt: А витамины
-ug: ۋىتامىن A
-uk: Вітамін A
-ur: ریئٹنول
-vi: Vitamin A
-zh: 維生素A
-# ast:Vitamina A
-# en-ca:Vitamin A
-# en-gb:Vitamin A
-# jbo:abumoi mivytcuxu'i
-# kk-cyrl:А витамині
-# kk-kz:А витамині
-# lfn:Vitamina A
-# pt-br:Vitamin A
-# scn:Vitamina A
-# sco:Vitamin A
-# sr-ec:витамин А
-# sr-el:vitamin A
-# tyv:А витамины
-# wuu:维生素A
-# zh-hans:维生素A
-# zh-hant:維生素A
-wikidata:en: Q18225
-wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_A
-# vitamin/vitamin-a has 1768 products in 17 languages @2018-11-20
-
-
-
-
-
-
-
-
-
-# description:en:Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement.
-
-< en:vitamins
-en: Riboflavin, vitamin b2, E101, B2
-af: Riboflavien
-ar: فيتامين ب2
-be: Рыбафлавін
-bg: Рибофлавин, Витамин B2
-bn: রিবোফ্লেবিন
-bs: Vitamin B2
-ca: riboflavina, Vitamina B2
-cs: riboflavin, vitamín B2
-cy: Ribofflafin, Fitamin B2
-da: Riboflavin, Vitamin B2
-de: Riboflavin, Vitamin B2
-dv: ވިޓަމިން ބީ2
-el: ριβοφλαβίνη, βιταμίνη Β2
-eo: riboflavino, vitamino B2
-es: riboflavina, vitamina b2
-et: Riboflaviin, Vitamiin B2
-eu: B2 bitamina
-fa: ویتامین ب۲
-fi: Riboflaviini
-fo: Riboflavin, Vitamin B2
-fr: riboflavine, vitamine b2, B2
-ga: Ribeaflaivin
-gl: Riboflavina, Vitamina B2
-he: ויטמין B2
-hi: रिबोफ्लेविन, विटामिन बी२
-hr: riboflavin, Vitamin B2, B2
-hu: Riboflavin, B2-vitamin
-hy: Վիտամին B2
-id: Riboflavin, Vitamin B2
-it: riboflavina, vitamina B2
-ja: リボフラビン, ビタミンB2
-kk: Рибофлавин
-ko: 리보플래빈, 바이타민 B2
-ky: Рибофлавин, Витамин В2
-lb: Riboflavin, Vitamin B2
-lt: Riboflavinas
-lv: Riboflavīns, B2 vitamīns
-mk: Рибофлавин
-ml: റൈബോഫ്ലേവിൻ
-ms: Riboflavin, Vitamin B2
-mt: Riboflavina
-nb: Riboflavin
-ne: भिटामिन बी-२
-nl: Riboflavine, vitamine B2
-nn: riboflavin, vitamin B2
-oc: Riboflavina, Vitamina B2
-or: ରାଇବୋଫ୍ଲାଭିନ, ଜୀବସାର ଖ୨
-pl: Ryboflawina, ryboflawiny, Witamina B2
-pt: riboflavina, vitamina B2
-ro: Riboflavină, Vitamina B2
-ru: рибофлавин, Витамин B2
-rw: Vitamini B2
-sh: Vitamin B2
-sk: Riboflavín, Vitamín B2
-sl: Riboflavin, Vitamin B2
-sr: riboflavin, vitamin B2
-su: Riboflavin
-sv: Riboflavin, Vitamin B2, B2
-ta: ரிபோஃபிளாவின்
-th: ไรโบเฟลวิน
-tr: Riboflavin, B2 vitamini
-uk: Рибофлавін, Вітамін B2
-uz: Riboflavin
-vi: Riboflavin
-wa: Riboflavene, Vitamene B2
-zh: 核黄素
-vegan:en: maybe
-# ingredient/vitamin-b2 has 4263 products in 10 languages @2018-11-23
-vegetarian:en: yes
-# ast:Vitamina B2
-# be-tarask:Рыбафлявін
-# de-ch:Riboflavin
-# en-ca:Riboflavin
-# en-gb:Riboflavin
-# pt-br:riboflavina
-# sco:Riboflavin
-# sr-ec:витамин Б2
-# sr-el:riboflavin, vitamin B2
-# tyv:Витамин В2
-# zh-cn:核黄素
-# zh-hans:核黄素
-# zh-hant:核黄素
-# zh-hk:核黄素
-# zh-sg:核黄素
-# zh-tw:核黄素
-wikidata:en: Q130365
-wikipedia:en: https://en.wikipedia.org/wiki/Riboflavin
-
-
-# description:en:Niacin, also known as nicotinic acid, is an organic compound and a form of vitamin B3, an essential human nutrient.
-
-< en:vitamins
-en: niacin, vitamin b3, vitamin PP, E375, B3, PP
-af: Niasien
-ar: نياسين
-be: Нікацінавая кіслата
-bg: Никотинова киселина, Витамин B3, Витамин PP
-bs: Vitamin B3
-ca: niacina, Vitamina B3, Vitamina PP
-cs: niacin, vitamín B3, vitamín PP
-cy: Niacin, Fitamin B3
-da: Niacin
-de: Niacin, Vitamin B3
-dv: ވިޓަމިން ބީ3
-eo: niacino, vitamino B3
-es: niacina, Vitamina B3, vitamina PP
-et: Niatsiin, Vitamiin B3
-eu: Niazina, B3 bitamina
-fa: ویتامین ب۳
-fi: Niasiini, B3-vitamiini
-fo: Niacin
-fr: niacine, vitamine b3, Vitamine PP
-ga: Aigéad nicitíneach
-gl: Niacina, Vitamina B3
-he: ויטמין B3
-hi: नाइयासिन
-hr: niacin, Vitamin B3, B3
-hu: Niacin, B3-vitamin, PP-vitamin, B3
-hy: Վիտամին B3
-id: Niasin, Vitamin B3
-it: niacina, vitamina PP
-ja: ナイアシン, ビタミンB3, ビタミンPP
-nl: Niacine, Vitamine B3, Vitamine PP
-pl: witamina b3, niacyna
-ru: Ниацин, витамин B3, витамин PP, E375, B3, никотиновая кислота
-sv: vitamin B3, B3
-# ast:Vitamina B3
-# azb:ویتامین ب۳
-# en-ca:Niacin
-# en-gb:Niacin
-wikidata:en: Q134658
-wikipedia:en: https://en.wikipedia.org/wiki/Niacin
-# ingredient/vitamin-b3 has 744 products in 8 languages @2018-11-23
-
-
-# description:en:Nicotinamide (NAM), also known as niacinamide, is a form of vitamin B3 found in food and used as a dietary supplement and medication.
-
-
-< en:vitamin B3
-en: Nicotinamide, niacinamide
-ar: نيكوتيناميد
-bg: никотинамид
-ca: niacinamida
-cs: Nikotinamid
-cy: nicotinamid
-de: Nicotinamid
-el: νικοτιναμίδη
-eo: nikotinamido
-fi: nikotiiniamidi, niasiiniamidi
-fr: nicotinamide, niacinamide
-hi: निकोटिनामाइड
-hr: nikotinamid
-hu: Nikotinamid
-hy: Նիկոտինամիդ
-id: Nikotinamida
-it: Nicotinamide
-ja: ニコチンアミド
-ko: 니코틴아마이드
-lv: nikotīnamīds
-nl: Nicotinamide
-or: ନିକୋଟିନାମାଇଡ଼
-pl: nikotynoamid
-pt: nicotinamida
-ru: Никотинамид
-sh: Nikotinamid
-sr: никотинамид
-tr: Nikotinamid
-uk: Нікотинамід
-vi: Nicotinamide
-zh: 烟酰胺
-# sr-ec:Никотинамид
-# sr-el:Nikotinamid
-# zh-cn:烟酰胺
-# zh-hans:烟酰胺
-# zh-hant:煙醯胺
-# zh-hk:菸鹼醯胺
-# zh-sg:烟酰胺
-# zh-tw:菸鹼醯胺
-wikidata:en: Q192423
-wikipedia:en: https://en.wikipedia.org/wiki/Nicotinamide
-# ingredient/fr:nicotinamide has 172 products in 2 languages @2019-01-16
-
-
-# description:en:Pantothenic acid, also called vitamin B5 (a B vitamin), is a water-soluble vitamin.
-< en:vitamins
-en: Pantothenic acid, vitamin B5, B5
-ar: فيتامين بي5
-bg: Пантотенова киселина, витамин B5, B5
-bs: Vitamin B5
-ca: àcid pantotènic, vitamina B5, B5
-cs: kyselina pantothenová, vitamín B5, B5
-cy: Asid pantothenig, Fitamin B5, B5
-de: Pantothensäure, Vitamin B5, B5
-dv: ވިޓަމިން ބީ5
-eo: Pantotena acido
-es: ácido pantoténico, Vitamina B5, B5
-et: Pantoteenhape, Vitamiin B5, B5
-eu: Azido pantoteniko, B5 bitamina
-fa: ویتامین ب۵
-fi: Pantoteenihappo, B5-vitamiini, B5
-fr: acide pantothénique, Vitamine B5, B5
-ga: Aigéad pantaitéineach
-gl: Ácido pantoténico, Vitamina B5
-he: ויטמין B5
-hi: विटामिन बी५
-hr: pantotenska kiselina, Vitamin B5, B5
-hu: pantoténsav, B5, B5-vitamin
-hy: Պանտոտենաթթու
-id: Asam pantotenat, Vitamin B5
-it: acido pantotenico, Vitamina B5, B5
-ja: パントテン酸, ビタミンB5
-kk: Пантотен қышқылы
-ko: 판토텐산
-ky: Пантотен кычкылы
-lb: Pantothensaier, Vitamin B5
-lt: Pantoteno rūgštis, B5
-lv: pantotēnskābe, B5 vitamīns, B5
-mk: Пантотенска киселина
-ml: പാന്റോത്തിനിക് ആസിഡ്
-mn: Пантотений хүчил
-ms: Asid pantotenik
-nb: pantotensyre
-nl: pantoteenzuur, Pantotheenzuur, B5
-oc: Acid pantotenic, Vitamina B5
-pl: kwas pantotenomy, Witamina B5, B5
-pt: ácido pantoténico, Vitamina b5, B5
-ro: acid pantotenic, vitamina B5, B5
-ru: пантотеновая кислота, Витамин B5, B5
-sh: Vitamin B5
-sk: Kyselina pantoténová, Vitamín B5, B5
-sl: Pantonenska kislina
-sr: Пантотенска киселина, витамин Б5
-sv: pantotensyra, Vitamin B5, B5
-ta: பான்டோதெனிக் அமிலம், உயிர்ச்சத்து பி5
-th: กรดแพนโทเทนิก, วิตามินบี5
-tr: Pantotenik asit, Vitamin B5
-uk: Пантотенова кислота, Вітамін В5
-ur: پینٹوتھینک تیزاب
-vi: Axit pantothenic
-zh: 泛酸
-# azb:پانتوتنیک اسید
-# sco:pantothenic acid
-# sr-ec:Пантотенска киселина, витамин Б5
-# sr-el:Vitamin B5
-# zh-cn:泛酸
-# zh-hans:泛酸
-# zh-hant:泛酸
-# zh-hk:泛酸
-# zh-sg:泛酸
-# zh-tw:泛酸
-wikidata:en: Q179894
-wikipedia:en: https://en.wikipedia.org/wiki/Pantothenic_acid
-# vitamin/pantothenic-acid has 1373 products in 12 languages @2018-11-19
-# fr:acide-pantothénique has 900 products in 9 languages @2018-11-19
-
-
-# description:en:Another common supplemental form of the vitamin is CALCIUM PANTOTHENATE. Calcium pantothenate is often used in dietary supplements because, as a salt, it is more stable than pantothenic acid.
-
-< en:Pantothenic acid
-en: calcium pantothenate
-de: Calcium-Pantothenat
-es: pantotenato de calcio
-fi: kalsiumpantotenaatti, kalsium-d-pantotenaatti
-fr: pantothénate de calcium
-hr: kalcijev pantotenat
-hu: kalcium-pantotenát
-it: pantotenato di calcio
-ja: パントテン酸カルシウム, パントテン酸Ca
-nl: calcium pantothenaat
-nn: kalsiumpantotenat
-wikidata:en: Q27261387
-wikipedia:en: https://en.wikipedia.org/wiki/Pantothenic_acid
-# ingredient/fr:pantothénate-de-calcium has 109 products in 4 languages @2019-04-21
-
-
-# description:en:Vitamin B6 refers to a group of chemically similar compounds which can be interconverted in biological systems.
-# Should this be split up in several chemical compounds?
-
-< en:vitamins
-en: vitamin b6, pyridoxamine, B6
-ar: فيتامين بي6
-az: Piridoksalfosfat
-bg: Витамин B6
-bn: পাইরিডক্সিন
-bs: Vitamin B6
-ca: vitamina B6, piridoxina, B6
-cs: vitamín B6
-da: Vitamin B6
-de: Vitamin B6
-dv: ވިޓަމިން ބީ6
-eo: vitamino B6
-es: vitamina b6, piridoxina, B6
-et: Vitamiin B6
-eu: B6 bitamina
-fa: ویتامین ب۶
-fi: B6-vitamiini, B6, pyridoksamiini
-fr: vitamine b6, B6
-fy: Fitamine B6
-gl: Vitamina B6
-gu: વિટામિન બી૬
-he: B6 ויטמין
-hi: विटामिन बी६
-hr: vitamin B6, B6
-hu: B6-vitamin, Piridoxamin, B6
-hy: Վիտամին B6
-id: Vitamin B6
-it: vitamina B6
-ja: ビタミンB6
-jv: Vitamin B6
-ko: 비타민 B6
-ky: Витамин В6
-lv: B6 vitamīns
-mk: Витамин Б6
-mn: B6 витамин
-ms: Vitamin B6
-my: ဗီတာမင်ဘီ-၆
-ne: भिटामिन बी-६
-nl: vitamine B6
-oc: Vitamina B6
-pl: witamina B6
-pt: vitamina B6, piridoxina
-ro: Vitamina B6
-ru: Витамин B6
-rw: Vitamini B6
-sh: Vitamin B6
-sk: vitamín B6
-sl: Vitamin B6
-sr: vitamin B6
-sv: vitamin B6, B6
-ta: உயிர்ச்சத்து பி6
-th: วิตามินบี6
-uk: Вітамін B6
-uz: Piridoksin
-vi: Vitamin B6
-zh: 维生素B6
-# ast:Vitamina B6
-# en-ca:Vitamin B6
-# en-gb:Vitamin B6
-# pt-br:Vitamina B6
-# sco:Vitamin B6
-# sr-ec:Витамин Б6
-# sr-el:vitamin B6
-# tyv:Витамин Б6
-# zh-cn:维生素B6
-# zh-hans:维生素B6
-# zh-hant:维生素B6
-# zh-hk:维生素B6
-# zh-sg:维生素B6
-# sh-tw:维生素B6
-wikidata:en: Q205130
-wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_B6
-# ingredient/vitamin-b6 has 2556 products in 12 languages  @2018-11-24
-
-< en:vitamin B6
-en: pyridoxine hydrochloride
-bg: пиридоксин хидрохлорид
-de: Pyridoxinhydrochlorid
-es: clorhidrato de piridoxina
-fi: pyridoksiinihydrokloridi
-fr: chlorhydrate de pyridoxine
-hr: piridoksin-hidroklorid, piridoksinhidrohlorid
-hu: Piridoxamin-hidroklorid
-nl: pyridoxine hydrochloride
-pt: cloridrato de piridoxina
-ru: пиридоксин гидрохлорид
-sr: piridoksin-hidrohlorid
-# sr-el:piridoksin-hidrohlorid
-wikidata:en: Q26841284
-# ingredient/pyridoxine-hydrochloride has 1751 products in 5 languages @2018-11-24
-
-
-# description:en:Biotin is a water-soluble B vitamin, also called vitamin B7 and formerly known as vitamin H or coenzyme R.
-
-< en:vitamins
-en: biotin, Vitamin H, Vitamin B7, B7
-ar: بيوتين
-be: біятын
-bg: биотин
-bs: Biotin
-ca: biotina, vitamina B7, Vitamina H, B7
-cs: Biotin, vitamin B7, vitamin H
-cy: Biotin
-da: Biotin
-de: Biotin, Vitamin B7, Vitamin H
-dv: ވިޓަމިން ބީ7
-el: βιοτίνη
-eo: biotino
-es: Biotina, Vitamina B7, Vitamina H, B7, D-biotina
-et: Biotiin, B7-vitamiin, H-vitamiin
-eu: Biotina, B7 bitamina
-fa: بیوتین
-fi: biotiini, B7-vitamiini, B7, H-vitamiini, D-biotiini
-fr: vitamine B7, vitamine H
-ga: Bitin
-gl: Biotina, Vitamina B7
-he: ביוטין
-hi: बायोटिन
-hr: biotin, Vitamin B7, Vitamin H, biotine
-hu: Biotin, B7-vitamin, H-vitamin, B7
-hy: Վիտամին H
-id: Biotin, Vitamin B7, Vitamin H
-it: Biotina, Vitamina B7, Vitamina H
-ja: ビオチン, ビタミンB7, ビタミンH
-kk: Биотин
-ko: 바이오틴, 비타민 B7, 비타민 H
-ky: Биотин
-lb: Biotin, Vitamin B7, Vitamin H
-lt: Biotinas, Vitaminas B7, Vitaminas H
-lv: biotīns
-mk: Биотин
-ml: ബയോട്ടിൻ
-nb: Biotin
-nl: biotine, Vitamine B7, Vitamine H
-nn: biotin
-oc: Biotina, Vitamina B7, Vitamina H
-pl: biotyna, witamina B7, witamina H
-pt: biotina, Vitamina B7, Vitamina H
-ro: Biotină, Vitamina B7, Vitamina H
-ru: биотин, Витамин B7, Витамин H
-sh: Biotin, Vitamin B7, Vitamin H
-sk: Biotín, Vitamín B7, Vitamín H
-sl: Biotin, Vitamin B7, Vitamin H
-sr: Биотин, витамин Х, Витамин Б7
-su: Biotin
-sv: Biotin, B7-vitamin, H-vitamin
-ta: பயோட்டின், உயிர்ச்சத்து பி7
-th: ไบโอติน, ตามินบี7
-tr: Biyotin, B7 vitamini, H vitamini
-uk: Біотин
-vi: Biotin
-zh: 生物素
-# azb:بیوتین
-# sco:biotin
-# sr-ec:Биотин, витамин Х, Витамин Б7
-# sr-el:Vitamin H
-# zh-cn:生物素
-# zh-hans:生物素
-# zh-hant:生物素
-# zh-hk:生物素
-# zh-sg:生物素
-# zh-tw:生物素
-wikidata:en: Q181354
-wikipedia:en: https://en.wikipedia.org/wiki/Biotin
-# ingredient/biotin has 145 products in 3 languages @2018-11-24
-
-< en:vitamins
-en: vitamin b8, B8
-ca: vitamina B8, B8
-de: Vitamin B8
-es: vitamina b8 B8
-fi: B8-vitamiini, B8
-fr: vitamine b8, b8
-hr: vitamin b8
-hu: B8-vitamin, B8
-it: vitamina b8, B8
-pl: witamina B8, B8
-pt: Vitamina B8
-# ingredient/vitamin-b8 has 35 products in 3 languages @2018-11-24
-
-
-
-
-
-
-
-# description:en:Vitamin K is a group of structurally similar, fat-soluble vitamins that the human body requires
-# for complete synthesis of certain proteins that are prerequisites for blood coagulation
-# and which the body also needs for controlling binding of calcium in bones and other tissues.
-
-< en:vitamins
-en: vitamin K
-af: Vitamien K
-ar: فيتامين ك
-az: K vitamini
-bg: Витамин K
-bs: Vitamin K
-ca: Vitamina K
-cs: vitamín K
-da: Vitamin K
-de: Vitamin K
-dv: ވިޓަމިން ކޭ
-es: Vitamina K
-eu: K bitamina
-fa: ویتامین کا
-fi: K-vitamiini, K-vitamiinit
-fr: vitamine K
-gl: Vitamina K
-he: ויטמין K
-hi: विटामिन के
-hr: vitamin K
-hu: K-vitamin
-hy: Վիտամին K
-id: Vitamin K
-is: K-vítamín
-it: vitamina K
-ja: ビタミンK
-jv: Vitamin K
-ka: ვიტამინი K
-ko: 비타민 K
-ky: Витамин К
-lt: Vitaminas K
-lv: K vitamīns
-ml: ജീവകം കെ
-mr: के-जीवनसत्त्व
-ms: Vitamin K
-my: ဗီတာမင်ကေ
-nb: Vitamin K
-ne: भिटामिन के
-nl: vitamine K
-nn: Vitamin K
-oc: Vitamina K
-pl: Witamina K
-pt: vitamina K
-ro: Vitamina K
-ru: Витамин K
-sh: Vitamin K
-sl: Vitamin K
-sr: витамин К
-su: Vitamin K
-sv: K-vitamin
-ta: உயிர்ச்சத்து கே
-th: วิตามินเค
-tr: K vitamini
-uk: Вітамін K
-vi: Vitamin K
-zh: 维生素K
-# ast:Vitamina K
-# nan:Bî-tá-mín K
-# sco:Vitamin K
-# sr-ec:витамин К
-# sr-el:vitamin K
-# tyv:Витамин К
-# zh-cn:维生素K
-# zh-hans:维生素K
-# zh-hant:维生素K
-# zh-hk:维生素K
-# zh-sg:维生素K
-# zh-tw:维生素K
-wikidata:en: Q182338
-wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_K
-# ingredient/vitamin-k has 85 products in 4 languages @2018-11-25
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -17543,10 +16896,10 @@ it: olio di sansa di oliva raffinato
 pl: rafinowana oliwa z wytłoczyn z oliwek, rafinowana oliwa z wytłoczyn oliwek
 
 
-#  comment:en:Beware of a confusion between the generic name (rapeseed oil) and more specific oil varieties: colza oil and canola oil. 
-#    Not all languages distinguish between the two. Probably where rapeseed is given, colza is meant. 
-#    The difference between the two oils is important due to different levels of erucic acid. 
-#    It seems that only the oils with a low erucic acid percentage are fit for humans. So the naming difference between rapeseed, 
+#  comment:en:Beware of a confusion between the generic name (rapeseed oil) and more specific oil varieties: colza oil and canola oil.
+#    Not all languages distinguish between the two. Probably where rapeseed is given, colza is meant.
+#    The difference between the two oils is important due to different levels of erucic acid.
+#    It seems that only the oils with a low erucic acid percentage are fit for humans. So the naming difference between rapeseed,
 #    colza and canola might just be a language issue.
 
 < en:vegetable oil and fat

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -12,51 +12,109 @@
 # http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32013R0609&from=FR
 
 
-en: Vitamin A
-bg: Витамин А
-de: Vitamin A
-el: Βιταμίνη A
-es: Vitamina A
-et: A-vitamiin
-fi: A-vitamiini
-fr: Vitamine A, vitamine Pro-A
-he: ויטמין A, רטינול
-hu: A-vitamin
-it: Vitamina A
-ja: ビタミンA, ビタミンＡ, ビタミン A, ビタミン Ａ, V.A, Ｖ．Ａ, V-A, ＶーＡ
-lt: Vitaminas A
-lv: A vitamīns
-mt: Vitamina A
-nl: Vitamine A
-pl: Witamina A
-pt: Vitamina A
-ro: Vitamina A
-sk: Vitamín A
-zh: 维生素A
-wikidata:en: Q18225
+# description:en:Vitamin A is a group of unsaturated nutritional organic compounds that includes retinol, retinal, retinoic acid
+# and several provitamin A carotenoids (most notably beta-carotene).
 
-< en:Vitamin A
+en: vitamin A
+xx: vitamin A, A vitamin
+af: vitamien A
+ar: ﻒﻴﺗﺎﻤﻴﻧ ﺄﻠﻓ
+az: A vitamini
+bg: витамин А
+ca: vitamina A
+cs: vitamín A
+cy: fitamin A
+de: Vitamin A
+dv: ވިޓަމިން އޭ
+el: вιταμίνη A
+eo: vitamino A
+es: vitamina A
+et: A-vitamiin
+eu: A bitamina
+fa: ﻮﯿﺗﺎﻤﯿﻧ ﺁ
+fi: A-vitamiini
+fo: A vitamin
+fr: vitamine A, vitamine Pro-A
+gl: vitamina A
+he: ויטמין A, רטינול
+hi: विटामिन ए
+hu: A-vitamin
+is: A-vítamín
+it: vitamina A
+ja: ビタミンA, ビタミンＡ, ビタミン A, ビタミン Ａ, V.A, Ｖ．Ａ, V-A, ＶーＡ
+ka: ვიტამინი A
+kn: ಎ ಜೀವಸತ್ವ
+ko: 비타민 A
+lt: vitaminas A
+lv: A vitamīns
+mk: витамин А
+ml: ജീവകം എ
+mn: витамин А
+mr: अ-जीवनसत्त्व
+mt: vitamina A
+ne: भिटामिन ए
+nl: vitamine A
+nn: vitamin A, A-vitamin
+oc: vitamina A
+or: ଜୀବସାର କ
+pa: ਵਿਟਾਮਿਨ ਏ
+pl: witamina A
+ps: ﻮﻳټﺎﻤﻴﻧ ﺍې
+pt: vitamina A
+ro: vitamine A, vitamina A
+ru: витамин А
+rw: vitamini A
+si: විටමින් A
+sk: vitamín A
+sq: vitamina A
+sw: vitamini A
+ta: உயிர்ச்சத்து ஏ
+te: విటమిన్ ఎ
+th: วิตามินเอ
+tr: A vitamini
+tt: А витамины
+ug: ۋﻰﺗﺎﻣﻰﻧ A
+uk: вітамін A
+ur: ﺮﯿﺋٹﻥﻮﻟ
+zh: 维生素A
+# ast:vitamina A
+# jbo:abumoi mivytcuxu'i
+# kk-cyrl:А витамині
+# kk-kz:А витамині
+# lfn:vitamina A
+# pt-br:vitamin A
+# scn:vitamina A
+# sr-ec:витамин А
+# sr-el:vitamin A
+# tyv:А витамины
+# wuu:维生素A
+# zh-hans:维生素A
+# zh-hant:維生素A
+wikidata:en: Q18225
+wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_A
+# vitamin/vitamin-a has 1768 products in 17 languages @2018-11-20
+
+< en:vitamin A
 en: retinol
+xx: retinol, vitamin A (retinol)
 bg: Ретинол
-de: Retinol
+ca: retinol, vitamina A (Retinol)
+de: Retinol, Vitamin A (Retinol)
 el: ρετινόλη
-es: retinol
+es: retinol, vitamina A (retinol)
 et: retinool
 fi: retinoli
-fr: rétinol
-hu: retinol
-it: retinolo
+fr: rétinol, vitamine A (rétinol)
+it: retinolo, vitamina A (retinolo)
 lt: retinolis
 lv: retinols
-nl: retinol
 wikidata:en: Q424976
 
 # description:en:Retinyl acetate (retinol acetate, vitamin A acetate) is a natural form of vitamin A which is the acetate ester of retinol.
 
-
-< en:Vitamin A
+< en:vitamin A
 en: retinyl acetate, retinol acetate, vitamin A acetate
-bg: Ретинил ацетат
+bg: ретинил ацетат
 ca: acetat de retinol
 cs: retinyl-acetát
 de: Retinylacetat
@@ -87,7 +145,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Retinyl_acetate
 
 # description:en:Retinyl palmitate, or vitamin A palmitate, is the ester of retinol (vitamin A) and palmitic acid, with formula C36H60O2.
 
-< en:Vitamin A
+< en:vitamin A
 en: retinyl palmitate, Vitamin A palmitate, palmitate
 bg: Ретинил палмитат
 cs: retinyl-palmitát
@@ -120,7 +178,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Retinyl_palmitate
 
 # description:en:β-Carotene is an organic, strongly colored red-orange pigment abundant in plants and fruits. Plant carotenoids are the primary dietary source of provitamin A worldwide, with β-carotene as the best-known provitamin A carotenoid.
 
-< en:Vitamin A
+< en:vitamin A
 #<en:carotene
 en: beta-carotene
 bg: Бета каротин
@@ -636,26 +694,74 @@ sk: D-alfa –tokoferolpolyetylénglykol-1000 sukcinát, TPGS
 sl: D-alfa-tokoferil polietilen glikol-1000 sukcinat, TPGS
 sv: D-alfa-tokoferyl-polyetylenglykol 1000 succinat, TPGS
 
-en: Vitamin K
-bg: Витамин K
-el: Βιταμίνη K
-es: Vitamina K
-et: K-vitamiin
-fi: K-vitamiini
-fr: Vitamine K
-hu: K-vitamin
-it: Vitamina K
-ja: ビタミンK, ビタミンＫ, ビタミン K, ビタミン Ｋ, V.K, Ｖ．Ｋ, V-K, ＶーＫ
-lt: Vitaminas K
-lv: K vitamīns
-mt: Vitamina K
-nl: Vitamine K
-pl: Witamina K
-pt: Vitamina K
-ro: Vitamina K
-sk: Vitamín K
+# description:en:Vitamin K is a group of structurally similar, fat-soluble vitamins that the human body requires
+# for complete synthesis of certain proteins that are prerequisites for blood coagulation
+# and which the body also needs for controlling binding of calcium in bones and other tissues.
 
-< en:Vitamin K
+en: vitamin K
+xx: vitamin K, K vitamin
+af: vitamien K
+ar: فيتامين ك
+az: K vitamini
+bg: витамин K
+ca: vitamina K
+cs: vitamín K
+de: Vitamin K
+dv: ވިޓަމިން ކޭ
+el: βιταμίνη K
+es: vitamina K
+et: K-vitamiin
+eu: K bitamina
+fa: ویتامین کا
+fi: K-vitamiini, K-vitamiinit
+fr: vitamine K
+gl: vitamina K
+he: ויטמין K
+hi: विटामिन के
+hu: K-vitamin
+hy: Վիտամին K
+is: K-vítamín
+it: vitamina K
+ja: ビタミンK, ビタミンＫ, ビタミン K, ビタミン Ｋ, V.K, Ｖ．Ｋ, V-K, ＶーＫ
+ka: ვიტამინი K
+ko: 비타민 K
+ky: витамин К
+lt: vitaminas K
+lv: K vitamīns
+ml: ജീവകം കെ
+mr: के-जीवनसत्त्व
+mt: vitamina K
+my: ဗီတာမင်ကေ
+ne: भिटामिन के
+nl: vitamine K
+oc: vitamina K
+pl: witamina K
+pt: vitamina K
+ro: vitamina K
+ru: витамин K
+sk: vitamín K
+sr: витамин К
+sv: K-vitamin
+ta: உயிர்ச்சத்து கே
+th: วิตามินเค
+tr: K vitamini
+uk: вітамін K
+zh: 维生素K
+# ast:Vitamina K
+# nan:Bî-tá-mín K
+# sr-ec:витамин К
+# tyv:Витамин К
+# zh-cn:维生素K
+# zh-hans:维生素K
+# zh-hant:维生素K
+# zh-hk:维生素K
+# zh-sg:维生素K
+# zh-tw:维生素K
+wikidata:en: Q182338
+wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_K
+# ingredient/vitamin-k has 85 products in 4 languages @2018-11-25
+
+< en:vitamin K
 en: phylloquinone, phytomenadione, Vitamin K1
 xx: K1
 ar: فايتوميناديون
@@ -698,16 +804,16 @@ wikipedia:en: https://en.wikipedia.org/wiki/Phytomenadione
 # ingredient/fr:k1 has 79 products@2019-04-16
 # vitamin/phylloquinone has 180 products in 8 languages @2019-4-16
 
-< en:Vitamin K
-en: Menaquinone, Vitamin K2
-bg: Менахинон
+< en:vitamin K
+en: menaquinone, vitamin K2
+bg: менахинон
 cs: menachinon
 de: Menachinon
 el: μενακινόνη
 es: menaquinona
 et: menakinoon
 fi: menakinoni
-fr: ménaquinone, Vitamine K2
+fr: ménaquinone, vitamine K2
 hu: menakinon
 it: menachinone
 ja: ビタミンK2, ビタミンＫ２, ビタミン K2, ビタミン Ｋ２, V.K2, Ｖ．Ｋ２, V.K₂, V-K2, ＶーＫ２, V-K₂
@@ -1103,50 +1209,133 @@ vegan:en: maybe
 vegetarian:en: maybe
 # ingredient/fr:mononitrate-de-thiamine has 83 products in 4 languages @2019-03-11
 
-en: Riboflavin, Vitamin B2
-bg: Рибофлавин
-da: Riboflavin
-el: Ριβοφλαβίνη
-es: Riboflavina, Vitamina B2
-et: Riboflaviin
-fi: Riboflaviini
-fr: Riboflavine, Vitamine B2
-hu: Riboflavin, B2-vitamin
-it: Riboflavina
+# description:en:Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement.
+
+en: riboflavin, vitamin B2
+xx: riboflavin, vitamin B2, B2 vitamin, E101, B2
+af: Riboflavien
+ar: ﻒﻴﺗﺎﻤﻴﻧ ﺏ2
+be: Рыбафлавін
+bg: Рибофлавин, Витамин B2
+bn: রিবোফ্লেবিন
+bs: vitamin B2
+ca: riboflavina, vitamina B2
+cs: riboflavin, vitamín B2
+cy: ribofflafin, fitamin B2
+de: Riboflavin, Vitamin B2
+dv: ވިޓަމިން ބީ2
+el: ριβοφλαβίνη, βιταμίνη Β2
+eo: riboflavino, vitamino B2
+es: riboflavina, vitamina B2
+et: riboflaviin, vitamiin B2
+eu: B2 bitamina
+fa: ﻮﯿﺗﺎﻤﯿﻧ ﺏ۲
+fi: riboflaviini
+fr: riboflavine, vitamine B2
+ga: ribeaflaivin
+gl: riboflavina, vitamina B2
+he: ויטמין B2
+hi: रिबोफ्लेविन, विटामिन बी२
+hu: riboflavin, B2-vitamin
+hy: Վիտամին B2
+it: riboflavina, vitamina B2
 ja: リボフラビン, ビタミンB2, ビタミンＢ２, ビタミン B2, ビタミン Ｂ２, V.B2, Ｖ．Ｂ２, V.B₂, V-B2, ＶーＢ２, V-B₂
-lt: Riboflavinas
-lv: Riboflavīns
-nl: Riboflavine
-pl: Ryboflawina
-pt: Riboflavina
-ro: Riboflavină
-sv: Riboflavin
+kk: Рибофлавин
+ko: 리보플래빈, 바이타민 B2
+ky: Рибофлавин, Витамин В2
+lt: riboflavinas
+lv: riboflavīns, B2 vitamīns
+mk: Рибофлавин
+ml: റൈബോഫ്ലേവിൻ
+mt: riboflavina
+ne: भिटामिन बी-२
+nl: riboflavine, vitamine B2
+oc: riboflavina, vitamina B2
+or: ରାଇବୋଫ୍ଲାଭିନ, ଜୀବସାର ଖ୨
+pl: ryboflawina, ryboflawiny, witamina B2
+pt: riboflavina, vitamina B2
+ro: riboflavină, vitamina B2
+ru: рибофлавин, Витамин B2
+rw: vitamini B2
+sh: Vitamin B2
+sk: Riboflavín, Vitamín B2
+ta: ரிபோஃபிளாவின்
+th: ไรโบเฟลวิน
+tr: riboflavin, B2 vitamini
+uk: Рибофлавін, Вітамін B2
+wa: riboflavene, vitamene B2
+zh: 核黄素
+vegan:en: maybe
+# ingredient/vitamin-b2 has 4263 products in 10 languages @2018-11-23
+vegetarian:en: yes
+# ast:Vitamina B2
+# be-tarask:Рыбафлявін
+# de-ch:Riboflavin
+# pt-br:riboflavina
+# sr-ec:витамин Б2
+# sr-el:riboflavin, vitamin B2
+# tyv:Витамин В2
+# zh-cn:核黄素
+# zh-hans:核黄素
+# zh-hant:核黄素
+# zh-hk:核黄素
+# zh-sg:核黄素
+# zh-tw:核黄素
+wikidata:en: Q130365
+wikipedia:en: https://en.wikipedia.org/wiki/Riboflavin
 
-en: Niacin, Vitamin B3, Vitamin PP
-bg: Ниацин
-el: Νιασίνη
-es: Niacina, Vitamina B3
-et: Niatsiin
-fi: Niasiini
-fr: Niacine, Vitamine B3, Vitamine PP
-hr: niacin, Vitamin B3, nijacin
-hu: Niacin, B3-vitamin, PP-vitamin
-it: Niacina
-ja: ナイアシン, ビタミンB3, ビタミンＢ３, ビタミン B3, ビタミン Ｂ３, V.B3, Ｖ．Ｂ３, V.B₃, V-B3, ＶーＢ３, V-B₃
-lt: Niacinas
-lv: Niacīns
-mt: Niaċina
-nb: Niacin
-nl: Niacine
-pl: Niacyna, witamina B3, witamina PP
-pt: Niacina
-ro: Niacină
-sk: Niacín
-sv: Niacin
+# description:en:Niacin, also known as nicotinic acid, is an organic compound and a form of vitamin B3, an essential human nutrient.
 
-< en:Niacin
+en: niacin, vitamin B3, vitamin PP
+xx: niacin, vitamin B3, B3 vitamin, vitamin PP, E375, B3, PP
+af: niasien
+ar: ﻦﻳﺎﺴﻴﻧ
+be: нікацінавая кіслата
+bg: ниацин, витамин B3, витамин PP
+bs: vitamin B3
+ca: niacina, vitamina B3, vitamina PP
+cs: niacin, vitamín B3, vitamín PP
+cy: niacin, fitamin B3
+de: Niacin, Vitamin B3
+dv: ވިޓަމިން ބީ3
+el: νιασίνη
+eo: niacino, vitamino B3
+es: niacina, vitamina B3, vitamina PP
+et: niatsiin, vitamiin B3
+eu: niazina, B3 bitamina
+fa: ﻮﯿﺗﺎﻤﯿﻧ ﺏ۳
+fi: niasiini, B3-vitamiini
+fr: niacine, vitamine B3, vitamine PP
+ga: aigéad nicitíneach
+gl: niacina, vitamina B3
+he: ויטמין B3
+hi: नाइयासिन
+hr: niacin, vitamin B3, nijacin
+hu: niacin, B3-vitamin, PP-vitamin
+hy: վիտամին B3
+id: niasin, vitamin B3
+it: niacina, vitamina PP
+ja: ナイアシン, ビタミンB3, ビタミンPP, ビタミンＢ３, ビタミン B3, ビタミン Ｂ３, V.B3, Ｖ．Ｂ３, V.B₃, V-B3, ＶーＢ３, V-B₃
+lt: niacinas
+lv: niacīns
+mt: niaċina
+nl: niacine, vitamine B3, vitamine PP
+pl: niacyna, witamina B3, witamina PP
+pt: niacina
+ro: niacină
+ru: ниацин, витамин B3, витамин PP
+sk: niacín
+# ast:vitamina B3
+# azb:ﻮﯿﺗﺎﻤﯿﻧ ﺏ۳
+# en-ca:niacin
+# en-gb:niacin
+wikidata:en: Q134658
+wikipedia:en: https://en.wikipedia.org/wiki/Niacin
+# ingredient/vitamin-b3 has 744 products in 8 languages @2018-11-23
+
+< en:niacin
 en: nicotinic acid
-bg: Никотинова киселина
+bg: никотинова киселина
 cs: kyselina nikotinová
 de: Nicotinsäure
 el: νικοτινικό οξύ
@@ -1163,57 +1352,158 @@ nl: nicotinezuur
 pl: kwas nikotynowy
 pt: ácido nicotínico
 ro: acid nicotinic
+ru: никотиновая кислота
 sk: kyselina nikotínová
 sl: nikotinska kislina
 sv: nikotinsyra
+wikidata:en: Q134658
 
-< en:Niacin
-en: nicotinamide
-bg: Никотинамид
+# description:en:Nicotinamide (NAM), also known as niacinamide, is a form of vitamin B3 found in food and used as a dietary supplement and medication.
+
+< en:niacin
+en: nicotinamide, niacinamide
+ar: ﻦﻴﻛﻮﺘﻴﻧﺎﻤﻳﺩ
+bg: никотинамид
+ca: niacinamida
 cs: nikotinamid
+cy: nicotinamid
 de: Nicotinamid
-el: νικοτιναμίδιο
+el: νικοτιναμίδη, νικοτιναμίδιο
+eo: nikotinamido
 es: nicotinamida
 et: nikotiinamiid
-fi: nikotiiniamidi
+fi: nikotiiniamidi, niasiiniamidi
+fr: nicotinamide, niacinamide
+hi: निकोटिनामाइड
+hr: nikotinamid
 hu: nikotinamid
+hy: Նիկոտինամիդ
+id: nikotinamida
 it: nicotinamide
+ja: ニコチンアミド
+ko: 니코틴아마이드
 lt: nikotinamidas
 lv: nikotīnamīds
 mt: nikotinamide
 nl: nicotinamide
-pl: nikotynamid, amid kwasu nikotynowego
+or: ନିକୋଟିନାମାଇଡ଼
+pl: nikotynoamid, nikotynamid, amid kwasu nikotynowego
 pt: nicotinamida
 ro: nicotinamidă
+ru: Никотинамид
+sh: nikotinamid
 sk: nikotínamid
 sl: nikotinamid
+sr: никотинамид
 sv: nikotinamid
+tr: nikotinamid
+uk: Нікотинамід
+vi: nicotinamide
+zh: 烟酰胺
+# sr-ec:Никотинамид
+# sr-el:Nikotinamid
+# zh-cn:烟酰胺
+# zh-hans:烟酰胺
+# zh-hant:煙醯胺
+# zh-hk:菸鹼醯胺
+# zh-sg:烟酰胺
+# zh-tw:菸鹼醯胺
+wikidata:en: Q192423
+wikipedia:en: https://en.wikipedia.org/wiki/Nicotinamide
+# ingredient/fr:nicotinamide has 172 products in 2 languages @2019-01-16
 
-en: Vitamin B6, Pyridoxin
-bg: Витамин B6, Пиридоксин
-de: Vitamin B6, Pyridoxin, B6
-el: Βιταμίνη B6
-es: Vitamina B6
-et: B6-vitamiin
+# description:en:Vitamin B6 refers to a group of chemically similar compounds which can be interconverted in biological systems.
+
+en: vitamin B6
+xx: vitamin B6, B6 vitamin, B6, pyridoxal 5′-phosphate
+ar: فيتامين بي6
+az: piridoksalfosfat
+bg: витамин B6
+bn: পাইরিডক্সিন
+ca: vitamina B6
+cs: vitamín B6
+de: Vitamin B6
+dv: ވިޓަމިން ބީ6
+el: βιταμίνη B6
+eo: vitamino B6
+es: vitamina B6
+et: B6-vitamiin, vitamiin B6
+eu: B6 bitamina
+fa: ویتامین ب۶
 fi: B6-vitamiini
-fr: Vitamine B6, Pyridoxine
-hr: vitamin B6, B6
-hu: B6-vitamin, piridoxin
-it: Vitamina B6, piridoxina
+fr: vitamine B6
+fy: fitamine B6
+gl: vitamina B6
+gu: વિટામિન બી૬
+he: B6 ויטמין
+hi: विटामिन बी६
+hu: B6-vitamin
+hy: Վիտամին B6
+it: vitamina B6
 ja: ビタミンB6, ビタミンＢ６, ビタミン B6, ビタミン Ｂ６, V.B6, Ｖ．Ｂ６, V.B₆, V-B6, ＶーＢ６, V-B₆
-lt: Vitaminas B6
+ko: 비타민 B6
+ky: витамин В6
+lt: vitaminas B6
 lv: B6 vitamīns
-mt: Vitamina B6
-nl: Vitamine B6
-pl: Witamina B6
-pt: Vitamina B6
-ro: Vitamina B6
-sk: Vitamín B6
+mk: витамин Б6
+mn: B6 витамин
+mt: vitamina B6
+my: ဗီတာမင်ဘီ-၆
+ne: भिटामिन बी-६
+nl: vitamine B6
+oc: vitamina B6
+pl: witamina B6
+pt: vitamina B6
+ro: vitamina B6
+ru: витамин B6
+rw: vitamini B6
+sk: vitamín B6
+ta: உயிர்ச்சத்து பி6
+th: วิตามินบี6
+uk: вітамін B6
 zh: 维生素B6
+# ast:vitamina B6
+# pt-br:vitamina B6
+# sr-ec:витамин Б6
+# tyv:витамин Б6
+# zh-cn:维生素B6
+# zh-hans:维生素B6
+# zh-hant:维生素B6
+# zh-hk:维生素B6
+# zh-sg:维生素B6
+# sh-tw:维生素B6
+wikidata:en: Q205130
+wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_B6
+# ingredient/vitamin-b6 has 2556 products in 12 languages  @2018-11-24
 
-< en:Vitamin B6
+< en:vitamin B6
+en: pyridoxine
+xx: pyridoxin
+ar: بيريدوكسين
+bg: пиридоксин
+ca: piridoxina
+de: Pyridoxin
+es: piridoxina
+fr: pyridoxine
+hu: piridoxin
+it: piridoxina
+nb: pyridoksin
+nn: pyridoksin
+pt: piridoxina
+uz: piridoksin
+wikidata:en: Q423746
+
+< en:vitamin B6
+en: pyridoxamine
+xx: pyridoxamin
+de: Pyridoxamin
+fi: pyridoksamiini
+hu: piridoxamin
+wikidata:en: Q2541149
+
+< en:vitamin B6
 en: pyridoxine hydrochloride
-bg: Пиридоксин хидрохлорид
+bg: пиридоксин хидрохлорид
 cs: pyridoxin-hydrochlorid
 de: Pyridoxinhydrochlorid
 el: υδροχλωρική πυριδοξίνη
@@ -1221,30 +1511,39 @@ es: clorhidrato de piridoxina
 et: püridoksiinvesinikkloriid
 fi: pyridoksiinihydrokloridi
 fr: chlorhydrate de pyridoxine
-hr: piridoksin-hidroklorid
+hr: piridoksin-hidroklorid, piridoksinhidrohlorid
 hu: piridoxin-hidroklorid
 it: cloridrato di piridossina
 lt: piridoksino hidrochloridas
 lv: piridoksīna hidrohlorīds
 mt: idroklorur tal-piridossina
-nl: pyridoxinehydrochloride
+nl: pyridoxinehydrochloride, pyridoxine hydrochloride
 pl: chlorowodorek pirydoksyny
 pt: cloridrato de piridoxina
 ro: clorhidrat de piridoxină
+ru: пиридоксин гидрохлорид
 sk: pyridoxínhydrochlorid
 sl: piridoksin hidroklorid
+sr: piridoksin-hidrohlorid
 sv: pyridoxinhydroklorid
+# sr-el:piridoksin-hidrohlorid
+wikidata:en: Q26841284
+# ingredient/pyridoxine-hydrochloride has 1751 products in 5 languages @2018-11-24
 
-< en:Vitamin B6
+< en:vitamin B6
+en: pyridoxamine hydrochloride
+hu: piridoxamin-hidroklorid
+wikidata:en: Q27225158
+
+< en:vitamin B6
 en: pyridoxine 5'-phosphate
 hu: pirodoxál-5-foszfát
 it: piridossalfosfato, piridossal fosfato, piridossal-5'-fosfato
 nl: pyridoxine-5'-fosfaat
 
-
-< en:Vitamin B6
+< en:vitamin B6
 en: pyridoxine dipalmitate
-bg: Пиридоксин дипалмитат
+bg: пиридоксин дипалмитат
 cs: pyridoxin-dipalmitát
 de: Pyridoxindipalmitat
 el: διπαλμιτική πυριδοξίνη
@@ -1532,78 +1831,195 @@ sk: hydroxokobalamín
 sl: hidroksokobalamin
 sv: hydroxykobalamin
 
-en: biotin
-bg: Биотин
-de: Biotin, Vitamin B7
-el: Βιοτίνη
-es: Biotina, Vitamina B7
-et: Biotiin
-fi: Biotiini
-fr: Biotine, Vitamine B7, Vitamine H
-hr: biotin
-hu: Biotin, B7-vitamin, H-vitamin
-it: Biotina
-lt: Biotinas
-lv: Biotīns
-mt: Bijotina
-nl: Biotine
-pl: Biotyna
-pt: Biotina
-ro: Biotină
-sk: Biotín
+# description:en:Biotin is a water-soluble B vitamin, also called vitamin B7 and formerly known as vitamin H or coenzyme R.
 
-< en:Biotin
-en: D-Biotin
-de: D-biotin
+en: biotin
+xx: biotin, vitamin B7, B7 vitamin, B7, vitamin H, H vitamin
+ar: بيوتين
+be: біятын
+bg: биотин
+ca: biotina, vitamina B7, vitamina H
+cs: biotin, vitamin B7, vitamin H
+de: Biotin, Vitamin B7, Vitamin H
+dv: ވިޓަމިން ބީ7
+el: βιοτίνη
+eo: biotino
+es: biotina, vitamina B7, vitamina H
+et: biotiin, B7-vitamiin, H-vitamiin
+eu: biotina, B7 bitamina
+fa: بیوتین
+fi: biotiini, B7-vitamiini, H-vitamiini
+fr: biotine, vitamine B7, vitamine H
+ga: bitin
+gl: biotina, vitamina B7
+he: ביוטין
+hi: बायोटिन
+hr: biotin, biotine
+hu: biotin, B7-vitamin, H-vitamin
+hy: Վիտամին H
+it: biotina, vitamina B7, vitamina H
+ja: ビオチン, ビタミンB7, ビタミンH
+kk: биотин
+ko: 바이오틴, 비타민 B7, 비타민 H
+ky: биотин
+lt: biotinas, vitaminas B7, vitaminas H
+lv: biotīns
+mk: биотин
+ml: ബയോട്ടിൻ
+mt: bijotina
+nl: biotine, vitamine B7, vitamine H
+oc: biotina, vitamina B7, vitamina H
+pl: biotyna, witamina B7, witamina H
+pt: biotina, vitamina B7, vitamina H
+ro: biotină, vitamina B7, vitamina H
+ru: биотин, витамин B7, витамин H
+sh: biotin, vitamin B7, vitamin H
+sk: biotín, vitamín B7, vitamín H
+sl: biotin, vitamin B7, vitamin H
+sr: биотин, витамин Х, витамин Б7
+sv: biotin, B7-vitamin, H-vitamin
+ta: பயோட்டின், உயிர்ச்சத்து பி7
+th: ไบโอติน, ตามินบี7
+tr: biyotin, B7 vitamini, H vitamini
+uk: біотин
+zh: 生物素
+# azb:بیوتین
+# sr-ec:биотин, витамин Х, Витамин Б7
+# sr-el:vitamin H
+# zh-cn:生物素
+# zh-hans:生物素
+# zh-hant:生物素
+# zh-hk:生物素
+# zh-sg:生物素
+# zh-tw:生物素
+wikidata:en: Q181354
+wikipedia:en: https://en.wikipedia.org/wiki/Biotin
+# ingredient/biotin has 145 products in 3 languages @2018-11-24
+
+< en:biotin
+en: D-biotin
+xx: D-biotin
+de: D-Biotin
+es: D-biotina
+fi: D-biotiini
 hr: D-biotin
 hu: D-biotin
-it: D-Biotina
+it: D-biotina
 nl: D-biotine
 
 # description:en:Vitamin B8 is a former designation given to several distinct chemical compounds, which is not considered a true vitamin
 
 < en:biotin
-en: vitamin b8, B8
-bg: витамин b8, витамин Б8, B8, инозитол
-ca: vitamina B8, B8
+en: vitamin B8
+xx: vitamin B8, B8 vitamin, B8
+bg: витамин b8, витамин Б8, инозитол
+ca: vitamina B8
 de: Vitamin B8
-es: vitamina b8, B8
-fi: B8-vitamiini, B8
-fr: vitamine b8, b8
-hu: B8-vitamin, B8
-it: vitamina b8, B8
+es: vitamina b8
+fi: B8-vitamiini
+fr: vitamine B8
+hu: B8-vitamin
+it: vitamina B8
 ja: ビタミンＢ８, ビタミン B8, ビタミン Ｂ８, V.B8, Ｖ．Ｂ８, V.B₈, V-B8, ＶーＢ８, V-B₈
-nl: vitamine b8, B8
-pl: witamina B8, B8
+nl: vitamine B8
+pl: witamina B8
+pt: vitamina B8
+wikidata:en: Q25113695
 # ingredient/vitamin-b8 has 35 products in 3 languages @2018-11-24
 
-en: Pantothenic Acid, Vitamin B5
-bg: Пантотенова киселина, Витамин B5
-cs: Kyselina pantothenová
-da: Pantotensyre, Pantothensyre
-de: Pantothensäure, Pantothenat
-el: Παντοθενικό οξύ
-es: Ácido pantoténico
-et: Pantoteenhape
-fi: Pantoteenihappo
-fr: Acide pantothénique, Vitamine B5
-hr: vitamin B5
-hu: Panoténsav, B5-vitamin
-it: Acido pantotenico
-ja: パントテン酸, ビタミンＢ５, ビタミン B5, ビタミン Ｂ５, V.B5, Ｖ．Ｂ５, V.B₅, V-B5, ＶーＢ５, V-B₅
-lt: Pantoteno rūgštis
-lv: Pantotēn-skābe
-mt: Aċidu Pantoteniku
-nl: Pantotheenzuur
-pl: Kwas pantotenowy
-pt: Ácido pantoténico
-ro: Acid pantotenic
-sk: Kyselina pantoténová
-sl: Pantotenska kislina
-sv: Pantotensyra
+# description:en:Pantothenic acid, also called vitamin B5 (a B vitamin), is a water-soluble vitamin.
 
-< en:Pantothenic Acid
-en: D-pantothenate calcium
+en: pantothenic acid
+xx: vitamin B5, B5 vitamin, B5
+ar: فيتامين بي5
+bg: пантотенова киселина, витамин B5
+ca: àcid pantotènic, vitamina B5
+cs: kyselina pantothenová, vitamín B5
+cy: asid pantothenig, fitamin B5
+da: pantotensyre, pantothensyre
+de: Pantothensäure, Pantothenat, Vitamin B5
+dv: ވިޓަމިން ބީ5
+el: παντοθενικό οξύ
+eo: pantotena acido
+es: ácido pantoténico, vitamina B5
+et: pantoteenhape, vitamiin B5
+eu: azido pantoteniko, B5 bitamina
+fa: ویتامین ب۵
+fi: pantoteenihappo, B5-vitamiini
+fr: acide pantothénique, vitamine B5
+ga: aigéad pantaitéineach
+gl: ácido pantoténico, vitamina B5
+he: ויטמין B5
+hi: विटामिन बी५
+hr: pantotenska kiselina
+hu: pantoténsav, panoténsav, B5-vitamin
+hy: Պանտոտենաթթու
+id: asam pantotenat
+it: acido pantotenico, vitamina B5
+ja: パントテン酸, ビタミンB5, ビタミンＢ５, ビタミン B5, ビタミン Ｂ５, V.B5, Ｖ．Ｂ５, V.B₅, V-B5, ＶーＢ５, V-B₅
+kk: пантотен қышқылы
+ko: 판토텐산
+ky: пантотен кычкылы
+lb: pantothensaier
+lt: pantoteno rūgštis
+lv: pantotēn-skābe, pantotēnskābe, B5 vitamīns
+mk: пантотенска киселина
+ml: പാന്റോത്തിനിക് ആസിഡ്
+mn: пантотений хүчил
+ms: asid pantotenik
+mt: aċidu pantoteniku
+nb: pantotensyre
+nl: pantoteenzuur, pantotheenzuur
+oc: acid pantotenic, vitamina B5
+pl: kwas pantotenowy, kwas pantotenomy, witamina B5
+pt: ácido pantoténico, vitamina b5
+ro: acid pantotenic, vitamina B5
+ru: пантотеновая кислота, витамин B5
+sk: kyselina pantoténová, vitamín B5
+sl: pantonenska kislina
+sr: пантотенска киселина, витамин Б5
+sv: pantotensyra
+ta: பான்டோதெனிக் அமிலம், உயிர்ச்சத்து பி5
+th: กรดแพนโทเทนิก, วิตามินบี5
+tr: pantotenik asit, vitamin B5
+uk: пантотенова кислота, вітамін В5
+ur: پینٹوتھینک تیزاب
+vi: axit pantothenic
+zh: 泛酸
+# azb:پانتوتنیک اسید
+# sco:pantothenic acid
+# sr-ec:Пантотенска киселина, витамин Б5
+# sr-el:Vitamin B5
+# zh-cn:泛酸
+# zh-hans:泛酸
+# zh-hant:泛酸
+# zh-hk:泛酸
+# zh-sg:泛酸
+# zh-tw:泛酸
+wikidata:en: Q179894
+wikipedia:en: https://en.wikipedia.org/wiki/Pantothenic_acid
+# vitamin/pantothenic-acid has 1373 products in 12 languages @2018-11-19
+# fr:acide-pantothénique has 900 products in 9 languages @2018-11-19
+
+# description:en:Another common supplemental form of the vitamin is CALCIUM PANTOTHENATE. Calcium pantothenate is often used in dietary supplements because, as a salt, it is more stable than pantothenic acid.
+
+< en:pantothenic acid
+en: calcium pantothenate
+de: Calcium-Pantothenat
+es: pantotenato de calcio
+fi: kalsiumpantotenaatti, kalsium-d-pantotenaatti
+fr: pantothénate de calcium
+hr: kalcijev pantotenat
+hu: kalcium-pantotenát
+it: pantotenato di calcio
+ja: パントテン酸カルシウム, パントテン酸Ca
+nl: calcium pantothenaat
+nn: kalsiumpantotenat
+wikidata:en: Q27261387
+# ingredient/fr:pantothénate-de-calcium has 109 products in 4 languages @2019-04-21
+
+< en:pantothenic acid
+en: calcium D-pantothenate, D-pantothenate calcium
 bg: D-пантотенат калций
 cs: D-pantothenát vápenatý
 de: Calcium-D-pantothenat
@@ -1626,6 +2042,7 @@ ro: D-pantotenat de calciu
 sk: D-pantotenát vápenatý
 sl: kalcijev D-pantotenat
 sv: kalcium-D-pantotenat
+wikidata:en: Q68577368
 
 < en:Pantothenic Acid
 en: D-pantothenate sodium
@@ -1650,9 +2067,10 @@ sk: D-pantotenát sodný
 sl: natrijev D-pantotenat
 sv: natrium-D-pantotenat
 
-< en:Pantothenic Acid
-en: dexpanthenol
-bg: Декспантенол
+< en:pantothenic acid
+en: dexpanthenol, D-panthenol
+bg: декспантенол
+de: D-Panthenol, Dexpanthenol
 el: δεξπανθενόλη
 es: dexpantenol
 et: dekspantenool
@@ -1670,6 +2088,7 @@ ro: dexpantenol
 sk: dexpantenol
 sl: dekspantenol
 sv: dexpantenol
+wikidata:en: Q47495755
 
 
 < en:vitamin A

--- a/tests/unit/expected_test_results/additives/fr-dextrines-maltees.json
+++ b/tests/unit/expected_test_results/additives/fr-dextrines-maltees.json
@@ -30,6 +30,7 @@
       "en:pantothenic-acid",
       "en:riboflavin",
       "en:thiamin",
+      "en:pyridoxine",
       "en:vitamin-b6",
       "en:retinol",
       "en:vitamin-a",

--- a/tests/unit/expected_test_results/additives/fr-lactoserum-with-minerals.json
+++ b/tests/unit/expected_test_results/additives/fr-lactoserum-with-minerals.json
@@ -47,6 +47,8 @@
       "en:vitamin-b8",
       "en:vitamin-b12",
       "en:cholecalciferol",
-      "en:phylloquinone"
+      "en:vitamin-b6",
+      "en:phylloquinone",
+      "en:riboflavin"
    ]
 }


### PR DESCRIPTION
Vitamins being in food/ingredients.txt is causing some issues with parsing and translations and splitting translation/synonym lists.

This moves all the specific vitamins out of the `food/ingredients.txt` file and into the `vitamins.txt` file, attempting to consolidate/merge the differences.

See also Slack discussion:
https://openfoodfacts.slack.com/archives/C02VDSWHT/p1743770992700109

B₆ vitamins have also been split up into individual chemical compounds. Previously, some vitamin B₆ synonyms would be compound names, and some compounds might even have other,  different compounds associated with them.

Other small things:
- some normalisation of casing
- some xx entries added
- some wikidata entries added