### PR TITLE
taxonomy: Add “Taco Truck” brand synonym

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -56,7 +56,7 @@ xx: DUG
 
 xx: Délisse
 
-xx: El Taco Truck, El Taco Truck AB
+xx: El Taco Truck, El Taco Truck AB, Taco Truck
 
 xx: Eldorado
 wikidata:en: Q5324313


### PR DESCRIPTION
There are currently 4 items associated with the/a “Taco Truck” brand:
https://world.openfoodfacts.org/facets/brands/taco-truck

All of them are from El Taco Truck, so seems like “Taco Truck” would be a good synonym.