### PR TITLE
fix: new tests for preferred nutrition set generation

### DIFF
--- a/lib/ProductOpener/Nutrition.pm
+++ b/lib/ProductOpener/Nutrition.pm
@@ -43,7 +43,7 @@ BEGIN {
 	use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
 		&generate_nutrient_set_preferred_from_sets
-    );    # symbols to export on request
+	);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
 
@@ -68,25 +68,25 @@ The generated preferred nutrient set
 =cut
 
 sub generate_nutrient_set_preferred_from_sets {
-    my ($nutrient_sets_ref) = @_; 
-    my @nutrient_sets = @$nutrient_sets_ref;
-    
-    my $nutrient_set_preferred_ref = {};
-    
-    if (@nutrient_sets) {
-        @nutrient_sets = sort_sets_by_priority(@nutrient_sets);
+	my ($nutrient_sets_ref) = @_;
+	my @nutrient_sets = @$nutrient_sets_ref;
 
-        if (%{$nutrient_sets[0]}) {
-            # set preparation, per, per_quantity and per_unit of preferred set as values of the nutrient_set with the highest priority
-            $nutrient_set_preferred_ref->{preparation} = $nutrient_sets[0]{preparation};
-            $nutrient_set_preferred_ref->{per} = $nutrient_sets[0]{per};
-            $nutrient_set_preferred_ref->{per_quantity} = $nutrient_sets[0]{per_quantity};
-            $nutrient_set_preferred_ref->{per_unit} = $nutrient_sets[0]{per_unit};
-        }
-        
-        set_nutrient_values($nutrient_set_preferred_ref, @nutrient_sets);
-    }
-    return $nutrient_set_preferred_ref;
+	my $nutrient_set_preferred_ref = {};
+
+	if (@nutrient_sets) {
+		@nutrient_sets = sort_sets_by_priority(@nutrient_sets);
+
+		if (%{$nutrient_sets[0]}) {
+			# set preparation, per, per_quantity and per_unit of preferred set as values of the nutrient_set with the highest priority
+			$nutrient_set_preferred_ref->{preparation} = $nutrient_sets[0]{preparation};
+			$nutrient_set_preferred_ref->{per} = $nutrient_sets[0]{per};
+			$nutrient_set_preferred_ref->{per_quantity} = $nutrient_sets[0]{per_quantity};
+			$nutrient_set_preferred_ref->{per_unit} = $nutrient_sets[0]{per_unit};
+		}
+
+		set_nutrient_values($nutrient_set_preferred_ref, @nutrient_sets);
+	}
+	return $nutrient_set_preferred_ref;
 }
 
 =head2 sort_sets_by_priority
@@ -108,46 +108,46 @@ Sorted array nutrient sets hashes
 =cut
 
 sub sort_sets_by_priority (@nutrient_sets) {
-    my %source_priority = (
-        manufacturer => 0,
-        packaging => 1,
-        usda => 2,
-        estimate => 3,
-        _default => 4,
-    );
+	my %source_priority = (
+		manufacturer => 0,
+		packaging => 1,
+		usda => 2,
+		estimate => 3,
+		_default => 4,
+	);
 
-    my %per_priority = (
-        "100g" => 0,
-        "100ml" => 0,
-        serving => 1,
-        _default => 2,
-    );
+	my %per_priority = (
+		"100g" => 0,
+		"100ml" => 0,
+		serving => 1,
+		_default => 2,
+	);
 
-    my %preparation_priority = (
-        prepared => 0,
-        as_sold => 1,
-        _default => 2,
-    );
+	my %preparation_priority = (
+		prepared => 0,
+		as_sold => 1,
+		_default => 2,
+	);
 
-    return sort {
-        my $source_key_a = defined $a->{source} ? $a->{source} : '_default';
-        my $source_key_b = defined $b->{source} ? $b->{source} : '_default';
-        my $source_a = $source_priority{$source_key_a};
-        my $source_b = $source_priority{$source_key_b};
+	return sort {
+		my $source_key_a = defined $a->{source} ? $a->{source} : '_default';
+		my $source_key_b = defined $b->{source} ? $b->{source} : '_default';
+		my $source_a = $source_priority{$source_key_a};
+		my $source_b = $source_priority{$source_key_b};
 
-        my $per_key_a = defined $a->{per} ? $a->{per} : '_default';
-        my $per_key_b = defined $b->{per} ? $b->{per} : '_default';
-        my $per_a = $per_priority{$per_key_a};
-        my $per_b = $per_priority{$per_key_b};
+		my $per_key_a = defined $a->{per} ? $a->{per} : '_default';
+		my $per_key_b = defined $b->{per} ? $b->{per} : '_default';
+		my $per_a = $per_priority{$per_key_a};
+		my $per_b = $per_priority{$per_key_b};
 
-        my $preparation_key_a = defined $a->{preparation} ? $a->{preparation} : '_default';
-        my $preparation_key_b = defined $b->{preparation} ? $b->{preparation} : '_default';
-        my $preparation_a = $preparation_priority{$preparation_key_a};
-        my $preparation_b = $preparation_priority{$preparation_key_b};
-        
-        # sort priority : source then per then preparation
-        return $source_a <=> $source_b || $per_a <=> $per_b || $preparation_a <=> $preparation_b;
-    } @nutrient_sets;
+		my $preparation_key_a = defined $a->{preparation} ? $a->{preparation} : '_default';
+		my $preparation_key_b = defined $b->{preparation} ? $b->{preparation} : '_default';
+		my $preparation_a = $preparation_priority{$preparation_key_a};
+		my $preparation_b = $preparation_priority{$preparation_key_b};
+
+		# sort priority : source then per then preparation
+		return $source_a <=> $source_b || $per_a <=> $per_b || $preparation_a <=> $preparation_b;
+	} @nutrient_sets;
 }
 
 =head2 set_nutrient_values
