### PR TITLE
chore(deps): upgrade openfoodfacts-webcomponent to 1.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@openfoodfacts/openfoodfacts-nodejs": "2.0.0-alpha.16",
-        "@openfoodfacts/openfoodfacts-webcomponents": "1.13.1",
+        "@openfoodfacts/openfoodfacts-webcomponents": "1.13.2",
         "@snyk/protect": "^1.1299.0",
         "@webcomponents/webcomponentsjs": "2.8.0",
         "@yaireo/tagify": ">=4.12.0 <4.36.0",
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@openfoodfacts/openfoodfacts-webcomponents": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-webcomponents/-/openfoodfacts-webcomponents-1.13.1.tgz",
-      "integrity": "sha512-SS9T3bWswRVBJxJkoodyJGpl6DEBGQCO/5aIUmDKJDnfd67+OBq/OU9KM+D+CMRy5Xgq2sCcHl/iIv8i4DfsFA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-webcomponents/-/openfoodfacts-webcomponents-1.13.2.tgz",
+      "integrity": "sha512-kjMNB9ewQ6W82auopcb4bB2Wmenk6llQTppQhdDbOskugXP7sXIleBOOzIyueZqCg/GtSrEm7r+n19aFPl8IOA==",
       "license": "LGPL-2.1-or-later",
       "dependencies": {
         "@lit-labs/signals": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "select2": "~4.0",
     "jsbarcode": "^3.12.1",
     "@openfoodfacts/openfoodfacts-nodejs": "2.0.0-alpha.16",
-    "@openfoodfacts/openfoodfacts-webcomponents": "1.13.1"
+    "@openfoodfacts/openfoodfacts-webcomponents": "1.13.2"
   },
   "devDependencies": {
     "@babel/core": "^7.28.3",


### PR DESCRIPTION
There was a major regression on Robotoff webcomponent on version 1.13.1.