### PR TITLE
fix: upgrade to webcomponents 1.14.1 to unbreak them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@openfoodfacts/openfoodfacts-nodejs": "2.0.0-alpha.18",
-        "@openfoodfacts/openfoodfacts-webcomponents": "1.14.0",
+        "@openfoodfacts/openfoodfacts-webcomponents": "1.14.1",
         "@snyk/protect": "^1.1299.0",
         "@webcomponents/webcomponentsjs": "2.8.0",
         "@yaireo/tagify": ">=4.12.0 <4.36.0",
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@openfoodfacts/openfoodfacts-webcomponents": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-webcomponents/-/openfoodfacts-webcomponents-1.14.0.tgz",
-      "integrity": "sha512-OrP5/2CXjjo2nkNArQAVtgaP2M9qvvseQCkEEcgCLvVDsQP2jI9N2wLZuFuRR9TgnLvxifCPcd6ppPjdvjZa4A==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-webcomponents/-/openfoodfacts-webcomponents-1.14.1.tgz",
+      "integrity": "sha512-LpBYV+l6/9iVm4n1j3PsarNI9j2ikod7BeC2U2alKI/sIcYxvGxoCdbdkTcX27NhQMlotbFifHsm8JlwSEf8Sg==",
       "license": "LGPL-2.1-or-later",
       "dependencies": {
         "@lit-labs/signals": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "select2": "~4.0",
     "jsbarcode": "^3.12.1",
     "@openfoodfacts/openfoodfacts-nodejs": "2.0.0-alpha.18",
-    "@openfoodfacts/openfoodfacts-webcomponents": "1.14.0"
+    "@openfoodfacts/openfoodfacts-webcomponents": "1.14.1"
   },
   "devDependencies": {
     "@babel/core": "^7.28.3",


### PR DESCRIPTION
This upgrade to webcomponents version 1.14.1 fixes webcomponents in general, but another upgrade to 1.14.2 is needed to get the Robotoff contributions to ingredients and nutrients working: openfoodfacts/openfoodfacts-server#12408