### PR TITLE
fix: corrections for mismatched-kj-nutrient-calculation data quality description in most languages

### DIFF
--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -182,26 +182,26 @@ es: El valor energético en kJ no coincide con el valor calculado a partir de ot
 fr: Valeur énergétique en kJ ne correspondant pas à la valeur calculée à partir des autres nutriments
 it: Il valore energetico in kJ non corrisponde al valore calcolato dagli altri nutrienti
 pt: O valor energético em kJ não corresponde ao valor calculado a partir de outros nutrientes
-description:ar: قيمة الطاقة بالكيلو كالوري لا تتطابق مع القيمة المحسوبة من العناصر الغذائية الأخرى. غالبًا ما يكون ذلك بسبب خطأ في جدول الحقائق الغذائية الذي أدخله المستخدمون. في بعض الأحيان ، يكون خطأ قادمًا من المنتج.
-description:bg: Енергийната стойност в kcal не съвпада със стойността, изчислена от други хранителни вещества. Често това се дължи на грешка в таблицата с хранителни стойности, въведена от потребителите. Понякога това е грешка, идваща от производителя.
-description:ca: El valor energètic en kcal no coincideix amb el valor calculat a partir d'altres nutrients. Sovint es deu a un error a la taula de dades nutricionals introduïda pels usuaris. De vegades, és un error del productor.
-description:cs: Energetická hodnota v kcal neodpovídá hodnotě vypočtené z ostatních živin. Často je to způsobeno chybou v tabulce nutričních hodnot zadané uživateli. Někdy je to chyba pocházející od výrobce.
-description:da: Energiværdien i kcal stemmer ikke overens med værdien beregnet ud fra andre næringsstoffer. Det skyldes ofte en fejl i næringsfaktatabellen, der er indtastet af brugerne. Nogle gange er det en fejl fra producenten.
-description:de: Der Energiegehalt in kcal stimmt nicht mit dem aus anderen Nährstoffen berechneten Wert überein. Dies liegt häufig an einem Fehler in der von den Nutzern eingegebenen Nährwerttabelle. Manchmal ist es ein Fehler des Herstellers.
-description:el: Η ενεργειακή αξία σε kcal δεν ταιριάζει με την τιμή που υπολογίζεται από άλλα θρεπτικά συστατικά. Συχνά οφείλεται σε σφάλμα στον πίνακα διατροφικών στοιχείων που εισάγεται από τους χρήστες. Μερικές φορές, είναι ένα σφάλμα που προέρχεται από τον παραγωγό.
-description:es: El valor energético en kcal no coincide con el valor calculado a partir de otros nutrientes. A menudo se debe a un error en la tabla de datos nutricionales introducida por los usuarios. A veces, es un error del productor.
-description:fi: Energia-arvo kcal ei vastaa muiden ravintoaineiden perusteella laskettua arvoa. Tämä johtuu usein käyttäjien syöttämän ravintosisältötaulukon virheestä. Joskus se on tuottajan virhe.
-description:fr: La valeur énergétique entrée en kcal ne correspond pas à la valeur calculée à partir des autres nutriments. C'est souvent dû à une erreur dans le tableau nutritionel complété par les utilisateurs. Parfois il s'agit d'une erreur sur le packaging.
-description:hr: Energetska vrijednost u kcal ne odgovara vrijednosti izračunatoj iz drugih hranjivih tvari. To je često zbog pogreške u tablici nutritivnih vrijednosti koju su unijeli korisnici. Ponekad je to pogreška proizvođača.
-description:hu: A kcal-ban megadott energiaérték nem egyezik a többi tápanyagból számított értékkel. Ez gyakran a felhasználók által megadott táplálkozási táblázat hibájából adódik. Néha a gyártótól származó hiba.
-description:it: Il valore energetico in kcal non corrisponde al valore calcolato dagli altri nutrienti. Spesso è dovuto a un errore nella tabella dei valori nutrizionali inserita dagli utenti. A volte è un errore proveniente dal produttore.
-description:ja: kcalのエネルギー値が、他の栄養素から計算された値と一致しません。多くの場合、ユーザーが入力した栄養成分表示の表に誤りがあることが原因です。生産者からのエラーである場合もあります。
-description:ko: kcal의 에너지 값이 다른 영양소로부터 계산된 값과 일치하지 않습니다. 이는 종종 사용자가 입력한 영양 성분표의 오류 때문입니다. 때로는 생산자의 오류이기도 합니다.
-description:nl: De energiewaarde in kcal komt niet overeen met de waarde die is berekend op basis van andere voedingsstoffen. Dit komt vaak door een fout in de voedingswaardetabel die door de gebruikers is ingevoerd. Soms is het een fout van de producent.
-description:pl: Wartość energetyczna w kcal nie odpowiada wartości obliczonej na podstawie innych składników odżywczych. Często wynika to z błędu w tabeli wartości odżywczych wprowadzonej przez użytkowników. Czasami jest to błąd pochodzący od producenta.
-description:pt: O valor energético em kcal não corresponde ao valor calculado a partir de outros nutrientes. Muitas vezes, isso ocorre devido a um erro na tabela de informações nutricionais inserida pelos usuários. Às vezes, é um erro do produtor.
-description:ru: Значение энергии в ккал не соответствует значению, вычисленному на основе других питательных веществ. Часто это связано с ошибкой в таблице пищевой ценности, введенной пользователями. Иногда это ошибка, допущенная производителем.
-description:zh: 千卡能量值与从其他营养素计算出的值不匹配。 这通常是由于用户输入的营养成分表中的错误造成的。 有时，这是生产商造成的错误。
+# description:ar: قيمة الطاقة بالكيلو كالوري لا تتطابق مع القيمة المحسوبة من العناصر الغذائية الأخرى. غالبًا ما يكون ذلك بسبب خطأ في جدول الحقائق الغذائية الذي أدخله المستخدمون. في بعض الأحيان ، يكون خطأ قادمًا من المنتج.
+description:bg: Енергийната стойност в kJ не съвпада със стойността, изчислена от други хранителни вещества. Често това се дължи на грешка в таблицата с хранителни стойности, въведена от потребителите. Понякога това е грешка, идваща от производителя.
+description:ca: El valor energètic en kJ no coincideix amb el valor calculat a partir d'altres nutrients. Sovint es deu a un error a la taula de dades nutricionals introduïda pels usuaris. De vegades, és un error del productor.
+description:cs: Energetická hodnota v kJ neodpovídá hodnotě vypočtené z ostatních živin. Často je to způsobeno chybou v tabulce nutričních hodnot zadané uživateli. Někdy je to chyba pocházející od výrobce.
+description:da: Energiværdien i kJ stemmer ikke overens med værdien beregnet ud fra andre næringsstoffer. Det skyldes ofte en fejl i næringsfaktatabellen, der er indtastet af brugerne. Nogle gange er det en fejl fra producenten.
+description:de: Der Energiegehalt in kJ stimmt nicht mit dem aus anderen Nährstoffen berechneten Wert überein. Dies liegt häufig an einem Fehler in der von den Nutzern eingegebenen Nährwerttabelle. Manchmal ist es ein Fehler des Herstellers.
+description:el: Η ενεργειακή αξία σε kJ δεν ταιριάζει με την τιμή που υπολογίζεται από άλλα θρεπτικά συστατικά. Συχνά οφείλεται σε σφάλμα στον πίνακα διατροφικών στοιχείων που εισάγεται από τους χρήστες. Μερικές φορές, είναι ένα σφάλμα που προέρχεται από τον παραγωγό.
+description:es: El valor energético en kJ no coincide con el valor calculado a partir de otros nutrientes. A menudo se debe a un error en la tabla de datos nutricionales introducida por los usuarios. A veces, es un error del productor.
+description:fi: Energia-arvo kJ ei vastaa muiden ravintoaineiden perusteella laskettua arvoa. Tämä johtuu usein käyttäjien syöttämän ravintosisältötaulukon virheestä. Joskus se on tuottajan virhe.
+description:fr: La valeur énergétique entrée en kJ ne correspond pas à la valeur calculée à partir des autres nutriments. C'est souvent dû à une erreur dans le tableau nutritionel complété par les utilisateurs. Parfois il s'agit d'une erreur sur le packaging.
+description:hr: Energetska vrijednost u kJ ne odgovara vrijednosti izračunatoj iz drugih hranjivih tvari. To je često zbog pogreške u tablici nutritivnih vrijednosti koju su unijeli korisnici. Ponekad je to pogreška proizvođača.
+description:hu: A kJ-ban megadott energiaérték nem egyezik a többi tápanyagból számított értékkel. Ez gyakran a felhasználók által megadott táplálkozási táblázat hibájából adódik. Néha a gyártótól származó hiba.
+description:it: Il valore energetico in kJ non corrisponde al valore calcolato dagli altri nutrienti. Spesso è dovuto a un errore nella tabella dei valori nutrizionali inserita dagli utenti. A volte è un errore proveniente dal produttore.
+description:ja: kJのエネルギー値が、他の栄養素から計算された値と一致しません。多くの場合、ユーザーが入力した栄養成分表示の表に誤りがあることが原因です。生産者からのエラーである場合もあります。
+description:ko: kJ의 에너지 값이 다른 영양소로부터 계산된 값과 일치하지 않습니다. 이는 종종 사용자가 입력한 영양 성분표의 오류 때문입니다. 때로는 생산자의 오류이기도 합니다.
+description:nl: De energiewaarde in kJ komt niet overeen met de waarde die is berekend op basis van andere voedingsstoffen. Dit komt vaak door een fout in de voedingswaardetabel die door de gebruikers is ingevoerd. Soms is het een fout van de producent.
+description:pl: Wartość energetyczna w kJ nie odpowiada wartości obliczonej na podstawie innych składników odżywczych. Często wynika to z błędu w tabeli wartości odżywczych wprowadzonej przez użytkowników. Czasami jest to błąd pochodzący od producenta.
+description:pt: O valor energético em kJ não corresponde ao valor calculado a partir de outros nutrientes. Muitas vezes, isso ocorre devido a um erro na tabela de informações nutricionais inserida pelos usuários. Às vezes, é um erro do produtor.
+# description:ru: Значение энергии в ккал не соответствует значению, вычисленному на основе других питательных веществ. Часто это связано с ошибкой в таблице пищевой ценности, введенной пользователями. Иногда это ошибка, допущенная производителем.
+# description:zh: 千卡能量值与从其他营养素计算出的值不匹配。 这通常是由于用户输入的营养成分表中的错误造成的。 有时，这是生产商造成的错误。
 
 < en:Nutrition errors
 en: Nutrition - Sugars plus starch greater than carbohydrates


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

As described in #12018, the long-text description for the data quality error with title "Energy value in kJ does not match value computed from other nutrients" seems to be incorrect.

This pull request backfills those descriptions with search-and-replaced copies of the equivalent data quality message for nutrient energy calculation mismatch in kcal.

Three languages are commented-out where I couldn't find the text string `kcal` to search-and-replace with `kJ`.

### Related issue(s) and discussion

- Fixes #12018