### PR TITLE
taxonomie: put bread category in cereal category, not cereal and potatoes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -34909,7 +34909,7 @@ nl: Kroketten
 en: Frozen kroketten
 fr: Croquettes hollandaises surgelées
 
-< en:Cereals and potatoes
+< en:Cereals and their products
 en: Breads
 bg: Хляб
 ca: Pans


### PR DESCRIPTION
Right now, breads category is in 'Cereals and potatoes' category altought there is a sub category named ''Cereals and their products" that suit it better. I changed that in the PR.

<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