@@ -173,33 +173,33 @@ The sorted array of nutrient set hashes used to generate the preferred set.
 =cut
 
 sub set_nutrient_values ($nutrient_set_preferred_ref, @nutrient_sets) {
-    foreach my $nutrient_set_ref (@nutrient_sets) {
-        # set nutrient values from set if preparation state is the same as in the preferred set and if set has nutrients
-        if (    defined $nutrient_set_ref->{preparation}
-            and $nutrient_set_ref->{preparation} eq $nutrient_set_preferred_ref->{preparation}
-            and exists $nutrient_set_ref->{nutrients} 
-            and ref $nutrient_set_ref->{nutrients} eq 'HASH') 
-        {
-            foreach my $nutrient (keys %{$nutrient_set_ref->{nutrients}}) {
-                # for each nutrient, set its values if values are not already present in preferred set
-                # (ie if nutrient not present in other set with highest priority)
-                if (!exists $nutrient_set_preferred_ref->{nutrients}{$nutrient}) {
-                    $nutrient_set_preferred_ref->{nutrients}{$nutrient} = $nutrient_set_ref->{nutrients}{$nutrient};
-                    nutrient_in_standard_unit($nutrient_set_preferred_ref->{nutrients}{$nutrient}, $nutrient);
-                    nutrient_in_wanted_per(
-                        $nutrient_set_preferred_ref->{nutrients}{$nutrient},
-                        $nutrient_set_ref->{per_quantity}, 
-                        $nutrient_set_ref->{per_unit},
-                        $nutrient_set_preferred_ref->{per_quantity}, 
-                        $nutrient_set_preferred_ref->{per_unit}
-                    );
-                    $nutrient_set_preferred_ref->{nutrients}{$nutrient}{source} = $nutrient_set_ref->{source};
-                    $nutrient_set_preferred_ref->{nutrients}{$nutrient}{source_per} = $nutrient_set_ref->{per};    
-                }
-            }
-        }
-    } 
-    return;
+	foreach my $nutrient_set_ref (@nutrient_sets) {
+		# set nutrient values from set if preparation state is the same as in the preferred set and if set has nutrients
+		if (    defined $nutrient_set_ref->{preparation}
+			and $nutrient_set_ref->{preparation} eq $nutrient_set_preferred_ref->{preparation}
+			and exists $nutrient_set_ref->{nutrients}
+			and ref $nutrient_set_ref->{nutrients} eq 'HASH')
+		{
+			foreach my $nutrient (keys %{$nutrient_set_ref->{nutrients}}) {
+				# for each nutrient, set its values if values are not already present in preferred set
+				# (ie if nutrient not present in other set with highest priority)
+				if (!exists $nutrient_set_preferred_ref->{nutrients}{$nutrient}) {
+					$nutrient_set_preferred_ref->{nutrients}{$nutrient} = $nutrient_set_ref->{nutrients}{$nutrient};
+					nutrient_in_standard_unit($nutrient_set_preferred_ref->{nutrients}{$nutrient}, $nutrient);
+					nutrient_in_wanted_per(
+						$nutrient_set_preferred_ref->{nutrients}{$nutrient},
+						$nutrient_set_ref->{per_quantity},
+						$nutrient_set_ref->{per_unit},
+						$nutrient_set_preferred_ref->{per_quantity},
+						$nutrient_set_preferred_ref->{per_unit}
+					);
+					$nutrient_set_preferred_ref->{nutrients}{$nutrient}{source} = $nutrient_set_ref->{source};
+					$nutrient_set_preferred_ref->{nutrients}{$nutrient}{source_per} = $nutrient_set_ref->{per};
+				}
+			}
+		}
+	}
+	return;
 }
 
 =head2 nutrient_in_standard_unit
