### PR TITLE
taxonomy: “Orphan” Kött/Mjölk från Sverige

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -3908,18 +3908,20 @@ label_categories:en: en:Geographic label
 origins:en: en:sweden
 web:sv: https://fransverige.se/
 
-< sv:Från Sverige
 xx: Kött från Sverige
 sv: Kött från Sverige
 image:en: fran-sverige-kott.90x90.png
 ingredients:en: en:meat
+label_categories:en: en:Geographic label
+origins:en: en:sweden
 web:sv: https://fransverige.se/svenska-ravaror-all-varldens-mat/vad-ar-fran-sverige/market-kott-fran-sverige/
 
-< sv:Från Sverige
 xx: Mjölk från Sverige
 sv: Mjölk från Sverige
 image:en: fran-sverige-mjolk.90x90.png
 ingredients:en: en:dairy
+label_categories:en: en:Geographic label
+origins:en: en:sweden
 web:sv: https://fransverige.se/svenska-ravaror-all-varldens-mat/vad-ar-fran-sverige/market-mjolk-fran-sverige/
 
 xx: Svenskt mjöl från egen kvarn


### PR DESCRIPTION
Kött and Mjölk från Sverige specifically refers to meat and milk respectively and doesn’t necessarily apply to the rest of the ingredients (I think?). Even if it does, if there’s only the Kött or Mjölk label on packaging and no “Från Sverige”, we probably don’t want to show both logos on product pages, which would be another result of this inheritance.

