### PR TITLE
taxonomy: Prepared meats

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -80634,17 +80634,6 @@ ciqual_food_name:fr: Blanquette de veau
 wikidata:en: Q1191278
 
 < en:Beef dishes
-en: Corned-beef
-de: Corned Beef
-fr: Corned-beef, Corned-beef appertisé, Corned-beef en conserve
-hr: Usoljena govedina
-ja: コーンビーフ
-ciqual_food_code:en: 28505
-ciqual_food_name:en: Corned-beef
-ciqual_food_name:fr: Corned-beef, appertisé
-wikidata:en: Q1133209
-
-< en:Beef dishes
 en: Beef Wellington
 
 # cottage pie is the first synonyme because more products are called cottage pie than sheperd's pie
@@ -89848,6 +89837,17 @@ hr: Goveđa pastrama
 ja: パストラミ
 nl: Rundvleespastrami
 
+< en:Prepared beef meats
+en: Corned beef
+de: Corned Beef
+fr: Corned-beef, Corned-beef appertisé, Corned-beef en conserve
+hr: Usoljena govedina
+ja: コーンビーフ
+ciqual_food_code:en: 28505
+ciqual_food_name:en: Corned-beef
+ciqual_food_name:fr: Corned-beef, appertisé
+wikidata:en: Q1133209
+
 < en:Prepared pork meats
 en: Coppa, Capicola, Capocollo
 fr: Coppa
@@ -91626,6 +91626,20 @@ origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01333, PGI-IT-01333-AM01
 protected_name_type:en: pgi
 #wikidata:en:
+
+< fr:Charcuteries cuites
+en: Lyoner
+de: Lyoner
+xx: Lyoner
+
+< en:Lyoner
+< en:Prepared pork meats
+en: Pork lyoner
+de: Schweine Lyoner
+
+< en:Lyoner
+en: Poultry lyoner
+de: Geflügel Lyoner
 
 < en:Prepared meats
 fr: Charcuteries diverses
@@ -118351,9 +118365,12 @@ ciqual_food_name:en: Plant-based ham, prepacked
 ciqual_food_name:fr: Spécialité végétale type jambon cuit, préemballée
 
 < en:Prepared meat cuts substitutes
-en: Vegan salami
+en: Salami substitutes, Vegan salami
 da: Vegansk salami
 sv: Vegansk salami
+
+< en:Prepared meat cuts substitutes
+en: Lyoner substitutes
 
 < en:Meat analogues
 en: Foie gras substitutes

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -90076,6 +90076,7 @@ ciqual_food_code:en: 28803
 ciqual_food_name:en: Cooked ham, smoked
 
 < en:Hams
+< en:Prepared pork meats
 en: White hams, white ham, cooked hams, cooked ham
 ca: Pernil dolç, pernil cuit
 de: Kochschinken
@@ -90218,6 +90219,7 @@ en: Game hams
 fr: Jambons de gibier
 
 < en:Hams
+< en:Prepared pork meats
 en: Cured hams, cured ham
 de: Unbehandelte Schinken
 es: jamón de país, jamón salado

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -89747,6 +89747,26 @@ food_groups:en: en:processed-meat
 nova:en: 3
 pnns_group_2:en: Processed meat
 
+< en:Prepared meats
+< en:Beef and its products
+en: Prepared beef meats
+fr: Charcuteries de bœuf
+
+< en:Prepared meats
+< en:Pork and its products
+en: Prepared pork meats
+fr: Charcuteries de porc
+
+< en:Prepared meats
+< en:Chicken and its products
+en: Prepared chicken meats
+fr: Charcuteries de poulet
+
+< en:Prepared meats
+< en:Turkey and its products
+en: Prepared turkey meats
+fr: Charcuteries de dinde
+
 < fr:Charcuteries cuites
 fr: Andouillettes
 agribalyse_food_code:en: 8550
@@ -89812,7 +89832,7 @@ ciqual_food_code:en: 8551
 ciqual_food_name:en: Chitterling sausage, sautéed/pan-fried
 ciqual_food_name:fr: Andouillette, sautée/poêlée
 
-< en:Prepared meats
+< en:Prepared pork meats
 en: Porchetta
 es: Porchetta
 fr: Porchetta
@@ -89821,14 +89841,14 @@ it: Porchetta
 ja: ポルケッタ
 wikidata:en: Q1106345
 
-< en:Prepared meats
+< en:Prepared beef meats
 en: Beef pastrami
 fr: Pastrami de bœuf
 hr: Goveđa pastrama
 ja: パストラミ
 nl: Rundvleespastrami
 
