### PR TITLE
taxonomy: correction ravioli

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -41461,7 +41461,7 @@ nl: Ravioli in blik/pot
 ro: Conserve de ravioli
 
 < en:Canned raviolis
-< en:Stuffed pastas in sauce
+< en:Meals with meat
 en: Canned raviolis filled with meat in tomato sauce
 fr: Raviolis à la viande en conserve, Raviolis à la viande sauce tomate en conserve, Raviolis à la viande sauce tomate appertisés
 agribalyse_food_code:en: 25019


### PR DESCRIPTION
Moved "canned ravioli" in "Stuffed pastas in sauce".