### PR TITLE
fix: Include lc in the Test Ingredients Analysis form

### DIFF
--- a/templates/web/pages/test_ingredients/test_ingredients_analysis.tt.html
+++ b/templates/web/pages/test_ingredients/test_ingredients_analysis.tt.html
@@ -7,6 +7,7 @@
     Ingredients text (language code: [% lc %]): <br/>
     <textarea id="ingredients_text" name="ingredients_text" style="height:8rem;">[% ingredients_text %]</textarea>
     <input type="hidden" name="type" value="[% type %]"/>
+    <input type="hidden" name="lc" value="[% lc %]"/>
     <input type="hidden" name="action" value='process'/>
     <input type="submit" name="submit">
 


### PR DESCRIPTION
### What

The form Test Ingredients Analysis did not include the `lc` language parameter as a form field, so it was not included in the request when the form was submitted. As a result, the parameter was lost and the ingredients were analysed in English.
