### PR TITLE
fix: do not consider microbial cultures and enzymes NOVA 3 markers

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -1136,7 +1136,7 @@ pt: Cultura microbial
 ro: Culturi microbiene
 sv: mikrobiell kultur, kultur, aktiva kulturer, levande kulturer, bakteriekultur
 # ingredient/culture has 683 products in 3 languages @2018-12-27
-nova:en: 3
+# note: microbial culture is not a NOVA 3 marker, it is contained in plain yoghurts that are NOVA 1
 vegan:en: maybe
 vegetarian:en: maybe
 wikipedia:en: https://en.wikipedia.org/wiki/Microbiological_culture
@@ -1704,7 +1704,8 @@ ur: خامرہ
 vi: enzym
 yi: ענזים
 zh: 酶
-nova:en: 3
+# enzymes should not be a NOVA 3 marker, commenting line below
+# nova:en: 3
 vegan:en: maybe
 vegetarian:en: maybe
 # als:Enzym
@@ -2171,7 +2172,6 @@ ko: 발효유
 lv: Skābpiena produkti
 ru: Кисломолочные продукты
 uk: Кисломолочний продукт
-# nova:en:4 should be set by children
 vegan:en: no
 vegetarian:en: maybe
 wikidata:en: Q3506176
@@ -2196,8 +2196,6 @@ ciqual_food_name:fr: Lait 2e âge, poudre soluble (préparation de suite)
 # description:en:BUTTER is a dairy product with high butterfat content which is solid when chilled and at room temperature in some regions, and liquid when warmed. It is made by churning fresh or fermented cream or milk to separate the butterfat from the buttermilk. It is generally used as a spread on plain or toasted bread products and a condiment on cooked vegetables, as well as in cooking, such as baking, sauce making, and pan frying.
 # comment:en:Butter is not added to the fat section (to much water?)
 
-# nova:en:butter
-# from:en:milk
 < en:dairy
 en: butter
 am: ቅቤ
@@ -3624,7 +3622,6 @@ vegetarian:en: yes
 
 ################################ MILK POWDERS ##################################
 
-# nova:en:milk-powder
 #process:en: en:powder
 < en:dairy
 en: milk powder, powdered milk, dry milk

--- a/tests/unit/expected_test_results/attributes/en-maybe-vegan.json
+++ b/tests/unit/expected_test_results/attributes/en-maybe-vegan.json
@@ -751,10 +751,6 @@
          [
             "ingredients",
             "en:starch"
-         ],
-         [
-            "ingredients",
-            "en:enzyme"
          ]
       ]
    },

--- a/tests/unit/expected_test_results/attributes/en-nova-groups-markers.json
+++ b/tests/unit/expected_test_results/attributes/en-nova-groups-markers.json
@@ -996,10 +996,6 @@
          [
             "ingredients",
             "en:sugar"
-         ],
-         [
-            "ingredients",
-            "en:microbial-culture"
          ]
       ],
       "4" : [


### PR DESCRIPTION
We mistakenly mark some plain yoghurts as NOVA 3 because of the microbial culture. They should be NOVA 1.