-< en:Prepared meats
+< en:Prepared pork meats
 en: Coppa, Capicola, Capocollo
 fr: Coppa
 hr: Coppa
@@ -90466,10 +90486,12 @@ wikidata:en: Q47325346
 fr: Grillons de canard
 
 < en:Poultry rillettes
+< en:Prepared turkey meats
 en: Turkey rillettes
 fr: Rillettes de dinde
 
 < en:Poultry rillettes
+< en:Prepared chicken meats
 en: chicken rillettes
 de: Hühnchen-Rillettes, Hühnchen Rillettes, Hühnchenrillettes
 fi: Kanarilletet
@@ -90492,6 +90514,7 @@ en: Lamb rillettes
 fr: Rillettes d’agneau
 
 < fr:Rillettes de viande rouge
+< en:Prepared beef meats
 en: Beef rillettes
 fr: Rillettes de bœuf
 hr: Goveđi rilet
@@ -90509,6 +90532,7 @@ en: Mutton rillettes
 fr: Rillettes de mouton
 
 < fr:Rillettes de viande rouge
+< en:Prepared pork meats
 en: Pork rillettes
 de: Schweinefleisch Rillettes
 fr: Rillettes de porc, Rillettes de cochon
@@ -90519,7 +90543,6 @@ ciqual_food_code:en: 8000
 ciqual_food_name:en: Rillettes, pork
 
 < en:Pork rillettes
-< en:Prepared meats
 en: Rillettes pure pork
 fr: Rillettes pur porc
 agribalyse_food_code:en: 8001
@@ -90696,6 +90719,7 @@ ciqual_food_name:fr: Saucisse (aliment moyen)
 intake24_category_code:en: SSGS
 
 < en:Sausages
+< en:Prepared beef meats
 en: Beef sausages, Beef sausage
 fr: Saucisses de bœuf, Saucisse de bœuf
 agribalyse_proxy_food_code:en: 30152
@@ -90719,6 +90743,7 @@ ciqual_food_code:en: 30050
 ciqual_food_name:en: Sausage meat, raw
 
 < en:Sausages
+< en:Prepared pork meats
 en: Pork sausages
 bg: Свински колбаси
 fr: Saucisses de porc, Saucisses au porc
@@ -90847,7 +90872,7 @@ ciqual_food_name:en: Tongue sausage w pistachios
 ciqual_food_name:fr: Saucisse de langue à la pistache
 
 < en:Sausages
-< en:Veal meat
+< en:Prepared beef meats
 en: Veal sausages, Veal Sausage
 bg: Телешки колбаси
 de: Kalbswürste
@@ -90858,12 +90883,10 @@ hr: Teleće kobasice
 pl: Kiełbasy cielęce, Kiełbasa cielęca
 wikidata:en: Q107261757
 
-< en:Horse fresh meat
 < en:Sausages
 en: Horse sausages
 fr: Saucisses de cheval
 
-< en:Cooked meats
 < en:Horse sausages
 en: Cooked horse sausages
 fr: Saucisses de cheval cuites
@@ -90875,7 +90898,7 @@ agribalyse_proxy_food_name:fr: Cheval, viande, rôtie/cuite au four
 en: Laap Coeng
 zh-hk: 臘腸
 
-< en:Chicken preparations
+< en:Prepared chicken meats
 < en:Poultry sausages
 en: Chicken sausages
 bg: Пилешки колбаси
@@ -90895,9 +90918,8 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Chicken Sausages - Prepared/Processed
 wikidata:en: Q47472153
 
-
 < en:Poultry sausages
-< en:Turkey preparations
+< en:Prepared turkey meats
 en: Turkey sausages
 bg: Пуешки колбаси
 de: Truthahnwurst
@@ -90938,6 +90960,7 @@ hr: Ovčetina merguez
 nl: Schaapsvlees-merguez
 
 < fr:Merguez
+< en:Prepared beef meats
 en: Beef merguez
 fr: Merguez de bœuf
 hr: Goveđi merguez
@@ -91014,7 +91037,7 @@ ciqual_food_code:en: 30732
 ciqual_food_name:en: Saveloy or cervelat, pure pork with garlic
 ciqual_food_name:fr: Cervelas à l'ail, pur porc
 
-< en:Cervelat
+< en:Pork
 en: Pork brain
 fr: Cervelle de porc
 agribalyse_food_code:en: 40005
@@ -91042,7 +91065,7 @@ it: Salsicce tedesche
 nl: Duitse worsten
 pl: Kiełbasa Niemiecka
 
