### PR TITLE
fix: change product barcode

### DIFF
--- a/lib/ProductOpener/Permissions.pm
+++ b/lib/ProductOpener/Permissions.pm
@@ -125,6 +125,7 @@ sub has_permission ($request_ref, $permission) {
 	}
 	else {
 		$log->error("has_permission - unknown permission", {permission => $permission}) if $log->is_error();
+		die "Unknown permission: $permission";
 	}
 
 	return $has_permission;

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -62,7 +62,7 @@
                 </p>
 
 
-        [% IF has_permission('product_change_product_code') %]
+        [% IF has_permission('product_change_code') %]
             <label for="new_code" id="label_new_code" class="moderator-only">[% label_new_code %]</label>
             <input type="text" name="new_code" id="new_code" class="text" value="" /><br/>
         [% END %]


### PR DESCRIPTION
There was a typo that prevented the box to changed the barcode of a product to be displayed.