### PR TITLE
fix: not displayed nutrition columns #11304

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9588,12 +9588,17 @@ sub data_to_display_nutrition_table ($product_ref, $comparisons_ref, $request_re
 	my @displayed_product_types = ();
 	my %displayed_product_types = ();
 
-	if ((not defined $product_ref->{nutrition_data}) or ($product_ref->{nutrition_data})) {
+	if (   (not defined $product_ref->{nutrition_data})
+		or ($product_ref->{nutrition_data})
+		or has_nutrition_data_for_product_type($product_ref, ""))
+	{
 		# by default, old products did not have a checkbox, display the nutrition data entry column for the product as sold
 		push @displayed_product_types, "";
 		$displayed_product_types{as_sold} = 1;
 	}
-	if ((defined $product_ref->{nutrition_data_prepared}) and ($product_ref->{nutrition_data_prepared} eq 'on')) {
+	if (   ((defined $product_ref->{nutrition_data_prepared}) and ($product_ref->{nutrition_data_prepared} eq 'on'))
+		or (has_nutrition_data_for_product_type($product_ref, "_prepared")))
+	{
 		push @displayed_product_types, "prepared_";
 		$displayed_product_types{prepared} = 1;
 	}

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -77,6 +77,7 @@ BEGIN {
 		&compute_units_of_alcohol
 		&compute_estimated_nutrients
 
+		&has_nutrition_data_for_product_type
 		&compare_nutriments
 
 		&extract_nutrition_from_image
@@ -2241,6 +2242,47 @@ sub compute_nutriscore ($product_ref, $current_version = "2023") {
 	return;
 }
 
+=head2 has_nutrition_data_for_product_type ($product_ref, $nutrition_product_type)
+
+Check if the product has nutrition data for the given type ("" or "_prepared").
+
+=head3 Arguments
+
+=head4 $product_ref - ref to the product
+
+=head4 $nutrition_product_type - string, either "" or "_prepared"
+
+=head3 Return values
+
+=head4 0 or 1
+
+=head4 0 if the product does not have nutrition data for the given type
+
+=head4 1 if the product has nutrition data for the given type
+
+=cut
+
+sub has_nutrition_data_for_product_type ($product_ref, $nutrition_product_type) {
+
+	if (not defined $product_ref->{nutriments}) {
+		return 0;
+	}
+
+	foreach my $nid (keys %{$product_ref->{nutriments}}) {
+		if (
+			(
+				   ($nutrition_product_type eq "") and ($nid !~ /_prepared/)
+				or (($nutrition_product_type eq "_prepared") and ($nid eq /_prepared$/))
+			)
+			and ($nid =~ /_(serving|100g)$/)
+			)
+		{
+			return 1;
+		}
+	}
+	return 0;
+}
+
 =head2 compute_nutrition_data_per_100g_and_per_serving ($product_ref)
 
 Input nutrition data is indicated per 100g or per serving.
@@ -2344,11 +2386,9 @@ sub compute_nutrition_data_per_100g_and_per_serving ($product_ref) {
 				elsif ((defined $serving_quantity) and ($serving_quantity > 5)) {
 					$product_ref->{nutriments}{$nid . $product_type . "_100g"}
 						= sprintf("%.2e", $value * 100.0 / $product_ref->{serving_quantity}) + 0.0;
-
-					# Record that we have a nutrient value for this product type (with a unit, not NOVA, alcohol % etc.)
-					$nutrition_data{$product_type} = 1;
 				}
-
+				# Record that we have a nutrient value for this product type (with a unit, not NOVA, alcohol % etc.)
+				$nutrition_data{$product_type} = 1;
 			}
 		}
 		# nutrition_data_<_/prepared>_per eq '100g' or '1kg'
@@ -2395,10 +2435,9 @@ sub compute_nutrition_data_per_100g_and_per_serving ($product_ref) {
 					$product_ref->{nutriments}{$nid . $product_type . "_serving"} = sprintf("%.2e",
 						$product_ref->{nutriments}{$nid . $product_type} / 100.0 * $product_ref->{serving_quantity})
 						+ 0.0;
-
-					# Record that we have a nutrient value for this product type (with a unit, not NOVA, alcohol % etc.)
-					$nutrition_data{$product_type} = 1;
 				}
+				# Record that we have a nutrient value for this product type (with a unit, not NOVA, alcohol % etc.)
+				$nutrition_data{$product_type} = 1;
 			}
 		}
 
@@ -2437,11 +2476,7 @@ sub compute_nutrition_data_per_100g_and_per_serving ($product_ref) {
 
 	# If we have nutrient data for as sold or prepared, make sure the checkbox are ticked
 	foreach my $product_type (sort keys %nutrition_data) {
-		if (   (not defined $product_ref->{"nutrition_data" . $product_type})
-			or ($product_ref->{"nutrition_data" . $product_type} ne "on"))
-		{
-			$product_ref->{"nutrition_data" . $product_type} = 'on';
-		}
+		$product_ref->{"nutrition_data" . $product_type} = 'on';
 	}
 
 	return;

--- a/tests/unit/food.t
+++ b/tests/unit/food.t
@@ -661,4 +661,9 @@ my %form = ();
 	}
 }
 
+is(has_nutrition_data_for_product_type({}, ""), 0);
+is(has_nutrition_data_for_product_type({nutriments => {"sugars_100g" => 5}}, ""), 1);
+is(has_nutrition_data_for_product_type({nutriments => {"sugars_100g" => 0}}, "_prepared"), 0);
+is(has_nutrition_data_for_product_type({nutriments => {"sugars_prepared_serving" => 10}}, "_prepared"), 1);
+
 done_testing();


### PR DESCRIPTION
fixes the computation of the nutrition_data and nutrition_data_prepared columns that indicates if we have nutrition data, and also add a check to display columns anyway if we have data (for old versions of products that have a bad value in nutrition_data)

fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/11304