### PR TITLE
build: allow stale dependency git repo clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,9 @@ clone_deps:
 				https://github.com/openfoodfacts/$$dep.git ${DEPS_DIR}/$$dep; \
 			echo "Cloned $$dep"; \
 		else \
-			cd ${DEPS_DIR}/$$dep && git pull; \
+			cd ${DEPS_DIR}/$$dep; \
+			git pull || \
+	                  1>&2 echo "Warning: unable to pull latest $$dep; are you online?"; \
 		fi; \
 	done
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

During a recent manual QA/testing process for #11884, I was working mostly offline (with my laptop's Internet connection turned off) in order to reduce distractions.

Attempting to restart the local development environment between tests failed at a `git pull` step in the `Makefile` -- and I'd like to suggest that we could make that step optional - with a warning if it fails - provided that the user already has a checkout of the dependency.

### Screenshot
N/A

### Related issue(s) and discussion
- This suggestion is based on practical experience from a round of testing described at: https://github.com/openfoodfacts/openfoodfacts-server/pull/11884#issuecomment-2939482998