### PR TITLE
feat: Add weight % for single-item packaging

### DIFF
--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -22,7 +22,7 @@
 
 =head1 NAME
 
-ProductOpener::Packaging 
+ProductOpener::Packaging
 
 =head1 SYNOPSIS
 
@@ -802,7 +802,7 @@ sub set_packaging_facets_tags ($product_ref) {
 
 =head2 set_packaging_misc_tags($product_ref)
 
-Set some tags in the /misc/ facet so that we can track the products that have 
+Set some tags in the /misc/ facet so that we can track the products that have
 (or don't have) packaging data.
 
 =cut
@@ -998,6 +998,12 @@ sub compute_weight_stats_for_parent_materials ($product_ref) {
 					$packagings_materials_main_weight = $parent_material_ref->{weight};
 				}
 			}
+			# If there’s no packaging weight defined, but there’s one packaging item and we know that
+			# the packaging is complete, we know that the weight of that item is 100% of the total
+			# packaging weight, even if we don’t know what that weight is.
+			elsif ((scalar @{$product_ref->{packagings}} == 1) and ($product_ref->{packagings_complete})) {
+				$parent_material_ref->{weight_percent} = 100;
+			}
 		}
 	}
 
@@ -1011,7 +1017,7 @@ sub compute_weight_stats_for_parent_materials ($product_ref) {
 	return;
 }
 
-=head2 initialize_packagings_structure_with_data_from_packaging_text ($product_ref, $response_ref) 
+=head2 initialize_packagings_structure_with_data_from_packaging_text ($product_ref, $response_ref)
 
 This function populates the packagings structure with data extracted from the packaging_text field.
 It is used only when there is no pre-existing data in the packagings structure.

--- a/tests/unit/packaging.t
+++ b/tests/unit/packaging.t
@@ -782,6 +782,60 @@ is(
 
 ) or diag Dumper $product_ref->{packagings_materials};
 
+# Single packaging item with unknown weight, complete
+
+$product_ref = {
+	lc => "sv",
+	packagings => [
+		{
+			material => 'plast',
+		},
+	],
+	packagings_complete => 1
+};
+
+ProductOpener::Packaging::canonicalize_packaging_components_properties($product_ref);
+ProductOpener::Packaging::aggregate_packaging_by_parent_materials($product_ref);
+ProductOpener::Packaging::compute_weight_stats_for_parent_materials($product_ref);
+
+is(
+	$product_ref->{packagings_materials},
+	{
+		'all' => {
+			'weight_percent' => 100
+		},
+		'en:plastic' => {
+			'weight_percent' => 100
+		}
+	}
+
+) or diag Dumper $product_ref->{packagings_materials};
+
+# Single packaging item with unknown weight, incomplete
+
+$product_ref = {
+	lc => "sv",
+	packagings => [
+		{
+			material => 'plast',
+		},
+	],
+	packagings_complete => 0
+};
+
+ProductOpener::Packaging::canonicalize_packaging_components_properties($product_ref);
+ProductOpener::Packaging::aggregate_packaging_by_parent_materials($product_ref);
+ProductOpener::Packaging::compute_weight_stats_for_parent_materials($product_ref);
+
+is(
+	$product_ref->{packagings_materials},
+	{
+		'all' => {},
+		'en:plastic' => {}
+	}
+
+) or diag Dumper $product_ref->{packagings_materials};
+
 # Empty product hash
 
 $product_ref = {};


### PR DESCRIPTION
### What

This handles the case where we know all the packaging (`packagings_complete` is set to true/`1`), it only consists of a single packaging item, _and_ we don’t know the weight of it. Even without knowing the actual weight, we do know that that single item makes up 100% of the packaging’s weight.