### PR TITLE
taxonomy: Fix and amend some `expected_ingredients`

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -78980,7 +78980,6 @@ pl: Ketchup pomidorowy, Keczup pomidorowy
 ru: Томатный кетчуп
 sv: Tomatketchup
 tr: Domates Ketçabı
-expected_ingredients:en: en:tomato
 
 < en:Tomato sauces
 en: Neapolitan sauces
@@ -108956,6 +108955,7 @@ it: Carote fresche
 nl: Verse wortel
 sv: Färska morötter
 bulk_proxy:en: en:carrots
+expected_ingredients:en: en:carrots
 sales_format:en: weight, package
 season_in_country_fr:en: 1,2,3,9,10,11,12
 
@@ -110299,7 +110299,6 @@ bg: Халапеньо
 fr: Jalapeño, chipotle, morita
 ja: ハラペーニョ
 nl: Jalapenopepers
-expected_ingredients:en: en:jalapeno pepper
 wikidata:en: Q504133
 
 < en:Jalapeños


### PR DESCRIPTION
I misunderstood how `expected_ingredients` worked when I added these[1], so removing again to stop them getting flagged for quality issues!

And while I was at it, I also added one that _could_ use it. :)

[1] I thought it would just want that ingredient to be in 
    the ingredient list, not that it would want it to be
    the sole ingredient.