### PR TITLE
feat: add "Edit this page" on every documentation page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ docs_dir: docs
 
 # Link to Github on every page
 repo_url: https://github.com/openfoodfacts/openfoodfacts-server
-edit_uri: blob/main/docs/
+edit_uri: edit/main/docs/
 # add canonical url
 site_url: https://openfoodfacts.github.io/openfoodfacts-server/
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ site_dir: gh_pages
 # for available extensions
 theme:
   name: material
+  features:
+    - content.action.edit
 
 markdown_extensions:
   - footnotes


### PR DESCRIPTION
Should add a link "Edit on Github" on every page, if I believe https://www.mkdocs.org/user-guide/configuration/#edit_uri
