### PR TITLE
fix: Get Keycloak anonymized migration to use the existing password

### DIFF
--- a/scripts/migrate_users_to_keycloak.pl
+++ b/scripts/migrate_users_to_keycloak.pl
@@ -209,7 +209,8 @@ sub convert_scrypt_password_to_keycloak_credentials ($hashed_password) {
 
 sub validate_user_emails() {
 	print '[' . localtime() . "] Starting email validation\n";
-	open(my $invalid_user_file, '>:encoding(UTF-8)', "$BASE_DIRS{CACHE_TMP}/invalid_users.csv") or die "Could not open invalid_users file $!";
+	open(my $invalid_user_file, '>:encoding(UTF-8)', "$BASE_DIRS{CACHE_TMP}/invalid_users.csv")
+		or die "Could not open invalid_users file $!";
 
 	my $all_emails = {};
 	if (opendir(my $dh, "$BASE_DIRS{USERS}/")) {

--- a/scripts/migrate_users_to_keycloak.pl
+++ b/scripts/migrate_users_to_keycloak.pl
@@ -114,14 +114,8 @@ sub convert_to_keycloak_user ($userid, $email, $anonymize) {
 
 	my $keycloak_user_ref;
 	eval {
-		my $credential
-			= $anonymize
-			? {
-			type => 'password',
-			value => 'offoff',
-			temporary => $JSON::false
-			}
-			: convert_scrypt_password_to_keycloak_credentials($user_ref->{'encrypted_password'});
+		# Use the existing password. Note in staging user will not be able to use "forgot password"
+		my $credential = convert_scrypt_password_to_keycloak_credentials($user_ref->{'encrypted_password'});
 		my $name = ($anonymize ? $userid : $user_ref->{name});
 		# Inverted expression from: https://github.com/keycloak/keycloak/blob/2eae68010877c6807b6a454c2d54e0d1852ed1c0/services/src/main/java/org/keycloak/userprofile/validator/PersonNameProhibitedCharactersValidator.java#L42C63-L42C114
 		$name =~ s/[<>&"$%!#?§;*~\/\\|^=\[\]{}()\x00-\x1F\x7F]+//g;


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

We need to set a password for Keycloak users in staging as otherwise there is no way to log in. Password will be copied from the existing value 
