### PR TITLE
taxonomy: move processing from ingredients

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1510,7 +1510,7 @@ bg: E150, Карамел
 ca: E150, Caramel
 cs: E150, karamel
 da: E150, Karamel
-de: E150, Karamell
+de: E150, Karamell, Caramel
 el: E150, καραμέλα
 eo: E150, karamelo
 es: E150, Caramelo, Caramelina
@@ -13935,7 +13935,6 @@ th: E451, ไตรฟอสเฟต
 tr: E451, Trifosfatlar
 uk: E451, Трифосфати
 zh: E451, 三磷酸盐
-
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
 e_number:en: 451
@@ -14126,7 +14125,6 @@ ro: E452(ii), Polifosfat de potasiu, Metafosfat de potasiu, Polimetafosfat de po
 sk: E452(ii), Polyfosforečnan draselný, Metafosforečnan draselný, polymetafosforečnan draselný
 sl: E452(ii), Kalijev polifosfat, kalijev metafosfat, kalijev polimetafosfat
 sv: E452(ii), Kaliumpolyfosfat, Kaliummetafosfat, kaliumpolymetafosfat
-
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
 e_number:en: 452

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -126,7 +126,8 @@ stopwords:fr: aux, au, de, le, du, la, a, et, avec, ou, en, proportion, variable
 # example: sojin umak bez glutena
 # example: marelice 8.3% (SADRŽE sumporni dioksid) / SADRŽI sulfite
 stopwords:hr: bez glutena, i/ili, i, ili, iz, max, min, najmanje, najviše, obično poznat kao, od, u promjenjivim omjerima, u promjenjivim udjelima, u različitim omjerima, u tragovima, bogat bjelančevinama, klasična mješavina, od čega, odgovara, titriran na 25 % 5-HTP, uključujući i, uključujući, sadrže, sadrži
-stopwords:hu: tartalmaz, változó arányban, min, zsírtartalom, összetevő, összetétel, amelyből, amiből
+# example: tejpor alapú termékek (milk-powder based product)
+stopwords:hu: tartalmaz, változó arányban, min, zsírtartalom, összetevő, összetétel, amelyből, amiből, alapú termékek
 stopwords:id: mengandung
 stopwords:is: úr
 # example: COCCO in proporzione variabile
@@ -234,21 +235,6 @@ sv: karamelliserad sockersirap, karamelliserat sockersirap, karamelliserad sirap
 fr: caramel au lait
 hu: tejkaramella
 it: caramello al latte
-
-
-< en:E150
-en: caramel powder
-bg: карамел на прах
-de: Karamell-Pulver, Caramelpulver, Karamellpulver
-fi: karamellijauhe
-fr: caramel en poudre
-# hr:karamel prahu # see ingredients_processings.txt
-hu: karamellpor
-it: caramello in polvere
-nl: karamelpoeder
-pl: proszek karmelowy, karmel w proszku
-pt: caramelo em pó
-# ingredient/fr:caramel-en-poudre has 69 products in 5 languages @2019-03-09
 
 < en:preparation
 en: caramel chocolate preparation
@@ -2069,7 +2055,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Xylanase
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-en: dairy, dairy product, dairy products, dairy food, dairy foods, milk product, milk products
+en: dairy, dairy product, dairy products, dairy food, dairy foods, milk product, milk products, product on base on milk
 af: Suiwelproduk
 als: Milcherzeugnis
 ar: منتجات الألبان
@@ -2078,7 +2064,7 @@ be: Малочныя прадукты
 br: Boued-laezh
 bs: Mliječni proizvodi
 bxr: Сагаан эдеэн
-ca: Làctic, producte làctic, llet i els seus derivats, llet i derivats, derivats làctics, làctics, productes làctics
+ca: Làctic, producte làctic, llet i els seus derivats, llet i derivats, derivats làctics, làctics, productes làctics, producte a base de llet, productes a base de llet
 ckb: سپیاتی
 cs: Mléčný výrobek
 cy: Cynnyrch llaeth
@@ -2086,7 +2072,7 @@ da: Mejeriprodukter
 de: Milcherzeugnisse, Milchprodukte, Molkereiprodukte, Milcherzeugnis, Milchprodukt, Molkereiprodukt
 el: Γαλακτοκομικά προϊόντα
 eo: Laktoprodukto
-es: productos lácteos, leche y sus derivados, leche y derivados, derivados lácteos, lácteos, lácteo
+es: productos lácteos, leche y sus derivados, leche y derivados, derivados lácteos, lácteos, lácteo, producto lácteo, producto a base de leche, productos a base de leche
 et: Piimatoode
 eu: Esneki
 fa: فراورده لبنی
@@ -2101,7 +2087,7 @@ hu: tejtermék, tejtermékek
 hy: Կաթնամթերք
 id: Produk susu
 is: Mjólkurafurð
-it: Latticini, derivati del latte, latte e derivati
+it: Latticini, derivati del latte, latte e derivati, prodotti a base di latte, a base di latte
 ja: 乳製品
 kab: Ifarisen n yiɣi
 kk: Сүт тағамдары
@@ -2164,35 +2150,19 @@ vegetarian:en: maybe
 wikidata:en: Q3506176
 wikipedia:en: https://en.wikipedia.org/wiki/Fermented_milk_products
 
-< en:dairy
-en: powdered milk products, dried milk products, product on base on milk powder
-# en:process:en:powder
-bg: сухо мляко на прах
-ca: producte làctic en pols, producte a base de llet en pols, productes làctics en pols, productes a base de llet en pols
-de: Trockenmilcherzeugnis
-es: producto lácteo en polvo, producto a base de leche en polvo, productos lácteos en polvo, productos a base de leche en polvo
-#fr:produits laitiers en poudre
-hr: mliječni proizvodi u prahu
-hu: tejpor alapú termékek
-it: prodotti a base di latte in polvere, a base di latte in polvere
-nova:en: 4
-
-en: First age baby milk powder, First milk powder, First infant milk formula in powder
-fr: Lait 1er âge en poudre soluble, Lait premier âge en poudre soluble, Préparation pour nourrissons en poudre soluble
-hr: mlijeko u prahu za bebe prve dobi
-it: latte in polvere per neonati prima infanzia
+< en:milk
+en: First age baby milk, First milk, First infant milk formula
+fr: Lait 1er âge, Lait premier âge, Préparation pour nourrissons
 ciqual_food_code:en: 3000
 ciqual_food_name:en: Baby milk, first age, powder
 ciqual_food_name:fr: Lait 1er âge, poudre soluble (préparation pour nourrissons)
 
-en: Second age baby milk powder, Second milk powder, Second infant milk formula in powder
-fr: Lait 2ème âge en poudre soluble, Lait deuxième âge en poudre soluble, Préparation de suite en poudre soluble
-hr: mlijeko u prahu za bebe druge dobi
-it: latte in polvere per neonati di seconda età
+< en:milk
+en: Second age baby milk, Second milk, Second infant milk formula
+fr: Lait 2ème âge, Lait deuxième âge, Préparation de suite
 ciqual_food_code:en: 3002
 ciqual_food_name:en: Baby milk, second age, powder
 ciqual_food_name:fr: Lait 2e âge, poudre soluble (préparation de suite)
-
 
 ################################ BUTTER related stuff ##########################
 
@@ -2615,13 +2585,13 @@ it: burro di capra
 # description:en:MILK - a white liquid nutrient-rich food produced by the mammary glands of mammals.
 
 < en:dairy
-en: milk
+en: milk, milk ingredients
 af: Melk
 am: ወተት
 an: Leit
-ar: حليب
+ar: الحليب, حليب
 as: গাখীৰ
-ay: Millk'i
+ay: Millk'i, süd
 az: Süd
 ba: Һөт
 be: Малако
@@ -2630,22 +2600,23 @@ bm: Nɔnɔ
 bn: দুধ
 br: Laezh
 bs: Mlijeko
-ca: llet
+ca: llet, ingredients de la llet
 ce: Шура
 co: Latti
 cs: Mléko
 cv: Сĕт
 cy: Llaeth
-da: Mælk, mælke
-de: Milch
+da: Mælk, mælke, mælks
+de: Milch, Milchbestandteile
 el: Γάλα, γάλακτος
-es: Leche
+eo: lakto
+es: Leche, Ingredientes de leche
 et: Piim, piimast, piima
 eu: Esne
 fa: شیر
-fi: maito, maidosta
+fi: maito, maidosta, maitoaineksia
 fo: Mjólk
-fr: Lait
+fr: Lait, substances laitières
 fy: Molke
 ga: Bainne
 gd: Bainne
@@ -2654,21 +2625,22 @@ gn: Kamby
 gu: દૂધ
 gv: Bainney
 he: חלב
-hr: mlijeko, mlijeka, mliječna, mliječno
+hr: mlijeko, mlijeka, mliječna, mliječno, mliječnih sastojaka
 ht: Lèt
-hu: Tej, Tejet, tejből
+hu: Tej, Tejet, tejből, tej összetevők
 hy: Կաթ
 ia: Lacte
 id: Susu
 ik: Immuk
 is: Mjólk
-it: Latte
+it: Latte, ingredienti del latte
 iu: ᐃᒻᒧᒃ
 ja: 乳
 jv: Susu
 ka: რძე
 kk: Сүт
-ko: 젖
+kn: ಮಿಲ್ಕ್
+ko: 젖, 유
 ku: Şîr
 ky: Сүт
 la: Lac
@@ -2676,8 +2648,8 @@ lb: Mëllech
 li: Mèlk
 ln: Míliki
 lo: ນົມ
-lt: Pienas, pieno
-lv: Piens, piena, vājpiena, pilnpiena
+lt: Pienas, pieno, pieniniai
+lv: Piens, piena
 mg: Ronono
 mk: Млеко
 ml: പാൽ
@@ -2686,9 +2658,9 @@ mr: दूध
 ms: Susu
 mt: ħalib
 my: နို့
-nb: Melk
+nb: Melk, Melke
 ne: दूध
-nl: melk
+nl: melk, melkbestanddelen
 nn: Mjølk
 no: melk
 nv: Abeʼ
@@ -2709,15 +2681,15 @@ sk: Mlieko
 sl: mleko
 sn: Mukaka
 so: Caano
-sq: Qumështi
+sq: Qumështi, qumesht
 sr: Млеко
 su: Susu
-sv: Mjölk
+sv: Mjölk, mjölks
 sw: Maziwa
 ta: பால்
 te: పాలు
 tg: Шир
-th: นม
+th: นม, น้ำนม
 tl: Gatas
 tr: Süt
 tt: Сөт
@@ -2726,7 +2698,7 @@ ur: دودھ
 vi: Sữa
 wa: Laecea
 yi: מילך
-zh: 乳
+zh: 乳, 奶
 zu: Ubisi
 carbon_footprint_fr_foodges_ingredient:fr: Lait semi-écrémé, pasteurisé
 carbon_footprint_fr_foodges_value:fr: 1.2
@@ -2812,111 +2784,6 @@ fr: lait enrichi de crème
 hr: mlijeko obogaćeno vrhnjem
 it: latte arrichito con crema
 
-< en:milk
-en: sterilised milk
-bg: стерилизирано мляко
-ca: llet esterilitzada
-da: steriliseret mælk
-de: Sterilisierte Milch
-es: Leche esterilizada
-fi: steriloitu maito
-fr: lait stérilisé
-hr: sterilizirano mlijeko
-hu: hőkezelt tej, sterilizált tej
-it: Latte sterilizzato
-lt: sterilizuotas pienas
-nl: gesteriliseerde melk
-pl: mleko sterylizowane
-sv: steriliserad mjölk
-# ingredient/fr:lait-sterilise-u-h-t has 8 products @2019-05-28
-
-# comment:en:Pasteurisation is a specific sterilisation method
-
-< en:milk
-en: pasteurised milk
-bg: пастьоризирано мляко
-ca: llet pasteuritzada
-cs: pasterizované mléko
-da: pasteuriseret mælk
-de: Pasteurisierte Milch
-es: leche pasteurizada
-et: pastöriseeritud piim
-fi: pastöroitu maito, pastöroidusta maidosta
-fr: lait pasteurisé
-hr: pasterizirano mlijeko
-hu: pasztőrözött tej, pasztörizált tej
-it: latte pastorizzato
-lt: pasterizuotas pienas
-nb: pasteurisert melk
-nl: gepasteuriseerde melk
-pl: Mleko pasteryzowane
-pt: leite pasteurizado
-ro: lapte pasteurizat
-ru: Пастеризованное молоко, молоко пастеризованное
-sv: pastöriserad mjölk
-tr: pastörize süt
-
-< en:sterilised milk
-en: UHT pasteurised milk
-bg: UHT пастьоризирано мляко
-ca: llet esterilitzada UHT
-de: UHT Milch
-es: leche esterelizada UHT
-fi: iskukuumennettu maito, UHT-käsitelty maito, UHT-maito
-fr: lait stérilisé U.H.T
-hr: uht pasterizirano mlijeko
-hu: UHT tej, ultrapasztőrözött tej
-it: Latte pastorizzato UHT
-pl: mleko UHT
-sv: UHT-behandlad mjölk
-
-#pasteurisation of 15s under 72–74 °C
-< en:pasteurised milk
-sv: lågpastöriserad mjölk
-
-#pasteurisation of 5s under 80 °C
-< en:pasteurised milk
-sv: högpastöriserad mjölk
-
-< en:pasteurised milk
-sv: opastöriserad mjölk
-
-< en:sterilised milk
-fr: lait thermisé
-
-
-< en:milk
-en: milk solids
-da: mælketørstoffer
-es: solidos lacteos, solidos de la leche
-he: מוצקי חלב
-hr: čvrste tvari mlijeka
-it: Solidi di latte
-
-< en:milk
-nl: vloeibare melkbestanddelen
-
-< en:milk
-en: lactose-free milk
-bg: мляко без лактоза, безлактозно мляко
-ca: llet sense lactosa
-de: laktosefreie Milch
-es: leche sin lactosa
-fr: lait sans lactose
-hr: mlijeko bez laktoze
-it: latte delattosato
-nl: lactosevrije melk
-pl: mleko bez laktozy
-
-< en:lactose-free milk
-en: whole lactose-free milk, lactose-free whole milk
-bg: пълномаслено мляко без лактоза
-de: Laktosefreie Vollmilch
-es: Leche entera sin lactosa
-fr: lait entier sans lactose, lait sans lactose entier
-hr: punomasno mlijeko bez laktoze
-it: latte intero senza lattosio, latte intero delattosato
-
 en: Follow-on milk
 ca: llet de seguiment
 de: Folgemilch
