### PR TITLE
fix: add energy and proteins for pet food nutrition

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -931,7 +931,8 @@ It is a list of nutrients names with eventual prefixes and suffixes:
 			'ammonium-chloride-', 'calcium-iodate-anhydrous-',
 			'cassia-gum-', 'choline-chloride-', 'copper-ii-sulphate-pentahydrate-',
 			'iron-ii-sulphate-monohydrate-', 'manganous-sulphate-monohydrate-',
-			'potassium-iodide-', 'sodium-selenite-', 'zinc-sulphate-monohydrate-'
+			'potassium-iodide-', 'sodium-selenite-', 'zinc-sulphate-monohydrate-',
+			'!energy-kj', '!energy-kcal', 'proteins-'
 		)
 	]
 );

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -932,7 +932,7 @@ It is a list of nutrients names with eventual prefixes and suffixes:
 			'cassia-gum-', 'choline-chloride-', 'copper-ii-sulphate-pentahydrate-',
 			'iron-ii-sulphate-monohydrate-', 'manganous-sulphate-monohydrate-',
 			'potassium-iodide-', 'sodium-selenite-', 'zinc-sulphate-monohydrate-',
-			'!energy-kj', '!energy-kcal', 'proteins-'
+			'!energy-kj', '!energy-kcal', 'protein-value-'
 		)
 	]
 );

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -6978,6 +6978,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Glutathione
 # following nutrients are for pet food
 # https://eur-lex.europa.eu/eli/reg/2009/767/2018-12-26
 # I- analytical constituents
+# crude fat ~ similar to human food fat
 zz: crude fat
 xx: crude fat
 en: crude fat, Fat Content
@@ -7006,6 +7007,8 @@ sl: surove maščobe, Vsebnost maščob
 sv: råfett, fettinnehåll
 unit:en: %
 
+# crude protein ~ similar to human food protein
+# protein value ~ how much the animal can actually use
 zz: crude protein
 xx: crude protein
 en: crude protein
@@ -7203,3 +7206,33 @@ fr: chlorure de choline
 hr: kolin klorid
 unit:en: mg
 
+
+# crude protein ~ similar to human food protein
+# protein value ~ how much the animal can actually use
+zz: protein value
+xx: protein value
+en: protein value
+bg: Протеинова стойност
+cs: hodnota proteinu
+da: proteinværdi
+de: Eiweißwert, Proteinwert
+el: Πρωτεϊνική αξία
+es: Valor proteico
+et: valgusisaldusväärtus
+fi: proteiiniarvo
+fr: valeur protéique
+hr: proteinska vrijednost
+hu: fehérjeérték
+it: valore proteico
+lt: baltymų vertė
+lv: proteīna vērtība
+mt: valur tal-proteina
+nl: eiwitwaarde
+pl: wartość białka
+pt: valor proteico
+ro: valoare proteică
+ru: Протеиновая ценность
+sk: hodnota bielkovín
+sl: beljakovinska vrednost
+sv: proteinvärde
+unit:en: g/kg


### PR DESCRIPTION
### What

Reported on Slack that energy appears on pet food nutrition facts.

As mentioned in EU regulation - https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02009R0767-20181226&qid=1734788661215 - enegy and proteins can appear (optional) on the packages. 

Hence, this PR adds energy (always visible) and proteins (not visible)


### Screenshot
#### BEFORE
<img width="939" height="519" alt="Screenshot_20250906_221720" src="https://github.com/user-attachments/assets/0ad82bfe-d635-49e4-81f3-686fa204d06d" />


#### AFTER
<img width="496" height="583" alt="Screenshot_20250906_225926" src="https://github.com/user-attachments/assets/aa686628-65b4-4475-a475-3287dee9d48e" />



### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #-none- (on Slack)
