### PR TITLE
taxonomy: Milk powder should not be in milk category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -51968,7 +51968,6 @@ ciqual_food_name:en: Milk, powder, whole
 ciqual_food_name:fr: Lait en poudre, entier
 
 < en:Milk powders
-< en:Semi-skimmed milks
 en: Semi-skimmed milk powder
 bg: Полуобезмаслено мляко на прах
 fr: Laits en poudre demi-écrémés


### PR DESCRIPTION
There is the category "milks liquid and powder" that contains both liquid and powder milks
Then there is the category "milks" that contains only liquid milk
And there is the category "milks powders" that contains only milk powder

But the category "Semi-skimmed milk powder" is in both "milk powder" and "Semi-skimmed milks" which is also in "milks"
I fixed that so no milk powder (even semi skimmed) lands in "milks" liquid category


<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

