### PR TITLE
chore: Update front_lint command to remove --fix option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ front_npm_update:
 	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm update
 
 front_lint:
-	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm run lint --fix
+	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm run lint
 
 front_build:
 	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm run build


### PR DESCRIPTION
### What

Removed the '--fix' option from the npm lint command in the Makefile. `make front_lint` is run as a PR check. It's supposed to fail in case of an error. Using the `--fix` option would hide JS/CSS/SCSS issues.

### Screenshot

N/A

### Related issue(s) and discussion

It looks like the parameter was added in 209a7338bd7567e60cbaf5fce57af1f1685014f9 by accident.