### PR TITLE
fix: make dev for pro platform needs postgres

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1170,11 +1170,7 @@ sub store_product ($user_id, $product_ref, $comment, $client_id = undef) {
 		$log->info("changing product type",
 			{old_product_type => $product_ref->{old_product_type}, product_type => $product_ref->{product_type}})
 			if $log->is_info();
-		# We need to remove the product from its previous collection, unless we are on the pro platform
-		# where we have only one collection for all product types
-		if (not $server_options{private_products}) {
-			$delete_from_previous_products_collection = 1;
-		}
+		$delete_from_previous_products_collection = 1;
 		delete $product_ref->{old_product_type};
 	}
 


### PR DESCRIPTION
A PR to be able to run the pro platform in a dev environment. Maybe not the right fix but it unblocks me.

Slack discussions: 

https://openfoodfacts.slack.com/archives/C02LDQDDD/p1759764416701789
https://openfoodfacts.slack.com/archives/C02LDQDDD/p1760090829660309

I'm still struggling to run the pro platform dev environment... If I run "make dev", I get:

`"service "incron" depends on undefined service "postgres": invalid compose project"
`
I can comment out the dependency on "postgres" in docker-compose.yml, and then "make dev" works. But when I run it and it tries to access postgres (the pro platform uses Minion to schedule tasks which uses Postgres), it fails....

`DBI connect('dbname=minion;host=postgres','productopener',...) failed: could not translate host name "postgres" to address: Temporary failure in name resolution at /opt/perl/local/lib/perl5/Mojo/Pg.pm line 73.`


