### PR TITLE
taxonomy: correction salty flaky biscuits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -118944,15 +118944,23 @@ wikidata:en: Q160525
 fr: mélange Sticks et Bretzels
 
 < en:Crackers(Appetizers)
-en: Puffed salty snacks, Salty snacks puff pastry, Salty palmiers
-fr: Biscuit apéritif feuilleté, Palmiers salés, Biscuits apéritifs soufflés, Gâteaux apéritifs soufflés
+en: Puffed salty snacks, Salty snacks puff pastry
+fr: Biscuits apéritifs soufflés, Gâteaux apéritifs soufflés
 hr: Napuhane slane grickalice
-nl: Gezouten vlinders, Gezouten palmiers
 ro: Pufuleți
+
+< en:Crackers(Appetizers)
+en: Salty flaky biscuits
+fr: Biscuits apéritifs feuilletés, Biscuit apéritif feuilleté
 agribalyse_food_code:en: 38407
 ciqual_food_code:en: 38407
 ciqual_food_name:en: Salty snacks, puff pastry
 ciqual_food_name:fr: Biscuit apéritif feuilleté
+
+< en: Salty flaky biscuits
+en: Salty palmiers
+fr: Palmiers salés
+nl: Gezouten vlinders, Gezouten palmiers
 
 < en:Crackers(Appetizers)
 en: Salty snacks with reduced fat, Crackers with reduced fat


### PR DESCRIPTION
Correction of salty biscuits categories. There was a mistranslation of the French word "feuilleté" in "puffed" instead of "flaky".