### PR TITLE
chore: upgrade from jquery-cropper to cropperjs v2

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -815,7 +815,6 @@ HTML
 	$request_ref->{scripts} .= <<HTML
 <script type="text/javascript" src="$static_subdomain/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/cropper.js"></script>
-<script type="text/javascript" src="$static_subdomain/js/dist/jquery-cropper.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/tagify.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/jquery.iframe-transport.js"></script>
@@ -848,7 +847,7 @@ HTML
 	font-weight:normal;
 	font-size:0.8rem;
 }
-.select_manage .ui-selectable li { 
+.select_manage .ui-selectable li {
 	height: 180px
 }
 CSS

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -824,7 +824,7 @@ HTML
 <script type="text/javascript">
 var admin = $moderator;
 </script>
-<script type="text/javascript" src="$static_subdomain/js/dist/product-multilingual.js?v=$file_timestamps{'js/dist/product-multilingual.js'}"></script>
+<script type="module" src="$static_subdomain/js/dist/product-multilingual.js?v=$file_timestamps{'js/dist/product-multilingual.js'}"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/product-history.js"></script>
 
 HTML

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -104,7 +104,6 @@ export function copyJs() {
     "./node_modules/blueimp-file-upload/js/*.js",
     "./node_modules/@yaireo/tagify/dist/tagify.js",
     "./node_modules/cropperjs/dist/cropper.js",
-    "./node_modules/jquery-cropper/dist/jquery-cropper.js",
     "./node_modules/jquery-form/src/jquery.form.js",
     "./node_modules/highcharts/highcharts.js",
     "./node_modules/jsvectormap/dist/jsvectormap.js",
@@ -184,7 +183,7 @@ function jQueryUiThemes() {
   const compressed = processed.
     pipe(gzip()).
     pipe(dest("./html/css/dist/jqueryui/themes/base"));
-  
+
   return processed && compressed;
 }
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -103,7 +103,7 @@ export function copyJs() {
     "./node_modules/blueimp-canvas-to-blob/js/canvas-to-blob.js",
     "./node_modules/blueimp-file-upload/js/*.js",
     "./node_modules/@yaireo/tagify/dist/tagify.js",
-    "./node_modules/cropperjs/dist/cropper.js",
+    "./node_modules/cropperjs/dist/cropper.esm.js",
     "./node_modules/jquery-form/src/jquery.form.js",
     "./node_modules/highcharts/highcharts.js",
     "./node_modules/jsvectormap/dist/jsvectormap.js",

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import Cropper from "cropperjs";
+import Cropper from "./cropper.esm.js";
 /*eslint dot-location: "off"*/
 /*eslint no-console: "off"*/
 /*global lang admin otherNutriments Tagify*/
@@ -220,7 +220,7 @@ function rotate_image(event) {
     angles[imagefield] += angle;
     angles[imagefield] = (360 + angles[imagefield]) % 360;
 
-    cropper.rotate(angle);
+    cropper.getCropperImage().$rotate(angle);
 
     //var selection = $('img#crop_' + imagefield ).cropper('getData');
     const selection = cropper.getCropBoxData();
@@ -378,7 +378,8 @@ function change_image(imagefield, imgid) {
             });
     });
 
-    $('img#crop_' + imagefield).on('ready', function () {
+        const cropperImage = cropper.getCropperImage();
+        cropperImage.addEventListener("cropper:ready", function () {
         $("#rotate_left_" + imagefield).attr("disabled", false);
         $("#rotate_right_" + imagefield).attr("disabled", false);
         $("." + crop_button).attr("disabled", false);

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -416,6 +416,10 @@ function change_image(imagefield, imgid) {
         ).checked;
         const image = document.getElementById("crop_" + imagefield);
 
+        if (!image) {
+          console.warn(`Element with ID "crop_${imagefield}" not found. Skipping Cropper reinitialization.`);
+          return;
+        }
         // Destroy existing cropper if present
         if (croppers[imagefield]) {
           croppers[imagefield].destroy();

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -17,13 +17,11 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+import Cropper from "cropperjs";
 /*eslint dot-location: "off"*/
 /*eslint no-console: "off"*/
 /*global lang admin otherNutriments Tagify*/
 /*exported add_line upload_image update_image update_nutrition_image_copy*/
-import Cropper from "cropperjs";
-// import "cropperjs/dist/cropper.css";
 
 //Polyfill, just in case
 if (!Array.isArray) {
@@ -215,6 +213,8 @@ function rotate_image(event) {
     const cropper = croppers[imagefield];
 
     if (!cropper) {
+      console.warn("Cropper instance not found for imagefield:", imagefield);
+
         return;
     }
     angles[imagefield] += angle;

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -212,13 +212,21 @@ function rotate_image(event) {
 
     const imagefield = event.data.imagefield;
     const angle = event.data.angle;
+    const cropper = croppers[imagefield];
+
+    if (!cropper) {
+        return;
+    }
     angles[imagefield] += angle;
     angles[imagefield] = (360 + angles[imagefield]) % 360;
 
-    croppers[imagefield]?.rotate(angle);
+    cropper.rotate(angle);
 
     //var selection = $('img#crop_' + imagefield ).cropper('getData');
-    const selection = croppers[imagefield]?.getCropBoxData();
+    const selection = cropper.getCropBoxData();
+    if (!selection) {
+        return;
+    }
 
     selection.x = selection.left;
     selection.y = selection.top;
@@ -231,7 +239,10 @@ function rotate_image(event) {
         const x2 = selection.x + selection.width;
         const y2 = selection.y + selection.height;
 
-        const container = croppers[imagefield]?.getContainerData();
+        const container = cropper.getContainerData();
+        if (!container){
+            return;
+        }
         const w = container.width;
         const h = container.height;
         console.log("selection - image - w:" + w + ' - h:' + h);
@@ -252,7 +263,7 @@ function rotate_image(event) {
         selection.left = selection.x;
         selection.top = selection.y;
 
-        croppers[imagefield]?.setCropBoxData(selection);
+        cropper.setCropBoxData(selection);
 
         console.log("selection - new - x:" + selection.x + " - y:" + selection.y + " - width:" + selection.width + " - height:" + selection.height);
     }
@@ -379,13 +390,12 @@ function change_image(imagefield, imgid) {
     $("#rotate_left_" + imagefield).click({ imagefield: imagefield, angle: -90 }, rotate_image);
     $("#rotate_right_" + imagefield).click({ imagefield: imagefield, angle: 90 }, rotate_image);
 
-    document
-      .getElementById("crop_" + imagefield)
-      .addEventListener("click", () => {
-        croppers[imagefield]?.clear();
-      });
-
     const imageElement = document.getElementById("crop_" + imagefield);
+    if (imageElement) {
+    imageElement.addEventListener("click", () => {
+      croppers[imagefield]?.clear();
+    });
+
     const cropper = new Cropper(imageElement, {
       viewMode: 2,
       guides: false,
@@ -397,7 +407,7 @@ function change_image(imagefield, imgid) {
       checkCrossOrigin: false,
     });
     croppers[imagefield] = cropper;
-
+  }
     document
       .getElementById("zoom_on_wheel_" + imagefield)
       .addEventListener("change", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,10 @@
         "@webcomponents/webcomponentsjs": "2.8.0",
         "@yaireo/tagify": ">=4.12.0 <4.36.0",
         "blueimp-file-upload": "^10.31.0",
-        "cropperjs": "^1.6.1",
+        "cropperjs": "^2.0.0",
         "foundation-sites": "5.5.3",
         "highcharts": "^9.2.2",
         "jquery": "2.2.4",
-        "jquery-cropper": "^1.0.2",
         "jquery-form": "^4.3.0",
         "jquery-ui": "1.14.1",
         "jsbarcode": "^3.11.6",
@@ -1764,6 +1763,126 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cropper/element": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element/-/element-2.0.0.tgz",
+      "integrity": "sha512-lsthn0nQq73GExUE7Mg/ss6Q3RXADGDv055hxoLFwvl/wGHgy6ZkYlfLZ/VmgBHC6jDK5IgPBFnqrPqlXWSGBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-canvas": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-canvas/-/element-canvas-2.0.0.tgz",
+      "integrity": "sha512-GPtGJgSm92crJhhhwUsaMw3rz2KfJWWSz7kRAlufFEV/EHTP5+6r6/Z1BCGRna830i+Avqbm435XLOtA7PVJwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-crosshair": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-crosshair/-/element-crosshair-2.0.0.tgz",
+      "integrity": "sha512-KfPfyrdeFvUC31Ws7ATtcalWWSaMtrC6bMoCipZhqbUOE7wZoL4ecDSL6BUOZxPa74awZUqfzirCDjHvheBfyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-grid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-grid/-/element-grid-2.0.0.tgz",
+      "integrity": "sha512-i78SQ0IJTLFveKX6P7svkfMYVdgHrQ8ZmmEw8keFy9n1ZVbK+SK0UHK5FNMRNI/gtVhKJOGEnK/zeyjUdj4Iyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-handle": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-handle/-/element-handle-2.0.0.tgz",
+      "integrity": "sha512-ZJvW+0MkK9E8xYymGdoruaQn2kwjSHFpNSWinjyq6csuVQiCPxlX5ovAEDldmZ9MWePPtWEi3vLKQOo2Yb0T8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-image": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-image/-/element-image-2.0.0.tgz",
+      "integrity": "sha512-9BxiTS/aHRmrjopaFQb9mQQXmx4ruhYHGkDZMVz24AXpMFjUY6OpqrWse/WjzD9tfhMFvEdu17b3VAekcAgpeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/element-canvas": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-selection/-/element-selection-2.0.0.tgz",
+      "integrity": "sha512-ensNnbIfJsJ8bhbJTH/RXtk2URFvTOO4TvfRk461n2FPEC588D7rwBmUJxQg74IiTi4y1JbCI+6j+4LyzYBLCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/element-canvas": "^2.0.0",
+        "@cropper/element-image": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-shade": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-shade/-/element-shade-2.0.0.tgz",
+      "integrity": "sha512-jv/2bbNZnhU4W+T4G0c8ADocLIZvQFTXgCf2RFDNhI5UVxurzWBnDdb8Mx8LnVplnkTqO+xUmHZYve0CwgWo+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/element-canvas": "^2.0.0",
+        "@cropper/element-selection": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/element-viewer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/element-viewer/-/element-viewer-2.0.0.tgz",
+      "integrity": "sha512-zY+3VRN5TvpM8twlphYtXw0tzJL2VgzeK7ufhL1BixVqOdRxwP13TprYIhqwGt9EW/SyJZUiaIu396T89kRX8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/element-canvas": "^2.0.0",
+        "@cropper/element-image": "^2.0.0",
+        "@cropper/element-selection": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/elements": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/elements/-/elements-2.0.0.tgz",
+      "integrity": "sha512-PQkPo1nUjxLFUQuHYu+6atfHxpX9B41Xribao6wpvmvmNIFML6LQdNqqWYb6LyM7ujsu71CZdBiMT5oetjJVoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.0",
+        "@cropper/element-canvas": "^2.0.0",
+        "@cropper/element-crosshair": "^2.0.0",
+        "@cropper/element-grid": "^2.0.0",
+        "@cropper/element-handle": "^2.0.0",
+        "@cropper/element-image": "^2.0.0",
+        "@cropper/element-selection": "^2.0.0",
+        "@cropper/element-shade": "^2.0.0",
+        "@cropper/element-viewer": "^2.0.0"
+      }
+    },
+    "node_modules/@cropper/utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cropper/utils/-/utils-2.0.0.tgz",
+      "integrity": "sha512-cprLYr+7kK3faGgoOsTW9gIn5sefDr2KwOmgyjzIXk+8PLpW8FgFKEg5FoWfRD5zMAmkCBuX6rGKDK3VdUEGrg==",
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4451,9 +4570,14 @@
       "dev": true
     },
     "node_modules/cropperjs": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.2.tgz",
-      "integrity": "sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-2.0.0.tgz",
+      "integrity": "sha512-TO2j0Qre01kPHbow4FuTrbdEB4jTmGRySxW49jyEIqlJZuEBfrvCTT0vC3eRB2WBXudDfKi1Onako6DKWKxeAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/elements": "^2.0.0",
+        "@cropper/utils": "^2.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7532,16 +7656,6 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
       "integrity": "sha512-lBHj60ezci2u1v2FqnZIraShGgEXq35qCzMv4lITyHGppTnA13rwR0MgwyNJh9TnDs3aXUvd1xjAotfraMHX/Q==",
       "license": "MIT"
-    },
-    "node_modules/jquery-cropper": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jquery-cropper/-/jquery-cropper-1.0.2.tgz",
-      "integrity": "sha512-UHjQNcuBoQspdVNx9JwA3bEFCo4crQ0RWL6PgFcfvq7Tx3n3WFzueoNHiRhsyC2eujZF8Udmts9Yqo9YJgnxmA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "cropperjs": ">=1.0.0 <2.0.0",
-        "jquery": ">=1.9.1"
-      }
     },
     "node_modules/jquery-form": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -37,25 +37,24 @@
     "win32"
   ],
   "dependencies": {
+    "@openfoodfacts/openfoodfacts-webcomponents": "1.6.0",
     "@snyk/protect": "^1.1296.2",
     "@webcomponents/webcomponentsjs": "2.8.0",
     "@yaireo/tagify": ">=4.12.0 <4.36.0",
     "blueimp-file-upload": "^10.31.0",
-    "cropperjs": "^1.6.1",
+    "cropperjs": "^2.0.0",
     "foundation-sites": "5.5.3",
     "highcharts": "^9.2.2",
     "jquery": "2.2.4",
-    "jquery-cropper": "^1.0.2",
     "jquery-form": "^4.3.0",
     "jquery-ui": "1.14.1",
+    "jsbarcode": "^3.11.6",
     "jsvectormap": "^1.6.0",
     "leaflet": "^1.7.1",
     "leaflet.markercluster": "1.5.3",
     "osmtogeojson": "^3.0.0-beta.4",
     "papaparse": "^5.5.2",
-    "select2": "~4.0",
-    "jsbarcode": "^3.11.6",
-    "@openfoodfacts/openfoodfacts-webcomponents": "1.6.0"
+    "select2": "~4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -51,7 +51,7 @@
 	font-weight:normal;
 	font-size:0.8rem;
 }
-.select_manage .ui-selectable li { 
+.select_manage .ui-selectable li {
 	height: 180px
 }
 
@@ -4047,7 +4047,6 @@ $(document).on("focus", ".select2", function (e) {
 <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -51,7 +51,7 @@
 	font-weight:normal;
 	font-size:0.8rem;
 }
-.select_manage .ui-selectable li { 
+.select_manage .ui-selectable li {
 	height: 180px
 }
 
@@ -4045,7 +4045,6 @@ $(document).on("focus", ".select2", function (e) {
 <script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality (not applicable here)
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->

### What

This PR removes the deprecated `jquery-cropper` dependency and migrates the image cropping functionality to `cropperjs` v2.

Changes made:
- Removed `jquery-cropper.js` reference from `gulpfile.ts`
- Refactored all `$(...).cropper()` jQuery-based usages to modern `Cropper` instance methods from `cropperjs` v2
- Updated JS file (`product-multilingual.js`) to use native DOM manipulation instead of jQuery

### Related issue

- Fixes #11874 
