### PR TITLE
feat: Include client IP in product update Redis events

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -138,7 +138,7 @@ use ProductOpener::Data qw/execute_query get_products_collection get_recent_chan
 use ProductOpener::MainCountries qw/compute_main_countries/;
 use ProductOpener::Text qw/remove_email remove_tags_and_quote/;
 use ProductOpener::HTTP qw/single_param create_user_agent/;
-use ProductOpener::Redis qw/push_to_redis_stream/;
+use ProductOpener::Redis qw/push_product_update_to_redis/;
 use ProductOpener::Food qw/%nutriments_lists %cc_nutriment_table/;
 use ProductOpener::Units qw/normalize_product_quantity_and_serving_size/;
 
@@ -1473,10 +1473,10 @@ sub store_product ($user_id, $product_ref, $comment, $client_id = undef) {
 	}
 
 	# Publish information about update on Redis stream
-	$log->debug("push_to_redis_stream",
+	$log->debug("push_product_update_to_redis",
 		{code => $code, product_id => $product_id, action => $action, comment => $comment, diffs => $diffs})
 		if $log->is_debug();
-	push_to_redis_stream($user_id, $product_ref, $action, $comment, $diffs);
+	push_product_update_to_redis($product_ref, $change_ref, $action);
 
 	return 1;
 }

--- a/scripts/check_products_in_mongodb.pl
+++ b/scripts/check_products_in_mongodb.pl
@@ -54,7 +54,6 @@ use ProductOpener::Mail qw/:all/;
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Data qw/get_products_collection/;
 use ProductOpener::LoadData qw/load_data/;
-use ProductOpener::Redis qw/push_to_redis_stream/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;

--- a/scripts/count_product_contributions_by_year.pl
+++ b/scripts/count_product_contributions_by_year.pl
@@ -51,7 +51,6 @@ use ProductOpener::Mail qw/:all/;
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Data qw/get_products_collection/;
 use ProductOpener::LoadData qw/load_data/;
-use ProductOpener::Redis qw/push_to_redis_stream/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;

--- a/scripts/migrations/2024_10_remove_duplicate_products_on_wrong_flavors.pl
+++ b/scripts/migrations/2024_10_remove_duplicate_products_on_wrong_flavors.pl
@@ -150,8 +150,14 @@ while (my $line = <$csv_fh>) {
 		move_code_to_other_flavors_codes($code);
 
 		# Push a deleted event to Redis
-		push_to_redis_stream("remove-duplicates-bot", $product_ref, "deleted",
-			"duplicate product: keep product on $kept_flavor, remove from $flavor", undef);
+		push_product_update_to_redis(
+			$product_ref,
+			{
+				"userid" => 'remove-duplicates-bot',
+				"comment" => "duplicate product: keep product on $kept_flavor, remove from $flavor"
+			},
+			"deleted"
+		);
 	}
 }
 

--- a/scripts/obsolete/normalize_code.pl
+++ b/scripts/obsolete/normalize_code.pl
@@ -53,7 +53,6 @@ use ProductOpener::Mail qw/:all/;
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Data qw/get_products_collection/;
 use ProductOpener::LoadData qw/load_data/;
-use ProductOpener::Redis qw/push_to_redis_stream/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;

--- a/scripts/product_revision_to_historical_events.pl
+++ b/scripts/product_revision_to_historical_events.pl
@@ -26,7 +26,6 @@ use utf8;
 use ProductOpener::Config qw/%options $query_url/;
 use ProductOpener::Store qw/retrieve_object/;
 use ProductOpener::Paths qw/%BASE_DIRS/;
-use ProductOpener::Redis qw/push_to_redis_stream/;
 use ProductOpener::Products qw/product_id_from_path product_iter/;
 use ProductOpener::Checkpoint;
 use ProductOpener::HTTP qw/create_user_agent/;
@@ -174,7 +173,7 @@ sub send_events() {
 	}
 
 	# Note pushing to redis will cause product to be reloaded