@@ -221,22 +221,22 @@ Name of the nutrient to normalize
 =cut
 
 sub nutrient_in_standard_unit ($nutrient_ref, $nutrient_name) {
-    if ($nutrient_name eq "energy-kcal" and $nutrient_ref->{unit} ne "kcal") {
-        $nutrient_ref->{value} = unit_to_kcal($nutrient_ref->{value}, $nutrient_ref->{unit});
-        $nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
-        $nutrient_ref->{unit} = "kcal";
-    }
-    elsif (($nutrient_name eq "energy" or $nutrient_name eq "energy-kj") and $nutrient_ref->{unit} ne "kj") {
-        $nutrient_ref->{value} = unit_to_kj($nutrient_ref->{value}, $nutrient_ref->{unit});
-        $nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
-        $nutrient_ref->{unit} = "kj";
-    }
-    elsif ($nutrient_ref->{unit} ne "g") {
-        $nutrient_ref->{value} = unit_to_g($nutrient_ref->{value}, $nutrient_ref->{unit});
-        $nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
-        $nutrient_ref->{unit} = "g";
-    }
-    return;
+	if ($nutrient_name eq "energy-kcal" and $nutrient_ref->{unit} ne "kcal") {
+		$nutrient_ref->{value} = unit_to_kcal($nutrient_ref->{value}, $nutrient_ref->{unit});
+		$nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
+		$nutrient_ref->{unit} = "kcal";
+	}
+	elsif (($nutrient_name eq "energy" or $nutrient_name eq "energy-kj") and $nutrient_ref->{unit} ne "kj") {
+		$nutrient_ref->{value} = unit_to_kj($nutrient_ref->{value}, $nutrient_ref->{unit});
+		$nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
+		$nutrient_ref->{unit} = "kj";
+	}
+	elsif ($nutrient_ref->{unit} ne "g") {
+		$nutrient_ref->{value} = unit_to_g($nutrient_ref->{value}, $nutrient_ref->{unit});
+		$nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
+		$nutrient_ref->{unit} = "g";
+	}
+	return;
 }
 
 =head2 nutrient_in_wanted_per
@@ -267,18 +267,18 @@ Wanted per unit of the nutrient
 
 =cut
 
-sub nutrient_in_wanted_per ($nutrient_ref, $original_per_quantity, $original_per_unit, $wanted_per_quantity, 
-    $wanted_per_unit) 
+sub nutrient_in_wanted_per ($nutrient_ref, $original_per_quantity, $original_per_unit, $wanted_per_quantity,
+	$wanted_per_unit)
 {
-    if ($original_per_quantity != $wanted_per_quantity) {
-        my $original_value = $nutrient_ref->{value};
+	if ($original_per_quantity != $wanted_per_quantity) {
+		my $original_value = $nutrient_ref->{value};
 
-        # set value of nutrient according to wanted per amount + unit
-        my $per_conversion_factor = g_to_unit(unit_to_g($original_per_quantity, $original_per_unit), $wanted_per_unit);
-        $nutrient_ref->{value} = ($original_value * $wanted_per_quantity) / $per_conversion_factor;
-        $nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
-    }
-    return;
+		# set value of nutrient according to wanted per amount + unit
+		my $per_conversion_factor = g_to_unit(unit_to_g($original_per_quantity, $original_per_unit), $wanted_per_unit);
+		$nutrient_ref->{value} = ($original_value * $wanted_per_quantity) / $per_conversion_factor;
+		$nutrient_ref->{value_string} = sprintf("%s", $nutrient_ref->{value});
+	}
+	return;
 }
 
 1;

