### PR TITLE
fix: is_valid_code() with leading zeroes

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -478,6 +478,8 @@ sub _try_normalize_code_gs1 ($code) {
 
 C<is_valid_code()> checks if the given code is a valid product code.
 
+It checks if the code is defined, if it contains only digits, and if its length is between 4 and 40 digits, excluding leading zeroes.
+
 =head3 Arguments
 
 Product Code: $code
@@ -491,7 +493,10 @@ Boolean value indicating if the code is valid or not.
 sub is_valid_code ($code) {
 	# Return an empty string if $code is undef
 	return '' if !defined $code;
-	return $code =~ /^\d{4,40}$/;
+	my $code_without_leading_zeroes = $code;
+	# Remove leading zeroes
+	$code_without_leading_zeroes =~ s/^0+//;
+	return $code_without_leading_zeroes =~ /^\d{4,40}$/;
 }
 
 =head2 split_code()

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -421,4 +421,12 @@ is(
 
 is(product_id_from_path("$BASE_DIRS{PRODUCTS}/123/456/789/product"), "123456789");
 
+# Test is_valid_code()
+
+is(is_valid_code('1234567890123'), 1, 'valid EAN13 code');
+is(is_valid_code('123'), '', '3 digit code');
+is(is_valid_code('00000123'), '', '3 digit code with leading 0s');
+is(is_valid_code('1234567890123456789012345678901234567890123456789012345678901234567890'), '', 'too long code');
+is(is_valid_code(undef), '', 'undefined code');
+
 done_testing();


### PR DESCRIPTION
Short codes with 3 digits or less and leading 0s should be rejected.