### PR TITLE
fix: text extraction issue for CZ and LT

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -5307,7 +5307,7 @@ my %phrases_after_ingredients_list = (
 	cs => [
 		'analytické složky',    # pet food
 		'balené v ochrannej atmosfére',    # packaged in protective atmosphere
-		'doporu)c|č)eny zp(u|ů)sob p(r|ř)(i|í)pravy',
+		'doporu(c|č)eny zp(u|ů)sob p(r|ř)(i|í)pravy',
 		'minim(a|á)ln(i|í) trvanlivost do',    # Expiration date
 		'po otev(r|ř)en(i|í)',    # After opening
 		'(návod k )?přípravě',    # preparation
@@ -5596,7 +5596,6 @@ my %phrases_after_ingredients_list = (
 		'tinka vartoti iki',    # valid until
 		'data ant pakuotės',    #date on package
 		'laikyti sausoje vietoje',    #Keep in dry place
-		'',
 	],
 
 	lv => [


### PR DESCRIPTION
### What
Fix bug for text extraction, reported on Slack **contribution** channel

### Screenshot
```
Unmatched ) in regex; marked by <-- HERE in m/\*?\s*\bdoporu) <-- HERE c|Ä)eny zp(u|Å¯)sob p(r|Å™)(i|Ã)pravy\b(.*)$/ at /srv/off/lib/ProductOpener/Ingredients.pm line 5862.
```

### Related issue(s) and discussion
- Fixes #-none-
