### PR TITLE
taxonomy: Tidy up “Puffed salty snacks (potato/soy based)”

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -118862,6 +118862,13 @@ fr: Biscuits Feuilletés auf fromage
 hr: Lisnato pecivo sa sirom
 nl: Kaasvlinders
 
+< en:Cheese puff pastries
+en: Cheese doodles
+hr: Crteži sa sirom
+nl: Kaasflips
+ro: Pufuleți cu brânză
+#wikidata:en: Q5089481
+
 < en:Crackers(Appetizers)
 fr: Crêpes dentelle salées, Crêpes dentelles salées
 
@@ -118939,35 +118946,14 @@ fr: mélange Sticks et Bretzels
 
 < en:Crackers(Appetizers)
 en: Puffed salty snacks, Salty snacks puff pastry, Salty palmiers
-fr: Biscuit apéritif feuilleté, Palmiers salés
+fr: Biscuit apéritif feuilleté, Palmiers salés, Biscuits apéritifs soufflés, Gâteaux apéritifs soufflés
 hr: Napuhane slane grickalice
 nl: Gezouten vlinders, Gezouten palmiers
+ro: Pufuleți
 agribalyse_food_code:en: 38407
 ciqual_food_code:en: 38407
 ciqual_food_name:en: Salty snacks, puff pastry
 ciqual_food_name:fr: Biscuit apéritif feuilleté
-
-< en:Crackers(Appetizers)
-en: Puffed salty snacks (potato/soy based)
-de: Gepuffte salzige Snacks (Kartoffel/Soja)
-fr: Biscuits apéritifs soufflés (à base de pomme de terre/soja), Gâteaux apéritifs soufflés
-hr: Lisnate slane grickalice (na bazi krumpira/soje)
-nl: Gepofte zoutjes (aardappel/soja basis)
-ro: Pufuleți
-agribalyse_proxy_food_code:en: 38108
-agribalyse_proxy_food_name:en: Puffed salty snacks, made from potato and soy
-agribalyse_proxy_food_name:fr: Biscuit apéritif soufflé, à base de pomme de terre et de soja
-gpc_category_code:en: 10006746
-gpc_category_description:en: Definition: Includes any products that can be described/observed as a type of food usually consumed between meals. They contain peanuts, peanut flavoured extracts,  cheese and/or cheese flavouring extracts, which are blended with other ingredients, reconstituted, and pressed into bite size shapes, or sliced products, which are fried in oil or oven-baked. These products are usually packaged in airtight bags, tubes, or plastic containers.
-gpc_category_name:en: Doodles/ Puffs
-#wikidata:en:Q9191304
-
-< en:Puffed salty snacks (potato/soy based)
-en: Cheese doodles
-hr: Crteži sa sirom
-nl: Kaasflips
-ro: Pufuleți cu brânză
-#wikidata:en:
 
 < en:Crackers(Appetizers)
 en: Salty snacks with reduced fat, Crackers with reduced fat
@@ -119014,12 +119000,21 @@ ciqual_food_name:en: Puffed salty snacks, made from potato
 ciqual_food_name:fr: Biscuit apéritif soufflé, à base de pomme de terre
 
 < en:Puffed salty snacks
-en: Puffed salty snacks made from potato and soy
-fr: Biscuit apéritif soufflé à base de pomme de terre et de soja
+en: Puffed salty snacks made from potato and soy, Puffed salty snacks (potato/soy based)
+de: Gepuffte salzige Snacks (Kartoffel/Soja)
+fr: Biscuit apéritif soufflé à base de pomme de terre et de soja, Biscuits apéritifs soufflés (à base de pomme de terre/soja)
+hr: Lisnate slane grickalice (na bazi krumpira/soje)
+nl: Gepofte zoutjes (aardappel/soja basis)
 agribalyse_food_code:en: 38108
+agribalyse_proxy_food_code:en: 38108
+agribalyse_proxy_food_name:en: Puffed salty snacks, made from potato and soy
+agribalyse_proxy_food_name:fr: Biscuit apéritif soufflé, à base de pomme de terre et de soja
 ciqual_food_code:en: 38108
 ciqual_food_name:en: Puffed salty snacks, made from potato and soy
 ciqual_food_name:fr: Biscuit apéritif soufflé, à base de pomme de terre et de soja
+gpc_category_code:en: 10006746
+gpc_category_description:en: Definition: Includes any products that can be described/observed as a type of food usually consumed between meals. They contain peanuts, peanut flavoured extracts,  cheese and/or cheese flavouring extracts, which are blended with other ingredients, reconstituted, and pressed into bite size shapes, or sliced products, which are fried in oil or oven-baked. These products are usually packaged in airtight bags, tubes, or plastic containers.
+gpc_category_name:en: Doodles/ Puffs
 
 < en:Cereals and their products
 en: Pie dough


### PR DESCRIPTION
Tacite and Olaf Görlitz made observations in Slack[1] that “Puffed salty snacks (potato/soy based)” had some wrong translations, seemed to be identical to “Puffed salty snacks made from potato and soy”, and also probably the wrong parent for “Cheese doodles”.

This merges “Puffed salty snacks (potato/soy based)” into “Puffed salty snacks made from potato and soy”, moves some translations from “Puffed salty snacks (potato/soy based)” to “Puffed salty snacks”, and sets the parent for “Cheese doodles” to be “Cheese puff pastries”.

[1]
https://openfoodfacts.slack.com/archives/C02VDSWHT/p1749725199812599
https://openfoodfacts.slack.com/archives/C02VDSWHT/p1749725219150049
https://openfoodfacts.slack.com/archives/C02VDSWHT/p1749725226999759
https://openfoodfacts.slack.com/archives/C02VDSWHT/p1749853184771419