### PR TITLE
Add badge placeholder for producer account

### DIFF
--- a/templates/web/pages/user_profile/user_profile.tt.html
+++ b/templates/web/pages/user_profile/user_profile.tt.html
@@ -15,6 +15,15 @@
 
 <p>[% lang("contributor_since") %][% sep %]: [% display_date_tag(registered_t) %]</p>
 
+[% IF user.producer_account %]
+  <div class="producer-badge">
+    <img src="/images/badges/producer.svg" alt="Producer badge" class="badge-icon" />
+    <span class="badge-label">Producer Account</span>
+    <a href="/producers/about" class="badge-link">(What’s this?)</a>
+  </div>
+[% END %]
+
+
 [% FOREACH link IN links %]
 	&rarr; <a href="[% link.url %]">[% link.text %]</a><br>
 [% END %]


### PR DESCRIPTION
### What

This change adds a visual badge to the user profile page to indicate if a user has a producer account. This helps increase transparency and visibility of verified producers within the Open Food Facts community.

The badge is displayed conditionally based on the `user.producer_account` flag and includes a label, icon, and a link to additional information.

### Screenshot

(Not included as this was a simple HTML template change.)

### Related issue(s) and discussion

- Fixes #9603
