### PR TITLE
docs: precise that user_id is username, not email

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -101,7 +101,7 @@ Create an account on the [Open Food Facts app](https://world.openfoodfacts.org/)
 
 - **The preferred one**:
   Use the login API to get a session cookie and use this cookie for authentication in your subsequent requests. However, the session must always be used from the same IP address, and there's a limit on sessions per user (currently 10) with older sessions being automatically logged out to stay within the limit.
-- If session conditions are too restrictive for your use case, include your account credentials as parameters for authenticated requests where `user_id` is your username and `password` is your password (do this on POST / PUT / DELETE requests, not on GET).
+- If session conditions are too restrictive for your use case, include your account credentials as parameters for authenticated requests where `user_id`^[user_id_not_email] is your username and `password` is your password (do this on POST / PUT / DELETE requests, not on GET).
 
 You can create a global account to allow your app users to contribute without registering individual accounts on the Open Food Facts website. This way, we know that these contributions came from your application.
 
@@ -113,6 +113,8 @@ We however ask that you send the [`app_name`, `app_version` and `app_uuid` param
 > Production and staging have different account databases, so **the account you create in the production environment will only work for production requests**. If you want to query (WRITE requests) the staging environment, you'll need to create another account there too.
 
 > Note: we're currently moving to a modern Auth system (Keycloak), so we will have new Auth options, hopefully this year.
+
+^[user_id_not_email]: user_id is the username of your account. You must not use your email address.
 
 ## Reference Documentation (OpenAPI)
 

--- a/docs/api/ref/api-v3.yml
+++ b/docs/api/ref/api-v3.yml
@@ -207,8 +207,15 @@ paths:
                   properties:
                     user_id:
                       type: string
+                      description: |
+                        Username for login
+
+                        Note: you must always use the username (and not the email)
+                        as it is far less brittle.
                     password:
                       type: string
+                      description: Password for login
+                      format: password
                     product:
                       $ref: ./schemas/product_update_api_v3.yaml
             examples:

--- a/docs/api/ref/api.yml
+++ b/docs/api/ref/api.yml
@@ -451,7 +451,11 @@ paths:
               properties:
                 user_id:
                   type: string
-                  description: Username for login
+                  description: |
+                    Username for login
+
+                    Note: you must always use the username (and not the email)
+                    as it is far less brittle.
                 password:
                   type: string
                   description: Password for login

--- a/docs/api/ref/requestBodies/add_or_edit_a_product.yaml
+++ b/docs/api/ref/requestBodies/add_or_edit_a_product.yaml
@@ -8,12 +8,15 @@ properties:
     example: "0074570036004"
   user_id:
     type: string
-    description: A valid username.
-    example: myusername
+    description: |
+      Username to authenticate with
+
+      Note: you must always use the username (and not the email)
+      as it is far less brittle.
   password:
     type: string
-    description: A valid corresponding password (related to specific environment).
-    example: mypassword
+    description: Password to authenticate with
+    format: password
   comment:
     type: string
     description: A comment for the change. It will be shown in product changes history.

--- a/docs/api/tutorial-off-api.md
+++ b/docs/api/tutorial-off-api.md
@@ -149,7 +149,7 @@ The sample response above for 100% Real Orange Juice `misc_tags` shows that the 
 
 ### Write data to make Nutri-Score computation possible
 
-The WRITE operations in the OFF API require authentication. Therefore you need a valid `user_id` and `password` to write the missing nutriment data to 100% Real Orange Juice.
+The WRITE operations in the OFF API require authentication. Therefore you need a valid `user_id`^[user_id_not_email] and `password` to write the missing nutriment data to 100% Real Orange Juice.
 
 > Sign up on the [Open Food Facts App](https://world.openfoodfacts.net/) to get your`user_id` and `password` if you don't have one.
 
@@ -188,6 +188,8 @@ If the request is successful, it returns a response that indicates that the fiel
     "status": 1
 }
 ```
+
+^[user_id_not_email]: user_id is the username of your account. You must not use your email address.
 
 ### Read newly computed Nutri-Score
 

--- a/docs/api/tutorial-uploading-photo-to-a-product.md
+++ b/docs/api/tutorial-uploading-photo-to-a-product.md
@@ -38,10 +38,12 @@ Multilingual products have several photos based on the languages present on the 
 
 ## Authentication
 
-The WRITE operations in the Open Food Facts API require authentication. Therefore you need a valid `user_id` and `password` to write the photo to 100% Real Orange Juice.
+The WRITE operations in the Open Food Facts API require authentication. Therefore you need a valid `user_id`^[user_id_not_email] and `password` to write the photo to 100% Real Orange Juice.
 
 > Sign up on the [Open Food Facts App](https://world.openfoodfacts.org/) to get your `user_id` and `password` if you dont have one.
 For more details, visit the : [Authentication paragraph in our introduction](../index.md#authentication).
+
+^[user_id_not_email]: user_id is the username of your account. You must not use your email address.
 
 ## Parameters
 


### PR DESCRIPTION
Make it really clear that it's better not to use email to login when using the API.