### PR TITLE
fix: Not able to add products without a bar code

### DIFF
--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -288,6 +288,11 @@ Write a JSON file with exclusive file locking
 =cut
 
 sub write_json($file_path, $ref) {
+	# If $ref is to a scalar then dereference it first
+	if (ref $ref eq 'SCALAR') {
+		$ref = $$ref;
+	}
+
 	# Open in append mode so that we can get a lock on the file before it is wiped
 	open(my $OUT, ">>", $file_path) or die "Can't write to $file_path";
 
@@ -347,7 +352,12 @@ Reads from a JSON file with shared file locking. Returns a hash. Dies on error
 =cut
 
 sub read_json($file_path) {
-	return $json_for_objects->decode(read_json_raw($file_path));
+	my $ref = $json_for_objects->decode(read_json_raw($file_path));
+	# return a reference if it isn't one already
+	if (ref $ref eq '') {
+		return \$ref;
+	}
+	return $ref;
 }
 
 =head2 store_object ($path, $ref)

--- a/tests/unit/store.t
+++ b/tests/unit/store.t
@@ -258,6 +258,13 @@ sub write_file($file_path, $content) {
 	ok((-e "$test_path-blessed.json"), "Verify that blessed objects are saved to json");
 	is(retrieve_object("$test_path-blessed"), {id => 10, true => true, false => false}, "Blessed objects retrieved OK");
 
+	# Converts to and from reference
+	my $raw_value = 'test';
+	store_object("$test_path-ref", \$raw_value);
+	my $ref_value = retrieve_object("$test_path-ref");
+	is(ref $ref_value, 'SCALAR', "Returns a reference to a scalar");
+	is($$ref_value, $raw_value, "Values match");
+
 	# Enable these on an ad-hoc basis to test locking. Can't leave enabled as coverage doesn't support threading
 	# use threads;
 	# # Verify that read waits for a current write to complete


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

Getting an error when adding a product without a bar code. Was caused because we store the last number in a file but the JSON serialization was not coping with this

Fixed by converting to and from refs when dealing with scalars

- Fixes #12331

