### PR TITLE
taxonomy: synonym mustard czech

### DIFF
--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -399,7 +399,7 @@ wikidata:en: Q28298
 en: mustard, brassica
 ar: خردل
 bg: синап, бял синап
-cs: hořčice
+cs: hořčice, hořčiči
 da: sennep, sennepsfrø, sennepspulver, dijonsennep
 de: Senf, Senfkörner, Senfmehl, Senfsaat, Senfsaaten, Senfsamen, Senfschrot, Senfkorn
 el: σινάπι, μουστάρδα


### PR DESCRIPTION
Added a synonym of mustard in czech based on a product containing this allergen: https://world.openfoodfacts.org/product/5051007128902/2-tortillas-mexicana-tesco
https://en.wiktionary.org/wiki/ho%C5%99%C4%8Dice