### PR TITLE
fix: build and save pro platform column names mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ reset_owner:
 	${DOCKER_COMPOSE_BUILD} run --rm --no-deps --user root backend chown www-data:www-data -R /opt/product-opener/ /mnt/podata /var/log/apache2 /var/log/httpd  || true
 	${DOCKER_COMPOSE_BUILD} run --rm --no-deps --user root frontend chown www-data:www-data -R /opt/product-opener/html/images/icons/dist /opt/product-opener/html/js/dist /opt/product-opener/html/css/dist
 
-init_backend: build_taxonomies build_lang
+init_backend: build_taxonomies build_lang build_pro_platform
 
 create_mongodb_indexes: run_deps
 	@echo "🥫 Creating MongoDB indexes …"
@@ -284,7 +284,7 @@ checks: front_build front_lint check_perltidy check_perl_fast check_critic check
 
 lint: lint_perltidy lint_taxonomies
 
-tests: build_taxonomies_test build_lang_test unit_test integration_test brands_sort_test
+tests: build_taxonomies_test build_lang_test build_pro_platform_test unit_test integration_test brands_sort_test
 
 # add COVER_OPTS='-e HARNESS_PERL_SWITCHES="-MDevel::Cover"' if you want to trigger code coverage report generation
 unit_test: create_folders
@@ -354,7 +354,7 @@ clean_tests:
 	${DOCKER_COMPOSE_TEST} down -v --remove-orphans
 	${DOCKER_COMPOSE_INT_TEST} down -v --remove-orphans
 
-update_tests_results: build_taxonomies_test build_lang_test update_unit_tests_results update_integration_tests_results
+update_tests_results: build_taxonomies_test build_lang_test build_pro_platform_test update_unit_tests_results update_integration_tests_results
 
 update_unit_tests_results:
 	@echo "🥫 Updated expected unit test results with actuals for easy Git diff"
@@ -493,6 +493,17 @@ build_taxonomies_test: create_folders
 	@echo "🥫 build taxonomies"
 # GITHUB_TOKEN might be empty, but if it's a valid token it enables pushing taxonomies to build cache repository
 	${DOCKER_COMPOSE_TEST} run --no-deps --rm -e GITHUB_TOKEN=${GITHUB_TOKEN} backend /opt/product-opener/scripts/taxonomies/build_tags_taxonomy.pl ${name}
+
+build_pro_platform: create_folders
+	$(MAKE) MOUNT_FOLDER=build-cache MOUNT_VOLUME=build_cache _bind_local
+	@echo "🥫 build pro platform"
+	${DOCKER_COMPOSE_BUILD} run --no-deps --rm backend /opt/product-opener/scripts/build_pro_platform_fields_columns_names.pl
+
+build_pro_platform_test: create_folders
+	$(MAKE) MOUNT_FOLDER=build-cache MOUNT_VOLUME=build_cache PROJECT_SUFFIX=_test _bind_local
+	@echo "🥫 build pro platform"
+	${DOCKER_COMPOSE_TEST} run --no-deps --rm backend /opt/product-opener/scripts/build_pro_platform_fields_columns_names.pl
+
 
 
 _clean_old_external_volumes:

--- a/docs/dev/how-to-release.md
+++ b/docs/dev/how-to-release.md
@@ -48,6 +48,13 @@ To deploy you need to execute the following steps:
    ./scripts/taxonomies/build_tags_taxonomy.pl
    ./scripts/build_lang.pl
    ```
+1. on the PRO platform, also rebuild the fields columns names
+   ```bash
+   sudo -u off bash
+   cd /srv/$SERVICE
+   source env/setenv.sh $SERVICE
+   ./scripts/build_pro_platform_fields_columns_names.pl
+   ```
 1. update the frontend assets you just downloaded
    ```bash
    sudo -u off /srv/$SERVICE/scripts/deploy/install-dist-files.sh $VERSION $SERVICE

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -50,6 +50,7 @@ BEGIN {
 
 		&load_csv_or_excel_file
 
+		&build_fields_columns_names_for_lang
 		&init_fields_columns_names_for_lang
 		&match_column_name_to_field
 		&init_columns_fields_match
@@ -71,7 +72,7 @@ use vars @EXPORT_OK;
 
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS ensure_dir_created ensure_dir_created_or_die/;
-use ProductOpener::Store qw/get_string_id_for_lang retrieve store/;
+use ProductOpener::Store qw/get_string_id_for_lang retrieve store store_config retrieve_config/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Food qw/%cc_nutriment_table %nutriments_tables/;
@@ -831,6 +832,43 @@ sub init_fields_columns_names_for_lang ($l) {
 		return;
 	}
 
+	my $path = "$BASE_DIRS{CACHE_BUILD}/pro/fields_column_names/$l";
+
+	$fields_columns_names_for_lang{$l} = retrieve_config($path);
+
+	if (not defined $fields_columns_names_for_lang{$l}) {
+		die("Could not load $path.json, run scripts/build_pro_platform_fields_columns_names.pl");
+	}
+
+	return $fields_columns_names_for_lang{$l};
+}
+
+=head2 build_fields_columns_names_for_lang ( $l )
+
+Creates global $fields_columns_names_for_lang for the specified language.
+
+The function creates a hash of all the possible localized column names
+that we can automatically recognize, and maps them to the corresponding field in OFF.
+
+The result is stored in the global variable %fields_columns_names_for_lang,
+and saved to a file.
+
+This function can be called through the script scripts/build_pro_platform_fields_column_names.pl
+
+=head3 Arguments
+
+=head4 $l - required
+
+Language code (string)
+
+=head3 Return value
+
+Reference to the column names hash.
+
+=cut
+
+sub build_fields_columns_names_for_lang ($l) {
+
 	$fields_columns_names_for_lang{$l} = {};
 
 	init_nutrients_columns_names_for_lang($l);
@@ -845,9 +883,9 @@ sub init_fields_columns_names_for_lang ($l) {
 	}
 	$fields_columns_names_for_lang{$l}{"kj"} = {field => "energy-kj_100g_value_unit", value_unit => "value_in_kj"};
 
-	ensure_dir_created($BASE_DIRS{CACHE_DEBUG});
+	my $path = "$BASE_DIRS{CACHE_BUILD}/pro/fields_column_names/$l";
 
-	store("$BASE_DIRS{CACHE_DEBUG}/fields_columns_names_$l.sto", $fields_columns_names_for_lang{$l});
+	store_config($path, $fields_columns_names_for_lang{$l});
 
 	return $fields_columns_names_for_lang{$l};
 }

--- a/scripts/build_pro_platform_fields_columns_names.pl
+++ b/scripts/build_pro_platform_fields_columns_names.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2023 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use Modern::Perl '2017';
+use utf8;
+
+use ProductOpener::Config qw/:all/;
+use ProductOpener::Producers qw/:all/;
+use ProductOpener::Lang qw/@Langs/;
+
+print STDERR "building pro platform fields columns names for all languages\n";
+
+# Generate the files that match potential column names from producers to OFF fields
+foreach my $l (@Langs) {
+	print STDERR "building fields columns names for language: $l\n";
+	build_fields_columns_names_for_lang($l);
+}
+
+print STDERR "done building tags taxonomy\n";
+
+exit(0);


### PR DESCRIPTION
When we upload CSV / Excel files to the pro platform, we currently recompute all possible column names to OFF field mappings for the current language (+ English), which can take quite a lot of time.

Instead we can just build all languages and store the corresponding mappings.