### PR TITLE
chore(dev): Update devcontainer to use different dir as home

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
     "../docker/run.yml",
     "../docker/devcontainer.yml"
   ],
-  "containerUser": "root",
+  "containerEnv": {
+    "HOME": "/tmp"
+  },
   "capAdd": [
     "SYS_PTRACE"
   ],


### PR DESCRIPTION
The previous home was `/var/www/`, which the vscode user wasn't allowed to write to.