@@ -2928,56 +2795,12 @@ it: latte di proseguimento
 # ingredient/fr:lait-de-suite has 54 products in 4 languages @2019-04-05
 
 < en:milk
-en: organic milk
-bg: биологично мляко, био мляко
-ca: llet ecològica, llet d'agricultura ecològica
-de: Bio-milch
-es: leche ecológica, leche de agricultura ecológica, leche orgánica
-fi: luomumaito
-fr: lait bio, lait issu de l'agriculture biologique
-hr: organsko mlijeko
-hu: bio tej
-it: Latte biologico
-lt: ekologiškas pienas
-# ingredient/fr:lait-bio has 24 products @2019-02-22
-
-< en:milk
 en: milk from France
 de: Milch aus Frankreich
 fr: lait origine france
 hr: mlijeko iz Francuske
 it: latte origine Francia, latte francese
 nl: melk uit Frankrijk
-
-#<en:milk
-#en:origin of the milk
-#bg:произход на млякото
-#ca:origen de la llet
-#es:origen de la leche
-
-# comment:en:Any milk can be fresh (whatever that means)
-< en:milk
-en: fresh milk
-bg: свежо мляко
-ca: llet fresca
-de: Frischmilch
-es: Leche fresca
-fi: tuore maito
-fr: lait frais
-hr: svježe mlijeko
-hu: friss tej
-it: latte fresco
-nl: verse melk
-pt: leite fresco
-# ingredient/fr:lait-frais has 79 products in 2 languages 2019-04-05
-
-< en:fresh milk
-bg: свежо пастьоризирано мляко
-ca: llet fresca pasteuritzada
-es: leche fresca pasteurizada, leche fluída pasteurizada
-fr: lait frais pasteurisé
-hu: pasztőrözött friss tej
-pt: leite fresco pasteurizado
 
 < en:milk
 de: Käsereimilch
@@ -2994,12 +2817,6 @@ hr: mlijeko od sijena
 it: latte fieno, latte fieno STG
 wikidata:en: Q1616491
 
-#hat has been added?
-< en:milk
-en: cultured pasteurized milk
-hr: kultivirano pasterizirano mlijeko
-it: latte pastorizzato fermentato
-
 ########################## LOW FAT and SKIMMED MILK ############################
 
 # description:en:LOW-FAT MILK is a 1% fat milk, sold in the United States
@@ -3013,486 +2830,16 @@ it: latte pastorizzato fermentato
 # 0.2% fat. We are thus using only one taxonomy entry for all milks with
 # a maximum of 0.5% fat
 
+# TODO, processing problem in some language "skimmed milk" is a single word (without milk)
 < en:milk
-en: skimmed milk, skim milk, non-fat milk, nonfat milk, fat-free milk, low-fat milk, 1% fat milk, lowfat milk
-ar: حليب منزوع الدسم
-bg: обезмаслено мляко
-ca: llet descremada, llet desnatada, llet sense greix, llet baixa en greixos
-cs: Odstředěné mléko
-da: skummetmælk
-de: Magermilch, entrahmte Milch, fettarme Milch
-es: Leche descremada, Leche desnatada, leche sin grasas, Leche baja en grasa
-et: Lõss
-fa: شیر خشک بدون چربی
-fi: rasvaton maito, Vähärasvainen maito
-fr: lait écrémé, lait maigre
-gl: Leite desnatado
-he: חלב רזה
-hr: obrano mlijeko, obrane mlijeko, obrani mlijeko
-hu: sovány tej, fölözött tej, alacsony zsírtartalmú tej
-id: Susu skim
-is: Undanrenna
-it: Latte scremato, latte senza grassi, latte magro
-lt: Nugriebtas pienas
-mk: обрано млеко
-ms: Susu skim
-nb: Skummet melk, skummetmelk
-nl: Magere melk, Taptemelk, ondermelk, afgeroomde melk, vetvrije melk
-no: skummet melk
+et: Lõss, lõssi, lössi
+is: Undanrenna, undanrennu
 pa: ਸਪਰੇਟਾ
-pl: odtłuszczone mleko, mleko odtłuszczone
-pt: Leite desnatado, leite magro
-ru: Обезжиренное молоко, молоко обезжиренное
-sv: Skummjölk, lättmjölk
-uk: Знежирене молоко
-vi: Sữa gầy
-zh: 脱脂牛奶
 ciqual_proxy_food_code:en: 19051
 ciqual_proxy_food_name:en: Milk, skimmed, pasteurised
 ciqual_proxy_food_name:fr: Lait écrémé, pasteurisé
-# yue:脫脂奶
 wikidata:en: Q2352187
 wikipedia:en: https://en.wikipedia.org/wiki/Skimmed_milk