--- a/tests/unit/expected_test_results/nutrition/convert_per_nutrients.json
+++ b/tests/unit/expected_test_results/nutrition/convert_per_nutrients.json
@@ -1,0 +1,60 @@
+{
+   "nutrition" : {
+      "nutrient_set_preferred" : {
+         "nutrients" : {
+            "sodium" : {
+               "source" : "packaging",
+               "source_per" : "serving",
+               "unit" : "g",
+               "value" : 1.25,
+               "value_string" : "1.25"
+            },
+            "sugars" : {
+               "source" : "manufacturer",
+               "source_per" : "serving",
+               "unit" : "g",
+               "value" : 6.3,
+               "value_string" : "6.3"
+            }
+         },
+         "per" : "serving",
+         "per_quantity" : "50",
+         "per_unit" : "g",
+         "preparation" : "as_sold"
+      },
+      "nutrient_sets" : [
+         {
+            "nutrients" : {
+               "sodium" : {
+                  "source" : "packaging",
+                  "source_per" : "serving",
+                  "unit" : "g",
+                  "value" : 1.25,
+                  "value_string" : "1.25"
+               }
+            },
+            "per" : "serving",
+            "per_quantity" : "100",
+            "per_unit" : "g",
+            "preparation" : "as_sold",
+            "source" : "packaging"
+         },
+         {
+            "nutrients" : {
+               "sugars" : {
+                  "source" : "manufacturer",
+                  "source_per" : "serving",
+                  "unit" : "g",
+                  "value" : 6.3,
+                  "value_string" : "6.3"
+               }
+            },
+            "per" : "serving",
+            "per_quantity" : "50",
+            "per_unit" : "g",
+            "preparation" : "as_sold",
+            "source" : "manufacturer"
+         }
+      ]
+   }
+}

--- a/tests/unit/nutrition.t
+++ b/tests/unit/nutrition.t
@@ -8,1016 +8,1075 @@ use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Nutrition qw/generate_nutrient_set_preferred_from_sets/;
 
