### PR TITLE
feat: explained nutriscore missing prepared nutrition

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -1207,7 +1207,12 @@ sub compute_attribute_nutrient_level ($product_ref, $target_lc, $level, $nid) {
 				display_taxonomy_tag($target_lc, "nutrients", "zz:$nid"),
 				lang_in_other_lc($target_lc, "unknown_quantity")
 			);
-			$attribute_ref->{missing} = lang_in_other_lc($target_lc, "missing_nutrition_facts");
+			if (has_tag($product_ref, "misc", "en:nutriscore-missing-prepared-nutrition-data")) {
+				$attribute_ref->{missing} = lang_in_other_lc($target_lc, "missing_nutrition_facts_prepared");
+			}
+			else {
+				$attribute_ref->{missing} = lang_in_other_lc($target_lc, "missing_nutrition_facts");
+			}
 			$attribute_ref->{panel_id} = "nutrition_facts_table";
 		}
 	}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9367,15 +9367,22 @@ sub data_to_display_nutriscore ($product_ref, $version = "2021") {
 				}
 				$missing_nutrients =~ s/, $//;
 
+				my $missing_nutrition_mgs_details
+					= has_tag($product_ref, "misc", "en:nutriscore-missing-prepared-nutrition-data")
+					? "nutriscore_missing_prepared_nutrition_data_details"
+					: "nutriscore_missing_nutrition_data_details";
 				push @nutriscore_warnings,
 					  lang("nutriscore_missing_nutrition_data") . "<p>"
-					. lang("nutriscore_missing_nutrition_data_details") . " <b>"
+					. lang($missing_nutrition_mgs_details) . " <b>"
 					. $missing_nutrients . "</b>" . "</p>";
 
 				if (not has_tag($product_ref, "misc", "en:nutriscore-missing-category")) {
 					$result_data_ref->{nutriscore_unknown_reason} = "missing_nutrition_data";
-					$result_data_ref->{nutriscore_unknown_reason_short}
-						= lang("nutriscore_missing_nutrition_data_short");
+					my $msg
+						= has_tag($product_ref, "misc", "en:nutriscore-missing-prepared-nutrition-data")
+						? "nutriscore_missing_prepared_nutrition_data_short"
+						: "nutriscore_missing_nutrition_data_short";
+					$result_data_ref->{nutriscore_unknown_reason_short} = lang($msg);
 				}
 				else {
 					$result_data_ref->{nutriscore_unknown_reason} = "missing_category_and_nutrition_data";

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5106,6 +5106,10 @@ msgctxt "missing_nutrition_facts"
 msgid "Missing nutrition facts"
 msgstr "Missing nutrition facts"
 
+msgctxt "missing_nutrition_facts_prepared"
+msgid "Missing nutrition facts for prepared product"
+msgstr "Missing nutrition facts for prepared product"
+
 msgctxt "ecoscore_p"
 msgid "Green-Score"
 msgstr "Green-Score"
@@ -6094,6 +6098,10 @@ msgctxt "nutriscore_missing_nutrition_data_details"
 msgid "Missing nutrition facts:"
 msgstr "Missing nutrition facts:"
 
+msgctxt "nutriscore_missing_prepared_nutrition_data_details"
+msgid "Missing nutrition facts for prepared product:"
+msgstr "Missing nutrition facts for prepared product:"
+
 msgctxt "nutriscore_missing_category_and_nutrition_data"
 msgid "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
 msgstr "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
@@ -6181,6 +6189,10 @@ msgstr "Missing category"
 msgctxt "nutriscore_missing_nutrition_data_short"
 msgid "Missing nutrition facts"
 msgstr "Missing nutrition facts"
+
+msgctxt "nutriscore_missing_prepared_nutrition_data_short"
+msgid "Missing prepared nutrition facts"
+msgstr "Missing prepared nutrition facts"
 
 msgctxt "nutriscore_missing_category_and_nutrition_data_short"
 msgid "Missing category and nutrition facts"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5118,6 +5118,10 @@ msgctxt "missing_nutrition_facts"
 msgid "Missing nutrition facts"
 msgstr "Missing nutrition facts"
 
+msgctxt "missing_nutrition_facts_prepared"
+msgid "Missing nutrition facts for prepared product"
+msgstr "Missing nutrition facts for prepared product"
+
 msgctxt "ecoscore_p"
 msgid "Green-Score"
 msgstr "Green-Score"
@@ -6106,6 +6110,10 @@ msgctxt "nutriscore_missing_nutrition_data_details"
 msgid "Missing nutrition facts:"
 msgstr "Missing nutrition facts:"
 
+msgctxt "nutriscore_missing_prepared_nutrition_data_details"
+msgid "Missing nutrition facts for prepared product:"
+msgstr "Missing nutrition facts for prepared product:"
+
 msgctxt "nutriscore_missing_category_and_nutrition_data"
 msgid "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
 msgstr "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
@@ -6193,6 +6201,10 @@ msgstr "Missing category"
 msgctxt "nutriscore_missing_nutrition_data_short"
 msgid "Missing nutrition facts"
 msgstr "Missing nutrition facts"
+
+msgctxt "nutriscore_missing_prepared_nutrition_data_short"
+msgid "Missing prepared nutrition facts"
+msgstr "Missing prepared nutrition facts"
 
 msgctxt "nutriscore_missing_category_and_nutrition_data_short"
 msgid "Missing category and nutrition facts"


### PR DESCRIPTION
Because, according to Tacite, many users are complaining (on nutri-patrol), not understanding why they don't get the nutri-score, while nutrition is set, but not prepared nutrition, necessary for some products.

<img width="872" height="295" alt="Capture d’écran du 2025-08-08 17-37-37" src="https://github.com/user-attachments/assets/918479ab-0bed-4079-a49b-9f8e2e86fe21" />