-
-< en:pasteurised milk
-#kept due to ciqual
-< en:skimmed milk
-en: pasteurized skimmed milk
-bg: пастьоризирано обезмаслено мляко
-ca: llet desnatada pasteuritzada, llet pasteuritzada desnatada, llet pasteuritzada descremada, llet descremada pasteuritzada
-de: pasteurisierte Magermilch, pasteurisierter Magermilch
-es: leche desnatada pasteurizada, leche pasteurizada desnatada, leche pasteurizada descremada, leche descremada pasteurizada
-fi: pastöroitu rasvaton maito
-fr: lait écrémé pasteurisé
-# hr:pasterizirano obrano mlijeko # see ingredients_processing.txt
-hu: pasztőrözött sovány tej, pasztörizál sovány tej, hőkezelt sovány tej
-it: latte magro pastorizzato
-ja: パスチャライズ牛乳
-lt: pasterizuotas nugriebtas pienas
-nb: pasteurisert skummet melk
-nl: gepasteuriseerde magere melk
-pt: leite pasteurizado desnatado, leite desnatado pasteurizado
-sv: pastöriserad skummjölk
-ciqual_food_code:en: 19051
-ciqual_food_name:en: Milk, skimmed, pasteurised
-ciqual_food_name:fr: Lait écrémé, pasteurisé
-# 1253 in 14 @2021-09-14
-
-#kept due to ciqual
-< en:skimmed milk
-< en:sterilised milk
-en: UHT sterilised skimmed milk, UHT skimmed milk, ultra heat treated skimmed milk
-ca: llet descremada esterilitzada UHT, llet desnatada esterilitzada UHT
-de: entrahmte H-Milch
-es: leche descremada esterilizada UHT, leche desnatada esterilizada UHT, leche UHT descremada
-fr: Lait écrémé stérilisé UHT, lait écrémé stérilisé u h t, lait stérilisé uht écrémé
-hr: uht sterilizirano obrano mlijeko
-hu: sovány UHT tej
-# 49 in 3 @2021-09-14
-it: latte scremato UHT sterilizzato
-nl: UHT-gesteriliseerde magere melk
-ciqual_food_code:en: 19050
-ciqual_food_name:en: Milk, skimmed, UHT
-ciqual_food_name:fr: Lait écrémé, UHT
-
-#<en:UHT sterilised skimmed milk
-#en:organic UHT sterilised skimmed milk
-#ca:llet desnatada esterilitzada UHT ecològica, llet descremada esterilitzada ecològica
-#es:leche desnatada esterilizada UHT ecológica, leche descremada esterilizada ecológica
-#fr:lait écrémé stérilisé uht issu de l'agriculture biologique
-
-
-< en:skimmed milk
-en: skimmed milk with 0.1% lactose-free milk fat
-hr: obrano mlijeko s 0.1% mliječne masti bez laktoze
-it: latte scremato con 0.1% di grassi senza lattosio
-
-< en:skimmed milk
-en: skimmed milk with 0.5% milk fat
-hr: obrano mlijeko s 0.5% mliječne masti
-it: latte scremato con 0.5% di grassi
-
-< en:lactose-free milk
-< en:skimmed milk
-en: lactose-free skimmed milk, skimmed lactose-free milk
-bg: обезмаслено мляко без лактоза
-fr: lait sans lactose écrémé, lait écrémé sans lactose
-hr: obrano mlijeko bez laktoze
-it: latte scremato senza lattosio, latte senza lattosio scremato
-
-< en:lactose-free-milk
-en: semi-skimmed lactose-free milk, lactose-free semi-skimmed milk
-bg: полуобезмаслено мляко без лактоза
-fr: lait sans lactose demi-écrémé, lait demi-écrémé sans lactose
-it: latte parzialmente scremato senza lattosio, latte senza lattosio parzialmente scremato
-
-
-################################# SEMI-SKIMMED MILK ############################
-
-# description:en:LAIT DEMI-ECREME has a butterfat percentage of 1.5-1.8% fat by regulation
-
-< en:milk
-en: semi-skimmed milk, reduced-fat milk, partly skimmed milk, partially skimmed milk, part skim milk
-bg: полуобезмаслено мляко
-ca: llet parcialment desnatada, llet semidesnatada, llet parcialment desgreixada
-da: letmælk
-de: teilentrahmte milch, Halbentrahmte Milch
-es: leche parcialmente desnatada, leche semidesnatada, Leche semidescremada, leche parcialmente descremada
-fi: kevytmaito
-fr: lait demi-écrémé, lait partiellement écrémé, lait semi-écrémé, Lait à 15.5 g/l de matière grasse
-hr: djelomično obrano mlijeko, djelimično obrano mlijeko
-hu: zsírszegény tej, félzsíros tej
-is: léttmjólk
-it: latte parzialmente scremato, Latte semiscremato
-nb: lettmelk
-nl: halfvolle melk, gedeeltelijk afgeroomde melk
-pl: Mleko półtłuste
-pt: leite meio gordo
-sv: mellanmjölk
-ciqual_proxy_food_code:en: 19041
-ciqual_proxy_food_name:en: Milk, semi-skimmed, UHT
-ciqual_proxy_food_name:fr: Lait demi-écrémé, UHT
-wikidata:en: Q10572454
-wikipedia:fr: https://fr.wikipedia.org/wiki/Lait_demi-écrémé
-
-< en:semi-skimmed milk
-fr: lait demi écrémé uht, lait stérilisé u h t demi-écrémé, lait demi-écrémé stérilisé uht, lait stérilisé uht demi-écrémé, lait demi-écrémé stérilisé u.h.t
-ca: llet parcialment desnatada esterilitzada UHT, llet semidesnatada esterilitzada UHT
-de: fettarme Haltbarmilch, fettarme H-milch
-es: leche parcialmente desnatada esterilizada UHT, leche semidesnatada esterilizada UHT, leche UHT parcialmente descremada
-it: Latte semiscremato UHT
-nl: halfvolle melk uht verhit
-pt: leite UHT meio gordo, leite meio gordo UHT
-ciqual_food_code:en: 19041
-ciqual_food_name:en: Milk, semi-skimmed, UHT
-ciqual_food_name:fr: Lait demi-écrémé, UHT
-#274 @2021-09-23
-
-< fr:lait demi écrémé uht
-fr: lait de montagne demi écrémé stérilisé uht
-
-#<en:semi-skimmed milk
-#en:organic semi-skimmed milk, semi-skimmed milk from organic farming
-#ca:llet parcialment desnatada ecològica, llet semidesnatada ecològica
-#de:Fettarme Milch aus biologischer Landwirtschaft
-#es:leche parcialmente desnatada ecológica, leche semidesnatada ecológica, leche parcialmente #descremada orgánica
-#fr:Lait demi-écrémé issu de l'agriculture biologique
-#hu:bio zsírszegény tej, zsírszegény bio tej
-#it:latte parzialmente scremato da agricoltura biologica
-#nl:biologische halfvolle melk
-# ingredient/nl:biologische-halfvolle-melk has 1 product @2019-05-24
-
-#<en:organic semi-skimmed milk
-#fr:lait demi-écrémé stérilisé uht biologique,lait demi-écrémé issu de l'agriculture biologique #stérilisé uht, lait demi-écrémé stérilisé uht issu de l'agriculture biologique, lait demi-écrémé #biologique
-#ca:llet semidesnatada esterilitzada UHT ecològica, llet parcialment desnatada esterilitzada UHT #ecològica
-#es:leche semidesnatada esterilizada UHT ecológica, leche parcialmente desnatada esterilizada UHT ecológica
-
-# description:en:PASTEURIZED SEMI-SKIMMED MILK has a butterfat percentage of 1.5-1.8% AND is pasteurised
-
-< en:semi-skimmed milk
-en: pasteurized semi-skimmed milk
-bg: пастьоризирано полуобезмаслено мляко
-ca: llet parcialment desnatada pasteuritzada, llet pasteuritzada parcialment desnatada, llet semidesnatada pasteuritzada, llet pasteuritzada semidesnatada
-de: pasteurisierte teilentrahmte Milch
-es: leche parcialmente desnatada pasteurizada, leche semidesnatada pasteurizada, leche pasteurizada parcialmente desnatada, leche pasteurizada semidesnatada, leche parcialmente descremada pasteurizada
-fi: pastöroitu kevytmaito
-fr: lait demi-écrémé pasteurisé, lait partiellement écrémé pasteurisé, lait pasteurise demi écrémé
-hr: pasterizirano djelomično obrano mlijeko
-hu: pasztőrözött zsírszegény tej
-it: latte pastorizzato parzialmente scremato, latte parzialmente scremato pastorizzato
-nl: gepasteuriseerde halfvolle melk
-pt: Leite pasteurizado parcialmente desnatado
-carbon_footprint_fr_foodges_ingredient:fr: Lait semi-écrémé, pasteurisé
-carbon_footprint_fr_foodges_value:fr: 1.2
-ciqual_food_code:en: 19042
-ciqual_food_name:en: Milk, semi-skimmed, pasteurised
-ciqual_food_name:fr: Lait demi-écrémé, pasteurisé
-#4146 @2021-09-23
-
-#<en:organic semi-skimmed milk
-#<en:UHT pasteurised milk
-#en:organic UHT pasteurised semi-skimmed milk
-#ca:llet semidesnatada ecològica esterilitzada UHT, llet parcialment desnatada ecològica #esterilitzada UHT
-#es:leche semidesnatada ecológica esterilizada UHT, leche parcialmente desnatada ecológica #esterilizada UHT
-#fr:lait demi-écrémé issu de l'agriculture biologique stérilisé u h t, lait demi-écrémé biologique #stérilisé uht
-
-#<en:pasteurized skimmed milk
-#en:organic pasteurized skimmed milk
-#de:pasteurisierte entrahmte Bio-Milch
-#fr:lait biologique écrémé et pasteurisé
-
-# comment:en:Is there a difference between pasteurized milk and sterilised milk?
-
-< en:semi-skimmed milk
-< en:sterilised milk
-en: sterilised semi-skimmed milk
-bg: стерилизирано полуобезмаслено мляко
-ca: llet parcialment desnatada esterilitzada, llet esterilitzada parcialment desnatada, llet semidesnatada esterilitzada
-de: sterilisierte teilentrahmte Milch, teilentrahmte Milch sterilisiert
-es: leche parcialmente desnatada esterelizada, leche semidesnatada esterilizada, leche esterilizada parcialmente desnatada, leche esterilizada semidesnatada
-fr: lait demi-écrémé stérilisé
-hr: sterilizirano poluobrano mlijeko
-it: latte sterilizzato parzialmente scremato, latte parzialmente scremato sterilizzato
-
-< en:lactose-free milk
-< en:pasteurised milk
-< en:semi-skimmed milk
-ca: llet de vaca sense lactosa semidesnatada pasteuritzada
-
-< en:semi-skimmed milk
-fr: lait de montagne partiellement écrémé
-
-< en:fresh milk
-< en:pasteurised milk
-< en:semi-skimmed milk
-en: fresh organic pasteurised semi-skimmed milk
-ca: llet fresca semidesnatada, llet fresca parcialment desnatda
-de: frische entrahmte Bio-Milch pasteurisiert
-es: leche fresca semidesnatada, leche fresca parcialmente desnatada
-fr: lait frais demi-écrémé
-hr: svježe organsko pasterizirano poluobrano mlijeko
-it: latte fresco organico pastorizzato parzialmente scremato
-
-#<en:organic semi-skimmed milk
-< en:fresh milk
-fr: Lait frais demi-écrémé microfiltré issu de l'agriculture biologique
-
-< en:fresh milk
-< en:semi-skimmed milk
-de: Frische fettarme Milch
-
-< en:semi-skimmed milk
-en: semi-skimmed milk with 1.5% milk fat
-bg: полуобезмаслено мляко с 1,5% масленост
-hr: djelomično obrano mlijeko s 1.5% mliječne masti
-it: latte parzialmente scremato con 1.5% di grasso
-
-< en:lactose-free milk
-< en:semi-skimmed milk
-en: semi-skimmed milk with 1.5% lactose-free milk fat
-hr: djelomično obrano mlijeko s 1,5% mliječne masti bez laktoze, djelomično obrano mlijeko s 1,5% mliječne masti bez laktoze (<0,1 g/100 g)
-it: latte parzialmente scremato con 1.5% di grasso senza lattosio
-
-################################## FULL FAT MILKS ##############################
-
-# description:fr:WHOLE MILK (around 3.5–4% fat), dans l'Union européenne, le lait entier doit contenir au minimum 3,50 % en masse de matière grasse.
-
-< en:milk
-en: whole milk, full cream milk
-bg: пълномаслено мляко
-bs: punomasno mleko
-ca: llet sencera
-cs: Plnotučné mléko
-da: sødmaelk
-de: Vollmilch
-es: leche entera
-fi: täysmaito
-fr: lait entier
-hr: mlijeko trajno, punomasno mlijeko
-hu: teljes tej
-is: nýmjólk
-it: latte intero
-ja: 全乳
-lt: nenugriebtas pienas
-nb: helmelk
-nl: volle melk
-pl: mleko pełne, pełne mleko
-pt: leite enteiro, leite integral
-ro: lapte integral
-sv: Helmjölk, sötmjölk
-zh: 全脂牛奶
-ciqual_food_code:en: 19023
-ciqual_food_name:en: Milk, whole, UHT
-ciqual_food_name:fr: Lait entier, UHT
-
-< en:fresh milk
-< en:whole milk
-en: fresh whole milk
-bg: прясно пълномаслено мляко
-ca: llet sencera fresca, llet fresca sencera
-de: Frische Vollmilch
-es: leche entera fresca, leche fresca entera, leche entera fluída, leche fluida entera
-fi: tuore täysmaito
-fr: lait entier frais, lait frais entier
-hr: svježe punomasno mlijeko
-hu: friss teljes tej
-it: latte intero fresco, latte fresco intero
-nl: verse volle melk
-ru: молоко цельное, цельное молоко
-
-< en:fresh whole milk
-fr: lait frais entier microfiltré
-
-< en:fresh whole milk
-fr: lait frais entier pasteurisé, lait frais pasteurisé entier
-ca: llet frecsa sencera pasteuritzada, llet fresca pasteuritzada sencera
-es: leche fresca entera pasteurizada, leche fresca pasteurizada entera
-it: latte intero fresco pastorizzato
-
-< en:fresh whole milk
-fr: lait frais de montagne entier pasteurisé
-
-< en:sterilised milk
-< en:whole milk
-fr: lait de montagne entier stérilisé uht
-
-< en:organic milk
-< en:whole milk
-en: organic whole milk
-bg: биологично пълномаслено мляко
-ca: llet sencera ecològica, llet sencera d'agricultura ecològica
-de: Bio-Vollmilch
-es: leche entera ecológica, leche entera de agricultura ecológica, leche entera orgánica
-fi: luomu täysmaito
-fr: lait entier bio, lait entier issu de l'agriculture biologique
-hr: organsko punomasno mlijeko
-hu: bio teljes tej
-it: latte intero biologico, latte biologico intero
-lt: ekologiškas nenugriebtas pienas
-nl: volle melk van biologische oorsprong
-
-< en:sterilised milk
-< en:whole milk
-en: sterilised whole milk
-bg: стерилизирано пълномаслено мляко
-ca: llet sencera esterilitzada, llet esterolitzada sencera
-de: sterilisierte Vollmilch
-es: leche entera esterilizada, leche esterilizada entera
-fi: steriloitu täysmaito
-fr: lait entier stérilisé
-hr: sterilizirano punomasno mlijeko
-hu: hőkezelt teljes tej
-it: latte intero sterilizzato, latte sterilizzato intero
-
-< en:UHT pasteurised milk
-< en:pasteurised whole milk
-en: UHT pasteurised whole milk
-bg: UHT пастьоризирано пълномаслено мляко
-ca: llet sencera esterilitzada UHT, llet esterilitzada UHT sencera
-de: Haltbare Vollmilch, H-Vollmilch
-es: leche entera esterilizada UHT, leche esterilizada UHT entera, leche UHT entera
-fi: iskukuumennettu täysmaito
-fr: lait entier stérilisé uht, lait entier stérilisé u h t, lait stérilisé uht entier, Lait pasteurisé entier pasteurisation haute
-hr: uht pasterizirano punomasno mlijeko
-hu: pasztőrözött UHT teljes tej
-it: Latte intero pastorizzato UHT
-nl: UHT gesteriliseerde volle melk
-pl: mleko pełne UHT
-ciqual_food_code:en: 19023
-ciqual_food_name:en: Milk, whole, UHT
-ciqual_food_name:fr: Lait entier, UHT
-# 105 in 2 languages @2021-09-22
-
-< en:UHT pasteurised whole milk
-en: organic UHT pasteurised whole milk
-ca: llet sencera esterilitzada UHT ecològica, llet sencera esterilitzada d'agricultura ecològica
-es: leche entera esterilizada UHT ecológica, leche entera esterilizada de agricultura ecológica
-fi: iskukuumennettu luomu täysmaito
-fr: lait entier stérilisé uht issu de l'agriculture biologique
-hr: organsko uht pasterizirano punomasno mlijeko
-it: latte intero pastorizzato UHT biologico
-
-< en:pasteurised milk
-< en:whole milk
-en: pasteurised whole milk, pasteurized whole milk
-bg: пастьоризирано пълномаслено мляко
-ca: llet sencera pasteuritzada, llet pasteuritzada senceea
-de: pasteurisierte Vollmilch
-es: leche entera pasteurizada, leche pasteurizada entera
-fi: pastöroitu täysmaito
-fr: lait entier pasteurisé
-hr: pasterizirano punomasno mlijeko
-hu: pasztőrözött teljes tej
-it: latte intero pastorizzato
-lt: pasterizuotas nenugriebtas pienas
-nl: volle gepasteuriseerde melk
-pl: mleko pełne pasteryzowane
-pt: Leite pasteurizado gordo
-ro: lapte integral pasteurizat
-ciqual_food_code:en: 19024
-ciqual_food_name:en: Milk, whole, pasteurised
-ciqual_food_name:fr: Lait entier, pasteurisé
-#1241 @2011-09-23
-
-< en:whole milk
-bg: стандартизирано пълномаслено мляко
-fr: lait entier standardisé
-hr: standardizirano punomasno mlijeko
-
-< en:milk
-en: milk with 1.0% milk fat
-hr: mlijeko s 1.0% mliječne masti, mlijeko s 1% mliječne masti
-
-< en:milk
-en: milk with 1.5% milk fat
-hr: mlijeko s 1.5% mliječne masti
-
-< en:milk
-en: milk with 2.0% milk fat
-hr: mlijeko s 2.0% mliječne masti, mlijeko s 2% mliječne masti
-
-< en:milk
-en: milk with 2.5% milk fat
-hr: mlijeko s 2.5% mliječne masti
-
-< en:milk
-en: milk with 2.8% milk fat
-hr: mlijeko s 2.8% mliječne masti
-
-< en:whole milk
-en: whole milk with 2.8% milk fat
-hr: mlijeko trajno s 2.8% mliječne masti
-
-< en:milk
-en: milk with 3.2% milk fat
-hr: mlijeko 3,2 % m.m.
-
-< en:whole milk
-en: whole milk with 3.5% milk fat
-hr: punomasno mlijeko s 3.5% mliječne masti
-
-< en:milk
-en: milk with 6.0% milk fat
-hr: punomasno mlijeko s 6.0% mliječne masti, punomasno mlijeko s 6% mliječne masti
-
-
-################################## RAW MILKS ###################################
-
-# description:en:RAW MILK - milk produced by female mammals (probably cow) before any treatment
-
-< en:milk
-en: raw milk
-bg: сурово мляко
-ca: llet crua
-de: Rohmilch
-es: Leche cruda
-fi: raakamaito, tilamaito
-fr: lait cru
-hr: sirovo mlijeko
-hu: nyers tej
-it: latte crudo
-ja: 生乳
-nl: rauwe melk
-pl: surowe mleko
-pt: leite cru
-ro: lapte crud
-ru: сырое молоко
-tr: çiğ süt, pastörize edilmemiş süt
-zh: 生牛奶
-wikipedia:en: https://en.wikipedia.org/wiki/Raw_milk
-
-< en:raw milk
-< en:whole milk
-fr: lait cru entier
-bg: сурово пълномаслено мляко
-ca: llet crua sencera
-es: leche cruda entera
-it: latte crudo intero
-lt: neapdorotas pilnas pienas
-nl: rauwe volle melk
-pl: surowe mleko pełne
-pt: leite cru integral
-ro: lapte crud integral
 
 ################################## COW MILKS ###################################
 
@@ -3517,6 +2864,7 @@ pt: leite de vaca
 ro: lapte de vacă, lapte de vaca
 ru: коровье молоко
 sv: Komjölk
+th: น้ำนมโค
 tr: inek sütü
 uk: Коров'яче молоко
 zh: 牛奶
@@ -3524,148 +2872,24 @@ wikipedia:fr: https://fr.wikipedia.org/wiki/Lait_de_vache
 
 # description:en:RAW COW MILK - milk produced by female cows before any treatment
 
+# TODO, processing problem, processing in the middle of the ingredient
 < en:cow's milk
-< en:raw milk
-en: raw cow's milk
-bg: сурово краве мляко
-ca: llet crua de vaca, llet de vaca crua
 de: Kuhrohmilch
-es: leche de vaca cruda, leche cruda de vaca
-fi: lehmän raakamaito, raaka lehmänmaito
-fr: lait de vache cru, lait cru de vache
-hr: sirovo kravlje mlijeko
-hu: nyers tehéntej
-it: Latte di mucca crudo
-nl: rauwe koemelk
-sv: opastöriserad komjölk
-
-< en:cow's milk
-< en:organic milk
-< en:sterilised milk
-fr: lait de vache bio thermisé
-ca: llet de vaca ecològica termitzada
-es: leche de vaca ecológica termizada
+fi: raaka lehmänmaito
 
 # WHOLE COWS MILK (around 3.5–4% fat), dans l'Union européenne, le lait entier doit contenir au minimum 3,50 % en masse de matière grasse.
 
+# TODO, processing problem, processing in the middle of the ingredient
 < en:cow's milk
-< en:whole milk
-en: whole cow's milk
-bg: пълномаслено краве мляко, краве пълномаслено мляко
 ca: llect de vaca sencera, llet sencera de vaca
 de: Kuhvollmilch
-es: Leche entera de vaca, leche de vaca entera
 fi: lehmän täysmaito
