### PR TITLE
taxonomy: fix some whole and semi-whole pastas categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -95647,7 +95647,7 @@ pl: Makarony z pszenicy durum, Makaron z pszenicy durum
 ru: Макаронные изделия из муки твёрдой пшеницы, макаронные изделия из муки твердой пшеницы, макаронные изделия группы А, Макаронные изделия. Группа «А»
 sv: Durumvetepasta, Pasta av durumvete
 
-< en:Durum wheat pasta
+< en: Whole or semi-whole durum wheat pasta
 en: Whole durum wheat pasta, durum wholewheat pasta
 es: Pastas de trigo duro integrales
 fr: Pâtes de blé dur complet
@@ -95659,7 +95659,8 @@ nl: Volkoren durum pasta
 en: Durum wheat pasta vysshiy sort GOST
 ru: Макаронные изделия группы А высший сорт по ГОСТ, Макаронные изделия группы А высшего сорта по ГОСТ, макаронные изделия из муки твёрдой пшеницы высший сорт ГОСТ
 
-< en:Durum wheat pasta
+< en: Whole or semi-whole durum wheat pasta
+en: Semi-whole durum wheat pasta
 es: Pastas de trigo duro semi-integrales
 fr: Pâtes de blé dur semi-complet
 it: Pasta di grano duro semi integrale
@@ -95917,9 +95918,11 @@ fr: Cannelloni à la ricotta et aux épinards
 fr: Coquillettes, coquillette
 wikidata:en: Q2996948
 
+< en: Whole durum wheat pasta
 < fr:Coquillettes
 fr: Coquillettes complètes
 
+< en:Semi-whole durum wheat pasta
 < fr:Coquillettes
 fr: Coquillettes semi-complètes
 
@@ -96514,7 +96517,7 @@ ru: Спагетти из муки твёрдой пшеницы, спагетт
 
 < en:Durum wheat spaghetti
 < en:Whole durum wheat pasta
-en: Whole durm wheat spaghetti
+en: Whole durum wheat spaghetti
 bg: Пълнозърнести спагети от твърда пшеница
 de: Vollkorn-Hartweizenspaghetti, Vollkorn-Spaghetti, Vollkornspaghetti
 es: Spaghetti di grano duro integrali, Spaghetti integrali


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
the category "Whole or semi-whole pastas" contains now both "Semi-whole pastas" and "Whole pastas".
Added also english translation

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