-	# push_to_redis_stream(
+	# push_product_update_to_redis(
 	# 	$change->{userid} // 'initial_import',
 	# 	{code=>$code, rev=>$rev},
 	# 	$action,

--- a/scripts/scanbot.pl
+++ b/scripts/scanbot.pl
@@ -506,7 +506,7 @@ foreach my $code (sort {$codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $co
 				$product_ref->{last_updated_t} = time() + 0;
 				store_object("$BASE_DIRS{PRODUCTS}/$path/product", $product_ref);
 				get_products_collection()->replace_one({"_id" => $product_ref->{_id}}, $product_ref, {upsert => 1});
-				push_to_redis_stream('scanbot', $product_ref, "updated", $year, {});
+				push_product_update_to_redis($product_ref, {"userid" => 'scanbot', "comment" => $year}, "updated");
 			}
 		}
 	}

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -82,7 +82,7 @@ use ProductOpener::MainCountries qw(compute_main_countries);
 use ProductOpener::PackagerCodes qw/normalize_packager_codes/;
 use ProductOpener::API qw/get_initialized_response/;
 use ProductOpener::LoadData qw/load_data/;
-use ProductOpener::Redis qw/push_to_redis_stream/;
+use ProductOpener::Redis qw/push_product_update_to_redis/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;
@@ -1055,34 +1055,18 @@ while (my $product_ref = $cursor->next) {
 									(defined $product_ref->{images}{selected}{$image_type}{$image_lc}{orientation})
 								and ($product_ref->{images}{selected}{$image_type}{$image_lc} != 0)
 								# only rotate images that have not been manually cropped
-								and (
-									(
-										not
-										defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x1}
-									)
-									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x1} <= 0)
-								)
-								and (
-									(
-										not
-										defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y1}
-									)
-									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y1} <= 0)
-								)
-								and (
-									(
-										not
-										defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x2}
-									)
-									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x2} <= 0)
-								)
-								and (
-									(
-										not
-										defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y2}
-									)
-									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y2} <= 0)
-								)
+								and
+								((not defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x1})
+									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x1} <= 0))
+								and
+								((not defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y1})
+									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y1} <= 0))
+								and
+								((not defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x2})
+									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{x2} <= 0))
+								and
+								((not defined $product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y2})
+									or ($product_ref->{images}{selected}{$image_type}{$image_lc}{generation}{y2} <= 0))
 								)
 							{
 								print STDERR "rotating image $image_type $image_lc by "
@@ -1565,7 +1549,9 @@ while (my $product_ref = $cursor->next) {
 					else {
 						$products_pushed_to_redis++;
 						print STDERR ". Pushed to Redis stream";
-						push_to_redis_stream('update_all_products', $product_ref, "reprocessed", $comment, {});
+						push_product_update_to_redis($product_ref,
+							{"userid" => 'update_all_products', "comment" => $comment},
+							"reprocessed");
 					}
 				}
 				else {

--- a/tests/integration/add_update_to_redis.t
+++ b/tests/integration/add_update_to_redis.t
@@ -41,7 +41,7 @@ my $response = $test_ua->post($url, Content => \%product_form, %$headers_in);
 # Stop logging
 my $logs = tail_log_read($tail);
 
-# Check that the push_to_redis_stream function was called and that Redis connection was successful
+# Check that the push_product_update_to_redis function was called and that Redis connection was successful
 ok($logs =~ /Pushing product update to Redis/, "pushing product update to Redis");
 # Check that the Redis call didn't trigger an error
 ok($logs =~ /Successfully pushed product update to Redis/, "successfully pushed product update to Redis");


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
Inlcude the client IP address and OAuth client_id in the redis events so that these can ultimately be used to generate the recent_changes data from off-query

### Related issue(s) and discussion
Part of discussion: https://github.com/openfoodfacts/openfoodfacts-query/discussions/150