-fr: Lait de vache entier, lait entier de vache
-hr: punomasno kravlje mlijeko
-hu: teljes tehéntej
-pl: mleko krowie pełne
-ro: lapte de vacă integral, lapte de vaca integral
-ru: молоко коровье цельное
-
-< en:whole cow's milk
-en: raw whole cow's milk
-bg: сурово пълномаслено краве мляко
-ca: llet de vaca sencera crua, llet sencera crua de vaca
-de: rohe Kuhvollmilch
-es: leche de vaca entera cruda, leche entera cruda de vaca
-fr: lait de vache entier cru
-hr: sirovo punomasno kravlje mlijeko
-# ingredient/fr:lait-de-vache-entier-cru has 10 products @2019-05-27
-
-< en:whole cow's milk
-en: pasteurised whole cow's milk
-bg: пастьоризирано пълномаслено краве мляко
-ca: llet sencera pasteuritzada de vaca, llet de vaca sencera pasteuritzada, llet pasteuritzada de vaca sencera, llet sencera de vaca pasteuritzada
-de: pasteurisierte Kuhvollmilch
-es: Leche entera pasteurizada de vaca, leche de vaca entera pasteurizada, leche pasteurizada de vaca entera, leche entera de vaca pasteurizada
-fr: lait de vache entier pasteurisé, lait pasteurisé de vache entier, lait entier de vache pasteurisé, lait entier pasteurisé de vache
-hr: pasterizirano punomasno kravlje mlijeko
-it: Latte vaccino intero pastorizzato
-nl: gepasteuriseerde volle koeienmelk
-ro: lapte de vacă integral pasteurizat, lapte de vaca integral pasteurizat
-
-< en:cow's milk
-en: semi-skimmed cow's milk
-bg: полуобезмаслено краве мляко
-ca: llet semidesnatada de vaca, llet de vaca semidesnatada, llet de vaca parcialment desnatada, llet parcialment desnatada de vaca
-de: teilentrahmte Kuhmilch, fettarme Kuhmilch
-es: leche semidesnatada de vaca, leche de vaca semidesnatada, leche de vaca parcialmente desnatada, leche parcialmente desnatada de vaca
-fr: lait de vache demi écrémé
-hr: poluobrano kravlje mlijeko
-nl: halfvolle koemelk
-
-< en:semi-skimmed cow's milk
-en: pasteurised semi-skimmed cow's milk
-bg: пастьоризирано полуобезмаслено краве мляко
-ca: llet de vaca semidesnatada pasteuritzada
-de: pasteurisierte teilentrahmte Kuhmilch
-es: leche de vaca pasteurizada semidesnatada, leche semidescremada pasteurizada, leche pasteurizada semidescremada, leche semi-descremada pasteurizada, leche de vaca semidescremada pasteurizada
-fr: lait de vache partiellement écrémé et pasteurisé
-hr: pasterizirano poluobrano kravlje mlijeko
-it: Latte vaccino pastorizzato parzialmente scremato
 
 # description:en:PASTEURISED COW MILK - raw cow milk that has been treated (pasteurisation)
 
+# TODO, processing problem, processing in the middle of the ingredient
 < en:cow's milk
-< en:pasteurised milk
-en: pasteurised cow's milk, pasteurised cows milk
-bg: пастьоризирано краве мляко
-ca: llet de vaca pasteuritzada, llet pasteuritzada de vaca
-de: Pasteuriseret komælk, pasteurisierte Kuhmilch
-es: leche de vaca pasteurizada, leche pasteurizada de vaca
-fi: pastöroitu lehmänmaito, pastöroitu lehmän maito
-fr: lait de vache pasteurisé, lait pasteurisé de vache
-hr: pasterizirano kravlje mlijeko
-hu: pasztőrözött tehéntej
-it: latte di mucca pastorizzato
-nb: pasteurisert kumelk
-nl: gepasteuriseerde koemelk
-pl: Mleko krowie pasteryzowane
-pt: Leite de vaca pasteurizado, Leite de vaca pasteurizada
-sv: pastöriserad komjölk
-tr: pastörize inek sütü
-
-< en:Cow's milk
-fr: lait de vache thermisé
-ca: llet de vaca termitzada, llet termitzada de vaca
-es: leche de vaca termizada, leche termizada de vaca
-it: latte di mucca termizzato
-nl: gestremde koeienmelk
-
-< en:Cow's milk
-fr: lait frais de nos vaches non homogeneise
-
-# <en:Cow's milk
-# en:unhomogenized pasteurized milk  # see ingredients_processing.txt
-# hr:nehomogenizirano pasterizirano mlijeko  # see ingredients_processing.txt
-
-< en:cow's milk
-en: skimmed cows milk
-bg: обезмаслено краве мляко
-ca: llet desnatada de vaca, llet descremada de vaca
-de: entrahmte Kuhmilch
-es: leche desnatada de vaca, leche descremada de vaca
-hr: obrano kravlje mlijeko
-it: latte vaccino scremato
-nl: magere koeienmelk
-
-< en:cow's milk
-en: pasteurized skimmed cow's milk
-bg: пастьоризирано обезмаслено краве мляко
-ca: llet fresca desnatada pasteuritzada de vaca
-de: pasteurisierte entrahmte Kuhmilch
-es: leche de vaca desnatada pasterizada
-hr: pasterizirano obrano kravlje mlijeko
-th: น้ำนมโคขาดมันเนย
-
-< en:cow's milk
-en: homogenized milk with 2.8% milk fats
-hr: homogenizirano mlijeko s 2.8% mliječne masti
-
-< en:cow's milk
-en: homogenized milk with 3.2% milk fats
-hr: homogenizirano mlijeko s 3.2% mliječne masti
+fr: lait frais de nos vaches
 
 ################################# GOAT MILKS ###################################
 
@@ -3716,18 +2940,10 @@ description:pl: Geitenmelk is de melk die gevormd wordt in de uier van een geit.
 wikidata:en: Q1418287
 # 1.797 in 16 @2021-08-25
 
+# TODO, processing problem, processing in the middle of the ingredient
 < en:goat milk
-en: whole goat milk, whole goat milk, raw goat milk
-bg: пълномаслено козе мляко
-ca: llet sencera de cabra, llet de cabra sencera, llet crua de cabra, llet de cabra crua
 de: Ziegenvollmilch, Ziegen-Vollmilch, Ziegen-Rohmilch, Ziegenrohmilch, unpasteurisierte Ziegenmilch
-es: leche entera de cabra, leche de cabra entera, leche cruda de cabra, leche de cabra cruda
-fi: vuohen täysmaito, vuohen raakamaito, raaka vuohenmaito
-fr: lait entier de chèvre, lait cru de chèvre, lait de chèvre cru
-hr: punomasno kozje mlijeko
-hu: teljes kecsketej, nyers kecsketej
-it: latte intero di capra
-nl: volle geitemelk
+fi: vuohen täysmaito, vuohen raakamaito
 ciqual_food_code:en: 19202
 ciqual_food_name:en: Goat milk, whole, raw
 ciqual_food_name:fr: Lait de chèvre, entier, cru
@@ -3900,8 +3116,9 @@ ciqual_food_code:en: 19250
 ciqual_food_name:en: Sheep milk, whole
 ciqual_food_name:fr: Lait de brebis, entier
 
+# < en:skimmed milk
+< en:milk
 < en:sheeps milk
-< en:skimmed milk
 en: skimmed sheeps milk, skimmed sheep milk, semi-skimmed sheeps milk
 ar: حليب الغنم قليل الدسم
 bg: частично обезмаслено овче мляко
@@ -4047,143 +3264,9 @@ it: panna da caffè
 nl: koffieroom
 # 14@2019-06-06
 
-# description:en:CONDENSED MILK is cow's milk from which water has been removed.  It is most often found in the form of "sweetened condensed milk" ("SCM"), with sugar added, and the terms "condensed milk" and "sweetened condensed milk" are often used interchangeably today. Sweetened condensed milk is a very thick, sweet product, which when canned can last for years without refrigeration if not opened. Condensed milk is used in numerous dessert dishes in many countries.
-
-#category/condensed-milks
-< en:milk
-en: condensed milk
-af: Kondensmelk
-ar: الحليب المبخر
-az: Qatılaşdırılmış süd
-be: згушчанае малако
-bg: кондензирано мляко
-ca: llet condensada
-cs: kondenzované mléko
-da: Kondenseret mælk
-de: Kondensmilch, Dosenmilch, Büchsenmilch, eingedickte Milch
-eo: kondensita lakto
-es: leche condensada
-et: kondenspiim
-eu: esne lurrundua, Esne kondentsatu
-fa: شیر تغلیظ‌شده
-fi: Kondensoitu maito
-fr: lait condensé, lait concentré
-gl: Leite condensado
-he: חלב מרוכז
-hr: kondenzirano mlijeko
-hu: sűrített tej
-hy: Խտացրած կաթ
-id: susu kental
-it: latte condensato
-ja: 加糖練乳
-kn: ಕಂಡೆನ್ಸ್‌ಡ್ ಮಿಲ್ಕ್
-ko: 연유
-lb: Béchsemëllech
-lt: Kondensuotas pienas
-ms: Susu pekat
-nb: kondensert melk
-nl: gecondenseerde melk
-pl: mleko skondensowane, mleko zagęszczone, skondensowane mleko, zagęszczone mleko
-pt: leche condensada, leite condensado
-ro: Lapte condensat
-ru: сгущённое молоко
-sl: Kondenzirano mleko
-sv: kondenserad mjölk
-th: นมข้นหวาน
-tl: Gatas na kondensada
-tr: Kondense süt
-tt: Куертылган сөт
-uk: згущене молоко
-vi: Sữa đặc
-zh: 煉奶
-# be-tarask:згушчанае малако
-# de-ch:Kondensmilch
-# en-ca:Condensed milk
-# en-gb:Condensed milk
-# pt-br:Leite condensado
-# yue:煉奶
-wikidata:en: Q2830455
-wikipedia:en: https://en.wikipedia.org/wiki/Condensed_milk
-# 6229 in 31 @2021-09-05
-
-< en:condensed milk
-en: sweetened condensed milk, condensed milk with sugar
-bg: подсладено кондензирано мляко
-ca: llet condensada ensucrada, llet ensucrada condensada
-cs: slazené kondenzované mléko
-da: sukret kondenseret mælk
-de: gezuckerte Kondensmilch, gezuckerte eingedickte Milch
-es: leche condensada azucarada, leche azucarada condensada
-et: magustatud kondenspiim
-fi: makeutettu kondensoitu maito, makeutettu maitotiiviste, sokeroitu maitotiiviste, sokeroitua maitotiivistettä
-fr: lait concentré sucré, lait condensé sucré
-hr: ugušćeno zaslađeno mlijeko, kondenzirano zaslađeno mlijeko
-hu: édesített sűrített tej, cukrozott sűrített tej
-it: latte concentrato zuccherato
-lt: saldintas kondensuotas pienas
-lv: saldinats iebiezinātais piens
-nb: sukkerholdig kondensert melk, sukret kondensert skummet melk, søt kondensert melk
-nl: gecondenseerde gesuikerde melk, gesuikerde gecondenseerde melk
-pl: mleko zagęszczone słodzone
-ro: lapte condensat indulcit
-ru: молоко цельное сгущенное с сахаром
-sv: sockrad kondenserad mjölk, söt kondenserad mjölk, sötad kondenserad mjölk
-wikidata:en: Q57271749
-# 2985 in 25 @2021-09-05
-
-< en:sweetened condensed milk
-en: sweetened condensed skimmed milk
-da: sukret kondenseret skummetmælk
-et: magustatud kooritud kondenspiim
-fi: makeutettu rasvaton maitotiiviste, sokeroitu rasvaton maitotiiviste
-fr: lait écrémé concentré sucré
-hr: zaslađeno kondenzirano obrano mlijeko
-it: latte scremato condensato zuccherato
-lt: saldintas sutirštintas nugriebtas pienas
-lv: saldināts iebiezināts vājpiens
-nl: gesuikerde gecondenseerde halfvolle melk
-sv: sockrad kondenserad skummjölk, söt kondenserad skummjölk
-# ingredient/fr:lait-ecreme-concentre-sucre has 398 products in 8 languages @2020-05-21
-
-< en:sweetened condensed milk
-en: sweetened condensed semi-skimmed milk
-ca: llet desnatada condensada ensucrada, llet descremada condensada ensucrada, llet desnatada ensucrada condensada, llet descremada ensucrada condensada, dolc de llet
-da: sockrad kondenserad mjölk
-de: gezuckerte Kondensmagermilch, Kondensmagermilch gezuckert
-el: ζαχαρούχο συμπυκνωμένο αποβουτυρωμένο γάλα
-es: leche desnatada condensada azucarada, leche descremada condensada azucarada, leche desnatada azucarada condensada, leche descremada azucarada condensada, dulce de leche
-fi: makeutettu tiivistetty vähärasvainen maito
-fr: lait écrémé condensé sucré, lait concentré sucré écrémé
-hr: zasladeno kondenzirano obrano mlijeko
-hu: sűrtett édesített zsírszegény tej, édesített sűrtett zsírszegény tej, cukrozott sűritett sovány tej
-it: latte magro condensato zuccherato
-nl: gesuikerde gecondenseerde magere melk
-pt: leite magro condensado açucarado
-ro: lapte degresat condensat indulcit
-sl: sladkano kondenzirano posneto mleko
-# ingredient/fr:lait-écrémé-condensé-sucré has 42 products in 4 languages @2019-04-18
-# usage:de: gezuckerte Kondensmagermilch (Milch, Zucker)
-
-< en:sweetened condensed milk
-en: sweetened condensed whole milk, Whole condensed milk with sugar
-ca: llet sencera condensada ensucrada
-da: sockrad kondenserad skummjölk
-de: gezuckerte Kondensvollmilch
-es: leche entera condensada azucadara
-fi: Makeutettu tiivistetty täysmaito
-fr: lait entier condensé sucré, lait entier concentré sucré, Lait concentré entier sucré
-hr: zaslađeno kondenzirano punomasno mlijeko
-hu: édesített sűrített teljes tej
-it: latte intero condensato zuccherato
-nl: gecondenseerde volle melk met suiker
-ciqual_food_code:en: 19027
-ciqual_food_name:en: Condensed milk, with sugar, whole
-ciqual_food_name:fr: Lait concentré sucré, entier
-# ingredient/fr:lait-entier-condensé-sucré has 37 products in 4 languages @2019-04-16
-
 # <en:compound
 # category:en: en:Milk jams
-< en:sweetened condensed milk
+< en:milk
 en: dulce de leche, milk jam
 xx: dulce de leche
 ar: دولسي دي ليتشه
@@ -4214,60 +3297,6 @@ ciqual_food_name:fr: Confiture de lait
 wikidata:en: Q17072931
 wikipedia:en: https://en.wikipedia.org/wiki/Dulce_de_leche
 
