### PR TITLE
fix: display selected image in product edit form

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -71,6 +71,7 @@ use JSON::MaybeXS;
 use Log::Any qw($log);
 use File::Copy qw(move);
 use Data::Dumper;
+use Data::DeepAccess qw(deep_get deep_set);
 
 # Function to display a form to add a product with a specific barcode (either typed in a field, or extracted from a barcode photo)
 # or without a barcode

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -301,10 +301,13 @@ HTML
 
 	my $image_url = '';
 
-	my $image_ref = deep_get($object_ref, "images", $image_type, $image_lc);
+	my $image_ref = deep_get($object_ref, "images", "selected", $image_type, $image_lc);
 
 	if (defined $image_ref) {
-		my $image_url = get_image_url($object_ref, $image_ref, $display_size);
+		$image_ref->{id} = $image_type . "_" . $image_lc;
+		$image_url = get_image_url($object_ref, $image_ref, $display_size);
+		# Keep only the filename
+		$image_url =~ s/.*\///;
 	}
 
 	$html


### PR DESCRIPTION
There's a small bug in v2.69.0 that is being deployed: in the web product edit form, it doesn't show that an image is already selected. This is a hot fix for it.