### PR TITLE
fix: Use testcontainer directly with simplified configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,6 @@ DOCKER_COMPOSE_TEST=COMPOSE_FILE="${COMPOSE_FILE_BUILD};${DEPS_DIR}/openfoodfact
 # Note the integration-test.yml file contains references to the docker-compose files from shared-services and auth
 DOCKER_COMPOSE_INT_TEST=COMPOSE_FILE="${COMPOSE_FILE_BUILD};docker/integration-test.yml" \
 	REDIS_URL="redis:6379" \
-	KEYCLOAK_BASE_URL=http://keycloak:8080 \
-	KEYCLOAK_TAG=main \
 	${DOCKER_COMPOSE_TEST_BASE}
 
 TEST_CMD ?= yath test
@@ -562,6 +560,7 @@ clean_folders: clean_logs
 
 clean_logs:
 	( rm -f logs/* logs/apache2/* logs/nginx/* || true )
+	echo "" > logs/apache2/log4perl.log
 
 clean: goodbye hdown prune prune_deps prune_cache clean_folders
 

--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,8 @@ integration_test: create_folders
 # this is the place where variables are important
 # note that we don't launch the frontend because it causes issues,
 # as we use localhost in tests (which is the backend)
+# Need to start dynamicfront explicitly so it is built on-demand. Just listing it as a depends_on for backend doesn't seem to do this
+	${DOCKER_COMPOSE_INT_TEST} up -d dynamicfront
 	${DOCKER_COMPOSE_INT_TEST} up -d backend
 # note: we need the -T option for ci (non tty environment)
 	${DOCKER_COMPOSE_INT_TEST} exec ${COVER_OPTS} -e JUNIT_TEST_FILE="tests/integration/outputs/junit.xml" -T backend yath --renderer=Formatter --renderer=JUnit tests/integration

--- a/docker/integration-test.yml
+++ b/docker/integration-test.yml
@@ -8,16 +8,9 @@ services:
           condition: service_started
 
   keycloak:
-    extends: 
-      file: ${DEPS_DIR}/openfoodfacts-auth/docker-compose.yml
-      service: keycloak
+    image: ghcr.io/openfoodfacts/openfoodfacts-auth:testcontainer
     environment:
-      - KEYCLOAK_BASE_URL
-      - CLIENTS=OFF,http://world.openfoodfacts.localhost
-      - OFF_CLIENT_SECRET=${OFF_CLIENT_SECRET}
-      - KC_BOOTSTRAP_ADMIN_USERNAME=test
-      - KC_BOOTSTRAP_ADMIN_PASSWORD=test
-      - KEYCLOAK_STARTUP=test
+      - KC_SPI_EVENTS_LISTENER_REDIS_EVENT_LISTENER_REDIS_URL=${REDIS_URL}
 
   backend:
     depends_on:


### PR DESCRIPTION
### What

Use new Keycloak testcontainer image with config built in which improves startup time

- Fixes https://github.com/openfoodfacts/openfoodfacts-auth/issues/207

Note this changes the way clients are created in Keycloak. Instead of creating them on-the-fly on startup they need to be created manually via the admin UI or API. The full process for creating a client would be as follows:

1. Create the client in Keycloak (copy from the OFF client if it needs full permission). The client id should match the Product Opener flavour in upper case
2. Get the secret and add this as a GitHub secret in openfoodfacts-server
3. Update the openfoodfacts-server image deployment script to add this secret to the environment.

For production the edits would be more manual