### PR TITLE
chore: Need to use backchannel URL for Keycloak

### DIFF
--- a/env/env.obf
+++ b/env/env.obf
@@ -16,6 +16,5 @@ NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
 #11901: Remove once production is migrated. Initially duplicate STO and JSON
 SERIALIZE_TO_JSON=1
 
-OIDC_DISCOVERY_URL=https://auth.openfoodfacts.org/realms/openfoodfacts/.well-known/openid-configuration
-OIDC_CLIENT_ID=OBF
-# oidc_client_secret and implementation level is set in Config2
+OIDC_DISCOVERY_URL=http://10.1.0.104:5600/realms/openfoodfacts/.well-known/openid-configuration
+# oidc_client_id, oidc_client_secret and implementation level is set in Config2

--- a/env/env.off
+++ b/env/env.off
@@ -16,6 +16,5 @@ NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
 #11901: Remove once production is migrated. Initially duplicate STO and JSON
 SERIALIZE_TO_JSON=1
 
-OIDC_DISCOVERY_URL=https://auth.openfoodfacts.org/realms/openfoodfacts/.well-known/openid-configuration
-OIDC_CLIENT_ID=OFF
-# oidc_client_secret and implementation level is set in Config2
+OIDC_DISCOVERY_URL=http://10.1.0.104:5600/realms/openfoodfacts/.well-known/openid-configuration
+# oidc_client_id, oidc_client_secret and implementation level is set in Config2

--- a/env/env.off-pro
+++ b/env/env.off-pro
@@ -21,6 +21,5 @@ PRODUCT_OPENER_FLAVOR_SHORT=off
 #11901: Remove once production is migrated. Initially duplicate STO and JSON
 SERIALIZE_TO_JSON=1
 
-OIDC_DISCOVERY_URL=https://auth.openfoodfacts.org/realms/openfoodfacts/.well-known/openid-configuration
-OIDC_CLIENT_ID=OFF_PRO
-# oidc_client_secret and implementation level is set in Config2
+OIDC_DISCOVERY_URL=http://10.1.0.104:5600/realms/openfoodfacts/.well-known/openid-configuration
+# oidc_client_id, oidc_client_secret and implementation level is set in Config2

--- a/env/env.opf
+++ b/env/env.opf
@@ -15,6 +15,5 @@ NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
 #11901: Remove once production is migrated. Initially duplicate STO and JSON
 SERIALIZE_TO_JSON=1
 
-OIDC_DISCOVERY_URL=https://auth.openfoodfacts.org/realms/openfoodfacts/.well-known/openid-configuration
-OIDC_CLIENT_ID=OPF
-# oidc_client_secret and implementation level is set in Config2
+OIDC_DISCOVERY_URL=http://10.1.0.104:5600/realms/openfoodfacts/.well-known/openid-configuration
+# oidc_client_id, oidc_client_secret and implementation level is set in Config2

--- a/env/env.opff
+++ b/env/env.opff
@@ -16,6 +16,5 @@ NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
 #11901: Remove once production is migrated. Initially duplicate STO and JSON
 SERIALIZE_TO_JSON=1
 
-OIDC_DISCOVERY_URL=https://auth.openfoodfacts.org/realms/openfoodfacts/.well-known/openid-configuration
-OIDC_CLIENT_ID=OPFF
-# oidc_client_secret and implementation level is set in Config2
+OIDC_DISCOVERY_URL=http://10.1.0.104:5600/realms/openfoodfacts/.well-known/openid-configuration
+# oidc_client_id, oidc_client_secret and implementation level is set in Config2

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2688,7 +2688,9 @@ sub retrieve_tags_taxonomy ($tagtype, $die_if_taxonomy_cannot_be_loaded = 0) {
 }
 
 sub country_to_cc ($country) {
-
+	if (not defined $country) {
+		return;
+	}
 	if ($country eq 'en:world') {
 		return 'world';
 	}

--- a/tests/unit/tags.t
+++ b/tests/unit/tags.t
@@ -916,6 +916,7 @@ is(
 is(country_to_cc('en:france'), 'fr');
 is(country_to_cc('en:world'), 'world');
 is(country_to_cc('unknown'), undef);
+is(country_to_cc(undef), undef);
 is(cc_to_country('fr'), 'en:france');
 is(cc_to_country('unknown'), 'en:world');
 is(cc_to_country(undef), 'en:world');


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

Can't use the public URL from the backend servers. Also removed redundant client_id from envorinment files.

Fixed cc_to_country to cope with undefined input
