### PR TITLE
ci: dependabot: ignore 'jquery' updates to v3.0.0+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,9 @@ updates:
         patterns:
           - "ts-node"
           - "typescript"
+    ignore:
+      - dependency-name: "jquery"
+        versions: [ ">= 3.0.0" ]  # https://github.com/openfoodfacts/openfoodfacts-server/pull/11109
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

We use `jquery` v2.x for compatibility with the Foundation UI framework, as described in #11109.

However, Dependabot isn't yet configured to know about this, so it attempts to suggest that we upgrade to `jquery` v3.x - e.g. #11820 that it opened earlier today.

So, let's [configure Dependabot to ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#ignoring-specific-dependencies) those particular updates.

### Related issue(s) and discussion

- Follow-up to #11109.