### PR TITLE
ci: Add reactions to comments for lint and update tests

### DIFF
--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -14,6 +14,11 @@ jobs:
       (github.event.comment.body == '/lint')
     runs-on: ubuntu-latest
     steps:
+    - name: Add reaction to comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.comment.id }}
+        reactions: eyes
     - name: Get repository, owner and branch name
       # see https://github.com/actions/checkout/issues/331
       id: get-branch
@@ -65,6 +70,11 @@ jobs:
       (github.event.comment.body == '/update_tests_results')
     runs-on: ubuntu-latest
     steps:
+    - name: Add reaction to comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.comment.id }}
+        reactions: eyes
     - name: Get repository, owner and branch name
       # see https://github.com/actions/checkout/issues/331
       id: get-branch


### PR DESCRIPTION

### What
ci: Add reactions to comments for lint and update tests so that the user is confident s(he) didn't do a mistake in invoking update_test_results or lint