### PR TITLE
taxonomy: correction compound dairy creams

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -50320,7 +50320,6 @@ incompatible_with:en: categories:en:milks, categories:en:creams, categories:en:H
 
 #this category is not made for vegan products but for dairy products used in replacement of cream
 < en:Dairies
-< en:Vegan products
 en: Compound dairy creams
 de: Sahne-Ersatz
 fr: Succédanés de la crème


### PR DESCRIPTION
removed the category vegan products on "Compound dairy creams". As explained in the taxonomy, this category is not for vegan products but for substitutes of cream made of dairy (mostly milk).