### PR TITLE
fix: product search: de-duplicate ingredient filtering controls

### DIFF
--- a/templates/web/pages/search_form/search_form.tt.html
+++ b/templates/web/pages/search_form/search_form.tt.html
@@ -69,18 +69,6 @@
                 </div>
             [% END %]
         </div>
-        [% FOREACH type IN ingredients %]
-            <div class="small-12 medium-12 large-6 columns">
-                <label>[% lang ("${type.tagtype}_p") FILTER ucfirst %]</label>
-                <input type="radio" name="[% type.tagtype %]" value="without" id="without_[% type.tagtype %]" [% type.search_ingredient_classes_checked_without %]/>
-                    <label for="without_[% type.tagtype %]">[% lang('search_without') %]</label>
-                <input type="radio" name="[% type.tagtype %]" value="with" id="with_[% type.tagtype %]" [% type.search_ingredient_classes_checked_with %]/>
-                    <label for="with_[% type.tagtype %]">[% lang('search_with') %]</label>
-                <input type="radio" name="[% type.tagtype %]" value="indifferent" id="indifferent_[% type.tagtype %]" [% type.search_ingredient_classes_checked_indifferent %]/>
-                    <label for="indifferent_[% type.tagtype %]">[% lang('search_indifferent') %]</label>
-            </div>
-        [% END %]
-    </div>
 
         <!-- Nutriments Form -->
 

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -640,48 +640,6 @@
             
         </div>
         
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Additifs</label>
-                <input type="radio" name="additives" value="without" id="without_additives" />
-                    <label for="without_additives">Sans</label>
-                <input type="radio" name="additives" value="with" id="with_additives" />
-                    <label for="with_additives">Avec</label>
-                <input type="radio" name="additives" value="indifferent" id="indifferent_additives" checked="checked"/>
-                    <label for="indifferent_additives">Indifférent</label>
-            </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Ingrédients issus de l'huile de palme</label>
-                <input type="radio" name="ingredients_from_palm_oil" value="without" id="without_ingredients_from_palm_oil" />
-                    <label for="without_ingredients_from_palm_oil">Sans</label>
-                <input type="radio" name="ingredients_from_palm_oil" value="with" id="with_ingredients_from_palm_oil" />
-                    <label for="with_ingredients_from_palm_oil">Avec</label>
-                <input type="radio" name="ingredients_from_palm_oil" value="indifferent" id="indifferent_ingredients_from_palm_oil" checked="checked"/>
-                    <label for="indifferent_ingredients_from_palm_oil">Indifférent</label>
-            </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Ingrédients pouvant être issus de l'huile de palme</label>
-                <input type="radio" name="ingredients_that_may_be_from_palm_oil" value="without" id="without_ingredients_that_may_be_from_palm_oil" />
-                    <label for="without_ingredients_that_may_be_from_palm_oil">Sans</label>
-                <input type="radio" name="ingredients_that_may_be_from_palm_oil" value="with" id="with_ingredients_that_may_be_from_palm_oil" />
-                    <label for="with_ingredients_that_may_be_from_palm_oil">Avec</label>
-                <input type="radio" name="ingredients_that_may_be_from_palm_oil" value="indifferent" id="indifferent_ingredients_that_may_be_from_palm_oil" checked="checked"/>
-                    <label for="indifferent_ingredients_that_may_be_from_palm_oil">Indifférent</label>
-            </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Ingrédients issus ou pouvant être issus de l'huile de palme</label>
-                <input type="radio" name="ingredients_from_or_that_may_be_from_palm_oil" value="without" id="without_ingredients_from_or_that_may_be_from_palm_oil" />
-                    <label for="without_ingredients_from_or_that_may_be_from_palm_oil">Sans</label>
-                <input type="radio" name="ingredients_from_or_that_may_be_from_palm_oil" value="with" id="with_ingredients_from_or_that_may_be_from_palm_oil" />
-                    <label for="with_ingredients_from_or_that_may_be_from_palm_oil">Avec</label>
-                <input type="radio" name="ingredients_from_or_that_may_be_from_palm_oil" value="indifferent" id="indifferent_ingredients_from_or_that_may_be_from_palm_oil" checked="checked"/>
-                    <label for="indifferent_ingredients_from_or_that_may_be_from_palm_oil">Indifférent</label>
-            </div>
-        
-    </div>
-
         <!-- Nutriments Form -->
 
         <h3>Nutriments</h3>

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -639,7 +639,7 @@
                 </div>
             
         </div>
