### PR TITLE
fix: product edit cancel button

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -818,7 +818,7 @@ const maximumRecentEntriesPerTag = 10;
     };
 
     $('#back-btn').click(function () {
-        window.location.href = window.location.origin + '/product/' + window.code;
+        window.location.href = window.location.origin + '/product/' + code;
     });
 
     initLanguageAdding();


### PR DESCRIPTION
I changed "var code;" to "let code;" because eslint was complaining in https://github.com/openfoodfacts/openfoodfacts-server/pull/12321
but it seems to have the side effect that window.code doesn't exist anymore. So replaced with code.

fixes #12392