### PR TITLE
fix: use added sugars value from nutrition facts in knowledge panel

### DIFF
--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -421,6 +421,7 @@ sub create_panel_from_json_template ($panel_id, $panel_template, $panel_data_ref
 		$panel_json =~ s/href="\//href="$formatted_subdomain\//g;
 
 		# Convert multilines strings between backticks `` into single line strings
+		# We use two backticks `` to remove line breaks and extra spaces
 		# In the template, we use multiline strings for readability
 		# e.g. when we want to generate HTML
 

--- a/lib/ProductOpener/KnowledgePanelsIngredients.pm
+++ b/lib/ProductOpener/KnowledgePanelsIngredients.pm
@@ -194,9 +194,13 @@ sub create_ingredients_added_sugars_panel ($product_ref, $target_lc, $target_cc,
 		# Estimate the % of added sugars
 		my $added_sugars_percent_estimate = estimate_added_sugars_percent_from_ingredients($product_ref);
 
+		# Get the % of added sugars from the nutrition facts if it is available
+		my $added_sugars_percent_nutrition_facts = deep_get($product_ref, qw(nutriments added-sugars_100g));
+
 		my $panel_data_ref = {
 			ingredients_added_sugars => \@added_sugars_ingredients,
-			added_sugars_percent_estimate => $added_sugars_percent_estimate
+			added_sugars_percent_estimate => $added_sugars_percent_estimate,
+			added_sugars_percent_nutrition_facts => $added_sugars_percent_nutrition_facts,
 		};
 
 		# Get the most specific category so that we can link to the category without added sugars

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -7608,6 +7608,10 @@ msgctxt "estimated_quantity_of_added_sugars"
 msgid "Estimated quantity of added sugars in ingredients"
 msgstr "Estimated quantity of added sugars in ingredients"
 
+msgctxt "quantity_of_added_sugars"
+msgid "Quantity of added sugars"
+msgstr "Quantity of added sugars"
+
 msgctxt "search_products_in_same_category_without_added_sugars"
 msgid "Search for products in the same category without added sugars:"
 msgstr "Search for products in the same category without added sugars:"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -7575,6 +7575,10 @@ msgctxt "estimated_quantity_of_added_sugars"
 msgid "Estimated quantity of added sugars in ingredients"
 msgstr "Estimated quantity of added sugars in ingredients"
 
+msgctxt "quantity_of_added_sugars"
+msgid "Quantity of added sugars"
+msgstr "Quantity of added sugars"
+
 msgctxt "search_products_in_same_category_without_added_sugars"
 msgid "Search for products in the same category without added sugars:"
 msgstr "Search for products in the same category without added sugars:"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -7537,6 +7537,10 @@ msgctxt "estimated_quantity_of_added_sugars"
 msgid "Estimated quantity of added sugars in ingredients"
 msgstr "Quantité estimée de sucres ajoutés dans les ingrédients"
 
+msgctxt "quantity_of_added_sugars"
+msgid "Quantity of added sugars"
+msgstr "Quantité de sucres ajoutés"
+
 msgctxt "search_products_in_same_category_without_added_sugars"
 msgid "Search for products in the same category without added sugars:"
 msgstr "Chercher des produits de la même catégorie sans sucres ajoutés :"

--- a/templates/api/knowledge-panels/health/ingredients/ingredients_added_sugars.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients_added_sugars.tt.json
@@ -6,7 +6,13 @@
     "expanded": false,
     "evaluation": "bad",
     "title_element": {
-        "title":"[% edq(lang("knowledge_panels_ingredients_added_sugars_title")) %][% IF panel.added_sugars_percent_estimate %] (~ [% sprintf("%d", panel.added_sugars_percent_estimate) %]%)[% END %]",
+        "title":``[% edq(lang("knowledge_panels_ingredients_added_sugars_title")) %]
+            [% IF panel.added_sugars_percent_nutrition_facts %]
+                ([% sprintf("%d", panel.added_sugars_percent_nutrition_facts) %]%)
+            [% ELSIF panel.added_sugars_percent_estimate %]
+                (~ [% sprintf("%d", panel.added_sugars_percent_estimate) %]%)
+            [% END %]
+            ``,
         "subtitle": "[% edq(lang("knowledge_panels_ingredients_added_sugars_subtitle")) %] [% display_taxonomy_tags_list("ingredients", panel.ingredients_added_sugars) %]",
         "icon_url": "[% static_subdomain %]/images/attributes/dist/nutrient-level-sugars-high.svg",
     },
@@ -17,7 +23,11 @@
             "text_element": {
                 "html":
                 `
+[% IF panel.added_sugars_percent_nutrition_facts %]
+<b>[% lang("quantity_of_added_sugars") %][% sep %]:</b> [% sprintf("%d", panel.added_sugars_percent_nutrition_facts) %]%               
+[% ELSE %]
 <b>[% lang("estimated_quantity_of_added_sugars") %][% sep %]:</b> [% sprintf("%d", panel.added_sugars_percent_estimate) %]%
+[% END %]
                 `,    
             },
         },


### PR DESCRIPTION
We currently always use the estimated added sugar percent from ingredient analysis for the Added sugars knowledge panel.
For some products, we can have added sugars specified in the nutrition facts, so we now use those by priority.

Before:

<img width="495" height="168" alt="image" src="https://github.com/user-attachments/assets/45788716-ece5-4daa-a865-529c7e8d37a1" />

After:

<img width="495" height="168" alt="image" src="https://github.com/user-attachments/assets/95cfb606-e334-4846-b1c6-721a0164d531" />

