### PR TITLE
taxonomy: correction stuffed tomatoes with rice

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -79925,9 +79925,8 @@ ciqual_food_name:en: Stuffed tomatoes
 ciqual_food_name:fr: Tomate farcie
 wikidata:en: Q6778637
 
-< en:Prepared vegetables
 < en:Rice dishes
-en: Rice stuffed tomatoes
+en: Stuffed tomatoes with rice, Rice stuffed tomatoes
 fr: Tomates farcies et riz, tomates farcies au riz, Tomate farcie au riz
 hr: Rižom punjene rajčice
 lt: Ryžiais įdaryti pomidorai


### PR DESCRIPTION
"Tomates farcies et riz" was badly translated as "Rice stuffed tomatoes" instead of "Stuffed tomatoes with rice". The rice is on the side. This category doesn't go in "en:Prepared vegetables" since the main ingredient is rice.