### PR TITLE
fix: free space during workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,6 +89,17 @@ jobs:
         restore-keys: taxonomies-
     - name: build
       run: make build container=backend
+    - name: Free disk space
+      run: |
+        echo "Before cleanup:"
+        df -h
+        docker system prune -af || true
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /usr/local/share/boost || true
+        echo "After cleanup:"
+        df -h
     - name: push backend image as artifact
       uses: ishworkh/container-image-artifact-upload@v2.0.0
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         echo "Before cleanup:"
         df -h
-        docker system prune -af || true
+        docker system prune -f || true
         sudo rm -rf /usr/local/lib/android || true
         sudo rm -rf /opt/ghc || true
         sudo rm -rf /usr/share/dotnet || true


### PR DESCRIPTION
### What

Github workflow is failing on the following PR: https://github.com/openfoodfacts/openfoodfacts-server/pull/12262

Due to 
> ##[error]Error: Command failed: docker save openfoodfacts-server/backend:dev -o /tmp/openfoodfacts-server_backend_dev
> write /tmp/.docker_temp_901694671: no space left on device

The following PR attempt to free some space before to call "ishworkh/container-image-artifact-upload@v2.0.0" step in "build_backend:" job

### Screenshot
<img width="1332" height="650" alt="Screenshot_20250907_221917" src="https://github.com/user-attachments/assets/c4e9b6cc-851b-44c0-974e-09277d537677" />

### Related issue(s) and discussion
- Fixes #-none-