-< en:condensed milk
-en: condensed whole milk
-ca: llet sencera condensada, llet condensada sencera
-de: kondensierte Vollmilch
-es: leche entera condensada, leche condensada entera
-fi: Tiivistetty täysmaito
-fr: lait entier condensé, lait entier concentré
-hr: kondenzirano punomasno mlijeko
-hu: sűrített teljes tej
-it: latte intero condensato
-nl: gecondenseerde volle melk
-ciqual_food_code:en: 19026
-ciqual_food_name:en: Condensed milk, without sugar, whole
-ciqual_food_name:fr: Lait concentré non sucré, entier
-# ingredient/condensed-whole-milk has 52 products in 5 languages @2019-04-16
-
-< en:condensed milk
-en: condensed semi-skimmed milk
-ca: llet semidesnatada condensada, llet parcialment desnatada condensada, llet condensada semidesnatada, llet condensada parcialment desnatada
-de: teilentrahmte Kondensmilch
-es: leche semidesnatada condensada, leche parcialmente desnatada condensada, leche condensada semidesnatada, leche condensada parcialmente desnatada
-fi: kondensoitu vähärasvainen maito, tiivistetty vähärasvainen maito
-fr: lait demi-écrémé condensé
-hr: kondenzirano poluobrano mlijeko
-hu: sűrített zsírszegény tej, sűrtett zsírszegény tej
-it: Latte semi-magro condensato
-nl: gecondenseerde halfvolle melk
-# ingredient/condensed-semi-skimmed-milk has 3 products in german @2019-04-16
-
-< en:condensed milk
-en: condensed skimmed milk, concentrated skim milk, concentrated skimmed milk
-bg: кондензирано обезмаслено мляко
-ca: llet descremada condensada, llet desnatada condensada, llet condensada descremada, llet condensada desnatada
-de: Kondensmagermilch, kondensierte Magermilch, konzentrierte Magermilch, Magermilchkonzentrat, eingedickte entrahmte Milch
-es: leche descremada condensada, leche desnatada condensada, leche condensada descremada, leche condensada desnatada
-fi: rasvaton maitotiiviste, kondensoitu rasvaton maito
-fr: lait écrémé concentré, concentré de lait écrémé, lait écrémé condensé, lait concentré écrémé
-hr: kondenzirano obrano mlijeko
-hu: sűrített sovány tej
-it: latte scremato concentrato, latte magro concentrato
-nl: gecondenseerde magere melk
-pt: leche condensada desnatada
-sv: kondenserad skummjölk
-# ingredient/condensed-skimmed-milk has 43 products @2019-04-16
-
-
-< en:condensed milk
-< en:powdered milk
-#en:process:en:powder
-fr: lait écrémé concentré ou en poudre
-ca: llet en pols condensada, llet condensada en pols
-es: leche en polvo condensada, leche condensada en polvo
-nl: gecondenseerde magere poedermelk
-
 < en:lactose
 < en:milk proteins
 en: lactose and milk proteins
@@ -4289,243 +3318,18 @@ vegetarian:en: yes
 
 ################################ MILK POWDERS ##################################
 
-# nova:en:milk-powder
-#process:en: en:powder
+# TODO, processing problem, main ingredient appears two times in the ingredient
 < en:dairy
-en: milk powder, powdered milk, dry milk
-bg: мляко на прах, сухо мляко
-ca: Llet en pols
-cs: Sušené mléko
-da: mælkepulver
-de: Milchpulver
-el: γάλα σε σκόνη
-es: Leche en polvo
-et: piimapulber
-fi: maitojauhe
-fr: lait en poudre, poudre de lait
-he: אבקת חלב
-hr: mlijeko u prahu
-hu: tejpor
-is: mjólkurduft
-it: latte in polvere
-ja: 粉乳
-ko: 분유
-lt: pieniniai milteliai, pieno milteliai
-lv: piena pulveris
-nb: melkepulver, pulvermelk, tørrmelk
-nl: melkpoeder
-pl: mleko w proszku
-pt: leite em pó
-ro: lapte praf
-ru: сухое молоко, молоко сухое, сухие молочные продукты
-sk: sušené mlieko
-sv: mjölkpulver
-tr: Süt tozu
-uk: сухе молоко
-zh: 奶粉
-ciqual_proxy_food_code:en: 19044
-ciqual_proxy_food_name:en: Milk, powder, semi-skimmed
-ciqual_proxy_food_name:fr: Lait en poudre, demi-écrémé
-ecobalyse:en: b6776a28-ec84-4bf3-988c-07b3c29f6136
-nova:en: 3
-vegan:en: no
-vegetarian:en: yes
-
-< en:milk from France
-< en:whole milk powder
-#en:process:en:powder
-fr: lait origine france en poudre écrémé
-
-< en:milk powder
-#process:en: en:powder
-en: Semi-skimmed milk powder
-bg: Полуобезмаслено мляко на прах
-ca: llet en pols parcialment desnatada, llet parcialment desnatada en pols, llet en pols semidesnatada, llet semidesnatada en pols
-es: leche en polvo parcialmente desnatada, leche parcialmente desnatada en polvo, leche en polvo semidesnatada, leche semidesnatada en polvo
-fr: lait en poudre demi-écrémé, lait en poudre partiellement écrémé, poudre de lait partiellement écrémé
-hr: poluobrano mlijeko u prahu
-nl: halfvolle poedermelk
-pt: leite meio gordo em pó
-# ingredient/fr:lait-en-poudre-demi-ecreme has 8 products @2019-05-31
-ciqual_food_code:en: 19044
-ciqual_food_name:en: Milk, powder, semi-skimmed
-ciqual_food_name:fr: Lait en poudre, demi-écrémé
-
-< en:milk powder
-fr: lait en poudre enrichi en matière grasse
-ca: llet en pols enriquida en matèria grassa
-es: leche en polvo enriquecida en materia grasa
-
-< en:milk powder
-fr: lait maigre en poudre, lait en poudre maigre
-
-
-< en:milk powder
 fr: lait écrémé à base de poudre de lait
 
-< en:milk powder
-fr: poudre de lait réhydratée
-
-< en:milk powder
-en: skimmed milk powder, nonfat dry milk, skimmed cow's milk powder
-bg: обезмаслено сухо мляко, обезмаслено мляко на прах, сухо обезмаслено мляко, сухо обезмаслно краве мляко
-ca: llet desnatada en pols, llet en pols desnatada
-cs: Sušené odstředěné mléko
-da: skummetmælkspulver
-de: Magermilchpulver, Magermilch-Pulver, Magermilch-Pulver und Magermilch-Konzentrat
-es: leche desnatada en polvo, leche en polvo desnatada, leche en polvo descremada
-et: lõssipulber, lössipulber, kooritud piimapulber
-fi: rasvaton maitojauhe, rasvatonta maitojauhetta, rasvatonmaitojauhe
-fr: lait en poudre écrémé, lait écrémé en poudre, poudre de lait écrémé
-he: אבקת חלב רזה
-# hr:obrano mlijeko u prahu, obrane mlijeko u prahu # see ingredients_processing.txt
-hu: sovány tejpor
-is: undanrennuduft
-it: latte scremato in polvere, latte in polvere scremato
-ja: 脱脂粉乳
-lt: nugriebto pieno milteliai, lieso pieno milteliai
-lv: sausais vajpiena pulveris
-nb: skummetmelkepulver, skummetmelkpulver
-nl: magere melkpoeder, mageremelkpoeder, mager melkpoeder
-pl: chude mleko w proszku, odtłuszczone mleko w proszku, mleko odtłuszczone w proszku, mleko w proszku odtłuszczone
-pt: leite magro em pó, leite em pó magro, leite desnatado em po
-ro: lapte praf degresat
-ru: обезжиренный молоко-порошок, молоко сухое обезжиренное, сухое обезжиренное молоко, молоко обезжиренное сухое, сухое безжиренное молоко, молоко сухое цельное и обезжиренное
-sk: sušené odstredené mlieko
-sq: qumesht i skremuar pluhur
-sv: skummjölkspulver
-tr: yağsız süt tozu, kaymağı alınmış süt tozu
-ciqual_food_code:en: 19054
-ciqual_food_name:en: Milk, powder, skimmed
-ciqual_food_name:fr: Lait en poudre, écrémé
-
-#<en:skimmed milk powder
-#nl:magere melkpoeder van biologische oorsprong, bio magere melkpoeder
-# ingredient/nl:magere-melkpoeder-van-biologische-oorsprong has 1 product @2019-05-24
-
-< en:skimmed milk powder
-en: caramelised skimmed milk powder
-de: Karamellisiertes entrahmtes Milchpulver
-fi: karamellisoitu rasvaton maitojauhe
-fr: Lait écrémé caramélisé en poudre
-hr: karamelizirano obrano mlijeko u prahu
-it: latte scremato in polvere caramellato
-
-< en:milk powder
-en: whole milk powder, dried whole milk, powdered whole milk, whole powdered milk, whole dry milk, dry whole milk
-bg: пълномаслено мляко на прах, пълномаслено сухо мляко, сухо пълномаслено мляко
-ca: Llet sencera en pols, llet en pols sencera
-cs: sušené plnotučné mléko
-da: sødmælkspulver
-de: Vollmilchpulver, Voll_milch_pulver
-el: γάλα Πλήρες σε σκόνη
-es: leche entera en polvo, leche en polvo entera
-et: täispiimapulber, koorimata piimapulber
-fi: täysmaitojauhe, kuivattu täysmaito, täysmaitojauhetta, rasvainen maitojauhe
-fr: lait entier en poudre, poudre de lait entier, lait en poudre entier
-he: אבקת חלב מלא, חלב מלא מיובש, חלב מלא יבש
-# hr:punomasno mlijeko u prahu # see ingredients_processing.txt
-hu: zsiros tejpor, teljes tejpor
-is: nýmjólkurduft
-it: latte intero in polvere
-ja: 全粉乳
-lt: nenugriebto pieno milteliai
-lv: pilnpiena pulveris
-nb: helmelkpulver, helmelk pulver
-nl: volle melkpoeder, vollemelkpoeder
-pl: pelne mleko w proszku, pełne mleko w proszku, mleko pełne w proszku, mleko w proszku pełne
-pt: leite entero em pó, leite em pó gordo, leite integral em pó, leite gordo em pó
-ro: lapte praf integral
-ru: цельное сухое молоко, сухое цельное молоко, молоко сухое цельное
-sk: sušené plnotučné mlieko
-sq: qumesht pluhur gjithë
-sv: helmjölkspulver, fetthaltigt mjölkpulver, sötmjölkspulver
-ciqual_food_code:en: 19021
-ciqual_food_name:en: Milk, powder, whole
-ciqual_food_name:fr: Lait en poudre, entier
-
-< en:whole milk powder
-en: whole cow's milk powder
-de: Kuhvollmilchpulver, Kuhmilchpulver
-es: leche entera de vaca en polvo
-hr: punomasno kravlje mlijeko u prahu
-
-< en:skimmed milk powder
-< en:whole milk powder
-en: skimmed and whole milk powder
-fr: poudres de lait écrémé et entier
-hr: obrano i punomasno mlijeko u prahu
-it: latte scremato e intero in polvere
-ru: молоко сухое цельное и обезжиренноё
-
-< en:whole milk powder
-en: reconstituted milk powder
-bg: възстановено мляко на прах
-ca: llet en pols reconstituida
-es: leche en polvo reconstituida
-hr: rekonstituirano mlijeko u prahu
-it: latte in polvere ricostituito
+# TODO, processing problem, main ingredient appears two times in the ingredient
+# en: reconstituted milk powder
+< en:dairy
 ru: восстановленное молоко из сухого молока
-
-< en:milk
-fr: lait écrémé reconstitué
-nl: gereconstitueerde melk
-
-< en:skimmed milk
-en: reconstituted skimmed milk
-bg: възтановено обезмаслено мляко
-ca: llet desnatada reconstituida, llet desnatada rehidratada, llet descremada rehidratada, llet descremada reconstituida
-de: rekonstituierte Magermilch
-es: leche desnatada reconstituida, leche desnatada rehidratada, leche descremada rehidratada, leche descremada reconstituida
-fr: lait écrémé réhydraté
-# hr:rekonstituirano obrano mlijeko # see ingredients_processing.txt
-hu: visszaállított sovány tej, feloldott sovány tej
-it: latte scremato reidratato
-lt: regeneruotas nugriebtas pienas
-nl: gerehydrateerde magere melk
-pl: odtworzone odtłuszczone mleko, odtworzone mleko odtłuszczone
-pt: leite magro reconstituído
-
-< en:skimmed milk powder
-bg: възстановено обезмаслено мляко на прах, възстановео обезмаслено сухо мляко
-ca: llet desnatada en pols reconstituida, llet desnatada en pols rehidratada
-es: leche desnatada en polvo reconstituida, leche desnatada en polvo rehidratada
-
-fr: matière grasse de lait anhydre
-it: grasso di latte anidro
-
-< en:milk
-fr: lait écrémé en poudre reconstitué, lait écrémé en poudre réhydraté
-
-< en:milk
-fr: lait entier en poudre reconstitué, lait entier reconstitué
-ca: llet sencera en pols reconstituida, llet en pols rehidratada
-es: leche entera en polvo reconstituida, leche en polvo rehidratada
-
-< en:milk
-en: modified milk ingredients
-ca: Ingredients de la llet modificats
-de: Modifizierte Milchbestandteile
-es: Ingredientes de leche modificados
-fi: Muunnettuja maitoaineksia
-fr: substances laitières modifiées
-hr: modificiranih mliječnih sastojaka
-hu: módosított tej összetevők
-it: ingredienti del latte modificati
-# ingredient/fr:substances-laitières-modifiées has 86 products @2019-02-22
-
-< en:milk
-fr: lait écrémé caillé
-ca: llet desnatada cuallada, llet descremada cuallada, llet cuallada desnatada, llet cuallada descremada
-es: leche desnatada cuajada, leche descremada cuajada, leche cuajada desnatada, leche cuahada descremada
-
-< en:milk
-en: milk filtrate
-hr: filtrat mlijeka
-it: filtrato di latte
 
 < en:coating
 < en:milk
+< en:preparation
 en: milk coating
 hr: mliječni preljev
 it: rivestimento al latte
@@ -5749,7 +4553,8 @@ it: Panna montata
 nl: slagroom
 pl: bita śmietana, bitej śmietany
 
