### PR TITLE
docs: a few fixes in the comments for Nutriscore

### DIFF
--- a/lib/ProductOpener/Nutriscore.pm
+++ b/lib/ProductOpener/Nutriscore.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2023 Association Open Food Facts
+# Copyright (C) 2011-2025 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -48,7 +48,7 @@ of a food product.
 		is_cheese => 0,
 		is_fat => 1, # for 2021 version
 		is_fat_oil_nuts_seed => 1, # for 2023 version
-	}
+	};
 
 	my ($nutriscore_score, $nutriscore_grade) = compute_nutriscore_score_and_grade(
 		$nutriscore_data_ref
@@ -101,8 +101,8 @@ use ProductOpener::Numbers qw/round_to_max_decimal_places/;
 Note: a significantly different Nutri-Score algorithm has been published in 2022 and 2023
 (respectively for foods and beverages).
 
-The functions related to the previous algorithm will be suffixed with _2021,
-and functions for the new algorithm will be suffixed with _2023.
+The functions related to the previous algorithm are suffixed with _2021,
+and functions for the new algorithm are suffixed with _2023.
 
 We will keep both algorithms for a transition period, and we will be able to remove the
 2021 algorithm and related functions after.
@@ -117,7 +117,7 @@ sub compute_nutriscore_score_and_grade ($nutriscore_data_ref, $version = "2021")
 	return compute_nutriscore_score_and_grade_2021($nutriscore_data_ref);
 }
 
-# methods returning the 2021 version for now, to ease switch, later on.
+# methods for an easy switch from version 2021 to version 2023.
 sub get_value_with_one_less_negative_point ($nutriscore_data_ref, $nutrient) {
 	return get_value_with_one_less_negative_point_2023($nutriscore_data_ref, $nutrient);
 }
@@ -152,7 +152,7 @@ The hash must contain values for the following keys:
 - sugars -> sugars in g / 100g or 100ml
 - saturated_fat -> saturated fats in g / 100g or 100ml
 - saturated_fat_ratio -> saturated fat divided by fat * 100 (in %)
-- sodium -> sodium in mg / 100g or 100ml (if sodium is computed from salt, it needs to use a sodium = salt / 2.5 conversion factor
+- sodium -> sodium in mg / 100g or 100ml (if sodium is computed from salt, it needs to use a sodium = salt / 2.5 conversion factor)
 - fruits_vegetables_nuts_colza_walnut_olive_oils -> % of fruits, vegetables, nuts, and colza / walnut / olive oils
 - fiber -> fiber in g / 100g or 100ml
 - proteins -> proteins in g / 100g or 100ml
@@ -265,7 +265,7 @@ sub get_value_with_one_less_negative_point_2021 ($nutriscore_data_ref, $nutrient
 For a given Nutri-Score nutrient value, return the smallest higher value that would result in more positive points.
 e.g. for a proteins value of 2.0 (which gives 1 point), return 3.3 (which gives 2 points)
 
-The value correspond to the smallest higher threshold + 1 increment so that it strictly greater than the threshold.
+The value corresponds to the smallest higher threshold + 1 increment so that it strictly greater than the threshold.
 
 Return undef is the input nutrient value already gives the maximum amount of points.
 
@@ -497,8 +497,9 @@ The hash must contain values for the following keys:
 - sugars -> sugars in g / 100g or 100ml
 - saturated_fat -> saturated fats in g / 100g or 100ml
 - saturated_fat_ratio -> saturated fat divided by fat * 100 (in %)
+- salt -> ???
 - sodium -> sodium in mg / 100g or 100ml (if sodium is computed from salt, it needs to use a sodium = salt / 2.5 conversion factor
-- fruits_vegetables_nuts_colza_walnut_olive_oils -> % of fruits, vegetables, nuts, and colza / walnut / olive oils
+- fruits_vegetables_legumes -> % of fruits, vegetables, nuts, and colza / walnut / olive oils
 - fiber -> fiber in g / 100g or 100ml
 - proteins -> proteins in g / 100g or 100ml
 
@@ -509,6 +510,7 @@ If the product is a beverage, water, cheese, or fat, it must contain a positive 
 - is_water
 - is_cheese
 - is_fat_oil_nuts_seeds
+- is_red_meat_product
 
 =head4 Output keys: details of the Nutri-Score computation
 
@@ -516,6 +518,7 @@ Returned values:
 
 - [nutrient]_value -> rounded values for each nutrient according to the Nutri-Score rules
 - [nutrient]_points -> points for each nutrient
+- [nutrient]_points_max -> ???
 - negative_nutrients -> list of nutrients that are counted in negative points
 - negative_points -> sum of negative nutrients points
 - positive_nutrients -> list of nutrients that are counted in positive points


### PR DESCRIPTION
A few fixes in the comments.

Some remarks. I do not know what is the use of the
`[nutrient]_points_max` property, so the comment contains question
marks.

In the 2023 version, I have added a comment for nutrient `salt` but I
have not removed `sodium`. The provisional comment for `salt` contains
only question marks, please write something interesting.

There is a problem with the signatures of functions
`get_value_with_one_less_negative_point_2023` and
`get_value_with_one_more_positive_point_2023`, but it is given in a
separate issue.

