### PR TITLE
taxonomy: Attempt at untangling blueberries

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -103813,7 +103813,13 @@ ciqual_proxy_food_name:en: Jam, strawberry
 ciqual_proxy_food_name:fr: Confiture de fraise (extra ou classique)
 
 < en:Berry jams
-en: Bilberries jams
+en: Blueberry jams
+da: Blåbærsyltetøj
+nb: Blåbærsyltetøy
+sv: Blåbärssylter
+
+< en:Blueberry jams
+en: Bilberry jams, Bilberries jams, Blaeberry jams, Blueberry jams (European)
 bg: Конфитюр от черни боровинки
 de: Heidelbeer-Konfitüren, Heidelbeermarmeladen
 es: Mermeladas y confituras de arándanos, Mermeladas de arándanos, Mermeladas de arándano, Confituras de arándanos
@@ -103824,8 +103830,11 @@ hu: Fekete áfonya lekvár
 it: Confetture di mirtilli, Marmellate di mirtilli
 nl: Bosbessenjams
 pt: Doces de mirtilo
-sv: Blåbärssylter
 wikidata:en: Q89999458
+
+< en:Blueberry jams
+en: American blueberry jams, Blueberry jams (American)
+wikidata:en: Q11961672
 
 < en:Berry jams
 en: Lingonberries jams


### PR DESCRIPTION
“Blueberry” is a term that is commonly used for different (albeit similar looking and closely related) berries; namely the Eurasian bilberries (Vaccinum sect. Myrtillus and V. uliginosum) and the North American blueberries (V. sect. Cyanococcus).

While they do have different names in English (bilberry and blueberry), many languages simply use “blueberry” without specific distinction of which berry it is.

This commit makes a “Blueberry jams” category covering both, with child categories for “Bilberry jams” and “American blueberry jams” for when it is known which specific type of “blueberry” was used.

Sources:
https://en.wikipedia.org/w/index.php?title=Bilberry&oldid=1291352354
https://en.wikipedia.org/w/index.php?title=Blueberry&oldid=1291531485