-< en:skimmed milk
+< en:cream
+< en:milk
 #<en:pasteurized cream
 en: Skim milk and pasteurized cream
 ca: crema de llet desnatat pasteuritzat, nata desnatat pasteuritzat
@@ -16113,7 +14918,7 @@ fr: matière grasse lactique, matière grasse laitière, matière grasse de lait
 hr: mlijecnu mast, mliječna mast, mliječne masti, mliječne masti
 hu: tejzsír
 is: mjólkurfita
-it: grasso del latte
+it: grasso del latte, grasso di latte
 lt: pieno riebalai
 lv: piena tauki
 nb: melkefett
@@ -27372,12 +26177,6 @@ uk: вівсяне молоко
 zh: 燕麦奶
 wikidata:en: Q20972637
 #28 @2021-09-22
-
-< en:oat milk
-en: oat milk powder
-de: Haferdrinkpulver
-hr: zobeno mlijeko u prahu
-it: latte d'avena in polvere
 
 # <en:compound
 en: oat base
@@ -44804,13 +43603,13 @@ es: Leche de coco
 fi: kookosmaito
 fr: lait de noix de coco, lait de coco
 hr: kokosovo mlijeko
-it: latte di noce di cocco
+it: latte di noce di cocco, latte di noci di cocco
 nb: kokosmelk
 nl: kokosmelk, kokosnootmelk, kokosroom
 pl: mleko kokosowe, mleczko kokosowe, mleka kokosowego, mleczka kokosowego, napój kokosowy, napój z kokosa
 pt: Leite de cocô
 ru: Кокосовое молоко
-sv: kokosmjölk
+sv: kokosmjölk, kokosmjölks
 zh: 椰子奶
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:lait-de-noix-de-coco
 # 87 products @2018-10-03
@@ -44853,27 +43652,6 @@ es: agua de coco natural
 fr: Eau de noix de coco naturelle
 hr: prirodna kokosova voda
 it: acqua di cocco naturale
-
-< en:coconut milk
-en: coconut milk powder, powdered coconut milk
-bg: кокосово мляко на прах
-ca: llet de coco en pols
-de: Kokosnussmilchpulver, Kokosmilchpulver
-es: leche de coco en polvo
-fi: kookosmaitojauhe
-fr: lait de noix de coco en poudre, lait de coco en poudre
-hr: kokosovo mlijeko u prahu
-it: latte di noci di cocco in polvere
-nl: kokosmelkpoeder
-pl: mleko kokosowe w proszku, mleczko kokosowe w proszku
-sv: kokosmjölkspulver
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:lait-de-noix-de-coco-en-poudre
-# 53 products in 3 languages @2018-10-03
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:lait-de-coco-en-poudre
-# 69 products in 3 languages @2018-10-03
-
-< en:coconut milk powder
-fr: lait de coco reconstitué
 
 #processing:en: en:extract
 #<en:coconut
@@ -74013,7 +72791,7 @@ wikidata:en: Q26736348
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 
-description:en: A MUSHROOM, or toadstool, is the fleshy, spore-bearing fruiting body of a fungus, typically produced above ground on soil or on its food source.
+# description:en: A MUSHROOM, or toadstool, is the fleshy, spore-bearing fruiting body of a fungus, typically produced above ground on soil or on its food source.
 # There is a wikipedia translation issue. Mushroom often refers to spores, so edible mushroom is better. However the edible part is not found on packages.
 #comment:nl:In dutch champignon refers to AGARICUS BISPORUS.
 
@@ -93230,6 +92008,7 @@ it: besciamella
 ja: ベシャメルソース
 kk: Бешамель
 ko: 베샤멜 소스
+lb: Béchsemëllech
 ms: Sos Béchamel
 nb: hvit saus
 nl: Bechamelsaus, bechamel

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -37,26 +37,29 @@ da: rå
 de: roh, rohe, roher, rohes
 el: ακατέργαστο
 es: crudo, cruda, crudos, crudas
-fi: raaka
+fi: raaka, tila
 fr: cru, crue, crus, crues, brut, non raffiné
-hr: nerafinirani, nerafinirano
+hr: nerafinirani, nerafinirano, sirovo
 hu: nyers, nyersen
-# da:parse:rå$
-# fi:parse:raaka$
-# sv:parse:rå$
 it: crudo, cruda, crudi, crude
 ja: 生
+lt: neapdorotas
 nl: rauw, rauwe
 pl: surowy, surowa, surowe
 pt: cru, crus
+ro: crud
+ru: сырое
 sv: rå, rått, råa
+tr: çiğ
+zh: 生
 
 en: fresh
-bg: пресно, пресен, пресна, пресни, прясно
+bg: пресно, пресен, пресна, пресни, прясно, свежо
 ca: fresc, fresca, frescos, fresques
 da: frisk, friske
 de: frisch, frische, frischer, frisches
 es: fresco, fresca, frescos, frescas
+fi: tuore
 fr: frais, fraîche, fraiche, fraîches, fraiches
 hr: svježe, sviježi, svježi, svježih, svježeg
 hu: friss
@@ -119,6 +122,20 @@ sv: vald, valda, valt, valda
 #pt:de qualidade superior
 #sv:överlägsen kvalitet
 
+# organic: implies certain standards (no synthetic pesticides, no gmos, animal welfare, etc.)
+en: organic, from organic farming
+bg: биологично, био
+ca: ecològica, d'agricultura ecològica
+de: Bio-, aus biologischer Landwirtschaft
+es: ecológica, de agricultura ecológica, orgánica
+fi: luomu
+fr: biologique, issu de l'agriculture biologique, bio
+hr: organsko
+hu: bio
+it: organico, da agricoltura biologica, biologico
+lt: ekologiškas
+nl: biologische, van biologische oorsprong
+
 en: unfiltered
 bg: непречистен, нефилтриран
 ca: no filtrat
@@ -141,7 +158,7 @@ ca: no homogeneïtzat
 da: uhomogeniseret
 de: nicht homogenisiert
 es: no homogeneizado
-fr: non-homogénéisé
+fr: non-homogénéisé, non homogeneise
 hr: nehomogenizirano
 it: non omogeneizzato
 lt: nehomogenizuotas
@@ -513,6 +530,7 @@ hr: koncentrirana kaša, koncentrirane kaše, kaša od koncentrirane, od koncent
 hu: koncentrált püré, püré koncentrált
 it: purea concentrata, purea di concentrata
 ja: 濃縮ピューレ, 濃縮ピューレー
+ms: pekat
 pl: puree skoncentrowane, puree z skoncentrowane
 pt: pure concentrado, pure de concentrado
 sv: koncentrerad puré, puré av koncentrerad
@@ -524,23 +542,47 @@ hu: morzsolt
 
 ##################### THE RESULT OF THE PROCESS ##############
 
-en: whole
+en: whole, and whole
 bg: цял, цяло, цяла, цели
 ca: sencer, sencera, sencers, senceres
-da: hele
-de: ganz, ganze, ganzer, ganzes
+da: hele, sød
+de: ganz, ganze, ganzer, ganzes, voll
 #ganz is not added as it is used in combination with fats (palm ganz gehärtet)
+el: Πλήρες
 es: entero, entera, enteros, enteras
-fi: kokonainen, kokonaiset
-fr: entier, entière, entiers, entières
+et: täis
+fi: kokonainen, kokonaiset, täys
+fr: entier, entière, entiers, entières, et entier
+he: מלא
 hr: cijele, cijeli
-hu: egész, egészben
+hu: egész, egészben, teljes
+is: ný
 it: intero, intera, interi, intere, integrale, integrali
 ja: 全
-pl: całe, w całości, cała, cały
-pt: inteiro, inteira, inteiros, inteiras, integral
+lt: nenugriebto, nenugriebtas
+lv: piln
+nb: hel
+nl: volle
+pl: całe, w całości, cała, cały, pelne, pełne
+pt: inteiro, inteira, inteiros, inteiras, integral, entero, enteiro, gordo
+ro: integral
+ru: цельное
+sq: gjithë
 sv: hel, hela
 # unclear what the dutch variant is
+
+< en:whole
+en: whole fat, full cream
+bg: пълномаслено
+bs: punomasno
+cs: plnotučné
+fi: rasvainen
+hr: punomasno, s mliječne masti, s 2.8% mliječne masti, s 3.2% mliječne masti, s 3.5% mliječne masti, s 6.0% mliječne masti, s 6% mliječne masti, s 10% mliječne masti, s 12% mliječne masti, s 18% mliječne masti, s 20% mliječne masti, s 25% mliječne masti, s 33% mliječne masti, s 36% mliječne masti
+hu: zsiros
+sk: plnotučné
+sv: fetthaltigt
+zh: 全脂
+
 
 en: halved, halves
 bg: наполовина
@@ -636,7 +678,7 @@ fi: rouhe
 nl: gries, grits, grut
 sv: färs
 
-en: powder, powdered
+en: powder, powdered, in powder
 af: poeier
 ar: مسحوق
 be: парашок
@@ -653,20 +695,20 @@ eo: pulvoro, pulvorigita
 es: en polvo, polvo de
 et: pulber
 fa: پودر
-fi: jauhe
-fr: en poudre, poudre de, poudre d', semoule de, semoule d', semoule, en semoule, poudre
-he: אבקה
+fi: jauhe, jauhetta
+fr: en poudre, poudre de, poudre d', semoule de, semoule d', semoule, en semoule, poudre, à base de poudre de, poudres de
+he: אבקה, אבקת
 hi: चूर्ण, पाउडर
 hr: prah, prah od, praha, prahu, u prahu
 ht: Poud
 hu: porított, por
 id: Bubuk
 io: Polvo
-is: duft
+is: duft, urduft
 it: in polvere, en polvere, polvere di, polvere d'
 ja: パウダー, 粉末, 末
 jv: Bubuk
-ko: 가루
+ko: 가루, 분
 lt: milteliai
 lv: pulveris
 mk: прав
@@ -680,6 +722,7 @@ ru: сухие, порошок
 # Google translates to dry
 sk: v prahu, sušená
 sl: v prahu
+sq: pluhur
 sr: прах
 sv: pulver
 te: పొడి
@@ -695,6 +738,9 @@ wikidata:en: Q2908004
 # nb:parse:$pulver
 # sv:parse:$pulver
 
+< en:powder
+en: soluble powder
+fr: poudre soluble, en poudre soluble, poudre soluble de
 
 #comment:en:Not all languages use (have?) a separate word for flour, but use powder instead
 #<en:powdered
@@ -716,7 +762,7 @@ hr: brašno, posije, prekrupa
 hu: liszt
 is: mjöl
 it: farina di, farina d'
-ja: 粉, フラワー
+ja: フラワー
 lt: miltai, miltų
 lv: milti
 nb: mel
@@ -731,7 +777,6 @@ sl: moka
 sr: пиринчано брашно
 sv: mjöl
 th: แป้ง
-zh: 粉
 wikidata:en: Q36465
 
 #######################################################################
@@ -956,36 +1001,6 @@ es: extracción en frío, extraído en frío, extraída en frío, extraídos en 
 fr: extraction à froid, extrait à froid, extraite à froid, extraits à froid, extraites à froid
 it: estratto a freddo
 
-en: defatted
-bg: обезмаслено, обезмаслен, обезмаслена, обезмаслени
-ca: desgreixat, desgreixada, desgreixats, desgreixades
-de: entfettet, entfettete, entfetteter, entfettetes, entfetteten, entfettetem
-es: desengrasado, desengrasada, desgrasado, desgrasada
-fr: dégraissé, dégraissée, dégraissés, dégraissées
-hu: zsírtalanított
-it: sgrassato, sgrassata
-ja: 脱脂
-nl: ontvet, ontvette
-pl: odtłuszczone, o obniżonej zawartości tłuszczu, odtłuszczony, odtłuszczona, odtłuszczonego
-pt: desengordurado, desengordurada
-ro: degresat
-
-#<en:defatted
-en: partially defatted
-bg: частично обезмаслен, частично обезмаслено
-ca: parcialment desgreixat, parcialment desgreixada, parcialment desgreixats, parcialment desgreixades
-de: teilentfettet, teilentfettete, teilentfettetes, teilentfetteter, teilentfetteten, teilentfettetem
-pl: częściowo odtłuszczone, częściowo odtłuszczony, częściowo odtłuszczona, częściowo odtłuszczonego, półtłusty
-pt: parcialmente desengordurado, parcialmente desengordurada
-ro: demidegresat
-
-#en:description:Sap is the fluid that comes from trees
-en: sap
-ca: saba
-es: savia
-it: linfa, linfa di, linfa d'
-pt: seiva, seivas, seiva de, seivas de
-
 en: juice, juices, juices of, juice from
 #en:comment:juice and mango pulp, juices and purees of fruit, vegetable juice color, chicken-meat-including-chicken-juices, juice-concentrates, reconstituted-vegetable-juice-blend, tomatoes-in-tomato-juice, chicken-meat-including-natural-chicken-juices, fruit-and-vegetable-juice-color, beet-juice-color
 az: şıresl
@@ -1073,13 +1088,13 @@ en: liquid
 ca: líquid
 da: flydende
 de: flüssiger
-es: líquido
+es: líquido, fluída
 fi: nestemäinen
 fr: liquide
 hr: tekući, tekuća
 it: liquido
 ja: 液
-nl: vloeibaar
+nl: vloeibaar, vloeibare
 pl: płyn, płyn z, masa z, masa, w płynie, płynny, płynna
 
 # en:description:To increase the strength and diminish the bulk of, as of a liquid or an ore; to intensify, by getting rid of useless material.
@@ -1094,10 +1109,10 @@ de: konzentriert, konzentrierter, konzentrierte, konzentriertes, konzentrierten,
 # de:parsing:before and after, space
 es: concentrado, concentrada, concentrados, concentradas
 fa: کنسانتره
-fi: tiivistetty, tiiviste, tiivisteitä
+fi: tiivistetty, tiiviste, tiivisteitä, tiivistettä
 fr: concentré, concentrée, concentrés, concentrées, concentré de
 hr: iz koncentrata, koncentriran, koncentrirani, koncentrani, koncentrat, koncentrat za, koncentrati, od koncentrata, konc
