### PR TITLE
fix: localization: lowercase the Spanish translation of the 'editors' resource string

### DIFF
--- a/po/tags/es.po
+++ b/po/tags/es.po
@@ -117,7 +117,7 @@ msgstr "depuración"
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
 msgctxt "editors:plural"
 msgid "editors"
-msgstr "Editores"
+msgstr "editores"
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
 msgctxt "editors:singular"


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

In the localization resources under the `po` directory, it seems that all tagnames should be lowercase.

However, there is a tagname in Spanish that begins with an uppercase ASCII character.  It seems to be the only one at the moment:

```sh
$ grep -rw -A 1 'msgid "editors"' po/tags | grep msgstr | grep '\.po-.*[A-Z]'
```

This pull request modifies it to be lowercase too, for consistency.

### Related issue(s) and discussion

- Discovered / noticed by https://github.com/openfoodfacts/openfoodfacts-server/pull/11861#issuecomment-2912151272