### PR TITLE
fix: Lacto-ovo-vegetarian taxonomy

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -19996,20 +19996,7 @@ es: La Sociedad Vegetariana
 he: איגוד הצמחונות
 wikidata:en: Q2154954
 
-en: Ovo-vegetarian
-ca: Ovovegetarià
-de: Ovo-vegetarisch
-es: Ovo-vegetariano
-fi: ovo-vegetaarinen
-fr: Ovo-végétarien
-hu: Ovo-vegetáriánus
-it: Ovo-vegetariano
-pt: Ovo-vegetariano
-sv: Ovo-vegetarisk, ovovegetarisk, ovovegetarianer
-wikidata:en: Q3543760
-
-< en:Lacto-vegetarian
-< en:Ovo-vegetarian
+< en:Vegetarian
 en: Ovo-lacto-vegetarian
 ca: Ovolactovegetarià
 de: Ovo-lacto-vegetarisch
@@ -20022,6 +20009,23 @@ pt: Ovo-lacto-vegetariano
 sv: Lakto-ovovegetarisk, lakto-ovovegetarianer
 wikidata:en: Q3544800
 
+# Ovo-vegetarians eat eggs, but not dairy
+< en:Ovo-lacto-vegetarian
+en: Ovo-vegetarian
+ca: Ovovegetarià
+de: Ovo-vegetarisch
+es: Ovo-vegetariano
+fi: ovo-vegetaarinen
+fr: Ovo-végétarien
+hu: Ovo-vegetáriánus
+it: Ovo-vegetariano
+pt: Ovo-vegetariano
+sv: Ovo-vegetarisk, ovovegetarisk, ovovegetarianer
+incompatible_with:en: ingredients:en:dairy, labels:en:contains-milk
+wikidata:en: Q3543760
+
+# Lacto-vegetarians eat dairy, but not eggs
+< en:Ovo-lacto-vegetarian
 en: Lacto-vegetarian
 ca: Lactovegetarià
 de: Lacto-vegetarisch
@@ -20032,6 +20036,7 @@ hu: Lakto-vegetáriánus
 it: Latto-vegetariano
 pt: Latto-vegetariano
 sv: Lakto-vegetarisk
+incompatible_with:en: ingredients:en:eggs # labels:en:contains-eggs
 wikidata:en: Q3496076
 
 # non English needs the English synonyms too so that "European V-Label Végétarien" can be recognized too

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-tags-fields.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-tags-fields.json
@@ -46,27 +46,27 @@
       ],
       "labels" : "en:organic,fr:max havelaar,vegan,Something unrecognized",
       "labels_hierarchy" : [
+         "en:vegetarian",
          "en:fair-trade",
          "en:organic",
-         "en:vegetarian",
          "en:fairtrade-international",
          "en:vegan",
          "en:max-havelaar",
          "en:Something unrecognized"
       ],
       "labels_tags" : [
+         "en:vegetarian",
          "en:fair-trade",
          "en:organic",
-         "en:vegetarian",
          "en:fairtrade-international",
          "en:vegan",
          "en:max-havelaar",
          "en:something-unrecognized"
       ],
       "labels_tags_en" : [
+         "Vegetarian",
          "Fair trade",
          "Organic",
-         "Vegetarian",
          "Fairtrade International",
          "Vegan",
          "Max Havelaar",


### PR DESCRIPTION
Currently the lacto- and ovo-vegetarian labels both derive from lacto-ovo-vegetarian, which will almost always be wrong. Ovo-vegetarians consume eggs but not dairy, while lacto-vegetarians consume dairy but not eggs—ovo-lacto-vegetarians consume both dairy and eggs.

This makes the `en:Ovo-lacto-vegetarian` labels instead be a parent of `en:Lacto-vegetarian` and `en:Ovo-vegetarian` instead, since anything that is either lacto- or oco-vegetarian will also be ovo-lacto-vegetarian. `en:Ovo-lacto-vegetarian` is additionally made a child of `en:Vegetarian` since the ovo/lacto modifier adds additional restrictions, so vegetarians who still consume non-human animal byproducts (like dairy and eggs) will be fine with this.