+use ProductOpener::Test qw/compare_to_expected_results init_expected_results/;
+
+my ($test_id, $test_dir, $expected_result_dir, $update_expected_results) = (init_expected_results(__FILE__));
+
 my @tests = (
-    [[], {}, "Generated set should be empty given empty list"],
-    [[{}], {}, "Generated set should be empty given list with empty sets"],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g",
-            nutrients => {
-                sodium => {
-                    value_string => "2.0", 
-                    value => 2, 
-                    unit => "g", 
-                    modifier => "<=",
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should be the same as the only set given list with one set",
-    ],
-    [ 
-        [
-            {},
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2.0", 
-                    value => 2, 
-                    unit => "g", 
-                    modifier => "<=",
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should be the same as the only non empty set given list with only one non empty set"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "usda", 
-                nutrients => {
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2.0", 
-                    value => 2, 
-                    unit => "g", 
-                    modifier => "<=",
-                    source => "packaging",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "5.2", 
-                    value => 5.2, 
-                    unit => "g", 
-                    source => "usda",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have all given nutrients given sets with different nutrients provided"
-    ],
-    [ 
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "usda", 
-                nutrients => {
-                    sodium => {
-                        value_string => "0.1", 
-                        value => 0.1, 
-                        unit => "g",
-                    },
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2.0", 
-                    value => 2, 
-                    unit => "g", 
-                    modifier => "<=",
-                    source => "packaging",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "5.2", 
-                    value => 5.2, 
-                    unit => "g", 
-                    source => "usda",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have nutrients from most important source given sets with same nutrients with different sources"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    },
-                    protein => {
-                        value_string => "6.2", 
-                        value => 6.2, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "prepared", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "0.1", 
-                        value => 0.1, 
-                        unit => "g",
-                    },
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "prepared", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "0.1", 
-                    value => 0.1, 
-                    unit => "g", 
-                    source => "packaging",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "5.2", 
-                    value => 5.2, 
-                    unit => "g", 
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have nutrients from most important preparation given sets with same nutrients with different preparations"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "250", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "0.1", 
-                        value => 0.1, 
-                        unit => "g",
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2.0", 
-                    value => 2, 
-                    unit => "g", 
-                    modifier => "<=",
-                    source => "packaging",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "5.2", 
-                    value => 5.2, 
-                    unit => "g", 
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have nutrients from most important per given sets with same nutrients with different per"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    protein => {
-                        value_string => "8.2", 
-                        value => 8.2, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    },
-                    protein => {
-                        value_string => "0",
-                        value => 0,
-                        unit => "g"
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "manufacturer", 
-                nutrients => {
-                    sodium => {
-                        value_string => "0", 
-                        value => 0, 
-                        unit => "g", 
-                    },
-                    sugars => {
-                        value_string => "7.6",
-                        value => 7.6,
-                        unit => "g",
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "manufacturer", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2", 
-                    value => 2, 
-                    unit => "g",
-                    modifier => "<=", 
-                    source => "manufacturer",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "7.6",
-                    value => 7.6,
-                    unit => "g",
-                    source => "manufacturer",
-                    source_per => "serving"
-                },
-                protein => {
-                    value_string => "0",
-                    value => 0,
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "100g"
-                }
-            }
-        },
-        "Generated set should have nutrients from most important source then per given sets with same nutrients with different sources and per"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "manufacturer", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            },
-            {
-                preparation => "prepared", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2.0", 
-                    value => 2, 
-                    unit => "g",
-                    modifier => "<=", 
-                    source => "manufacturer",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have nutrients from most important source then preparation given sets with same nutrients with different sources and preparations"
-    ],
-    [
-        [
-            {
-                preparation => "prepared", 
-                per => "serving", 
-                per_quantity => "250", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "2.0", 
-                        value => 2, 
-                        unit => "g", 
-                        modifier => "<="
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sugars => {
-                        value_string => "5.2", 
-                        value => 5.2, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sugars => {
-                    value_string => "5.2", 
-                    value => 5.2, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have nutrients from most important per then preparation given sets with same nutrients with different per and preparations"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    sodium => {
-                        value_string => "200.0", 
-                        value => 200, 
-                        unit => "mg", 
-                        modifier => "<="
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "0.2", 
-                    value => 0.2, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "100g",
-                    modifier => "<=",
-                }
-            }
-        },
-        "Generated set should have normalized weight units for nutrients"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    "energy-kcal" => {
-                        value_string => "125", 
-                        value => 125, 
-                        unit => "kj", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                "energy-kcal" => {
-                    value_string => "30", 
-                    value => 30, 
-                    unit => "kcal",
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have normalized unit for energy-kcal nutrient"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    energy => {
-                        value_string => "30", 
-                        value => 30, 
-                        unit => "kcal", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                energy => {
-                    value_string => "125", 
-                    value => 125, 
-                    unit => "kj",
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have normalized unit for energy nutrient"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    "energy-kj" => {
-                        value_string => "30", 
-                        value => 30, 
-                        unit => "kcal", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                "energy-kj" => {
-                    value_string => "125", 
-                    value => 125, 
-                    unit => "kj",
-                    source => "packaging",
-                    source_per => "100g",
-                }
-            }
-        },
-        "Generated set should have normalized unit for energy-kj nutrient"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    "sodium" => {
-                        value_string => "2.5", 
-                        value => 2.5, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "50", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    "sugars" => {
-                        value_string => "6.3", 
-                        value => 6.3, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "100g", 
-            per_quantity => "100", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "2.5", 
-                    value => 2.5, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "12.6", 
-                    value => 12.6, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "serving",
-                }
-            }
-        },
-        "Generated set should have converted per when different per in nutrients given nutrient with most priority with per in 100g/ml"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "100g", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    "sodium" => {
-                        value_string => "2.5", 
-                        value => 2.5, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "50", 
-                per_unit => "g", 
-                source => "manufacturer", 
-                nutrients => {
-                    "sugars" => {
-                        value_string => "6.3", 
-                        value => 6.3, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "serving", 
-            per_quantity => "50", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "1.25", 
-                    value => 1.25, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "100g",
-                },
-                sugars => {
-                    value_string => "6.3", 
-                    value => 6.3, 
-                    unit => "g",
-                    source => "manufacturer",
-                    source_per => "serving",
-                }
-            }
-        },
-        "Generated set should have converted per when different per in nutrients given nutrient with most priority with per in serving"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "100", 
-                per_unit => "g", 
-                source => "packaging", 
-                nutrients => {
-                    "sodium" => {
-                        value_string => "2.5", 
-                        value => 2.5, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "50", 
-                per_unit => "g", 
-                source => "manufacturer", 
-                nutrients => {
-                    "sugars" => {
-                        value_string => "6.3", 
-                        value => 6.3, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "serving", 
-            per_quantity => "50", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "1.25", 
-                    value => 1.25, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "serving",
-                },
-                sugars => {
-                    value_string => "6.3", 
-                    value => 6.3, 
-                    unit => "g",
-                    source => "manufacturer",
-                    source_per => "serving",
-                }
-            }
-        },
-        "Generated set should have converted per when different per in nutrients given nutrients per in different servings"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "100", 
-                per_unit => "mg", 
-                source => "packaging", 
-                nutrients => {
-                    "sodium" => {
-                        value_string => "2.5", 
-                        value => 2.5, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "50", 
-                per_unit => "g", 
-                source => "manufacturer", 
-                nutrients => {
-                    "sugars" => {
-                        value_string => "6.3", 
-                        value => 6.3, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "serving", 
-            per_quantity => "50", 
-            per_unit => "g", 
-            nutrients => {
-                sodium => {
-                    value_string => "1250", 
-                    value => 1250, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "serving",
-                },
-                sugars => {
-                    value_string => "6.3", 
-                    value => 6.3, 
-                    unit => "g",
-                    source => "manufacturer",
-                    source_per => "serving",
-                }
-            }
-        },
-        "Generated set should have converted per when different per in nutrients given nutrients per in different servings with wanted in g"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "100", 
-                per_unit => "mg", 
-                source => "packaging", 
-                nutrients => {
-                    "sodium" => {
-                        value_string => "0.25", 
-                        value => 0.25, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "5", 
-                per_unit => "kg", 
-                source => "manufacturer", 
-                nutrients => {
-                    "sugars" => {
-                        value_string => "6.3", 
-                        value => 6.3, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "serving", 
-            per_quantity => "5", 
-            per_unit => "kg", 
-            nutrients => {
-                sodium => {
-                    value_string => "12500", 
-                    value => 12500, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "serving",
-                },
-                sugars => {
-                    value_string => "6.3", 
-                    value => 6.3, 
-                    unit => "g",
-                    source => "manufacturer",
-                    source_per => "serving",
-                }
-            }
-        },
-        "Generated set should have converted per when different per in nutrients given nutrients per in different servings with wanted in not in g"
-    ],
-    [
-        [
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "1", 
-                per_unit => "l", 
-                source => "packaging", 
-                nutrients => {
-                    "sodium" => {
-                        value_string => "0.25", 
-                        value => 0.25, 
-                        unit => "g", 
-                    }
-                }
-            },
-            {
-                preparation => "as_sold", 
-                per => "serving", 
-                per_quantity => "50", 
-                per_unit => "ml", 
-                source => "manufacturer", 
-                nutrients => {
-                    "sugars" => {
-                        value_string => "6.3", 
-                        value => 6.3, 
-                        unit => "g", 
-                    }
-                }
-            }
-        ],
-        {
-            preparation => "as_sold", 
-            per => "serving", 
-            per_quantity => "50", 
-            per_unit => "ml", 
-            nutrients => {
-                sodium => {
-                    value_string => "0.0125", 
-                    value => 0.0125, 
-                    unit => "g",
-                    source => "packaging",
-                    source_per => "serving",
-                },
-                sugars => {
-                    value_string => "6.3", 
-                    value => 6.3, 
-                    unit => "g",
-                    source => "manufacturer",
-                    source_per => "serving",
-                }
-            }
-        },
-        "Generated set should have converted per when different per in nutrients given nutrients per in different servings with volume units"
-    ],
-);      
+	[[], {}, "Generated set should be empty given empty list"],
+	[[{}], {}, "Generated set should be empty given list with empty sets"],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.0",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should be the same as the only set given list with one set",
+	],
+	[
+		[
+			{},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.0",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should be the same as the only non empty set given list with only one non empty set"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "usda",
+				nutrients => {
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.0",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "packaging",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "5.2",
+					value => 5.2,
+					unit => "g",
+					source => "usda",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have all given nutrients given sets with different nutrients provided"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "usda",
+				nutrients => {
+					sodium => {
+						value_string => "0.1",
+						value => 0.1,
+						unit => "g",
+					},
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.0",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "packaging",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "5.2",
+					value => 5.2,
+					unit => "g",
+					source => "usda",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have nutrients from most important source given sets with same nutrients with different sources"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					},
+					protein => {
+						value_string => "6.2",
+						value => 6.2,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "prepared",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "0.1",
+						value => 0.1,
+						unit => "g",
+					},
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "prepared",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "0.1",
+					value => 0.1,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "5.2",
+					value => 5.2,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have nutrients from most important preparation given sets with same nutrients with different preparations"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "250",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "0.1",
+						value => 0.1,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.0",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "packaging",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "5.2",
+					value => 5.2,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have nutrients from most important per given sets with same nutrients with different per"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					protein => {
+						value_string => "8.2",
+						value => 8.2,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					},
+					protein => {
+						value_string => "0",
+						value => 0,
+						unit => "g"
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "manufacturer",
+				nutrients => {
+					sodium => {
+						value_string => "0",
+						value => 0,
+						unit => "g",
+					},
+					sugars => {
+						value_string => "7.6",
+						value => 7.6,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "manufacturer",
+				nutrients => {
+					sodium => {
+						value_string => "2",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "manufacturer",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "7.6",
+					value => 7.6,
+					unit => "g",
+					source => "manufacturer",
+					source_per => "serving"
+				},
+				protein => {
+					value_string => "0",
+					value => 0,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g"
+				}
+			}
+		},
+		"Generated set should have nutrients from most important source then per given sets with same nutrients with different sources and per"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "manufacturer",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			},
+			{
+				preparation => "prepared",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.0",
+					value => 2,
+					unit => "g",
+					modifier => "<=",
+					source => "manufacturer",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have nutrients from most important source then preparation given sets with same nutrients with different sources and preparations"
+	],
+	[
+		[
+			{
+				preparation => "prepared",
+				per => "serving",
+				per_quantity => "250",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "2.0",
+						value => 2,
+						unit => "g",
+						modifier => "<="
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sugars => {
+						value_string => "5.2",
+						value => 5.2,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sugars => {
+					value_string => "5.2",
+					value => 5.2,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have nutrients from most important per then preparation given sets with same nutrients with different per and preparations"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					sodium => {
+						value_string => "200.0",
+						value => 200,
+						unit => "mg",
+						modifier => "<="
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "0.2",
+					value => 0.2,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+					modifier => "<=",
+				}
+			}
+		},
+		"Generated set should have normalized weight units for nutrients"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					"energy-kcal" => {
+						value_string => "125",
+						value => 125,
+						unit => "kj",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				"energy-kcal" => {
+					value_string => "30",
+					value => 30,
+					unit => "kcal",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have normalized unit for energy-kcal nutrient"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					energy => {
+						value_string => "30",
+						value => 30,
+						unit => "kcal",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				energy => {
+					value_string => "125",
+					value => 125,
+					unit => "kj",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have normalized unit for energy nutrient"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					"energy-kj" => {
+						value_string => "30",
+						value => 30,
+						unit => "kcal",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				"energy-kj" => {
+					value_string => "125",
+					value => 125,
+					unit => "kj",
+					source => "packaging",
+					source_per => "100g",
+				}
+			}
+		},
+		"Generated set should have normalized unit for energy-kj nutrient"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					"sodium" => {
+						value_string => "2.5",
+						value => 2.5,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "50",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					"sugars" => {
+						value_string => "6.3",
+						value => 6.3,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "100g",
+			per_quantity => "100",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "2.5",
+					value => 2.5,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "12.6",
+					value => 12.6,
+					unit => "g",
+					source => "packaging",
+					source_per => "serving",
+				}
+			}
+		},
+		"Generated set should have converted per when different per in nutrients given nutrient with most priority with per in 100g/ml"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "100g",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					"sodium" => {
+						value_string => "2.5",
+						value => 2.5,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "50",
+				per_unit => "g",
+				source => "manufacturer",
+				nutrients => {
+					"sugars" => {
+						value_string => "6.3",
+						value => 6.3,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "serving",
+			per_quantity => "50",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "1.25",
+					value => 1.25,
+					unit => "g",
+					source => "packaging",
+					source_per => "100g",
+				},
+				sugars => {
+					value_string => "6.3",
+					value => 6.3,
+					unit => "g",
+					source => "manufacturer",
+					source_per => "serving",
+				}
+			}
+		},
+		"Generated set should have converted per when different per in nutrients given nutrient with most priority with per in serving"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "100",
+				per_unit => "g",
+				source => "packaging",
+				nutrients => {
+					"sodium" => {
+						value_string => "2.5",
+						value => 2.5,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "50",
+				per_unit => "g",
+				source => "manufacturer",
+				nutrients => {
+					"sugars" => {
+						value_string => "6.3",
+						value => 6.3,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "serving",
+			per_quantity => "50",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "1.25",
+					value => 1.25,
+					unit => "g",
+					source => "packaging",
+					source_per => "serving",
+				},
+				sugars => {
+					value_string => "6.3",
+					value => 6.3,
+					unit => "g",
+					source => "manufacturer",
+					source_per => "serving",
+				}
+			}
+		},
+		"Generated set should have converted per when different per in nutrients given nutrients per in different servings"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "100",
+				per_unit => "mg",
+				source => "packaging",
+				nutrients => {
+					"sodium" => {
+						value_string => "2.5",
+						value => 2.5,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "50",
+				per_unit => "g",
+				source => "manufacturer",
+				nutrients => {
+					"sugars" => {
+						value_string => "6.3",
+						value => 6.3,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "serving",
+			per_quantity => "50",
+			per_unit => "g",
+			nutrients => {
+				sodium => {
+					value_string => "1250",
+					value => 1250,
+					unit => "g",
+					source => "packaging",
+					source_per => "serving",
+				},
+				sugars => {
+					value_string => "6.3",
+					value => 6.3,
+					unit => "g",
+					source => "manufacturer",
+					source_per => "serving",
+				}
+			}
+		},
+		"Generated set should have converted per when different per in nutrients given nutrients per in different servings with wanted in g"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "100",
+				per_unit => "mg",
+				source => "packaging",
+				nutrients => {
+					"sodium" => {
+						value_string => "0.25",
+						value => 0.25,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "5",
+				per_unit => "kg",
+				source => "manufacturer",
+				nutrients => {
+					"sugars" => {
+						value_string => "6.3",
+						value => 6.3,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "serving",
+			per_quantity => "5",
+			per_unit => "kg",
+			nutrients => {
+				sodium => {
+					value_string => "12500",
+					value => 12500,
+					unit => "g",
+					source => "packaging",
+					source_per => "serving",
+				},
+				sugars => {
+					value_string => "6.3",
+					value => 6.3,
+					unit => "g",
+					source => "manufacturer",
+					source_per => "serving",
+				}
+			}
+		},
+		"Generated set should have converted per when different per in nutrients given nutrients per in different servings with wanted in not in g"
+	],
+	[
+		[
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "1",
+				per_unit => "l",
+				source => "packaging",
+				nutrients => {
+					"sodium" => {
+						value_string => "0.25",
+						value => 0.25,
+						unit => "g",
+					}
+				}
+			},
+			{
+				preparation => "as_sold",
+				per => "serving",
+				per_quantity => "50",
+				per_unit => "ml",
+				source => "manufacturer",
+				nutrients => {
+					"sugars" => {
+						value_string => "6.3",
+						value => 6.3,
+						unit => "g",
+					}
+				}
+			}
+		],
+		{
+			preparation => "as_sold",
+			per => "serving",
+			per_quantity => "50",
+			per_unit => "ml",
+			nutrients => {
+				sodium => {
+					value_string => "0.0125",
+					value => 0.0125,
+					unit => "g",
+					source => "packaging",
+					source_per => "serving",
+				},
+				sugars => {
+					value_string => "6.3",
+					value => 6.3,
+					unit => "g",
+					source => "manufacturer",
+					source_per => "serving",
+				}
+			}
+		},
+		"Generated set should have converted per when different per in nutrients given nutrients per in different servings with volume units"
+	],
+);
 
 foreach my $test_ref (@tests) {
 
 	my $nutrient_sets_ref = $test_ref->[0];
 	my $nutrient_set_preferred = $test_ref->[1];
-    my $test_name = $test_ref->[2];
+	my $test_name = $test_ref->[2];
 
 	is(generate_nutrient_set_preferred_from_sets($nutrient_sets_ref), $nutrient_set_preferred, $test_name);
+}
+
+@tests = [
+	# Generated set should have converted per when different per in nutrients given nutrients per in different servings
+	"convert_per_nutrients",
+	{
+		nutrition => {
+			nutrient_sets => [
+				{
+					preparation => "as_sold",
+					per => "serving",
+					per_quantity => "100",
+					per_unit => "g",
+					source => "packaging",
+					nutrients => {
+						"sodium" => {
+							value_string => "2.5",
+							value => 2.5,
+							unit => "g",
+						}
+					}
+				},
+				{
+					preparation => "as_sold",
+					per => "serving",
+					per_quantity => "50",
+					per_unit => "g",
+					source => "manufacturer",
+					nutrients => {
+						"sugars" => {
+							value_string => "6.3",
+							value => 6.3,
+							unit => "g",
+						}
+					}
+				}
+			]
+		}
+	},
+
+];
+
+foreach my $test_ref (@tests) {
+
+	my $testid = $test_ref->[0];
+	my $product_ref = $test_ref->[1];
+
+	my $nutrient_set_preferred_ref
+		= generate_nutrient_set_preferred_from_sets($product_ref->{nutrition}{nutrient_sets});
+	if (defined $nutrient_set_preferred_ref) {
+		$product_ref->{nutrition}{nutrient_set_preferred} = $nutrient_set_preferred_ref;
+	}
+
+	compare_to_expected_results($product_ref, "$expected_result_dir/$testid.json",
+		$update_expected_results, {id => $testid});
 }
 
 done_testing();


### PR DESCRIPTION
What we are doing in many unit tests is to give as input a product object, and then we store the updated product object and compare it to the version we expect.

I just added one of the tests to show why this is useful: generate_nutrient_set_preferred_from_sets() generates the correct preferred set, but it changed the input nutrient sets.

So I think it would be best to convert all tests to this format.