### PR TITLE
ci: Add devcontainers configuration to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,13 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 300
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "all"
+    groups:
+      devcontainers:
+        patterns:
+          - "*"


### PR DESCRIPTION

### What
- ci: Add devcontainers configuration to dependabot
- stolen from @john-gom 

  - package-ecosystem: "devcontainers"
    directory: "/"
    schedule:
      interval: "monthly"
    allow:
      - dependency-type: "all"
    groups:
      devcontainers:
        patterns:
          - "*"