### PR TITLE
taxonomy: Cheese modifications

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -44746,7 +44746,7 @@ fr: Préparations pour fondue
 
 < en:Cheese preparations
 en: Processed cheeses, Processed cheese, Melted cheese
-bg: Преработени сирена, 
+bg: Преработени сирена, Топено сирене
 de: Schmelzkäse
 es: Queso procesado, Queso fundido
 fi: sulatejuusto, sulatettu juusto


### PR DESCRIPTION
I merged "fromages fondus" and "fromages à pâte fondue" which are the same thing according to Wikipedia. I split the category "fr: Fondues". This is a French meal made of a preparation of melted cheese and wine in which you soak bread pieces. The category contained both the preparation of cheese and wine that you just have to heat up and some grated cheese that you have to prepare. I created two categories "Preparations for fondue" and "Grated cheeses for fondue". Finally I created a category "Cheese preparations" to put the "Preparations for fondue" and the processed/melted cheeses.