### PR TITLE
build: add a stop_deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,10 @@ restart: run_deps
 	${DOCKER_COMPOSE} restart backend frontend
 	@echo "🥫  started service at http://openfoodfacts.localhost"
 
+stop: stop_deps
+	@echo "🥫 Stopping containers …"
+	${DOCKER_COMPOSE} stop
+
 status: run_deps
 	@echo "🥫 Getting container status …"
 	${DOCKER_COMPOSE} ps

--- a/Makefile
+++ b/Makefile
@@ -598,6 +598,11 @@ prune_deps: clone_deps
 		cd ${DEPS_DIR}/$$dep && $(MAKE) prune; \
 	done
 
+stop_deps:
+	@for dep in ${DEPS} ; do \
+		cd ${DEPS_DIR}/$$dep && ( $(MAKE) stop || env -i docker compose stop ) ; \
+	done
+
 #-----------#
 # Utilities #
 #-----------#


### PR DESCRIPTION
Because it's annoying to have a lot of running containers

See also:
* https://github.com/openfoodfacts/openfoodfacts-auth/pull/235
* https://github.com/openfoodfacts/openfoodfacts-shared-services/pull/15
that adds the "stop" targets to dependencies.