### PR TITLE
taxonomy: Add bread clips and clip bands (packaging)

### DIFF
--- a/taxonomies/packaging_shapes.txt
+++ b/taxonomies/packaging_shapes.txt
@@ -474,6 +474,17 @@ nl: clip, klemmetje
 pt: Atilho, atilhos, presilha, presilhas, fita, fitas, cordão, cordões, atadura, ataduras, fecho, fechos, fexo, feixo, fexos, feixos, fio, fios
 description:fr: Ce qui sert à relier deux ou plusieurs pièces d'un ouvrage ou à le fixer.
 description:nl: Een klein werktuig waarin iets door samendrukken bijeengehouden of vastgezet kan worden
+wikidata:en: Q2002016
+
+< en:fastener
+en: bread clip, bag clip, occlupanid
+description:en: Usually a single plastic piece, in a roughly square shape, through which the neck of a plastic bag can be threaded.
+wikidata:en: Q3018341
+
+< en:fastener
+en: clipband, clip band
+description:en: A typically short (~5 cm/2″) band of some material (plastic or paper are common), reinforced with metal wires along the edges.
+wikidata:en: Q134396173
 
 # fr:Liens ( collier , ficelle , ruban , ruban adhésif , bolduc , feuillard , bande , cordon , fil , elastique , bracelet…) in data from Les Mousquetaires
 en: Tie, knot


### PR DESCRIPTION
Descriptions based on Wikipedia articles and Wikidata item descriptions (which have in part been written by me, too):
https://en.wikipedia.org/wiki/Bread_clip
https://www.wikidata.org/wiki/Q134396173

See also Slack discussion:
https://openfoodfacts.slack.com/archives/C0J39NZD0/p1746655894146059