### PR TITLE
fix: Upgrade to PostgreSQL 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
   memcached:
     image: memcached:1.6-alpine
   postgres:
-    image: postgres:12-alpine
+    image: pgautoupgrade/pgautoupgrade:13-alpine
     # we want postgres for off, but not for pro profile
     profiles: ["off"]
     environment:


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

Upgrade docker to use PostgreSQL 13 as this corresponds to Production and a recent Minion upgrade has removed support for PostgreSQL 12.

### Related issue(s) and discussion
- Fixes #12281

