### PR TITLE
fix: make robots.txt static

### DIFF
--- a/conf/nginx-docker/nginx.conf
+++ b/conf/nginx-docker/nginx.conf
@@ -58,7 +58,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(.well-known|files|data|exports|dump)/ {
+	location ~ ^/(.well-known|files|data|exports|dump|robots.txt)/ {
 		include snippets/off.cors-headers.include;
 		include /etc/nginx/snippets/expiry-headers.include;
 		# fist try in files_resources

--- a/conf/nginx-docker/nginx.conf
+++ b/conf/nginx-docker/nginx.conf
@@ -58,7 +58,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(.well-known|files|data|exports|dump|robots.txt)/ {
+	location ~ ^/(.well-known|files|data|exports|dump)/ {
 		include snippets/off.cors-headers.include;
 		include /etc/nginx/snippets/expiry-headers.include;
 		# fist try in files_resources
@@ -85,7 +85,7 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
-	location ~ /(favicon\.ico)$ {
+	location ~ /(favicon\.ico|robots\.txt)$ {
 		include /etc/nginx/snippets/off.cors-headers.include;
 		include /etc/nginx/snippets/expiry-headers.include;
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/obf
+++ b/conf/nginx/sites-available/obf
@@ -73,7 +73,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(favicon.ico) {
+	location ~ ^/(favicon.ico|robots.txt) {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -112,14 +112,14 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(favicon.ico) {
+	location ~ ^/(favicon.ico|robots.txt) {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;
 	}
 
 	# Static files are served directly by NGINX
-	location ~ ^/(.well-known|files|data|exports|dump|robots.txt)/ {
+	location ~ ^/(.well-known|files|data|exports|dump)/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
 		# First attempt to serve request from resource, then as file,

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -119,7 +119,7 @@ server {
 	}
 
 	# Static files are served directly by NGINX
-	location ~ ^/(.well-known|files|data|exports|dump)/ {
+	location ~ ^/(.well-known|files|data|exports|dump|robots.txt)/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
 		# First attempt to serve request from resource, then as file,

--- a/conf/nginx/sites-available/off-pro
+++ b/conf/nginx/sites-available/off-pro
@@ -56,7 +56,7 @@ server {
 		gunzip on;
 	}
 
-	location ~ ^/(favicon.ico) {
+	location ~ ^/(favicon.ico|robots.txt) {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/opf
+++ b/conf/nginx/sites-available/opf
@@ -72,7 +72,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(favicon.ico) {
+	location ~ ^/(favicon.ico|robots.txt) {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/opff
+++ b/conf/nginx/sites-available/opff
@@ -72,7 +72,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(favicon.ico) {
+	location ~ ^/(favicon.ico|robots.txt) {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/html/robots.txt
+++ b/html/robots.txt
@@ -1,0 +1,141 @@
+User-agent: *
+Disallow: /api
+Disallow: /cgi
+Disallow: /facets
+
+User-agent: Googlebot
+Disallow: /api
+Disallow: /cgi
+Allow: /cgi/product_image.pl
+Allow: /cgi/opensearch.pl
+
+User-agent: Bingbot
+Disallow: /api
+Disallow: /cgi
+Disallow: /facets
+Allow: /cgi/product_image.pl
+Allow: /cgi/opensearch.pl
+
+User-agent: SEOkicks-Robot
+Disallow: /
+
+User-agent: DotBot
+User-agent: dotbot
+Disallow: /
+
+# http://www.searchmetrics.com
+User-agent: SearchmetricsBot
+Disallow: /
+
+# http://www.majestic12.co.uk/projects/dsearch/mj12bot.php
+User-agent: MJ12bot
+Disallow: /
+
+# http://www.domaintools.com/webmasters/surveybot.php
+User-agent: SurveyBot
+Disallow: /
+
+# http://www.seodiver.com/bot
+User-agent: SEOdiver
+Disallow: /
+
+# http://openlinkprofiler.org/bot
+User-agent: spbot
+Disallow: /
+
+# http://www.wotbox.com/bot/
+User-agent: wotbox
+Disallow: /
+
+User-agent: Cliqzbot/3.0
+Disallow: /
+
+User-agent: Cliqzbot
+Disallow: /
+
+User-agent: SeekportBot
+Disallow: /
+
+User-agent: Seekport Bot
+Disallow: /
+
+User-agent: Seekport
+Disallow: /
+
+User-agent: Paracrawl
+Disallow: /
+
+User-agent: Scrapy/1.5.0
+Disallow: /
+
+User-agent: Scrapy
+Disallow: /
+
+User-agent: VelenPublicWebCrawler (velen.io)
+Disallow: /
+
+User-agent: VelenPublicWebCrawler
+Disallow: /
+
+User-agent: SemrushBot/2~bl
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MegaIndex.ru/2.0
+Disallow: /
+
+User-agent: MegaIndex.ru
+Disallow: /
+
+User-agent: YandexMarket
+Disallow: /
+
+User-agent: YandexBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: AliyunSecBot/Aliyun
+Disallow: /
+
+User-agent: YisouSpider
+Disallow: /


### PR DESCRIPTION
robots.txt is currently generated for every request by Product Opener, so that we can have different rules:
- based on user-agent (e.g. to allow some facets like /brands for some crawlers)
- based on cc + lc (to be able to list facets like /facets/marques in French for instance, and also to disallow crawling of subdomaines like fr-en)

It's not very convenient though, as some robots use tons of ips, and some of those send thousands of requests for robots.txt, that go to our low priority Apache, which is often overloaded and not responding.

I would really like to make robots.txt static again, so that it can be served instantly by nginx.

This PR contains a simple robots.txt:

- it disallows /facets for everyone, except Googlebog and Bingbot
- it disallows / for a bunch of robots that have been crawling us hard in the past

It doesn't solve the issues of disallowing things like fr-en and /facets/dates-d-ajout, or sending slightly different robots.txt to some crawlers.

We could pre-generate a bunch of files like /html/robots/[cc]-[lc].txt for all combinations of countries and languages.

We could also normalize URLs to English, so that /facets/marque becomes /facet/brand as we discussed when we added the /facets/ prefix

