### PR TITLE
fix: disable off-query for API queries that may need unsupported fields

### DIFF
--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -205,7 +205,8 @@ sub execute_product_query ($parameters_ref, $query_ref, $fields_ref, $sort_ref, 
 	defined $$data_debug_ref or $$data_debug_ref = "data_debug start\n";
 
 	# If possible, send to off-query, unless off_query is set to 0
-	if (can_use_off_query($data_debug_ref)) {
+	# or the request parameters include no_off_query set to 1 (e.g. for API queries that could ask for fields not supported by off-query)
+	if (can_use_off_query($data_debug_ref) and not $parameters_ref->{no_off_query}) {
 
 		$$data_debug_ref .= "using off_query\n";
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1716,7 +1716,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 		if (not defined $results_count) {
 
 			my $count_results;
-			# do not use the smaller if we are on the producers platform
+			# do not use off-query if we are on the producers platform
 			if (can_use_off_query(\$request_ref->{data_debug})) {
 				set_request_stats_time_start($request_ref->{stats}, "off_query_aggregate_tags_query");
 				$count_results = execute_aggregate_tags_query($aggregate_count_parameters);
@@ -5375,6 +5375,11 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				if $log->is_debug();
 
 			set_request_stats_time_start($request_ref->{stats}, "mongodb_query");
+			# For API queries, we do not want to send the product list queries to off-query as off-query supports a limited set
+			# of fields that it can return. (we can use it for the count as off-query will return an error if a filter is not supported)
+			if ($api) {
+				$request_parameters_ref->{no_off_query} = 1;
+			}
 			$cursor = execute_query(
 				sub {
 					return execute_product_query($request_parameters_ref, $query_ref, $fields_ref, $sort_ref, $limit,


### PR DESCRIPTION
Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/12059

https://github.com/openfoodfacts/openfoodfacts-server/pull/12045 was too aggressive: we should not send API search / list of products queries to off-query, as they expect to get all product fields.

Some API queries may ask only for supported fields, so we could add support for that at a later point.