### PR TITLE
fix(deps): Force Imager::Zxing version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,16 +181,16 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
 # Install zxing-cpp from source until 2.1 or higher is available in Debian: https://github.com/openfoodfacts/openfoodfacts-server/pull/8911/files#r1322987464
 RUN set -x && \
     cd /tmp && \
-    wget https://github.com/zxing-cpp/zxing-cpp/archive/refs/tags/v2.1.0.tar.gz && \
-    tar xfz v2.1.0.tar.gz && \
-    cmake -S zxing-cpp-2.1.0 -B zxing-cpp.release \
+    wget https://github.com/zxing-cpp/zxing-cpp/archive/refs/tags/v2.3.0.tar.gz && \
+    tar xfz v2.3.0.tar.gz && \
+    cmake -S zxing-cpp-2.3.0 -B zxing-cpp.release \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_WRITERS=OFF -DBUILD_READERS=ON -DBUILD_EXAMPLES=OFF && \
     cmake --build zxing-cpp.release -j8 && \
     cmake --install zxing-cpp.release && \
     cd / && \
-    rm -rf /tmp/v2.1.0.tar.gz /tmp/zxing-cpp*
+    rm -rf /tmp/v2.3.0.tar.gz /tmp/zxing-cpp*
 
 # Run www-data user AS host user 'off' or developper uid
 ARG USER_UID

--- a/cpanfile
+++ b/cpanfile
@@ -96,7 +96,8 @@ requires 'Apache2::Connection::XForwardedFor';
 
 # GS1 Sunrise 2027
 requires 'GS1::SyntaxEngine::FFI';
-requires 'Imager::zxing';
+requires 'Imager', '>= 1.025, < 1.026';
+requires 'Imager::zxing', '>= 1.001, < 1.002';
 requires 'Imager::File::AVIF';
 requires 'Imager::File::HEIF';
 requires 'Imager::File::JPEG';


### PR DESCRIPTION
### What

Enforce older version of Imager::Zxing to be used to fix build issue introduced by CPAN package changes.