### PR TITLE
Move EU countries list to countries taxonomy and refactor code to use…

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -2036,22 +2036,16 @@ sub check_labels ($product_ref) {
 		}
 	}
 
-	# In EU, compare label claim and nutrition
-	# https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
-	my @eu_countries = (
-		"en:austria", "en:belgium", "en:bulgaria", "en:croatia", "en:cyprus", "en:czech republic",
-		"en:denmark", "en:france", "en:estonia", "en:finland", "en:germany", "en:greece",
-		"en:hungary", "en:ireland", "en:italy", "en:latvia", "en:lithuania", "en:luxembourg",
-		"en:malta", "en:netherlands", "en:poland", "en:portugal", "en:romania", "en:slovakia",
-		"en:slovenia", "en:spain", "en:sweden"
-	);
-	my $european_product = 0;
-	foreach my $eu_country (@eu_countries) {
-		if (has_tag(($product_ref, "countries", $eu_country))) {
-			$european_product = 1;
-			last;
-		}
-	}
+       # In EU, compare label claim and nutrition
+       # Now using the 'regional_entity:en: european-union' property in the countries taxonomy
+       my $european_product = 0;
+       my $eu_countries = get_all_tags_having_property($product_ref, 'countries', 'regional_entity:en');
+       foreach my $country (keys %{$eu_countries}) {
+	       if ($eu_countries->{$country} eq 'european-union') {
+		       $european_product = 1;
+		       last;
+	       }
+       }
 
 	if (    (defined $product_ref->{nutriments})
 		and (defined $product_ref->{labels_tags})

--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -3105,6 +3105,7 @@ be: Аўстрыя
 be-tarask:Аўстрыя
 be-x-old:Аўстрыя
 bg: Австрия
+regional_entity:en: european-union
 bi: Austria
 bn: অস্ট্রিয়া
 bo: ཨོ་སི་ཐྲི་ཡ།
@@ -4398,6 +4399,7 @@ osm_relation:en: 59065
 wikidata:en: Q184
 
 en: Belgium, Kingdom of Belgium, BE, BEL
+regional_entity:en: european-union
 ace: Bèlgia
 af: België
 als: Belgien
@@ -6782,6 +6784,7 @@ osm_relation:en: 2103120
 wikidata:en: Q921
 
 en: Bulgaria, Republic of Bulgaria, BG, BGR
+regional_entity:en: european-union
 ab: Былгариа
 ace: Bulgaria
 af: Bulgarye, Bulgarië
@@ -10221,6 +10224,7 @@ osm_relation:en: 287667
 wikidata:en: Q800
 
 en: Croatia, Republic of Croatia, HR, HRV, HR, HRV
+regional_entity:en: european-union
 ab: Хорватиа
 ace: Kroasia
 af: Kroasië
@@ -10753,6 +10757,7 @@ language_codes:en: en,nl,pap
 osm_relation:en: 1216719
 
 en: Cyprus, Republic of Cyprus, CY, CYP
+regional_entity:en: european-union
 ace: Siprus
 af: Siprus
 als: Republik Zypern
@@ -10970,6 +10975,7 @@ language_codes:en: el,tr
 osm_relation:en: 307787
 
 en: Czech Republic, Czechia, CZ, CZE
+regional_entity:en: european-union
 ab: Чехиа
 ace: Rèpublik Cèkô
 af: Tsjeggië
@@ -11590,6 +11596,7 @@ country_code_3:en: COD
 language_codes:en: fr
 
 en: Denmark, DK, Kingdom of Denmark, Danish Kingdom, Danmark, Kongeriget Danmark, DK, DNK
+regional_entity:en: european-union
 ace: Denmark
 af: Denemarke
 als: Dänemark
@@ -13480,6 +13487,7 @@ country_code_3:en: ERI
 language_codes:en: ar,en,ti
 
 en: Estonia, Republic of Estonia, Estland, Eesti, EE, EST
+regional_entity:en: european-union
 ace: Èstonia
 af: Estland
 als: Estland
@@ -14734,6 +14742,7 @@ country_code_3:en: FJI
 language_codes:en: en,fj
 
 en: Finland, Republic of Finland, Finlande, Finlandia, Finnland, Finnia, Soome, Land of Thousand Lakes, FI, FIN
+regional_entity:en: european-union
 ab: Суоми
 ace: Finlandia
 af: Finland
@@ -14990,6 +14999,7 @@ country_code_3:en: FIN
 language_codes:en: fi,sv
 
 en: France, The Hexagon, French Republic, FR, FRA
+regional_entity:en: european-union
 ace: Peurancih
 af: Frankryk
 ak: France
@@ -16214,6 +16224,7 @@ country_code_3:en: GEO
 language_codes:en: ka
 
 en: Germany, FRG, BRD, Bundesrepublik Deutschland, Federal Republic of Germany, DE, DEU
+regional_entity:en: european-union
 ab: Алмантәыла
 ace: Jeureuman
 af: Duitsland
@@ -16845,6 +16856,7 @@ country_code_3:en: GIB
 language_codes:en: en
 
 en: Greece, Hellenic Republic, Hellas, GR, GRC
+regional_entity:en: european-union
 ab: Барзентәыла
 ace: Yunani
 af: Griekeland
@@ -19103,6 +19115,7 @@ country_code_3:en: HKG
 language_codes:en: zh,en
 
 en: Hungary, HU, HUN
+regional_entity:en: european-union
 ab: Мадиартәыла
 ace: Hongaria
 af: Hongarye
@@ -20924,6 +20937,7 @@ country_code_3:en: ISR
 language_codes:en: he,ar,ru,en
 
 en: Italy, Italia, Italian Republic, Italië, IT, ITA
+regional_entity:en: european-union
 ab: Италиа
 ace: Itali
 af: Italië
@@ -23201,6 +23215,7 @@ country_code_3:en: LAO
 language_codes:en: lo
 
 en: Latvia, Republic of Latvia, Latvian Republic, LV, LVA
+regional_entity:en: european-union
 ace: Latvia
 af: Letland
 als: Lettland
@@ -24441,6 +24456,7 @@ country_code_3:en: LIE
 language_codes:en: de
 
 en: Lithuania, Republic of Lithuania, LT, LTU
+regional_entity:en: european-union
 ab: Литва
 ace: Lithuania
 af: Litaue
@@ -24695,6 +24711,7 @@ country_code_3:en: LTU
 language_codes:en: lt
 
 en: Luxembourg, Luxemburg, Grand Duchy of Luxembourg, LU, LU, LUX
+regional_entity:en: european-union
 ace: Luksèmburg, Luxemburg
 af: Luxemburg, Luxembourg, Groothertogdom Luxemburg
 als: Luxemburg
@@ -26032,6 +26049,7 @@ country_code_3:en: MLI
 language_codes:en: fr
 
 en: Malta, Republic of Malta, MT, MLT
+regional_entity:en: european-union
 ace: Malta
 af: Malta
 als: Malta


### PR DESCRIPTION
Moved the EU countries list from a hardcoded array in the code to the countries taxonomy.
Each EU country now has the property regional_entity:en: european-union in countries.txt

The code in DataQualityFood.pm was refactored to use this property for EU country detection, making the list easier to maintain and more consistent.


>Fixes #12247