### PR TITLE
taxonomy: delete "Chocolate yoghurt drinks" category that has no product

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -53370,11 +53370,6 @@ pt: Bebidas de iogurte de baunilha
 ciqual_food_code:en: 19508
 
 < en:Flavoured yogurt drinks
-en: Chocolate yoghurt drinks
-fr: Yaourts à boire goût chocolat
-nl: Yoghurt dranken met chocolade
-
-< en:Flavoured yogurt drinks
 en: Fruit flavoured yogurt drinks
 nl: Fruitdrinkyoghurts, Drinkyoghurts met fruitsmaak
 


### PR DESCRIPTION
There was only [one product](https://world.openfoodfacts.org/product/4025500294014/dairy-milk-mousse-cadbury) in category "Chocolate yoghurt drinks". But I put it in [Chocolate Milk](https://world.openfoodfacts.org/facets/categories/chocolate-milks) instead.
And now the category is empty, so I deleted it as @Freso suggested it in another PR of mine.

Here the link to check [there is no product in the category](https://world.openfoodfacts.org/facets/categories/chocolate-yoghurt-drinks)

<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