-hu: sűrítmény, sűrített, koncentrátum
+hu: koncentrátum
 it: concentrato, concentrato di, concentrato d', concentrati, concentrata, concentrate
 ja: 濃縮
 ko: 농축물
@@ -1170,7 +1185,7 @@ sv: koncentrerad extrakt
 #fr:pâte de, pâte d'
 #hr:pasta, pasta od
 #it:pasta di, pasta d'
-ja: ペースト
+ja: ペースト, 練
 #pl:pasta z, pasta
 #sv:pasta
 
@@ -1200,9 +1215,10 @@ sk: z koncentrátu
 sv: från koncentrat
 
 #en:description:Dehydration by artificial or natural processes
+# anhydrous: No water, dehydrated: Water removed, dried: Less water.
 en: dried, dry
 ar: مجف
-bg: изсушен, изсушено, изсушена, изсушени, сушен, сушено, сушена, сушени
+bg: изсушен, изсушено, изсушена, изсушени, сушен, сушено, сушена, сушени, сухо
 ca: dessecat, dessecade, dessecades, dessecats
 co: secchi
 cs: sušené, sušená, sušenná, sušený, suseny
@@ -1212,25 +1228,25 @@ es: seco, seca, secos, secas, secados, secadas, desecado, desecada, desecados, d
 et: kuivatatud
 fi: kuivattu, kuivatut
 fr: séché, séchée, séchés, séchées, sèches
-he: מיובשים, מיובש
+he: מיובשים, מיובש, יבש
 hr: sušena, sušene, sušeni, sušeno, suha, suhe, suhi, suho, suhog
 hu: szárított
 it: secco, secca, secchi, secche, essiccato, essiccati, essiccata, essiccate
 ja: ドライ, 乾燥
 lt: džiovinti, džiovinta
-lv: žāvēti
-nb: tørkede
+lv: žāvēti, sausais
+nb: tørkede, tørr
 nl: gedroogd, gedroogde
 nn: tørket
 pl: suszony, suszona, suszone, suszonych, suszonej, suszonego, susz z, susz, suszu
 pt: seco, seca, secos, secas
 ro: uscate
-ru: сушеный, Сушеное, сушёная, сушёный
+ru: сушеный, Сушеное, сушёная, сушёный, сухое, из сухого
 sk: sušené
 sr: sušeno
 sv: torkad, torkade
 th: ตาก, ออบแห้ง
-uk: сушена
+uk: сушена, сухе
 
 # <en:dried
 en: semi-dried
@@ -1327,7 +1343,23 @@ pl: syrop
 pt: Xarope
 sv: sirap
 
-#<en:dried
+# anhydrous: No water, dehydrated: Water removed, dried: Less water.
+en: anhydrous
+ar: لامائي
+ca: Anhidre
+da: Vandfri
+es: 	Anhidro
+eu: 	Anhidro
+fa: 	انیدروز
+fr: 	Anhydre
+id: 	Anhidrat
+it: 	Anidro
+nl: 	Watervrij
+pt: 	Anidro
+vi: 	Khan
+zh: 	无水物
+
+# anhydrous: No water, dehydrated: Water removed, dried: Less water.
 en: dehydrated
 bg: дехидратиран, дехидратирано, дехидратирана, дехидратирани
 ca: deshidratat, deshidratada
@@ -1364,13 +1396,14 @@ bg: рехидратиран, рехидратирано, рехидратира
 ca: rehidratat, rehidratada
 da: rehydreret, rehydrerede
 de: rehydriert, rehydrierte, rehydrierter, rehydriertes, rehydrierten, rehydriertem
-es: rehidritado, rehidritada, rehidritados, rehidritadas
+es: rehidritado, rehidritada, rehidritados, rehidritadas, rehidratada
 fi: rehydratoitu
 fr: réhydraté, réhydratée, réhydratés, réhydratées
 hr: rehidrirana, rehidrirani
 hu: rehidratált
 it: reidratato, reidratata, reidratati, reidratate
 nb: rehydrerte, rehydrert
+nl: gerehydrateerde
 pl: uwodnione, uwodniony, uwodniona
 pt: reidratado, reidratada, reidratados, reidratadas
 sv: rehydrerat, rehydrerad, rehydrerade
@@ -1415,17 +1448,20 @@ pt: parcialmente hidratado, parcialmente hidratada, parcialmente hidratados, par
 sv: delvis hydrerad, delvis hydrerade
 
 en: reconstituted
-bg: реконституиран, реконституирано, реконституирана, реконституирани
+bg: реконституиран, реконституирано, реконституирана, реконституирани, възстановено, възтановено, възстановео
 ca: reconstituida
 da: rekonstitueret, rekonstituerede
 de: rekonstituiert, rekonstituierte, rekonstituierter, rekonstituiertes, rekonstituierten, rekonstituiertem, wiederaufbereitet, wiederaufbereitete, wiederaufbereiteter, wiederaufbereitetes
 es: reconstituido, reconstituida, reconstituidos, reconstituidas
 fr: reconstitué, reconstituée, reconstitués, reconstituées
 hr: rekonstituirano
+hu: visszaállított, feloldott
 it: ricostituito, ricostituita, ricostituiti, ricostituite, riconstituito, riconstituita, riconstituiti, riconstituite
 lt: regeneruotas
+nl: gereconstitueerde
 pl: odtworzony, odtworzone, odtworzona, odtworzonego, odtworzonej, odtworzonych
 pt: reconstituído, reconstituída, reconstituídos, reconstituídas
+ru: восстановленное
 sv: rekonstituerad, rekonstituerade
 
 en: partially reconstituted
@@ -1602,10 +1638,12 @@ sv: maskinurbenat
 # currently not well supported, so we also have entries for "mechanically separated meat" in the ingredients taxonomy
 
 en: solids
-da: tørstof
-es: sólidos de
+da: tørstof, tørstoffer
+es: sólidos, sólidos de, sólidos de la, solidos, solidos de, solidos de la
 fi: kuiva-aine
 fr: solides du
+he: מוצקי
+hr: čvrste tvari
 it: solidi di
 nb: tørrstoff
 sv: fast
@@ -1625,6 +1663,122 @@ wikidata:en: Q7601513
 #en:germ, gluten, starch, wet-milling
 #fr:germe, gluten, amidon
 #hr:klica, gluten, škrob
+
+en: condensed
+af: Kondens
+ar: المبخر
+az: Qatılaşdırılmış
+be: згушчанае
+bg: кондензирано
+ca: condensada
+cs: kondenzované
+da: kondenserad, kondenseret
+de: Kondens, kondensierte, dosen, büchsen
+el: συμπυκνωμένο
+eo: kondensita
+es: condensada
+et: kondens
+eu: lurrundua, kondentsatu
+fa: تغلیظ‌شده
+fi: kondensoitu
+fr: condensé, condensée, condensés, condensées
+gl: condensado
+he: מרוכז
+hr: kondenzirano, ugušćeno
+hu: sűrített, sűrtett, sűrítmény
+hy: Խտացրած
+id: kental
+it: condensato
+kn: ಕಂಡೆನ್ಸ್‌ಡ್
+ko: 연
+lb: kondenséiert
+lt: sutirštintas, kondensuotas
+lv: iebiezināts, iebiezinātais
+nb: kondensert
+nl: gecondenseerde
+pl: skondensowane
+pt: condensada, condensado
+ro: condensat
+ru: сгущенное, сгущённое
+sl: kondenzirano
+sv: kondenserad
+th: ข้น
+tl: na kondensada
+tr: Kondense
+tt: Куертылган
+uk: згущене
+vi: đặc
+zh: 煉
+
+# description:en:LOW-FAT MILK is a 1% fat milk, sold in the United States
+# description:en:Skimmed milk (British English) is made when all the cream is removed from whole milk. It tends to contain around 0.1% fat. Láit écrémé has a maximum of 0.5% fat.
+# description:en:Skim milk (American English), is made when all the cream is removed from whole milk. It tends to contain around 0% fat.
+# Nonfat, skim milk and skimmed milk are often used as synonyms and the
+# regulatory differences are small, with the average being between 0.0% and
+# 0.2% fat. We are thus using only one taxonomy entry for all milks with
+# a maximum of 0.5% fat
+
+en: skimmed, skim, non-fat, nonfat, fat-free, low-fat, lowfat, defatted, 1% fat, with 0.5% milk fat
+ar: منزوع الدسم
+bg: обезмаслено, обезмаслно, обезмаслен, обезмаслена, обезмаслени
+ca: desnatada, descremada, desgreixat, desgreixada, desgreixats, desgreixades, sense greix, baixa en greixos
+cs: odstředěné, odstředěné
+da: skummet
+de: Mager, entrahmtes, entrahmte, entfettet, entfettete, entfetteter, entfettetes, entfetteten, entfettetem, fettarme
+el: αποβουτυρωμένο
+es: desnatada, descremada, desengrasado, desengrasada, desgrasado, desgrasada, sin grasas, baja en grasa
+et: koorimata, kooritud
+fa: خشک بدون چربی
+fi: rasvaton, rasvatonta, Vähärasvainen
+fr: écrémé, maigre, dégraissé, dégraissée, dégraissés, dégraissées
+gl: desnatado
+he: רזה
+hr: obrano, obrane, obrani, fölözött, alacsony zsírtartalmú, s 0.5% mliječne masti, s 0.1% mliječne masti
+hu: sovány, zsírtalanított
+id: skim
+is: undanrennur
+it: scremato, magro, sgrassato, sgrassata, senza grassi, magro
+ja: 脱脂
+lt: nugriebtas, nugriebto, lieso
+lv: vaj, vāj
+mk: обрано
+ms: skim
+nb: skummet
+nl: mager, magere, ontvet, ontvette, tapte, onder, afgeroomde, vetvrije
+no: skummet
+pl: odtłuszczone, chude, o obniżonej zawartości tłuszczu, odtłuszczony, odtłuszczona, odtłuszczonego
+pt: magro, desnatado, desengordurado, desengordurada
+ro: degresat
+ru: обезжиренноё, и обезжиренноё, обезжиренный, обезжиренное, безжиренное, и обезжиренное
+sk: odstredené
+sl: posneto
+sq: i skremuar
+sv: skum, lätt
+th: ขาดมันเนย
+tr: yağsız, kaymağı alınmış
+uk: Знежирене
+vi: gầy
+zh: 脱脂
+
+< en:skimmed
+en: semi-skimmed, partially defatted, reduced-fat, partly skimmed, partially skimmed, part skim
+bg: Полуобезмаслено, частично обезмаслен, частично обезмаслено
+ca: parcialment desnatada, semidesnatada, parcialment desgreixat, parcialment desgreixada, parcialment desgreixats, parcialment desgreixades
+da: let
+de: teilentrahmte, teilentfettet, teilentfettete, teilentfettetes, teilentfetteter, teilentfetteten, teilentfettetem, halbentrahmte
+es: parcialmente desnatada, semidesnatada, semidescremada, parcialmente descremada
+fi: kevyt
+fr: semi-écrémé, demi-écrémé, partiellement écrémé
+hr: poluobrano, djelomično obrano, djelimično obrano, s 1.5% mliječne masti, s 1.0% mliječne masti, s 1% mliječne masti, s 2.0% mliječne masti, s 2% mliječne masti, s 2.5% mliječne masti
+hu: zsírszegény, félzsíros
+is: létt
+it: semi-magro, parzialmente scremato, semiscremato
+nb: lett
+nl: halfvolle, gedeeltelijk afgeroomde
+pl: częściowo odtłuszczone, częściowo odtłuszczony, częściowo odtłuszczona, częściowo odtłuszczonego, półtłusty, półtłuste
+pt: meio gordo, parcialmente desengordurado, parcialmente desengordurada, parcialmente desnatado
+ro: demidegresat
+sv: mella
 
 #######################################################################
 #
@@ -1668,29 +1822,78 @@ nl: ontdooid
 pt: descongelado, descongelada, descongelados, descongeladas
 sv: ofryst, ofrossad
 
+#en:description:Sterilization (or sterilisation) refers to any process that removes, kills, or deactivates all forms of life and other biological agents present in or on a specific surface, object, or fluid. Sterilization can be achieved through various means, including heat, chemicals, irradiation, high pressure, and filtration.
+# Sterilized: higher temperature (more than 100'C) than pasteurised, kills spores, longer conservation
+en: sterilized, sterilised
+bg: стерилизирано, стерилизиран, стерилизирана, стерилизирани
+ca: esterilitzat, esterilitzada
+da: steriliseret
+de: sterilisiert, sterilisierte, sterilisierter, sterilisiertes, sterilisierten, sterilisiertem
+es: esterilizado, esterilizada, esterilizados, esterilizadas
+fi: steriloitu
+fr: stérilisé, stérilisée, stérilisés, stérilisées
+hr: sterilizirano
+hu: hőkezelt, sterilizált
+it: sterilizzato, sterilizzata, sterilizzati, sterilizzate
+lt: sterilizuotas
+nl: gesteriliseerd, gesteriliseerde
+pl: sterylizowane
+pt: esterilizado, esterilizada, esterilizados, esterilizadas
+sv: steriliserad
+wikidata:en: Q191618
+wikipedia:en: https://en.wikipedia.org/wiki/Sterilization_(microbiology)
+
+# Pasteurized: lower temperature (less than 100'C) than sterilized, cannot kill all spores, shorter conservation, preserve taste
 en: pasteurised, pasteurized
 bg: пастьоризиран, пастьоризирана, пастьоризирано, пастьоризирани
 ca: pasteuritzada, pasteuritada, pasteuritzat, pasteuritzats
+cs: pasterizované
 da: pasteuriseret
 de: pasteurisiert, pasteurisierte, pasteurisierter, pasteurisiertes
 es: pasteurizado, pasteurizada, pasteurizados, pasteurizadas, producto pasteurizado, producto pasteurizada, pasterizada
-fi: pastöroitu
-fr: pasteurisé, pasteurisée, pasteurisés, pasteurisées
+et: pastöriseeritud
+fi: pastöroitu, pastöroidusta
+fr: pasteurisé, pasteurisée, pasteurisés, pasteurisées, et pasteurisé
 hr: pasterizirano, pasterizirana, pasterizirani
