### PR TITLE
chore: Use slim base image and don't install recommended packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ ARG CPANMOPTS=
 ######################
 # Base modperl image stage
 ######################
-FROM debian:bullseye AS modperl
+FROM debian:bullseye-slim AS modperl
 
 # Install cpm to install cpanfile dependencies
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt set -x && \
-    apt update && \
-    apt install -y \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         apache2 \
         apt-utils \
         cpanminus \
@@ -45,6 +45,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
         # Packages from ./cpanfile:
         # If cpanfile specifies a newer version than apt has, cpanm will install the newer version.
         #
+        libfile-slurp-perl \
         libtie-ixhash-perl \
         libwww-perl \
         libimage-magick-perl \
@@ -87,9 +88,9 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt set -x && \
     # rerun apt update, because last RUN might be in cache
     ( ( [ ! -e /var/cache/apt/pkgcache.bin ] || [ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ] ) && \
-      apt update || true \
+      apt-get update || true \
     ) && \
-    apt install -y \
+    apt-get install -y --no-install-recommends \
         #
         # cpan dependencies that can be satisfied by apt even if the package itself can't:
         #
@@ -221,7 +222,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     set -x && \
     # also run apt update if needed because some package might need to apt install
     ( ( [ ! -e /var/cache/apt/pkgcache.bin ] || [ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ] ) && \
-      apt update || true \
+      apt-get update || true \
     ) && \
     # first install some dependencies that are not well handled
     cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ "Apache::Bootstrap" && \

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@
 # If a minimum version number is specified, "cpanm --skip-satisfied" will install a newer version than apt if one is available in cpan.
 requires 'Array::Diff';
 requires 'CGI', '>= 4.53, < 5.0'; # libcgi-pm-perl
+requires 'File::Slurp'; # libfile-slurp-perl
 requires 'Tie::IxHash'; # libtie-ixhash-perl
 requires 'LWP::Authen::Digest'; # libwww-perl
 requires 'LWP::UserAgent'; # libwww-perl


### PR DESCRIPTION
### What

Use slim base image and don't install recommended packages to reduces the image size.

### Screenshot

N/A

### Related issue(s) and discussion

N/A

### Results

#### Original

Uncompressed size (`docker inspect`): 2304932834 Bytes
`docker history`: 
```
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
f2a1c6993135   3 minutes ago   CMD ["apache2ctl" "-D" "FOREGROUND"]            0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   ENTRYPOINT ["/docker-entrypoint.sh"]            0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   USER www-data                                   0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   WORKDIR /opt/product-opener/                    0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY ./docker/docker-entrypoint.sh / # build…   2.35kB    buildkit.dockerfile.v0
<missing>      3 minutes ago   EXPOSE map[80/tcp:{}]                           0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY . /opt/product-opener/ # buildkit          440MB     buildkit.dockerfile.v0
<missing>      3 hours ago     RUN /bin/sh -c mkdir -p var/run/apache2/ && …   1.12MB    buildkit.dockerfile.v0
<missing>      3 hours ago     RUN /bin/sh -c a2dismod mpm_event &&     a2e…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago     ENV PATH=/opt/perl/local/bin:/usr/local/sbin…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago     ENV PERL5LIB=/opt/product-opener/lib/:/opt/p…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago     COPY /tmp/local/ /opt/perl/local/ # buildkit    92.6MB    buildkit.dockerfile.v0
<missing>      7 hours ago     RUN /bin/sh -c rm /etc/apache2/sites-enabled…   0B        buildkit.dockerfile.v0
<missing>      7 hours ago     RUN |3 ZXING_VERSION=2.3.0 USER_UID=1000 USE…   329kB     buildkit.dockerfile.v0
<missing>      7 hours ago     ARG USER_GID                                    0B        buildkit.dockerfile.v0
<missing>      7 hours ago     ARG USER_UID                                    0B        buildkit.dockerfile.v0
<missing>      7 hours ago     RUN |1 ZXING_VERSION=2.3.0 /bin/sh -c set -x…   1.1MB     buildkit.dockerfile.v0
<missing>      7 hours ago     ARG ZXING_VERSION=2.3.0                         0B        buildkit.dockerfile.v0
<missing>      7 hours ago     RUN /bin/sh -c set -x &&     ( ( [ ! -e /var…   940MB     buildkit.dockerfile.v0
<missing>      7 hours ago     RUN /bin/sh -c set -x &&     apt update &&  …   706MB     buildkit.dockerfile.v0
<missing>      2 days ago      # debian.sh --arch 'amd64' out/ 'bullseye' '…   124MB     debuerreotype 0.16
```

#### Slimmed

Uncompressed size (`docker inspect`): 1317015765 Bytes
`docker history`:
```
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
759819382980   52 seconds ago   CMD ["apache2ctl" "-D" "FOREGROUND"]            0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   ENTRYPOINT ["/docker-entrypoint.sh"]            0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   USER www-data                                   0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   WORKDIR /opt/product-opener/                    0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   COPY ./docker/docker-entrypoint.sh / # build…   2.35kB    buildkit.dockerfile.v0
<missing>      52 seconds ago   EXPOSE map[80/tcp:{}]                           0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   COPY . /opt/product-opener/ # buildkit          440MB     buildkit.dockerfile.v0
<missing>      57 seconds ago   RUN /bin/sh -c mkdir -p var/run/apache2/ && …   784kB     buildkit.dockerfile.v0
<missing>      58 seconds ago   RUN /bin/sh -c a2dismod mpm_event &&     a2e…   0B        buildkit.dockerfile.v0
<missing>      58 seconds ago   ENV PATH=/opt/perl/local/bin:/usr/local/sbin…   0B        buildkit.dockerfile.v0
<missing>      58 seconds ago   ENV PERL5LIB=/opt/product-opener/lib/:/opt/p…   0B        buildkit.dockerfile.v0
<missing>      58 seconds ago   COPY /tmp/local/ /opt/perl/local/ # buildkit    95.5MB    buildkit.dockerfile.v0
<missing>      3 hours ago      RUN /bin/sh -c rm /etc/apache2/sites-enabled…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago      RUN |3 ZXING_VERSION=2.3.0 USER_UID=1000 USE…   328kB     buildkit.dockerfile.v0
<missing>      3 hours ago      ARG USER_GID                                    0B        buildkit.dockerfile.v0
<missing>      3 hours ago      ARG USER_UID                                    0B        buildkit.dockerfile.v0
<missing>      3 hours ago      RUN |1 ZXING_VERSION=2.3.0 /bin/sh -c set -x…   1.1MB     buildkit.dockerfile.v0
<missing>      3 hours ago      ARG ZXING_VERSION=2.3.0                         0B        buildkit.dockerfile.v0
<missing>      3 hours ago      RUN /bin/sh -c set -x &&     ( ( [ ! -e /var…   185MB     buildkit.dockerfile.v0
<missing>      3 hours ago      RUN /bin/sh -c set -x &&     apt-get update …   513MB     buildkit.dockerfile.v0
<missing>      2 days ago       # debian.sh --arch 'amd64' out/ 'bullseye' '…   80.7MB    debuerreotype 0.16
```

Most savings seem to stem from not installing all recommended packages. If we need anything, we should add it as an explicit dependency.