### PR TITLE
taxonomy: Sort brands.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ import_sample_data: run_deps
 	else \
 	 	echo "🥫 Not importing sample data into MongoDB (only for po_off project)"; \
 	fi
-	
+
 import_more_sample_data: run_deps
 	@echo "🥫 Importing sample data (~2000 products) into MongoDB …"
 	${DOCKER_COMPOSE} run --rm backend bash /opt/product-opener/scripts/import_more_sample_data.sh
@@ -275,7 +275,7 @@ checks: front_build front_lint check_perltidy check_perl_fast check_critic check
 
 lint: lint_perltidy lint_taxonomies
 
-tests: build_taxonomies_test build_lang_test unit_test integration_test
+tests: build_taxonomies_test build_lang_test unit_test integration_test brands_sort_test
 
 # add COVER_OPTS='-e HARNESS_PERL_SWITCHES="-MDevel::Cover"' if you want to trigger code coverage report generation
 unit_test: create_folders
@@ -297,6 +297,11 @@ integration_test: create_folders
 	${DOCKER_COMPOSE_INT_TEST} exec ${COVER_OPTS} -e JUNIT_TEST_FILE="tests/integration/outputs/junit.xml" -T backend yath --renderer=Formatter --renderer=JUnit tests/integration
 	${DOCKER_COMPOSE_INT_TEST} stop
 	@echo "🥫 integration tests success"
+
+brands_sort_test:
+	@echo "🥫 checking order of brands.txt"
+	@diff -u <(git grep -ih '^xx:' taxonomies/brands.txt) <(git grep -ih '^xx:' taxonomies/brands.txt|LANG='C.UTF-8' sort -bf)
+	@echo "🥫 brands.txt ordered as expected"
 
 # stop all tests dockers
 test-stop:
@@ -513,7 +518,7 @@ prune:
 
 prune_cache:
 	@echo "🥫 Pruning Docker builder cache …"
-	docker builder prune -f --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" 
+	docker builder prune -f --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}"
 
 clean_folders: clean_logs
 	( rm html/images/products || true )

--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -11,7 +11,6 @@
 # Note: an old draft owners/brands taxonomy lives in taxonomies/unused/brands.txt, but it is hierarchic, which is something we do not want in this taxonomy.
 # You can usefully read: https://wiki.openfoodfacts.org/Brands to get up and running on the subtleties of the topic.
 
-
 xx: Albert Heijn
 
 xx: Aldi
@@ -21,12 +20,13 @@ xx: Alesto
 xx: alpro
 wikidata:en: Q498666
 
-xx: Änglamark
-wikidata:en: Q65229572
+xx: Bio Village
 
 xx: bonÀrea
 
 xx: Carrefour BIO
+
+xx: Chaque Jour Sans Gluten
 
 # This brand is used by different organisations in different countries,
 # that, as far as I can tell, do not have any sort of formal connection
@@ -38,6 +38,8 @@ wikidata:en: Q134125853
 xx: dmBio, dm Bio
 
 xx: Dr. Oetker
+
+xx: Délisse
 
 xx: Eldorado
 wikidata:en: Q5324313
@@ -71,7 +73,8 @@ xx: Kellogg's, Kelloggs, Kellogg
 
 xx: Leader Price, Leaderprice
 
-xx: Maître CoQ
+# Portuguese version of Marque Repère
+xx: Marca Guia
 
 xx: Marks & Spencers, Marks and Spencers
 wikidata:en: Q714491
@@ -79,28 +82,13 @@ wikidata:en: Q714491
 xx: Marque Repère
 wikidata:en: Q3294723
 
-# Portuguese version of Marque Repère
-xx: Marca Guia
-
 # Swedish burger chain
 xx: Max
 wikidata:en: Q1912172
 
-xx: Bio Village
-
-xx: Chaque Jour Sans Gluten
-
-xx: Délisse
+xx: Maître CoQ
 
 xx: NAT&vie, NAT&vie veggie
-
-xx: Récoltons l'Avenir, Récoltons l'Avenir l'agriculture durable
-
-xx: Soutenons nos agriculteurs
-
-xx: Tokapi
-
-xx: Turini
 
 xx: Naturli'
 
@@ -120,9 +108,13 @@ wikidata:en: Q3102193
 
 xx: Rice Krispies
 
+xx: Récoltons l'Avenir, Récoltons l'Avenir l'agriculture durable
+
 xx: Sainsbury's, Sainsburys
 
 xx: Sol&Mar
+
+xx: Soutenons nos agriculteurs
 
 xx: Special K
 
@@ -132,7 +124,11 @@ wikidata:en: Q10688845
 xx: Takovo
 wikidata:en: Q58177342
 
+xx: Tokapi
+
 xx: Trader Joe's
+
+xx: Turini
 
 xx: Urtekram
 wikidata:en: Q12340334
@@ -148,4 +144,7 @@ xx: Zeina's
 
 xx: Zeta
 wikidata:en: Q10724505
+
+xx: Änglamark
+wikidata:en: Q65229572
 


### PR DESCRIPTION
The current `brands.txt` is _almost_ fully sorted alphabetically. This commit now commits to this and sorts all the entries, as per `sort -bi` in the `C.UTF-8` locale. This ignores case (`-f`) and leading whitespace (`-b`).

I also tried with the `--dictionary-order` and `--ignore-nonprinting` options, but these seem to fully ignore non-ASCII characters, leading to a less human-sensible ordering (e.g., “Änglamark” getting sorted with the n’s as “nglamark”).

It also adds a test in the `Makefile` to check for the brand ordering going forward.