### PR TITLE
fix: use 'yes' instead of 'en:yes' for vegan / vegetarian ingredients properties

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2269,8 +2269,8 @@ Text to analyze
 
 								# d'origine végétale -> not a geographic origin, add en:vegan
 								if ($origin_string =~ /vegetal|végétal/i) {
-									$vegan = "en:yes";
-									$vegetarian = "en:yes";
+									$vegan = "yes";
+									$vegetarian = "yes";
 								}
 								else {
 
@@ -2587,8 +2587,8 @@ Text to analyze
 					my $origin_string = $';
 					# d'origine végétale -> not a geographic origin, add en:vegan
 					if ($origin_string =~ /vegetal|végétal/i) {
-						$vegan = "en:yes";
-						$vegetarian = "en:yes";
+						$vegan = "yes";
+						$vegetarian = "yes";
 					}
 					else {
 						$origin = join(",",
@@ -3117,11 +3117,11 @@ Text to analyze
 
 					# If we have a label for the ingredient that indicates if it is vegan or not, override the value
 					if ($labels =~ /\ben:vegan\b/) {
-						$ingredient{vegan} = "en:yes";
-						$ingredient{vegetarian} = "en:yes";
+						$ingredient{vegan} = "yes";
+						$ingredient{vegetarian} = "yes";
 					}
 					if ($labels =~ /\ben:vegetarian\b/) {
-						$ingredient{vegetarian} = "en:yes";
+						$ingredient{vegetarian} = "yes";
 					}
 				}
 

--- a/tests/integration/expected_test_results/facets/brand_-brand1.json
+++ b/tests/integration/expected_test_results/facets/brand_-brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 9,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 9,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_-unknown.json
+++ b/tests/integration/expected_test_results/facets/brand_-unknown.json
@@ -1,6 +1,6 @@
 {
    "count" : 8,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 8,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_brand1.json
+++ b/tests/integration/expected_test_results/facets/brand_brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 5,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 5,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_brand2_brand_-brand1.json
+++ b/tests/integration/expected_test_results/facets/brand_brand2_brand_-brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 2,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 2,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/brand_unknown.json
+++ b/tests/integration/expected_test_results/facets/brand_unknown.json
@@ -1,6 +1,6 @@
 {
    "count" : 6,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 6,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category-vitamins.json
+++ b/tests/integration/expected_test_results/facets/category-vitamins.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_-apples.json
+++ b/tests/integration/expected_test_results/facets/category_-apples.json
@@ -1,6 +1,6 @@
 {
    "count" : 11,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 11,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_-apples_label_-organic.json
+++ b/tests/integration/expected_test_results/facets/category_-apples_label_-organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 3,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 3,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_-apples_label_organic.json
+++ b/tests/integration/expected_test_results/facets/category_-apples_label_organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 8,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 8,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_apples.json
+++ b/tests/integration/expected_test_results/facets/category_apples.json
@@ -1,6 +1,6 @@
 {
    "count" : 3,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 3,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_apples_label_organic.json
+++ b/tests/integration/expected_test_results/facets/category_apples_label_organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 3,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 3,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_-brand1.json
+++ b/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_-brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_brand1.json
+++ b/tests/integration/expected_test_results/facets/category_bananas_label_organic_brand_brand1.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/contributor-alice-label_organic.json
+++ b/tests/integration/expected_test_results/facets/contributor-alice-label_organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 10,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 10,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/contributor-alice.json
+++ b/tests/integration/expected_test_results/facets/contributor-alice.json
@@ -1,6 +1,6 @@
 {
    "count" : 13,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 13,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/contributor-bob.json
+++ b/tests/integration/expected_test_results/facets/contributor-bob.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/de-accented-cafe-label.json
+++ b/tests/integration/expected_test_results/facets/de-accented-cafe-label.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/label_fair-trade_label_-organic.json
+++ b/tests/integration/expected_test_results/facets/label_fair-trade_label_-organic.json
@@ -1,6 +1,6 @@
 {
    "count" : 2,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 2,
    "page_size" : 20,
    "products" : [

--- a/tests/integration/expected_test_results/facets/packager-code_fr-85-222-003-ce.json
+++ b/tests/integration/expected_test_results/facets/packager-code_fr-85-222-003-ce.json
@@ -1,6 +1,6 @@
 {
    "count" : 1,
-   "page" : "1",
+   "page" : 1,
    "page_count" : 1,
    "page_size" : 20,
    "products" : [

--- a/tests/unit/expected_test_results/ingredients/en-vegetal-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetal-ingredients.json
@@ -8,8 +8,8 @@
          "percent_max" : 100,
          "percent_min" : 20,
          "text" : "Gelatin",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:charcoal",
@@ -19,8 +19,8 @@
          "percent_max" : 50,
          "percent_min" : 0,
          "text" : "Charcoal",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:ferment",
@@ -30,8 +30,8 @@
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
          "text" : "ferments",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:rennet",
@@ -41,8 +41,8 @@
          "percent_max" : 25,
          "percent_min" : 0,
          "text" : "rennet",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:flavouring",
@@ -52,8 +52,8 @@
          "percent_max" : "5",
          "percent_min" : 0,
          "text" : "flavours",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis" : {

--- a/tests/unit/expected_test_results/ingredients/fr-vegetal-origin.json
+++ b/tests/unit/expected_test_results/ingredients/fr-vegetal-origin.json
@@ -8,8 +8,8 @@
          "percent_max" : 100,
          "percent_min" : 33.3333333333333,
          "text" : "mono- et diglycérides d'acides gras",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "from_palm_oil" : "maybe",
@@ -19,8 +19,8 @@
          "percent_max" : 50,
          "percent_min" : 0,
          "text" : "huile",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:e428",
@@ -29,8 +29,8 @@
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
          "text" : "gélatine",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis" : {

--- a/tests/unit/expected_test_results/ingredients/nl-e471-niet-dierlijk.json
+++ b/tests/unit/expected_test_results/ingredients/nl-e471-niet-dierlijk.json
@@ -9,8 +9,8 @@
          "percent_max" : 100,
          "percent_min" : 100,
          "text" : "e471",
-         "vegan" : "en:yes",
-         "vegetarian" : "en:yes"
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis" : {

--- a/tests/unit/ingredients_analysis.t
+++ b/tests/unit/ingredients_analysis.t
@@ -93,6 +93,20 @@ my @tests = (
 		["en:palm-oil-free", "en:non-vegan", "en:vegetarian-status-unknown"]
 	],
 
+	# vegan maybe ingredients
+	[
+		{lc => "en", ingredients_text => "coagulating enzyme"},
+		["en:palm-oil-free", "en:maybe-vegan", "en:maybe-vegetarian"]
+	],
+	[
+		{lc => "en", ingredients_text => "coagulating enzyme (vegetal)"},
+		["en:palm-oil-free", "en:vegan", "en:vegetarian"]
+	],
+	[
+		{lc => "en", ingredients_text => "something unknown (vegetal)"},
+		["en:palm-oil-content-unknown", "en:vegan", "en:vegetarian"]
+	],
+
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
In the ingredients structure, we have inconsistent values for the "vegetarian" and "vegan" properties. In the taxonomy, they are set to "yes", "no", "maybe", but in the ingredients analysis, if there was a label or vegetal origin (e.g. "coagulating enzyme (vegan)", we would put "en:yes" as a value.