### PR TITLE
fix: cache OCR, make cloud_vision default

### DIFF
--- a/cgi/ingredients.pl
+++ b/cgi/ingredients.pl
@@ -49,12 +49,6 @@ my $id = single_param('id');
 my $ocr_engine = single_param('ocr_engine');
 my $annotations = single_param('annotations') || 0;
 
-if (not defined $ocr_engine) {
-	$ocr_engine = "tesseract";
-
-	# $ocr_engine = "google_cloud_vision";
-}
-
 $log->debug("start", {code => $code, id => $id}) if $log->is_debug();
 
 if (not defined $code) {

--- a/cgi/nutrition.pl
+++ b/cgi/nutrition.pl
@@ -50,12 +50,6 @@ my $id = single_param('id');
 my $ocr_engine = single_param('ocr_engine');
 my $annotations = single_param('annotations') | 0;
 
-if (not defined $ocr_engine) {
-	$ocr_engine = "tesseract";
-
-	# $ocr_engine = "google_cloud_vision";
-}
-
 $log->debug("start", {code => $code, id => $id}) if $log->is_debug();
 
 if (not defined $code) {

--- a/cgi/packaging.pl
+++ b/cgi/packaging.pl
@@ -49,12 +49,6 @@ my $id = single_param('id');
 my $ocr_engine = single_param('ocr_engine');
 my $annotations = single_param('annotations') | 0;
 
-if (not defined $ocr_engine) {
-	$ocr_engine = "tesseract";
-
-	# $ocr_engine = "google_cloud_vision";
-}
-
 $log->debug("start", {code => $code, id => $id}) if $log->is_debug();
 
 if (not defined $code) {

--- a/lib/ProductOpener/Config2_docker.pm
+++ b/lib/ProductOpener/Config2_docker.pm
@@ -45,6 +45,7 @@ BEGIN {
 		$mongodb_host
 		$mongodb_timeout_ms
 		$memd_servers
+		$tesseract_ocr_available
 		$google_cloud_vision_api_key
 		$google_cloud_vision_api_url
 		$crowdin_project_identifier
@@ -97,6 +98,7 @@ $mongodb_timeout_ms = 50000;    # config option max_time_ms/maxTimeMS
 
 $memd_servers = ["memcached:11211"];
 
+$tesseract_ocr_available = $ENV{TESSERACT_OCR_AVAILABLE} // 1;    # Set to 0 to disable Tesseract OCR
 $google_cloud_vision_api_key = $ENV{GOOGLE_CLOUD_VISION_API_KEY};
 $google_cloud_vision_api_url = $ENV{GOOGLE_CLOUD_VISION_API_URL} || "https://vision.googleapis.com/v1/images:annotate";
 

--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -47,6 +47,7 @@ BEGIN {
 		$admin_email
 		$producers_email
 
+		$tesseract_ocr_available
 		$google_cloud_vision_api_key
 		$google_cloud_vision_api_url
 
@@ -233,6 +234,7 @@ $conf_root = $ProductOpener::Config2::conf_root;
 
 $geolite2_path = $ProductOpener::Config2::geolite2_path;
 
+$tesseract_ocr_available = $ProductOpener::Config2::tesseract_ocr_available;
 $google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 $google_cloud_vision_api_url = $ProductOpener::Config2::google_cloud_vision_api_url;
 

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -46,6 +46,7 @@ BEGIN {
 		$admin_email
 		$producers_email
 
+		$tesseract_ocr_available
 		$google_cloud_vision_api_key
 		$google_cloud_vision_api_url
 
@@ -425,6 +426,7 @@ $sftp_root = $ProductOpener::Config2::sftp_root;    # might be undef
 
 $geolite2_path = $ProductOpener::Config2::geolite2_path;
 
+$tesseract_ocr_available = $ProductOpener::Config2::tesseract_ocr_available;
 $google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 $google_cloud_vision_api_url = $ProductOpener::Config2::google_cloud_vision_api_url;
 

--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -46,6 +46,7 @@ BEGIN {
 		$admin_email
 		$producers_email
 
+		$tesseract_ocr_available
 		$google_cloud_vision_api_key
 		$google_cloud_vision_api_url
 
@@ -231,6 +232,7 @@ $conf_root = $ProductOpener::Config2::conf_root;
 
 $geolite2_path = $ProductOpener::Config2::geolite2_path;
 
+$tesseract_ocr_available = $ProductOpener::Config2::tesseract_ocr_available;
 $google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 $google_cloud_vision_api_url = $ProductOpener::Config2::google_cloud_vision_api_url;
 

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -46,6 +46,7 @@ BEGIN {
 		$admin_email
 		$producers_email
 
+		$tesseract_ocr_available
 		$google_cloud_vision_api_key
 		$google_cloud_vision_api_url
 
@@ -233,6 +234,7 @@ $conf_root = $ProductOpener::Config2::conf_root;
 
 $geolite2_path = $ProductOpener::Config2::geolite2_path;
 
+$tesseract_ocr_available = $ProductOpener::Config2::tesseract_ocr_available;
 $google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 $google_cloud_vision_api_url = $ProductOpener::Config2::google_cloud_vision_api_url;
 

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -118,6 +118,7 @@ BEGIN {
 
 		&display_image
 
+		&select_ocr_engine
 		&extract_text_from_image
 		&send_image_to_cloud_vision
 
@@ -821,8 +822,8 @@ sub generate_resized_images ($path, $filename, $image_source, $sizes_ref, @sizes
 			last;
 		}
 		else {
-			$log->info("jpeg written", {path => "jpeg:$path/$filename.$max.jpg"})
-				if $log->is_info();
+			$log->debug("jpeg written", {path => "jpeg:$path/$filename.$max.jpg"})
+				if $log->is_debug();
 		}
 
 		$sizes_ref->{$max} = {w => $img->Get('width'), h => $img->Get('height')};
@@ -1233,7 +1234,7 @@ sub process_image_upload_using_filehandle ($product_ref, $filehandle, $user_id, 
 		$imgid = -2;
 	}
 
-	$log->info("upload processed", {imgid => $imgid}) if $log->is_info();
+	$log->debug("upload processed", {imgid => $imgid}) if $log->is_debug();
 
 	${$imgid_ref} = $imgid;
 
@@ -1440,7 +1441,7 @@ sub process_image_move ($user_id, $code, $imgids, $move_to, $ownerid) {
 					);
 				}
 				else {
-					$log->info(
+					$log->debug(
 						"moved image to other product",
 						{
 							source_path => "$BASE_DIRS{PRODUCTS_IMAGES}/$path/$imgid.jpg",
@@ -1454,7 +1455,7 @@ sub process_image_move ($user_id, $code, $imgids, $move_to, $ownerid) {
 				}
 			}
 			else {
-				$log->info(
+				$log->debug(
 					"moved image to trash",
 					{
 						source_path => "$BASE_DIRS{PRODUCTS_IMAGES}/$path/$imgid.jpg",
@@ -1917,7 +1918,7 @@ sub process_image_unselect ($product_ref, $image_type, $image_lc) {
 	local $log->context->{image_type} = $image_type;
 	local $log->context->{image_lc} = $image_lc;
 
-	$log->info("unselecting image") if $log->is_info();
+	$log->debug("unselecting image") if $log->is_debug();
 
 	if (deep_exists($product_ref, "images", "selected", $image_type, $image_lc)) {
 		delete $product_ref->{images}{selected}{$image_type}{$image_lc};
@@ -2347,6 +2348,53 @@ sub compute_orientation_from_cloud_vision_annotations ($annotations_ref) {
 	return;
 }
 
+=head2 select_ocr_engine ($requested_ocr_engine)
+
+Select the OCR engine to use based on the requested OCR engine and the available engines.
+
+If the requested OCR engine is not available, we return the first available one.
+
+=head3 Arguments
+
+=head4 $requested_ocr_engine
+
+Either 'tesseract' or 'google_cloud_vision'.
+
+=head3 Return values
+
+- 'google_cloud_vision' if Google Cloud Vision API key is available
+- 'tesseract' if Tesseract OCR is available
+- undef if no OCR engine is available
+
+=cut
+
+sub select_ocr_engine($requested_ocr_engine) {
+
+	my $ocr_engine;
+
+	if ($requested_ocr_engine eq 'tesseract') {
+		$ocr_engine = 'tesseract' if $ProductOpener::Config::tesseract_ocr_available;
+	}
+	elsif ($requested_ocr_engine eq 'google_cloud_vision') {
+		$ocr_engine = 'google_cloud_vision' if $ProductOpener::Config::google_cloud_vision_api_key;
+	}
+
+	# Default to google cloud vision if available, otherwise tesseract if available, otherwise return undef
+	if (not defined $ocr_engine) {
+		if ($ProductOpener::Config::google_cloud_vision_api_key) {
+			$ocr_engine = 'google_cloud_vision';
+		}
+		elsif ($ProductOpener::Config::tesseract_ocr_available) {
+			$ocr_engine = 'tesseract';
+		}
+	}
+
+	$log->debug("select_ocr_engine", {requested_ocr_engine => $requested_ocr_engine, ocr_engine => $ocr_engine})
+		if $log->is_debug();
+
+	return $ocr_engine;
+}
+
 =head2 extract_text_from_image( $product_ref, $id, $field, $ocr_engine, $results_ref )
 
 Perform OCR for a specific image (either a source image, or a selected image) and return the results.
@@ -2371,9 +2419,10 @@ If $id is a field name, the last selected image for that field is used.
 Field to update in the product object.
 e.g. ingredients_text_from_image, nutrition_text_from_image, packaging_text_from_image
 
-=head4 OCR engine $ocr_engine
+=head4 Requested OCR engine $requested_ocr_engine
 
-Either "tesseract" or "google_cloud_vision"
+Either "tesseract" or "google_cloud_vision".
+Note: if the requested OCR engine is not available, we will select the first available one.
 
 =head4 Results reference $results_ref
 
@@ -2381,9 +2430,17 @@ A hash reference to store the results.
 
 =cut
 
-sub extract_text_from_image ($product_ref, $image_type, $image_lc, $field, $ocr_engine, $results_ref) {
+sub extract_text_from_image ($product_ref, $image_type, $image_lc, $field, $requested_ocr_engine, $results_ref) {
 
 	delete $product_ref->{$field};
+
+	my $ocr_engine = select_ocr_engine($requested_ocr_engine);
+
+	# Return if the OCR engine is undef
+	if (not defined $ocr_engine) {
+		$results_ref->{error} = "no OCR engine available";
+		return;
+	}
 
 	my $path = product_path($product_ref);
 	$results_ref->{status} = 1;    # 1 = nok, 0 = ok
@@ -2527,6 +2584,34 @@ sub send_image_to_cloud_vision ($image_path, $json_file, $features_ref, $gv_logs
 	my $url
 		= $ProductOpener::Config::google_cloud_vision_api_url . "?key="
 		. $ProductOpener::Config::google_cloud_vision_api_key;
+
+	# If we already have a CloudVision result JSON file that is less than 1 month old, we return it
+	# instead of sending the image to the API. This is in particular useful for integration tests
+	# that make the same request multiple times.
+
+	if (-e $json_file) {
+		my $mtime = (stat($json_file))[9];
+		my $age = time() - $mtime;
+		if ($age < 30 * 24 * 60 * 60) {    # less than 30 days old
+			print($gv_logs "CV:getting existing cached JSON file for $url\n");
+			$log->debug("using cached cloud vision result", {path => $json_file, age => $age}) if $log->is_debug();
+			open(my $IN, "<:raw", $json_file) or die "Could not read $json_file: $!\n";
+			# use an eval block to catch errors in the JSON decoding in case the file is corrupted
+			my $response;
+			eval {
+				my $gzip_handle = IO::Uncompress::Gunzip->new($IN)
+					or die "Cannot create gzip filehandle: $GzipError\n";
+				my $json_response = do {local $/; <$gzip_handle>};
+				$gzip_handle->close;
+				close $IN;
+				$response = decode_json($json_response);
+			};
+			if (defined $response) {
+				return $response;
+			}
+		}
+	}
+
 	print($gv_logs "CV:sending to $url\n");
 
 	my $ua = create_user_agent();
@@ -2553,12 +2638,12 @@ sub send_image_to_cloud_vision ($image_path, $json_file, $features_ref, $gv_logs
 	$request->content($json);
 
 	my $cloud_vision_response = $ua->request($request);
-	# $log->info("google cloud vision response", { json_response => $cloud_vision_response->decoded_content, api_token => $ProductOpener::Config::google_cloud_vision_api_key });
+	# $log->debug("google cloud vision response", { json_response => $cloud_vision_response->decoded_content, api_token => $ProductOpener::Config::google_cloud_vision_api_key });
 
 	my $cloudvision_ref = undef;
 	if ($cloud_vision_response->is_success) {
 
-		$log->info("request to google cloud vision was successful for $image_path") if $log->is_info();
+		$log->debug("request to google cloud vision was successful for $image_path") if $log->is_debug();
 
 		my $json_response = $cloud_vision_response->decoded_content(charset => 'UTF-8');
 
@@ -2567,7 +2652,7 @@ sub send_image_to_cloud_vision ($image_path, $json_file, $features_ref, $gv_logs
 		# Adding creation timestamp, to know when the OCR has been generated
 		$cloudvision_ref->{created_at} = time();
 
-		$log->info("saving google cloud vision json response to file", {path => $json_file}) if $log->is_info();
+		$log->debug("saving google cloud vision json response to file", {path => $json_file}) if $log->is_debug();
 
 		if (open(my $OUT, ">:raw", $json_file)) {
 			my $gzip_handle = IO::Compress::Gzip->new($OUT)


### PR DESCRIPTION
This PR is to implement improvements triggered by a production issue we had with the DART plugin integration tests overloading the OFF server with tesseract requests.

It:
- makes cloud vision the default if ocr_engine parameter is not passed
- enables disabling tesseract and/or cloud vision in Config2.pm
- for Cloud Vision, if we have a JSON OCR file that is less than 30 days, we serve it back immediately (will help with the requests made by the DART plugin integration tests)

Related: https://github.com/openfoodfacts/openfoodfacts-dart/issues/1109