### PR TITLE
fix: add new make restart_backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,11 @@ restart: run_deps
 	${DOCKER_COMPOSE} restart backend frontend
 	@echo "🥫  started service at http://openfoodfacts.localhost"
 
+restart_backend:
+	@echo "🥫 Restarting backend container …"
+	${DOCKER_COMPOSE} restart backend
+	@echo "🥫 Apache restarted successfully at http://openfoodfacts.localhost"
+
 stop: stop_deps
 	@echo "🥫 Stopping containers …"
 	${DOCKER_COMPOSE} stop


### PR DESCRIPTION
I'm very often using "make restart" when I code (because of changes to .pm files). It's taking a bit more time than before because it restarts the dependencies.

This new "make restart_backend" only restarts Apache. It takes 10 seconds instead of 15. Not big but I run this command a lot. :) 