-        
+
         <!-- Nutriments Form -->
 
         <h3>Nutriments</h3>

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -639,48 +639,6 @@
                 </div>
             
         </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Additives</label>
-                <input type="radio" name="additives" value="without" id="without_additives" />
-                    <label for="without_additives">Without</label>
-                <input type="radio" name="additives" value="with" id="with_additives" />
-                    <label for="with_additives">With</label>
-                <input type="radio" name="additives" value="indifferent" id="indifferent_additives" checked="checked"/>
-                    <label for="indifferent_additives">Indifferent</label>
-            </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Ingredients from palm oil</label>
-                <input type="radio" name="ingredients_from_palm_oil" value="without" id="without_ingredients_from_palm_oil" />
-                    <label for="without_ingredients_from_palm_oil">Without</label>
-                <input type="radio" name="ingredients_from_palm_oil" value="with" id="with_ingredients_from_palm_oil" />
-                    <label for="with_ingredients_from_palm_oil">With</label>
-                <input type="radio" name="ingredients_from_palm_oil" value="indifferent" id="indifferent_ingredients_from_palm_oil" checked="checked"/>
-                    <label for="indifferent_ingredients_from_palm_oil">Indifferent</label>
-            </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Ingredients that may be from palm oil</label>
-                <input type="radio" name="ingredients_that_may_be_from_palm_oil" value="without" id="without_ingredients_that_may_be_from_palm_oil" />
-                    <label for="without_ingredients_that_may_be_from_palm_oil">Without</label>
-                <input type="radio" name="ingredients_that_may_be_from_palm_oil" value="with" id="with_ingredients_that_may_be_from_palm_oil" />
-                    <label for="with_ingredients_that_may_be_from_palm_oil">With</label>
-                <input type="radio" name="ingredients_that_may_be_from_palm_oil" value="indifferent" id="indifferent_ingredients_that_may_be_from_palm_oil" checked="checked"/>
-                    <label for="indifferent_ingredients_that_may_be_from_palm_oil">Indifferent</label>
-            </div>
-        
-            <div class="small-12 medium-12 large-6 columns">
-                <label>Ingredients from or that may be from palm oil</label>
-                <input type="radio" name="ingredients_from_or_that_may_be_from_palm_oil" value="without" id="without_ingredients_from_or_that_may_be_from_palm_oil" />
-                    <label for="without_ingredients_from_or_that_may_be_from_palm_oil">Without</label>
-                <input type="radio" name="ingredients_from_or_that_may_be_from_palm_oil" value="with" id="with_ingredients_from_or_that_may_be_from_palm_oil" />
-                    <label for="with_ingredients_from_or_that_may_be_from_palm_oil">With</label>
-                <input type="radio" name="ingredients_from_or_that_may_be_from_palm_oil" value="indifferent" id="indifferent_ingredients_from_or_that_may_be_from_palm_oil" checked="checked"/>
-                    <label for="indifferent_ingredients_from_or_that_may_be_from_palm_oil">Indifferent</label>
-            </div>
-        
-    </div>
 
         <!-- Nutriments Form -->
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Removes a duplicate set of radiobox controls for filtering product search based on ingredient-related properties (additives, relationship to palm oil) from the HTML template used by `cgi/search.pl`.

### Screenshots

#### Before (bug)

![image](https://github.com/user-attachments/assets/77e28199-6b54-45e4-8f23-dffa353d2e30)

#### After (fix)

![image](https://github.com/user-attachments/assets/c1ebf32b-d7f7-496e-9429-bfb4149ace63)

### Related issue(s) and discussion
Also removes a closing `</div>` that was causing an HTML parsing/validation error:

![image](https://github.com/user-attachments/assets/09939d4f-8b85-4ed6-9e09-7a22d105cdf5)

Resolves #11832.