-hu: pasztőrözött, pasztörizált
+hu: pasztőrözött, pasztörizált, pasztörizál
 it: pastorizzato, pastorizzata, pastorizzate, pastorizzati
 ja: パスチャライズ
+lt: pasterizuotas
 nb: pasteurisert
 nl: gepasteuriseerd, gepasteuriseerde
 pl: pasteryzowana, pasteryzowane, pasteryzowany, pasteryzowanego, pasteryzowanej
 pt: pasteurizado, pasteurizados, pasteurizada, pasteurizadas
 ro: pasteurizat, pasteurizata
-ru: пастеризованные
+ru: пастеризованные, Пастеризованное
 sr: pasterizovana
 sv: pastöriserad
+tr: pastörize
+
+#pasteurisation of 15s under 72–74 °C
+< en:pasteurised
+en: low-pasteurized
+sv: lågpastöriserad
+
+#pasteurisation of 5s under 80 °C
+< en:pasteurised
+en: high-pasteurized
+sv: högpastöriserad
 
 < en:pasteurised
-sv: högpastöriserad
+< en:sterilised
+en: UHT, UHT pasteurised, UHT sterilised, ultra heat treated
+bg: UHT, UHT пастьоризирано
+ca: UHT, esterilitzada UHT
+de: UHT, H-, Haltbar, Haltbare
+es: UHT, esterelizada UHT, esterilizada UHT
+fi: UHT, iskukuumennettu, UHT-käsitelty
+fr: UHT, stérilisé U.H.T, stérilisé u h t, stérilisé uht, pasteurisation haute
+hr: UHT, uht pasterizirano, uht sterilizirano, trajno
+hu: UHT, pasztőrözött UHT
+it: UHT, pastorizzato UHT, UHT sterilizzato, uht verhit
+nl: UHT, UHT-gesteriliseerde
+pl: UHT
+sv: UHT, UHT-behandlad
 
 en: thermised, thermized, thermalised, thermalized
 ca: termitzada
@@ -1698,7 +1901,7 @@ de: thermisiert
 es: termizada
 fr: thermisé
 it: termizzato
-nl: thermisch behandeld
+nl: thermisch behandeld, gestremde
 pt: termizado
 
 en: heat treated
@@ -1712,6 +1915,8 @@ es: sin pasteurizar, no pasteurizado, no pasteurizados
 fr: non pasteurisé
 pl: niepasteryzowana, niepasteryzowane, niepasteryzowany
 pt: não pasteurizado, não pasteurizados, não pasteurizada, não pasteurizadas
+sv: opastöriserad
+tr: pastörize edilmemiş
 
 en: pre-cooked, precooked
 ca: precuit
@@ -1816,7 +2021,10 @@ en: caramelized, caramelised
 bg: карамелизиран, карамелизирана, карамелизирано, карамелизирани
 bs: karamelizovani
 ca: caramel-litzat
-hr: karamelizirani, karameliziranih
+de: Karamellisiertes
+fi: karamellisoitu
+fr: caramélisé
+hr: karamelizirani, karameliziranih, karamelizirano
 hu: karamellizált
 it: caramellato, caramellata, caramellati, caramellate
 nl: gekarameliseerde, gekaramelliseerde
@@ -1988,11 +2196,22 @@ nl: verrijkt, verrijkte, verrijkt, verrijkte
 pl: wzbogacany, wzbogacana, wzbogacane, wzbogacanej, wzbogacanego, wzbogacanych, fortyfikowany, fortyfikowana, fortyfikowane
 pt: enriquecido, enriquecida, enriquecidos, enriquecidas, enriquecido com, enriquecida com, enriquecidos com, enriquecidas com, enriquecido em, enriquecida em, enriquecidos em, enriquecidas em
 
+< en:enriched
+en: enriched with fat
+ca: enriquida en matèria grassa
+es: enriquecida en materia grasa
+fr: enrichi en matière grasse
+
 en: fortified
 es: fortificado, fortificada, fortificados, fortificadas
 fr: fortifié, fortifiée, fortifiés, fortifiées
 it: fortificato, fortificata, fortificati, fortificate
 pt: fortificado, fortificada, fortificados, fortificadas
+
+# <en:condensed
+en: thickened
+de: eingedickte
+fr: épaissi
 
 #<en:unadded
 en: unenriched
@@ -2087,18 +2306,32 @@ nl: ongezouten
 pl: bez soli, niesolone
 pt: sem sal, não salgado
 
-en: sweetened
-bg: подсладено, подсладен, подсладена, подсладени
-de: gesüßt, gesüßte
-es: endulzado, endulzada, endulzados, endulzadas
-fi: makeutettu, makeutetut
-hr: zaslađene
-hu: édesített
-it: addolcito, addolciti, addolcita, addolcite
-nl: gezoet, gezoete
+en: sweetened, sugared, with sugar
+bg: подсладено, подсладен, подсладена, подсладени, захаросано, захаросан, захаросана, захаросани
+ca: ensucrada, amb sucre, dolc de
+cs: slazené
+da: sockrad, sukret
+de: gesüßt, gesüßte, gezuckert, gezuckerte, gezuckerter, gezuckertes
+el: ζαχαρούχο
+es: endulzado, endulzada, endulzados, endulzadas, azucarado, azucarada, azucarados, azucaradas, dulce de, azucadara
+et: magustatud
+fi: makeutettu, makeutetut, sokeroitu, sokeroidut, sokeroitua, sokeroituja
+fr: sucré, sucrée, sucrés, sucrées, sucree, sucrees
+hr: zaslađene, zaslađeno, zasladeno
+hu: édesített, cukrozott
+it: addolcito, addolciti, addolcita, addolcite, zuccherato, zuccherati, zuccherata, zuccherate
+ja: 加糖
+lt: saldintas
+lv: saldināts, saldinats
+nb: sukkerholdig, sukret, søt
+nl: gezoet, gezoete, gesuikerd, gesuikerde, met suiker
 pl: słodzony, słodzona, słodzone, słodzonych, słodzonej, słodzonego
-pt: adoçado, adoçada, adoçados, adoçadas, adocicado, adocicada, adocicados, adocicadas
-sv: sötad
+pt: adoçado, adoçada, adoçados, adoçadas, adocicado, adocicada, adocicados, adocicadas, açucarado, açucarada, açucarados, açucaradas
+ro: indulcit
+ru: с сахаром
+sl: sladkano
+sv: sötad, söt, sockrad
+th: หวาน
 
 < en:concentrated
 < en:sweetened
@@ -2112,22 +2345,6 @@ it: non zuccherato, non zuccherati, senza zucchero aggiunto, senza zuccheri aggi
 nl: ongezoet
 pl: niesłodzony, niesłodzona, niesłodzone
 pt: não adoçado, não adoçada, não adoçados, não adoçadas, não adocicado, não adocicada, não adocicados, não adocicadas, não açucarado, não açucarada, não açucarados, não açucaradas, sem açúcar, sem açúcares
-
-#<en:sweetened
-en: sugared
-bg: захаросано, захаросан, захаросана, захаросани
-ca: amb sucre
-de: gezuckert, gezuckerte, gezuckerter, gezuckertes
-es: azucarado, azucarada, azucarados, azucaradas
-fi: sokeroitu, sokeroidut, sokeroitua, sokeroituja
-fr: sucré, sucrée, sucrés, sucrées, sucree, sucrees
-#better not add fr:sucre and fr:sucres
-hu: cukrozott
-it: zuccherato, zuccherati, zuccherata, zuccherate
-ja: 加糖
-nl: gesuikerd, gesuikerde
-pt: açucarado, açucarada, açucarados, açucaradas
-sv: sockrad
 
 #<en:sugared
 de: leicht gezuckert, leicht gezuckerte, leicht gezuckerter, leicht gezuckertes
@@ -2343,21 +2560,6 @@ hr: rafinirano, djelomično rafinirano
 #en:Desugared, partially desugared
 #fr:Dessucré, partiellement dessucré
 #hr:bez šećera, sa smanjenom količinom šećera
-
-#en:description:Sterilization (or sterilisation) refers to any process that removes, kills, or deactivates all forms of life and other biological agents present in or on a specific surface, object, or fluid. Sterilization can be achieved through various means, including heat, chemicals, irradiation, high pressure, and filtration.
-en: sterilized
-bg: стерилизирано, стерилизиран, стерилизирана, стерилизирани
-ca: esterilitzat
-de: sterilisiert, sterilisierte, sterilisierter, sterilisiertes, sterilisierten, sterilisiertem
-es: esterilizado, esterilizada, esterilizados, esterilizadas
-fr: stérilisé, stérilisée, stérilisés, stérilisées
-hr: sterilizirano
-it: sterilizzato, sterilizzata, sterilizzati, sterilizzate
-nl: gesteriliseerd
-pt: esterilizado, esterilizada, esterilizados, esterilizadas
-wikidata:en: Q191618
-wikipedia:en: https://en.wikipedia.org/wiki/Sterilization_(microbiology)
-
 en: Homogenized
 bg: Хомогенизирано
 ca: homogeneïtzat
@@ -2373,6 +2575,35 @@ ro: omogenizat
 wikidata:en: Q1165158
 wikipedia:en: https://en.wikipedia.org/wiki/Homogenization_(chemistry)
 
+# for ingredients, lactose-free is not a processing but involves a chemical process, 
+# use of enzyme lactase to break down lactose into simpler sugars (glucose and galactose), 
+# which are easier to digest for those with lactose intolerance.
+en: lactose-free
+bg: без лактоза, безлактозно
+ca: sense lactosa
+de: laktosefreie
+es: sin lactosa
+fr: sans lactose
+hr: bez laktoze
+it: delattosato, senza lattosio
+nl: lactosevrije
+pl: bez laktozy
+
+# result of a filtration
+en: filtrate
+cs: Filtrát
+fr: filtrat
+hr: filtrat
+hu: szűrlet
+it: filtrato
+ru: Фильтрат
+sl: filtrat
+
+# microfiltration: filtration process where a contaminated fluid is passed through a special 
+# pore-sized membrane filter to separate microorganisms and suspended particles from process liquid
+en: microfiltrated
+fr: microfiltré
+
 #######################################################################
 #
 #                P R E P A R I N G   P R O C E S S E S
@@ -2380,7 +2611,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Homogenization_(chemistry)
 #######################################################################
 # Processes used multiple processes and ingredients
 
-en: fermented
+en: fermented, soured, cultured
 bg: ферментирало, ферментирал, ферментирала, ферментирали
 ca: fermentat
 cs: fermentovaný, fermentované, fermentovaná
@@ -2388,7 +2619,7 @@ da: fermenteret
 de: fermentiert, fermentierte, fermentierten, fermentiertem, fermentierter, fermentiertes
 es: fermentado
 fr: fermenté, fermentée, fermentés, fermentées
-hr: fermentirano, fermentirana
+hr: fermentirano, fermentirana, kultivirano
 hu: fermentált
 it: fermentato, fermentata, fermentati, fermentate
 ja: 発酵
@@ -2396,6 +2627,12 @@ pl: fermentowany, fermentowana, fermentowane, kiszony, kiszona, kiszone, kiszony
 pt: fermentado, fermentada, fermentados, fermentadas
 sv: fermenterat
 wikidata:en: Q6950796
+
+< en:fermented
+en: curdled
+ca: cuallada
+es: cuajada, cuahada
+fr: caillé, caillés
 
 fr: lactofermenté
 bg: лактоферментирано, лактоферментиран, лактоферментирана, лактоферментирани
@@ -2783,9 +3020,9 @@ ca: modificat, modificada, modificats, modificades
 da: modificeret, modificerede, modificerede, modificerede
 de: modifiziert, modifizierte, modifizierten, modifizierten
 es: modificado, modificada, modificados, modificadas
-fi: muokattu, muokattu, muokatut, muokatut
+fi: muokattu, muokattu, muokatut, muokatut, muunnettuja
 fr: modifié, modifiée, modifiés, modifiées
-hr: modificiran, modificirana, modificirani, modificirane
+hr: modificiran, modificirana, modificirani, modificirane, modificiranih
 hu: módosított, módosított, módosítottak, módosítottak
 it: modificato, modificata, modificati, modificate
 nl: gewijzigd, gewijzigde, gewijzigden, gewijzigde
@@ -2813,4 +3050,21 @@ fr: préparé, préparée, préparés, préparées
 < en:prepared
 en: freshly prepared
 fr: fraîchement préparé, fraîchement préparée, fraîchement préparés, fraîchement préparées
+
+#######################################################################
+#
+#                D O U B L E - M E A N I N G
+#
+#######################################################################
+
+< en:flour
+< en:powder
+en: powder or flour
+ja: 粉
+zh: 粉
+
+< en:concentrated
+< en:powder
+en: concentrated or powder
+fr: concentré ou en poudre
 


### PR DESCRIPTION
### What

#### Remarks:

- **Remark 1**: lost of ciqual

beside the benefit of 1) reducing the taxonomy file size and 2) having visibility of processing methods, the ciqual codes - for milk powder for example - are removed from the taxonomy.

- **Remark 2**: some ingredients have been added in the past (by me) to cover percentage of fat in the milk. Percentage can also be moved in the processing.

Example:

> en: skimmed milk with 0.1% lactose-free milk fat
> hr: obrano mlijeko s 0.1% mliječne masti bez laktoze
> it: latte scremato con 0.1% di grassi senza lattosio

It leads to duplicates in the processing key-value for the ingredient. 

> "processing": "en:lactose-free,en:skimmed,en:skimmed",


Duplicates could be removed maybe in the future?

- **Remark 3**: in some languages a single word defines skimmed-milk and semi-skimmed-milk. This is problematic.

> et: Lõss, lõssi, lössi
> is: Undanrenna, undanrennu
> pa: ਸਪਰੇਟਾ

- **Remark 4**: for some ingredients the processing method is in the middle of the inredients 

> de: Kuhrohmilch


But for most of the cases, the processing is extracted beside being in the middle of the ingredient. There might be already something in place to tackle that in the code but not covering all cases

- **Remark 5**: added some languages to parse the processing from the ingredients in Ingredient.pm, but also found some exception that need to be tackled 

For Example, 'hu' already "match after the ingredient, does not require a space" "match before the ingredient, require a space" but also should match before without space, like for tejpor





### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

