### PR TITLE
fix: API blame parameter

### DIFF
--- a/lib/ProductOpener/APIProductRead.pm
+++ b/lib/ProductOpener/APIProductRead.pm
@@ -204,7 +204,7 @@ sub read_product_api ($request_ref) {
 				$changes_ref = [];
 			}
 			$response_ref->{blame} = {};
-			compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $response_ref->{blame});
+			compute_product_history_and_completeness($product_ref, $changes_ref, $response_ref->{blame});
 		}
 
 	}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10699,7 +10699,7 @@ sub display_product_api ($request_ref) {
 				$changes_ref = [];
 			}
 			$response{blame} = {};
-			compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $response{blame});
+			compute_product_history_and_completeness($product_ref, $changes_ref, $response{blame});
 		}
 
 		if (single_param("jqm")) {

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -775,7 +775,7 @@ while (my $product_ref = $cursor->next) {
 					$fix_rev_not_incremented_fixed++;
 					$product_ref->{rev} = $last_rev;
 					my $blame_ref = {};
-					compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $blame_ref);
+					compute_product_history_and_completeness($product_ref, $changes_ref, $blame_ref);
 					compute_data_sources($product_ref, $changes_ref);
 					store_object("$BASE_DIRS{PRODUCTS}/$path/changes", $changes_ref);
 				}
@@ -1255,7 +1255,7 @@ while (my $product_ref = $cursor->next) {
 			my $blame_ref = {};
 
 			my $changes_ref = retrieve_object("$BASE_DIRS{PRODUCTS}/$path/changes");
-			compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $blame_ref);
+			compute_product_history_and_completeness($product_ref, $changes_ref, $blame_ref);
 
 			if (
 					(defined $blame_ref->{nutriments})
@@ -1371,7 +1371,7 @@ while (my $product_ref = $cursor->next) {
 				$changes_ref = [];
 			}
 			my $blame_ref = {};
-			compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $blame_ref);
+			compute_product_history_and_completeness($product_ref, $changes_ref, $blame_ref);
 			compute_data_sources($product_ref, $changes_ref);
 			store_object("$BASE_DIRS{PRODUCTS}/$path/changes", $changes_ref);
 		}


### PR DESCRIPTION
and some call to compute_product_history_and_completeness

ex: http://world.openfoodfacts.localhost/api/v2/product/5601244500087/?blame=1
<img width="1061" height="740" alt="Capture d’écran du 2025-08-27 10-42-35" src="https://github.com/user-attachments/assets/1cb2e524-f06d-4a0d-93da-139fd4811eb5" />
<img width="1061" height="564" alt="Capture d’écran du 2025-08-27 10-42-58" src="https://github.com/user-attachments/assets/654bbd26-fd61-4978-9dcb-eb7cb257937b" />