-< en:German sausages
+< en:Sausages
 en: Frankfurter sausages, Frankfurter sausage
 de: Frankfurter Würstchen
 es: salchichas Frankfurt, frankfurt
@@ -91084,7 +91107,7 @@ fr: Saucisses sèches de foie, Saucisses de foie
 wikidata:en: Q111211562
 
 < en:Liver sausages
-< en:Pork preparations
+< en:Pork prepared meats
 en: Pork liver sausages
 de: Schweineleberwürste, Schweineleberwurst
 fr: Saucisses de foie de porc
@@ -91464,6 +91487,7 @@ it: Prosciutti di pollame
 nl: Gevogelte bilvlees
 
 < en:Poultry hams
+< en:Prepared chicken meats
 en: Cooked chicken breast slices, chicken ham
 de: Hähnchen-brustfilet in Scheiben
 es: Fiambre de pechuga de pollo, Pechuga de pollo cocida en lonchas
@@ -91498,6 +91522,7 @@ en: Reconstituted chicken breast slices
 fr: Blancs de poulet reconstitués
 
 < en:Poultry hams
+< en:Prepared turkey meats
 en: Cooked turkey breast slices, Turkey ham, cooked turkey breast
 es: Fiambre de pechuga de pavo, Pechuga de pavo cocida en lonchas
 fr: Blancs de dinde en tranches, blanc de dinde en tranche, jambon de dinde

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -85360,9 +85360,6 @@ nl: Vleesbrood
 wikidata:en: Q3807565
 
 < en:Meat preparations
-de: Fleischkäse
-
-< en:Meat preparations
 en: Frikandel
 fr: Fricadelles, fricandelles
 hr: Frikandel
@@ -89822,6 +89819,11 @@ ciqual_food_code:en: 8551
 ciqual_food_name:en: Chitterling sausage, sautéed/pan-fried
 ciqual_food_name:fr: Andouillette, sautée/poêlée
 
+< en:Prepared meats
+de: Fleischkäse, Leberkäse
+xx: Fleischkäse, Leberkäse
+wikidata:en:Q681841
+
 < en:Prepared pork meats
 en: Porchetta
 es: Porchetta
@@ -90472,7 +90474,6 @@ agribalyse_food_code:en: 8025
 ciqual_food_code:en: 8025
 ciqual_food_name:en: Rillettes, pure goose
 
-< en:Ducks
 < en:Poultry rillettes
 en: Duck rillettes
 de: Entenfleischaufstriche
@@ -90670,7 +90671,7 @@ agribalyse_food_code:en: 8081
 ciqual_food_code:en: 8081
 ciqual_food_name:en: Rillettes, salmon
 
-< en:Salmon Rillettes
+< en:Salmon rillettes
 en: Pink salmon rillettes
 fr: Rillettes de saumon rose
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -85003,7 +85003,7 @@ ciqual_food_code:en: 25172
 ciqual_food_name:en: Meat in sauce (average)
 ciqual_food_name:fr: Viande en sauce (aliment moyen)
 
-< en:Meats
+< en:Prepared meats
 en: Dried meats
 bg: Сушено месо
 ca: Carns assecades
@@ -85019,6 +85019,7 @@ nl: Gedroogd vlees
 pt: Carnes secas
 
 < en:Dried meats
+< en:Prepared beef meats
 en: Beef jerkies, beef jerky
 de: Trockenfleisch vom Rind
 fi: kuivalihat
@@ -86746,7 +86747,10 @@ hr: Tartar od goveđeg mesa
 pl: Tatar wołowy
 
 < en:Ground meat preparations
+< en:Beef preparations
 fr: Américains préparés, hâchés américains
+nl: Filet Americain
+wikidata:en:Q22348764
 
 < en:Beef
 < en:Steaks
@@ -86796,11 +86800,8 @@ lt: Jautienos ruošiniai
 nl: Rundvleesproducten
 pt: Preparados de bife
 
-< en:Ground beef preparations
-nl: Filet Americain
-
-< en:Beef preparations
 < en:Dried meats
+< en:Prepared beef meats
 en: Meat of the grisons, Viande des Grisons, Bündnerfleisch, Dried beef meat
 de: Bündnerfleisch
 es: Bindenfleisch


### PR DESCRIPTION
Created sub-categories for prepared meat by meat type (pork, beef, chicken, turkey). Created new categories for "lyoner" and "lyoner substitutes". Moved a few categories that were uncorrectly categorized.