### PR TITLE
taxonomy: Remove `simple` language entries

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -451,7 +451,6 @@ se: Afganistána
 sgs: Afganėstans, Afganistanas
 sh: Afganistan
 si: ඇෆ්ගනිස්ථානය
-simple: Afghanistan
 sk: Afganistan
 sl: Afganistan
 so: Afgaanistan
@@ -686,7 +685,6 @@ se: Albánia
 sg: Albanïi
 sgs: Albanėjė
 sh: Albanija
-simple: Albania
 sk: Albánsko
 sl: Albanija
 so: Albania
@@ -787,7 +785,6 @@ pl: Alderney
 pt: Alderney
 ro: Alderney
 ru: Олдерни, Олдрни, Альдерней
-simple: Alderney
 sk: Alderney
 sl: Alderney
 sr: Олдерни, Alderney
@@ -979,7 +976,6 @@ se: Algeria
 sg: Alazëri
 sgs: Alžīrs
 sh: Alžir
-simple: Algeria
 sk: Alžírsko
 sl: Alžirija
 sm: Algeria
@@ -1124,7 +1120,6 @@ rw: Samowa Nyamerika
 scn: Samoa Miricana
 se: Amerihká Samoa
 sh: Američka Samoa
-simple: American Samoa
 sk: Americká Samoa
 sl: Ameriška Samoa
 sm: Amerika Sāmoa
@@ -1338,7 +1333,6 @@ sg: Andôro
 sgs: Anduora, Andora
 sh: Andora
 si: ඇන්ඩෝරා
-simple: Andorra
 sk: Andorra
 sl: Andora
 so: Andorra
@@ -1560,7 +1554,6 @@ sco: Angolae
 se: Angola
 sg: Angoläa
 sh: Angola
-simple: Angola
 sk: Angola
 sl: Angola
 sn: Angola
@@ -1702,7 +1695,6 @@ ru: Ангилья, Ангуилла, Ангилла
 rue: Анґуіла, Анґуілла
 rw: Angwiya
 sh: Angvila, Angilja, Anguila
-simple: Anguilla
 sk: Anguilla
 sl: Angvila, Anguilla
 sq: Anguilla, Anguillë, Anguila
@@ -1766,7 +1758,6 @@ nb: Antarktis
 pl: Antarktyka
 ro: Antarctica
 ru: Антарктика
-simple: Antarctic
 sq: Antarktis
 tk: Antarktida
 uk: Антарктика
@@ -1934,7 +1925,6 @@ scn: Antàrtidi
 sco: Antarcticae
 se: Antárktis
 sh: Antarktik
-simple: Antarctica
 sk: Antarktída
 sl: Antarktika
 sm: Anetatika
@@ -2112,7 +2102,6 @@ scn: Antigua e Barbuda
 sco: Antigua an Barbuda
 se: Antigua ja Barbuda
 sh: Antigva i Barbuda
-simple: Antigua and Barbuda
 sk: Antigua a Barbuda
 sl: Antigva in Barbuda
 so: Antigua iyo Barbuda
@@ -2335,7 +2324,6 @@ sco: Argentinae
 se: Argentiinná
 sgs: Argentėna, Argentina
 sh: Argentina
-simple: Argentina
 sk: Argentína
 sl: Argentina
 so: Arjantiina
@@ -2568,7 +2556,6 @@ sg: Armenïi
 sgs: Armienėjė
 sh: Jermenija
 si: ආර්මේනියාව
-simple: Armenia
 sk: Arménsko
 sl: Armenija
 sm: Amenia
@@ -2722,7 +2709,6 @@ rw: Aruba
 sah: Аруба
 sgs: Aruba
 sh: Aruba, Аруба
-simple: Aruba
 sk: Aruba
 sl: Aruba
 so: Aruba
@@ -2817,7 +2803,6 @@ pt: Ilha de Ascensão, Ascensão, Ilha Ascensão
 ro: Ascension
 ru: Остров Вознесения, Вознесения Остров, Вознесения
 sh: Otok Ascension, Ascension
-simple: Ascension Island
 sk: Ascension
 sl: Ascension, Otok Ascension
 sr: Асенсион, Акнезијско острво, Ascension
@@ -3024,7 +3009,6 @@ sg: Ostralïi
 sgs: Australėjė
 sh: Australija
 si: ඕස්ට්‍රේලියාව
-simple: Australia
 sk: Austrália
 sl: Avstralija
 sm: Ausetalia
@@ -3277,7 +3261,6 @@ sco: Austrick
 se: Nuortariika
 sh: Austrija
 si: ඔස්ට් රියාව
-simple: Austria
 sk: Rakúsko
 sl: Avstrija
 sm: Austilia
@@ -3521,7 +3504,6 @@ sco: Azerbaijan
 se: Aserbaižan
 sgs: Azėrbaidžians, Azerbaidžans
 sh: Azerbejdžan
-simple: Azerbaijan
 sk: Azerbajdžan
 sl: Azerbajdžan
 sm: Azerbaijin
@@ -3725,7 +3707,6 @@ sco: Bahrain
 se: Bahrain
 sgs: Bahreins
 sh: Bahrein
-simple: Bahrain
 sk: Bahrajn
 sl: Bahrajn
 so: Baxrayn
@@ -3936,7 +3917,6 @@ sd: بنگلاديش
 se: Bangladesh
 sh: Bangladeš
 si: බංගලාදේශය
-simple: Bangladesh
 sk: Bangladéš
 sl: Bangladeš
 so: Bangladesh
@@ -4122,7 +4102,6 @@ scn: Barbados
 sco: Barbados
 se: Barbados
 sh: Barbados
-simple: Barbados
 sk: Barbados
 sl: Barbados
 so: Barbados
@@ -4341,7 +4320,6 @@ se: Vilges-Ruošša
 sg: Belarüsi
 sh: Belorusija
 si: බෙලාරස්
-simple: Belarus
 sk: Bielorusko
 sl: Belorusija
 so: Belarus
@@ -4581,7 +4559,6 @@ se: Belgia
 sg: Bêleze
 sgs: Belgėjė
 sh: Belgija
-simple: Belgium
 sk: Belgicko
 sl: Belgija
 sma: Belgia
@@ -4790,7 +4767,6 @@ se: Belize
 sgs: Belėzos
 sh: Belize
 si: බෙලීස්
-simple: Belize
 sk: Belize
 sl: Belize
 so: Belise
@@ -4982,7 +4958,6 @@ sco: Benin
 se: Benin
 sg: Benëen
 sh: Benin
-simple: Benin
 sk: Benin
 sl: Benin
 sn: Benin
@@ -5125,7 +5100,6 @@ rue: Бермуды
 rw: Berimuda
 scn: Bermuda
 sh: Bermudi, Bermuda
-simple: Bermuda
 sk: Bermudy
 sl: Bermudi, Bermudski otoki, Bermuda, Bermudsko otočje
 so: Bermuda
@@ -5302,7 +5276,6 @@ scn: Bhutan
 sco: Bhutan
 se: Bhutan
 sh: Butan
-simple: Bhutan
 sk: Bhután
 sl: Butan
 so: Butaan
@@ -5516,7 +5489,6 @@ scn: Bolivia
 sco: Bolivie
 se: Bolivia
 sh: Bolivija
-simple: Bolivia
 sk: Bolívia
 sl: Bolivija
 so: Boliifia
@@ -5809,7 +5781,6 @@ se: Bosnia ja Hercegovina
 sgs: Bosnėjė ėr Hercuogovėna, Bosnėjė ė Hercėgovina
 sh: Bosna i Hercegovina
 si: බොස්නියා සහ හර්සගෝවිනා
-simple: Bosnia and Herzegovina
 sk: Bosna a Hercegovina
 sl: Bosna in Hercegovina
 sm: Bosnia ma Herzegovina
@@ -6014,7 +5985,6 @@ sco: Botswana
 se: Botswana
 sg: Botswana
 sh: Bocvana
-simple: Botswana
 sk: Botswana
 sl: Bocvana
 sn: Botswana
@@ -6123,7 +6093,6 @@ ro: Insula Bouvet
 ru: Остров Буве, Буве остров
 rw: Ikirwa cya Bouve
 sh: Otok Bouvet
-simple: Bouvet Island
 sk: Bouvetov ostrov
 sl: Bouvetov otok
 sr: Буве
@@ -6337,7 +6306,6 @@ scn: Brasili
 sco: Brazil
 se: Brasilia
 sh: Brazil
-simple: Brazil
 sk: Brazília
 sl: Brazilija
 so: Barasiil
@@ -6458,7 +6426,6 @@ ro: Teritoriul Britanic din Oceanul Indian
 ru: Британская территория в Индийском океане, Британские территории в Индийском океане, Британская территория Индийского океана
 rw: Teritwari y’Inyanja y’Abahinde Nyongereza
 sh: Britanski teritorij Indijskog oceana, Britanska indijska okeanska teritorija, Britanska Teritorija Indijskog Oceana, Britanska teritorija Indijskog okeana
-simple: British Indian Ocean Territory
 sk: Britské indickooceánske územie
 sl: Britansko ozemlje v Indijskem oceanu, Britanski teritorij v Indijskem oceanu, Britanski indijskooceanski teritorij
 sr: Британска територија Индијског океана, Британска индијска океанска територија, Британска територија у Индијском океану
@@ -6559,7 +6526,6 @@ ru: Британские Виргинские острова, Вирджинск
 rw: Ibirwa bya Virigini Nyongereza
 scn: British Virgin Islands
 sh: Britanski Djevičanski otoci, Britanska Devičanska Ostrva, Devičanska ostrva, Britanska Virdžinska Ostrva
-simple: British Virgin Islands
 sk: Britské Panenské ostrovy
 sl: Britanski Deviški otoki
 sq: Ishujt e Virgjër Britanikë, Ishujt e Virgjër Britanike
@@ -6735,7 +6701,6 @@ se: Brunei
 sg: Brunêi
 sh: Brunej
 si: බෲනායි
-simple: Brunei
 sk: Brunej
 sl: Brunej
 so: Barunay
@@ -6974,7 +6939,6 @@ sg: Bulugarïi
 sgs: Bulgarėjė, Bolgarėjė
 sh: Bugarska, Бугарска
 si: බල්ගේරියාව
-simple: Bulgaria
 sk: Bulharsko, Bulharská republika
 sl: Bolgarija, Republika Bolgarija, Bulgarija, Bulgaria
 sm: Bultalia
@@ -7180,7 +7144,6 @@ sco: Burkina Faso
 se: Burkina Faso
 sg: Burkina Faso
 sh: Burkina Faso
-simple: Burkina Faso
 sk: Burkina
 sl: Burkina Faso
 sn: Burkina Faso
@@ -7379,7 +7342,6 @@ sco: Burundi
 se: Burundi
 sg: Burundïi
 sh: Burundi
-simple: Burundi
 sk: Burundi
 sl: Burundi
 sn: Burundi
@@ -7576,7 +7538,6 @@ sco: Cambodie
 se: Kampučea
 sh: Kambodža
 si: කාම්බෝජය
-simple: Cambodia
 sk: Kambodža
 sl: Kambodža
 so: Kambodiya
@@ -7774,7 +7735,6 @@ se: Kamerun
 sg: Kamerün
 sgs: Kamerūns
 sh: Kamerun
-simple: Cameroon
 sk: Kamerun
 sl: Kamerun
 sn: Cameroon
@@ -8023,7 +7983,6 @@ se: Canada
 sg: Kanadäa
 sgs: Kanada
 sh: Kanada
-simple: Canada
 sk: Kanada
 sl: Kanada
 sn: Canada
@@ -8234,7 +8193,6 @@ se: Kap Verde
 sg: Azûâ tî Kâpo-Vêre
 sgs: Žalėjė Ėškīšolė Respoblėka, Žaliasā Kīšolīs
 sh: Zelenortska Republika
-simple: Cape Verde
 sk: Kapverdy
 sl: Zelenortski otoki
 sn: Cape Verde
@@ -8408,7 +8366,6 @@ ro: Insulele Cayman
 ru: Каймановы острова
 rw: Ibirwa bya Kayimani
 sh: Kajmanski Otoci
-simple: Cayman Islands
 sk: Kajmanie ostrovy
 sl: Kajmanski otoki
 sq: Ishujt Cayman
@@ -8574,7 +8531,6 @@ sco: Central African Republic
 se: Gaska-Afrihká dásseváldi
 sg: Ködörösêse tî Bêafrîka
 sh: Srednjoafrička Republika
-simple: Central African Republic
 sk: Stredoafrická republika
 sl: Srednjeafriška republika
 sn: Central African Republic
@@ -8770,7 +8726,6 @@ se: Chad
 sg: Sâde
 sh: Čad
 si: චෑඩ්
-simple: Chad
 sk: Čad
 sl: Čad
 sn: Chad
@@ -9025,7 +8980,6 @@ se: Chile
 sg: Shilïi
 sh: Čile
 si: චිලි ජනරජය
-simple: Chile
 sk: Čile
 sl: Čile
 so: Jili
@@ -9273,7 +9227,6 @@ se: Kiinná
 sg: Sînä
 sh: Narodna Republika Kina
 si: චීනය
-simple: People's Republic of China
 sk: Čína
 sl: Ljudska republika Kitajska
 sm: Saina
@@ -9404,7 +9357,6 @@ ru: Остров Рождества, Рождества остров
 rw: Ikirwa cya Noheli
 scn: Ìsula Christmas
 sh: Božićni otok, Božićno ostrvo, Božićna ostrva
-simple: Christmas Island
 sk: Vianočný ostrov
 sl: Božični otok
 sr: Божићно Острво, Божићна Острва
@@ -9502,7 +9454,6 @@ ru: Кокосовые острова, Кокосовые (Килинг) ост�
 rw: Ibirwa bya Koko
 scn: Ìsuli Cocos
 sh: Kokosovi Otoci, Kokos (Kiling) Ostrva, Keelingovi otoci, Kokosovi (Keeling) Otoci, Kokosova ostrva, Kokosovi (Keelingovi) Otoci, Kilingova ostrva
-simple: Cocos
 sk: Kokosové ostrovy, Territory of Keeling Islands, Territory of Cocos (Keeling) Islands, Territory of Cocos Islands, Cocos Islands, Keeling Islands
 sr: Кокосова острва, Острва Килинг, Cocos Islands
 su: Kapuloan Cocos, Kapuloan Kokos
@@ -9689,7 +9640,6 @@ sco: Colombie
 se: Kolombia
 sgs: Kuolombėjė, Kolumbijė, Kolumbėjė
 sh: Kolumbija
-simple: Colombia
 sk: Kolumbia
 sl: Kolumbija
 so: Kolombiya
@@ -9876,7 +9826,6 @@ sco: Comoros
 se: Komorosullot
 sg: Kömôro
 sh: Komori
-simple: Comoros
 sk: Komory
 sl: Komori
 sn: Comoros
@@ -10007,7 +9956,6 @@ ru: Острова Кука, Кука острова
 rw: Ibirwa bya Kuke
 scn: Ìsuli Cook
 sh: Kukova Ostrva, Ostrva Kuk, Cookovi otoci, Кукови отоци, Кукова Острва, Kukovi otoci, Otoci Cook, Cook otoci
-simple: Cook Islands
 sk: Cookove ostrovy
 sl: Cookovi otoki, Cookovo otočje
 sr: Кукова Острва, Острва Кук
@@ -10175,7 +10123,6 @@ sco: Costa Rica
 se: Costa Rica
 sh: Kostarika
 si: කෝස්ට රිකා
-simple: Costa Rica
 sk: Kostarika
 sl: Kostarika
 so: Kosta Rika
@@ -10392,7 +10339,6 @@ sco: Croatie
 se: Kroatia
 sg: Kroasïi
 sh: Hrvatska
-simple: Croatia
 sk: Chorvátsko
 sl: Hrvaška
 sm: Croatia
@@ -10606,7 +10552,6 @@ sco: Cuba
 se: Cuba
 sh: Kuba
 si: කියුබාව
-simple: Cuba
 sk: Kuba
 sl: Kuba
 so: Kuuba
@@ -10728,7 +10673,6 @@ ro: Curaçao, Curacao
 ru: Кюрасао
 sco: Curaçao
 sh: Kurasao
-simple: Curaçao
 sk: Curaçao, Curacao
 sr: Курасао, Curaçao
 srn: Korsow, Curacao, Curaçao
@@ -10914,7 +10858,6 @@ se: Kypros
 sgs: Kėpros
 sh: Cipar
 si: සයිප්‍රස්
-simple: Republic of Cyprus
 sk: Cyprus
 sl: Ciper
 sm: Cyprus
@@ -11150,7 +11093,6 @@ sco: Czech Republic
 se: Čeahkka
 sh: Češka Republika
 si: චෙක් ජනරජය
-simple: Czech Republic
 sk: Česko
 sl: Češka
 sm: Czechs Republic
@@ -11352,7 +11294,6 @@ se: Elefántačalánriddu
 sg: Kôdivüära
 sh: Obala Slonovače
 si: අයිවරි කෝස්ට්
-simple: Côte d'Ivoire
 sk: Pobrežie Slonoviny
 sl: Slonokoščena obala
 sn: Côte d'Ivoire
@@ -11541,7 +11482,6 @@ se: Kongo demokráhtalaš dásseváldi
 sg: Kùodùorùosêse tî Ngunuhalëzo tî Kongö
 sh: Demokratska Republika Kongo
 si: කොංගෝ ප්‍රජාතන්ත්‍රවාදී ජනරජය
-simple: Democratic Republic of the Congo
 sl: Demokratična republika Kongo
 sn: Democratic Republic of the Congo
 so: Jamhuuriyada Dimuqaraadiga Kongo
@@ -11779,7 +11719,6 @@ sg: Danemêrke
 sgs: Danėjė
 sh: Danska
 si: ඩෙන්මාර්කය
-simple: Denmark
 sk: Dánsko
 sl: Danska
 sma: Danmaarke
@@ -11979,7 +11918,6 @@ sco: Djibouti
 se: Djibouti
 sg: Dibutùii
 sh: Džibuti
-simple: Djibouti
 sk: Džibutsko
 sl: Džibuti
 sn: Djibouti
@@ -12155,7 +12093,6 @@ sco: Dominica
 se: Dominica
 sgs: Duomėnė̅ka
 sh: Dominika
-simple: Dominica
 sk: Dominika
 sl: Dominika
 so: Dominika
@@ -12327,7 +12264,6 @@ sco: Dominican Republic
 se: Dominikána dásseváldi
 sgs: Duomėnėkas Respoblėka, Duomėnė̅kas Respoblėka, Duomėnė̅kas Respublika
 sh: Dominikanska Republika
-simple: Dominican Republic
 sk: Dominikánska republika
 sl: Dominikanska republika
 sq: Republika Dominikane
@@ -12456,7 +12392,6 @@ sah: ГДР
 scn: Ripùbblica Dimucràtica Tidesca
 sco: East Germany
 sh: Nemačka Demokratska Republika
-simple: German Democratic Republic
 sk: Nemecká demokratická republika
 sl: Nemška demokratična republika
 sq: Gjermania Lindore
@@ -12635,7 +12570,6 @@ sco: Ecuador
 se: Ecuador
 sgs: Ekvaduors
 sh: Ekvador
-simple: Ecuador
 sk: Ekvádor
 sl: Ekvador
 so: Ikwadoor
@@ -12859,7 +12793,6 @@ sco: Egyp
 se: Egypta
 sg: Kâmitâ
 sh: Egipat
-simple: Egypt
 sk: Egypt
 sl: Egipt
 sm: Aikupito
@@ -13058,7 +12991,6 @@ sco: El Salvador
 se: El Salvador
 sh: Salvador
 si: එල් සැල්ව‍ඩෝ
-simple: El Salvador
 sk: Salvádor
 sl: Salvador
 so: El Salfador
@@ -13231,7 +13163,6 @@ sco: Equatorial Guinea
 se: Beaivvedási Guinea
 sg: Ginëe tî Ekuatëre
 sh: Ekvatorijalna Gvineja
-simple: Equatorial Guinea
 sk: Rovníková Guinea
 sl: Ekvatorialna Gvineja
 sn: Equatorial Guinea
@@ -13425,7 +13356,6 @@ sco: Eritrea
 se: Eritrea
 sg: Eritrëe
 sh: Eritreja
-simple: Eritrea
 sk: Eritrea
 sl: Eritreja
 sn: Eritrea
@@ -13661,7 +13591,6 @@ se: Estteeana
 sgs: Estėjė
 sh: Estonija
 si: එස්ටෝනියා
-simple: Estonia
 sk: Estónsko
 sl: Estonija
 sma: Estlaante
@@ -13883,7 +13812,6 @@ se: Etiopia
 sg: Etiopïi
 sh: Etiopija
 si: ඉතියෝපියාව
-simple: Ethiopia
 sk: Etiópia
 sl: Etiopija
 sm: Ethiopia
@@ -14087,7 +14015,6 @@ sco: European Union
 se: Eurohpá Uniovdna
 sh: Evropska unija
 si: යුරෝපා සංගමය
-simple: European Union
 sk: Európska únia
 sl: Evropska unija
 sq: Bashkimi Evropian
@@ -14227,7 +14154,6 @@ sah: Фолклэнд арыылара
 scn: Ìsuli Falkland
 se: Falklandsullot
 sh: Falklandi
-simple: Falkland Islands
 sk: Falklandy
 sl: Falklandski otoki
 sq: Ishujt Falkland
@@ -14371,7 +14297,6 @@ sco: Faroe Islands, Faroes, The Faroe Islands
 se: Fearsullot
 sh: Farski Otoci, Ovčji Otoci, Фарска острва, Farska Ostrva, Føroyar
 si: ෆාරෝ දිවයින්
-simple: Faroe Islands
 sk: Faerské ostrovy
 sl: Ferski otoki, Farski otoki
 so: Jasiiradaha Feroe
@@ -14523,7 +14448,6 @@ scn: Stati Fidirati di Micronesia
 sco: Micronesie
 se: Mikronesia
 sh: Mikronezija
-simple: Micronesia
 sk: Mikronézia
 sl: Mikronezija
 sm: Micronisia
@@ -14688,7 +14612,6 @@ se: Fiži
 sg: Fidyïi
 sh: Fidži
 si: ෆීජි
-simple: Fiji
 sk: Fidži
 sl: Fidži
 sm: Fiti
@@ -14921,7 +14844,6 @@ se: Suopma
 sgs: Soumėjė, Soumėjės Respoblėka, Suomėjė
 sh: Finska
 si: ෆින්ලන්තය
-simple: Finland
 sk: Fínsko
 sl: Finska
 sm: Finalagi
@@ -15193,7 +15115,6 @@ se: Frankriika
 sgs: Prancūzėjė, France, République française, Prancozėjė
 sh: Francuska, Француска, Republika Francuska
 si: ප් රංශය
-simple: France
 sk: Francúzsko, Francúzska republika
 sl: Francija
 sm: Farani
@@ -15362,7 +15283,6 @@ scn: Guyana francisi
 sco: French Guiana
 se: Frankriikka Guayana
 sh: Francuska Gvajana
-simple: French Guiana
 sk: Francúzska Guyana
 sl: Francoska Gvajana
 sm: Farani Guiana
@@ -15479,7 +15399,6 @@ scn: Pulinesia francisi, Polinesia francisi, Polinesia Francisa, Pulinesia franc
 se: Frankriikka Polynesia
 sgs: Prancūzėjės Polinezėjė, Prancūzėjės Polėnezėjė, Prancūzijės Polėnezijė
 sh: Francuska Polinezija
-simple: French Polynesia
 sk: Francúzska Polynézia
 sl: Francoska Polinezija
 sr: Француска Полинезија
@@ -15729,7 +15648,6 @@ sg: Gaböon
 sgs: Gabuons
 sh: Gabon
 si: ගැබොන්
-simple: Gabon
 sk: Gabon
 sl: Gabon
 sn: Gabon
@@ -15950,7 +15868,6 @@ sco: The Gambie
 se: Gámbia
 sg: Gambïi
 sh: Gambija
-simple: The Gambia
 sk: Gambia
 sl: Gambija
 sn: Gambia
@@ -16162,7 +16079,6 @@ se: Georgia
 sgs: Grozėjė, Gruzėjė
 sh: Gruzija
 si: ජෝර්ජියා
-simple: Georgia
 sk: Gruzínsko
 sl: Gruzija
 so: Joorjiya
@@ -16422,7 +16338,6 @@ sco: Germany
 se: Duiska
 sh: Nemačka
 si: ජර්මනිය
-simple: Germany
 sk: Nemecko
 sl: Nemčija
 sm: Siamani
@@ -16643,7 +16558,6 @@ sco: Ghana
 se: Ghana
 sg: Ganäa
 sh: Gana
-simple: Ghana
 sk: Ghana
 sl: Gana
 sn: Ghana
@@ -16810,7 +16724,6 @@ rw: Giburalitari
 scn: Gibbilterra
 sco: Gibraltar
 sh: Gibraltar
-simple: Gibraltar
 sk: Gibraltár
 sl: Gibraltar
 so: Jibraltaar
@@ -17028,7 +16941,6 @@ sco: Greece
 se: Greika
 sh: Grčka
 si: ග් රීසිය
-simple: Greece
 sk: Grécko
 sl: Grčija
 sm: Kuliti
@@ -17218,7 +17130,6 @@ sco: Greenland
 se: Kalaallit Nunaat
 sgs: Grenlandėjė
 sh: Grenland
-simple: Greenland
 sk: Grónsko
 sl: Grenlandija
 so: Griinland
@@ -17386,7 +17297,6 @@ scn: Grenada
 sco: Grenada
 se: Grenada
 sh: Grenada
-simple: Grenada
 sk: Grenada
 sl: Grenada
 sq: Grenada
@@ -17512,7 +17422,6 @@ rw: Gwadelupe
 sco: Guadeloupe
 se: Guadeloupe
 sh: Gvadalupa
-simple: Guadeloupe
 sk: Guadeloupe
 sl: Guadeloupe
 sq: Guadalupa
@@ -17624,7 +17533,6 @@ sco: Guam
 se: Guam
 sh: Guam
 si: ගුආම්
-simple: Guam
 sk: Guam
 sl: Guam
 sm: Guam
@@ -17794,7 +17702,6 @@ scn: Guatemala
 sco: Guatemala
 se: Guatemala
 sh: Gvatemala
-simple: Guatemala
 sk: Guatemala
 sl: Gvatemala
 sm: Tuatemala
@@ -17917,7 +17824,6 @@ ru: Гернси, Гернсей
 rw: Gwasi
 sco: Guernsey
 sh: Guernsey, Gernzi, Gernsi, Guernsej
-simple: Guernsey
 sk: Guernsey
 sl: Guernsey
 sq: Guernsey
@@ -18085,7 +17991,6 @@ sco: Guinea
 se: Guinea
 sg: Ginëe
 sh: Gvineja
-simple: Guinea
 sk: Guinea
 sl: Gvineja
 sm: Guinea
@@ -18268,7 +18173,6 @@ sco: Guinea-Bissau
 se: Guinea-Bissau
 sg: Ginëe-Bisau
 sh: Gvineja Bisau
-simple: Guinea-Bissau
 sk: Guinea-Bissau
 sl: Gvineja Bissau
 sn: Guinea-Bissau
@@ -18451,7 +18355,6 @@ sc: Guyana
 sco: Guyana
 se: Guyana
 sh: Gvajana
-simple: Guyana
 sk: Guyana
 sl: Gvajana
 so: Guyana
@@ -18638,7 +18541,6 @@ sco: Haiti
 se: Haiti
 sh: Haiti
 si: හෙයිටි
-simple: Haiti
 sk: Haiti
 sl: Haiti
 so: Haiti
@@ -18725,7 +18627,6 @@ ro: Insula Heard și Insulele McDonald, Insula Heard şi Insulele McDonald
 ru: Остров Херд и острова Макдональд, Херд и Макдональд, Макдоналд, Острова Херд и Макдоналд, Остров Херд и Острова Макдоналд, Острова Хёрд и Макдоналд, Острова Херд и Макдональд, Острова Хеда и Макдоналда, Херд
 rw: Icyirwa Hadi n’Ibirwa MakeDonalidi
 sh: Otok Heard i otočje McDonald, Ostrvo Herd i arhipelag Mekdonald, Otok Heard i Otoci McDonald, Herd i MekDonald ostrva, Heard i McDonald Otoci
-simple: Heard Island and McDonald Islands
 sk: Heardov ostrov, Teritórium Heardovho ostrova a Macdonaldových ostrovov
 sl: Otok Heard in otočje McDonald, Otoki Heard in McDonald, Otočje McDonald, Otok Heard
 sr: Острва Херд и Макдоналд
@@ -18890,7 +18791,6 @@ scn: Honduras
 sco: Honduras
 se: Honduras
 sh: Honduras
-simple: Honduras
 sk: Honduras
 sl: Honduras
 sm: Honilagi
@@ -19059,7 +18959,6 @@ scn: Hong Kong
 sco: Hong Kong
 sh: Hong Kong
 si: හොංකොං
-simple: Hong Kong
 sk: Hongkong
 sl: Hong Kong
 sq: Hong Kong
@@ -19284,7 +19183,6 @@ se: Ungára
 sgs: Vengrėjė, Vėngrėjė
 sh: Mađarska
 si: හන්ගේරියානු සමුහාණ්ඩුව
-simple: Hungary
 sk: Maďarsko
 sl: Madžarska
 sm: Hungary
@@ -19530,7 +19428,6 @@ se: Islánda
 sg: Islânde
 sh: Island
 si: අයිස්ලන්තය
-simple: Iceland
 sk: Island
 sl: Islandija
 sm: Aiselani
@@ -19779,7 +19676,6 @@ sd: ڀارت
 se: India
 sh: Indija
 si: භාරත ජනරජය
-simple: India
 sk: India
 sl: Indija
 sm: Igitia
@@ -20015,7 +19911,6 @@ se: Indonesia
 sg: Ênndonezïi
 sh: Indonezija
 si: ඉන්දුනීසියාව
-simple: Indonesia
 sk: Indonézia
 sl: Indonezija
 sm: Indyunisia
@@ -20241,7 +20136,6 @@ sco: Iran
 se: Iran
 sh: Iran
 si: ඉරානය
-simple: Iran
 sk: Irán
 sl: Iran
 so: Iiraan
@@ -20457,7 +20351,6 @@ se: Irak
 sgs: Iraks, Ėraks
 sh: Irak
 si: ඉරාක ජනරජය
-simple: Iraq
 sk: Irak
 sl: Irak
 so: Ciraaq
@@ -20553,7 +20446,6 @@ pl: Kurdystan, Kurdyjski Okręg Autonomiczny, Region Kurdystanu
 pt: Curdistão iraquiano
 ru: Иракский Курдистан
 sh: Irački Kurdistan
-simple: Iraqi Kurdistan
 sr: Јужни Курдистан, Курдистан, Ирачки Курдистан
 sr-ec:Јужни Курдистан
 sr-el:Južni Kurdistan
@@ -20668,7 +20560,6 @@ rw: Ikirwa cya Man
 scn: Ìsula di Man
 sco: Isle o Man
 sh: Otok Man
-simple: Isle of Man
 sk: Man
 sl: Man
 sq: Ishulli i Njeriut
@@ -20870,7 +20761,6 @@ se: Israel
 sgs: Izraelis, Ėzraelis, Izraelės
 sh: Izrael
 si: ඊශ්‍රායලය
-simple: Israel
 sk: Izrael
 sl: Izrael
 sm: Israel
@@ -21124,7 +21014,6 @@ sco: Italy
 se: Itália
 sg: Italùii
 sh: Italija
-simple: Italy
 sk: Taliansko
 sl: Italija
 sm: Italia
@@ -21333,7 +21222,6 @@ sco: Jamaica
 se: Jamaica
 sh: Jamajka
 si: ජැමෙයිකාව
-simple: Jamaica
 sk: Jamajka
 sl: Jamajka
 so: Jamayka
@@ -21442,7 +21330,6 @@ ro: Insula Jan Mayen
 ru: Ян-Майен
 se: Jan Mayen
 sh: Jan Mayen
-simple: Jan Mayen
 sk: Jan Mayen
 sl: Jan Mayen
 sq: Jan Mayen
@@ -21654,7 +21541,6 @@ sd: جاپان
 se: Japána
 sh: Japan
 si: ජපානය
-simple: Japan
 sk: Japonsko
 sl: Japonska
 sm: Iapani
@@ -21800,7 +21686,6 @@ ru: Джерси
 rw: Jersey
 sco: Jersey
 sh: Jersey
-simple: Jersey
 sk: Jersey
 sl: Jersey
 sq: Jersey
@@ -21981,7 +21866,6 @@ scn: Giurdania
 sco: Jordan
 se: Jordánia
 sh: Jordan
-simple: Jordan
 sk: Jordánsko
 sl: Jordanija
 so: Urdun
@@ -22195,7 +22079,6 @@ sco: Kazakhstan
 se: Kazakstána
 sh: Kazahstan
 si: කසක්ස්තානය
-simple: Kazakhstan
 sk: Kazachstan
 sl: Kazahstan
 so: Kasakhstan
@@ -22407,7 +22290,6 @@ sco: Kenyae
 se: Kenia
 sg: Kenyäa
 sh: Kenija
-simple: Kenya
 sk: Keňa
 sl: Kenija
 sn: Kenya
@@ -22578,7 +22460,6 @@ scn: Kiribati
 sco: Kiribati
 se: Kiribati
 sh: Kiribati
-simple: Kiribati
 sk: Kiribati
 sl: Kiribati
 sm: Kilibati
@@ -22758,7 +22639,6 @@ scn: Kuwait
 sco: Kuwait
 se: Kuwait
 sh: Kuvajt
-simple: Kuwait
 sk: Kuvajt
 sl: Kuvajt
 so: Kuwayt
@@ -22950,7 +22830,6 @@ sd: ڪِرگزِستانُ
 se: Kirgisistan
 sgs: Kirkizėjė, Kirgizija, Kirgėzėja
 sh: Kirgistan
-simple: Kyrgyzstan
 sk: Kirgizsko
 sl: Kirgizistan
 so: Qargistan
@@ -23151,7 +23030,6 @@ sco: Laos
 se: Laos
 sh: Laos
 si: ලාඕසය
-simple: Laos
 sk: Laos
 sl: Laos
 so: Laos
@@ -23371,7 +23249,6 @@ scn: Lettunia
 sco: Latvie
 se: Latvia
 sh: Letonija
-simple: Latvia
 sk: Lotyšsko
 sl: Latvija
 sma: Lettlaante
@@ -23578,7 +23455,6 @@ scn: Lìbbanu
 sco: Lebanon
 se: Libanon
 sh: Libanon
-simple: Lebanon
 sk: Libanon
 sl: Libanon
 so: Lubnaan
@@ -23761,7 +23637,6 @@ se: Lesotho
 sg: Lesôtho
 sgs: Lesuots
 sh: Lesoto
-simple: Lesotho
 sk: Lesotho
 sl: Lesoto
 sn: Lesotho
@@ -23959,7 +23834,6 @@ sco: Liberie
 se: Liberia
 sg: Liberïa
 sh: Liberija
-simple: Liberia
 sk: Libéria
 sl: Liberija
 sn: Liberia
@@ -24166,7 +24040,6 @@ se: Libya
 sg: Libïi
 sh: Libija
 si: ලිබියාව
-simple: Libya
 sk: Líbya
 sl: Libija
 sm: Libya
@@ -24386,7 +24259,6 @@ se: Liechtenstein
 sgs: Lichtenšteins, Lichtenštėins
 sh: Lihtenštajn
 si: ලීච්ටන්ස්ටෙයින්
-simple: Liechtenstein
 sk: Lichtenštajnsko
 sl: Lihtenštajn
 so: Liechtenstein
@@ -24628,7 +24500,6 @@ sco: Lithuanie
 se: Lietuva
 sg: Lituanïi
 sh: Litva
-simple: Lithuania
 sk: Litva
 sl: Litva
 sma: Litauia
@@ -24876,7 +24747,6 @@ sco: Luxembourg
 se: Luxemburg
 sgs: Lioksembōrgs
 sh: Luksemburg, Луксембург
-simple: Luxembourg
 sk: Luxembursko
 sl: Luksemburg, Veliko vojvodstvo Luksemburg, Luxembourg
 sma: Luhksembuurj
@@ -25041,7 +24911,6 @@ rw: Makawo
 scn: Macau
 sco: Macau
 sh: Makao
-simple: Macau
 sk: Macao
 sl: Macao
 sq: Makao
@@ -25228,7 +25097,6 @@ se: Madagaskar
 sg: Madagaskära
 sh: Madagaskar
 si: මැඩගස්කරය
-simple: Madagascar
 sk: Madagaskar
 sl: Madagaskar
 sm: Madagascar
@@ -25419,7 +25287,6 @@ sco: Malawi
 se: Malawi
 sg: Malawïi
 sh: Malavi
-simple: Malawi
 sk: Malawi
 sl: Malavi
 sn: Malawi
@@ -25612,7 +25479,6 @@ sco: Malaysie
 se: Malesia
 sg: Malezïi
 sh: Malezija
-simple: Malaysia
 sk: Malajzia
 sl: Malezija
 so: Malaysiya
@@ -25794,7 +25660,6 @@ sd: مالديپ
 se: Malediivvat
 sh: Maldivi
 si: දිවෙහි රාජ්ජේ
-simple: Maldives
 sk: Maldivy
 sl: Maldivi
 so: Jasiirada Maldiif
@@ -25979,7 +25844,6 @@ se: Mali
 sg: Malïi
 sh: Mali
 si: මාලි
-simple: Mali
 sk: Mali
 sl: Mali
 sn: Mali
@@ -26203,7 +26067,6 @@ se: Malta
 sgs: Malta
 sh: Malta
 si: මෝල්ටාව
-simple: Malta
 sk: Malta
 sl: Malta
 sm: Malitia
@@ -26368,7 +26231,6 @@ scn: Ìsuli Marshall
 sco: Marshall Islands
 se: Marshallsullot
 sh: Maršalovi Otoci
-simple: Marshall Islands
 sk: Marshallove ostrovy
 sl: Marshallovi otoki
 sm: Marshall Islands
@@ -26498,7 +26360,6 @@ scn: Martinica
 sco: Martinique
 se: Martinique
 sh: Martinik
-simple: Martinique
 sk: Martinik
 sl: Martinik
 sq: Martinika
@@ -26673,7 +26534,6 @@ se: Mauritánia
 sg: Moritanïi
 sgs: Maurėtanėjė
 sh: Mauritanija
-simple: Mauritania
 sk: Mauritánia
 sl: Mavretanija
 sn: Mauritania
@@ -26863,7 +26723,6 @@ se: Mauritius
 sg: Mörîsi
 sh: Mauricijus
 si: මුරුසි සමුහාණ්ඩුව
-simple: Mauritius
 sk: Maurícius
 sl: Mauritius
 sn: Mauritius
@@ -26991,7 +26850,6 @@ scn: Mayotte
 sco: Mayotte
 se: Mayotte
 sh: Mayotte
-simple: Mayotte
 sk: Mayotte
 sl: Mayotte
 so: Mayotte
@@ -27200,7 +27058,6 @@ scn: Mèssicu
 sco: Mexico
 se: Meksiko
 sh: Meksiko
-simple: Mexico
 sk: Mexiko
 sl: Mehika
 sm: Mexico
@@ -27425,7 +27282,6 @@ sco: Moldovae
 se: Moldova
 sgs: Moldavėjė
 sh: Moldavija
-simple: Moldova
 sk: Moldavsko
 sl: Moldavija
 so: Moldofa
@@ -27639,7 +27495,6 @@ sco: Monaco
 se: Monaco
 sgs: Muonaks, Monaks
 sh: Monako
-simple: Monaco
 sk: Monako
 sl: Monako
 so: Monako
@@ -27843,7 +27698,6 @@ sco: Mongolie
 se: Mongolia
 sh: Mongolija
 si: මොංගෝලියාව
-simple: Mongolia
 sk: Mongolsko
 sl: Mongolija
 sm: Mogitolia
@@ -28054,7 +27908,6 @@ sco: Montenegro
 se: Montenegro
 sgs: Joudkalnėjė
 sh: Crna Gora
-simple: Montenegro
 sk: Čierna Hora
 sl: Črna gora
 sm: Montenegro
@@ -28185,7 +28038,6 @@ ro: Montserrat
 ru: Монтсеррат
 rw: Monserati
 sh: Montserrat
-simple: Montserrat
 sk: Montserrat
 sl: Montserrat
 sq: Montserrati
@@ -28351,7 +28203,6 @@ sco: Morocco
 se: Marokko
 sg: Marôko
 sh: Maroko
-simple: Morocco
 sk: Maroko
 sl: Maroko
 sn: Morocco
@@ -28544,7 +28395,6 @@ sco: Mozambique
 se: Mosambik
 sg: Mözämbîka
 sh: Mozambik
-simple: Mozambique
 sk: Mozambik
 sl: Mozambik
 sn: Mozambique
@@ -28741,7 +28591,6 @@ sco: Burma
 se: Myanmar
 sh: Mianmar
 si: බුරුමය
-simple: Myanmar
 sk: Mjanmarsko
 sl: Mjanmar
 so: Burma
@@ -28850,7 +28699,6 @@ ro: Naxcivan, Regiunea Nahicevan, Nahicevan
 ru: Нахичеванская Автономная Республика, Нахичеванская Республика, Нахичеванская АР, Нахчыванская Автономная Республика, Нахичеванская автономия
 sco: Nakhchivan
 sh: Nahčivan, Nahičevan
-simple: Nakhchivan
 sl: Nahičevan, Naxcivan
 sr: Нахчиван
 sr-ec:Нахчиван
@@ -29013,7 +28861,6 @@ sco: Namibie
 se: Namibia
 sg: Namibùii
 sh: Namibija
-simple: Namibia
 sk: Namíbia
 sl: Namibija
 sn: Namibia
@@ -29203,7 +29050,6 @@ scn: Nauru
 sco: Nauru
 se: Nauru
 sh: Nauru
-simple: Nauru
 sk: Nauru
 sl: Nauru
 sm: Nauru
@@ -29391,7 +29237,6 @@ sd: نيپال
 se: Nepal
 sh: Nepal
 si: නේපාලය
-simple: Nepal
 sk: Nepál
 sl: Nepal
 so: Nebal
@@ -29629,7 +29474,6 @@ sco: Netherlands
 se: Vuolleeatnamat
 sh: Holandija
 si: නෙදර්ලන්තය
-simple: Netherlands
 sk: Holandsko
 sl: Nizozemska
 sma: Vuelielaanteh
@@ -29780,7 +29624,6 @@ rw: Nuveli Kalidoniya
 sco: New Caledon, New Caledonia
 se: Ođđa-Kaledonia
 sh: Nova Kaledonija
-simple: New Caledonia
 sk: Nová Kaledónia
 sl: Nova Kaledonija, Nouvelle-Calédonie
 sm: Niu Kaletonia
@@ -29967,7 +29810,6 @@ sco: New Zealand
 se: Ođđa-Selánda
 sgs: Naujuojė Zelandėjė, Naujuoji Zelandėjė
 sh: Novi Zeland
-simple: New Zealand
 sk: Nový Zéland
 sl: Nova Zelandija
 sm: Niu Sila
@@ -30151,7 +29993,6 @@ scn: Nicaragua
 sco: Nicaragua
 se: Nicaragua
 sh: Nikaragva
-simple: Nicaragua
 sk: Nikaragua
 sl: Nikaragva
 so: Nikaragua
@@ -30329,7 +30170,6 @@ se: Niger
 sg: Nizëre
 sh: Niger
 si: නයිජර්
-simple: Niger
 sk: Niger
 sl: Niger
 sn: Niger
@@ -30534,7 +30374,6 @@ sco: Nigerie
 se: Nigeria
 sg: Nizerïa
 sh: Nigerija
-simple: Nigeria
 sk: Nigéria
 sl: Nigerija
 sn: Nigeria
@@ -30664,7 +30503,6 @@ rw: Niyuwe
 scn: Niui, Niue
 se: Niue
 sh: Niue, Ниуе
-simple: Niue
 sk: Niue
 sl: Niue
 sm: Niue
@@ -30769,7 +30607,6 @@ rw: Ibirwa bya Norufoluki
 scn: Ìsula Norfolk
 sco: Norfolk Island
 sh: Otok Norfolk, Norfolk, Ostrvo Norfok, Ostrvo Norfolk
-simple: Norfolk Island
 sk: Norfolk
 sr: Острво Норфок, Острво Норфолк, Норфолк
 su: Pulo Norfolk
@@ -30945,7 +30782,6 @@ sco: North Korea
 se: Davvi-Korea
 sh: Demokratska Narodna Republika Koreja
 si: උතුරු කොරියාව
-simple: North Korea
 sk: Kórejská ľudovodemokratická republika
 sl: Severna Koreja
 so: Waqooyiga Kuuriya
@@ -31162,7 +30998,6 @@ scn: Ripùbblica di Macidonia
 sco: North Macedonie
 se: Davvi-Makedonia
 sh: Sjeverna Makedonija
-simple: Republic of Macedonia
 sk: Severné Macedónsko
 sl: Severna Makedonija
 so: Jamhuuriyada Waqooyiga Macedonia
@@ -31279,7 +31114,6 @@ rw: Ibirwa bya Mariyana y’Amajyaruguru
 scn: Ìsuli Marianni Sittintriunali
 se: Davve-Mariánat
 sh: Sjeverni Marijanski Otoci
-simple: Northern Mariana Islands
 sk: Severné Mariány
 sl: Severni Marianski otoki
 sr: Северна Маријанска острва
@@ -31498,7 +31332,6 @@ sco: Norawa
 se: Norga
 sgs: Nuorvegėjė, Norvegėjė
 sh: Norveška
-simple: Norway
 sk: Nórsko
 sl: Norveška
 sma: Nøørje, Nöörje
@@ -31700,7 +31533,6 @@ sco: Oman
 se: Oman
 sh: Oman
 si: ඕමානය
-simple: Oman
 sk: Omán
 sl: Oman
 so: Cumaan
@@ -31910,7 +31742,6 @@ sd: پاڪستان
 se: Pakistan
 sh: Pakistan
 si: පාකිස්ථානය
-simple: Pakistan
 sk: Pakistan
 sl: Pakistan
 so: Bakistaan
@@ -32083,7 +31914,6 @@ scn: Palau
 sco: Palau
 se: Palau
 sh: Palau
-simple: Palau
 sk: Palau
 sl: Palau
 sm: Palau
@@ -32146,7 +31976,6 @@ nl: Palestijnse Gebieden
 pt: Territórios palestinianos
 pt-br:Territórios palestinianos
 ru: палестинские территории
-simple: Palestinian territories
 sk: Palestínske okupované územia
 ur: فلسطینی علاقہ جات
 yo: Àwọn Agbègbè ilẹ̀ Palẹstínì
@@ -32296,7 +32125,6 @@ scn: Panamà
 sco: Panama
 se: Panama
 sh: Panama
-simple: Panama
 sk: Panama
 sl: Panama
 so: Banama
@@ -32479,7 +32307,6 @@ se: Papua-Ođđa-Guinea
 sg: Papû Finî Ginëe
 sgs: Papua Naujuojė Gvėniejė, Papua Naujuoji Gvinėjė, Papua Naujuojė Gvinėjė
 sh: Papua Nova Gvineja
-simple: Papua New Guinea
 sk: Papua-Nová Guinea
 sl: Papua Nova Gvineja
 sm: Papua
@@ -32658,7 +32485,6 @@ sah: Парагуай
 sco: Paraguay
 se: Paraguay
 sh: Paragvaj
-simple: Paraguay
 sk: Paraguaj
 sl: Paragvaj
 so: Paraguay
@@ -32870,7 +32696,6 @@ se: Peru
 sgs: Perū, Peru
 sh: Peru
 si: පේරූ
-simple: Peru
 sk: Peru
 sl: Peru
 sn: Peru
@@ -33069,7 +32894,6 @@ se: Filippiinnat
 sg: Filipîni
 sh: Filipini
 si: පිලිපීනය
-simple: Philippines
 sk: Filipíny
 sl: Filipini
 sm: Filipaina
@@ -33197,7 +33021,6 @@ sah: Питкэрн
 scn: Pitcairn
 se: Pitcairn
 sh: Pitkern, Otoci Pitcairn, Pitcairn, Pitkern Ostrva, Pitkernski Otoci
-simple: Pitcairn
 sk: Pitcairnove ostrovy
 sl: Pitcairnovi otoki, Pitcairn, Otoki Pitcairn, Pitcairnski otoki, Pitcairnovo otočje
 sr: Острва Питкерн, Питкарнска острва, Питкерн Острва, Питкерн, Острво Питкерн
@@ -33424,7 +33247,6 @@ sg: Pölôni
 sgs: Lėnkėjė, Lenkija, Lenkėjė
 sh: Poljska
 si: පෝලන්තය
-simple: Poland
 sk: Poľsko
 sl: Poljska
 sm: Polagi
@@ -33677,7 +33499,6 @@ sco: Portugal
 se: Portugal
 sh: Portugal
 si: පෘතුගාලය
-simple: Portugal
 sk: Portugalsko
 sl: Portugalska
 sm: Portugal
@@ -33849,7 +33670,6 @@ rw: Puwerito Riko
 scn: Portu Ricu
 sco: Puerto Rico
 sh: Portoriko
-simple: Puerto Rico
 sk: Portoriko
 sl: Portoriko
 so: Buerto Riko
@@ -34028,7 +33848,6 @@ se: Qatar
 sgs: Katars
 sh: Katar
 si: කටාර්
-simple: Qatar
 sk: Katar
 sl: Katar
 so: Qatar
@@ -34213,7 +34032,6 @@ scn: Taiwan
 sco: Republic o Cheenae
 se: Taiwan
 sh: Republika Kina
-simple: Republic of China
 sk: Taiwan
 sl: Tajvan, Republika Kitajska
 sm: Saina Taipei
@@ -34433,7 +34251,6 @@ se: Eire, Irlánda
 sgs: Airėjė, Ireland, Airėjės Respoblėka
 sh: Irska, Ирска, Republika Irska
 si: අයර්ලන්ත සමූහාණ්ඩුව
-simple: Republic of Ireland
 sk: Írsko, Írska republika
 sl: Irska, Republika Irska
 sma: Iirlaante
@@ -34620,7 +34437,6 @@ se: Kongo dásseváldi
 sg: Ködörösêse tî Kongöo
 sh: Republika Kongo
 si: කොංගෝ ජනරජය
-simple: Republic of the Congo
 sl: Republika Kongo
 sn: Republic of the Congo
 so: Jamhuuriyadda Kongo
@@ -34720,7 +34536,6 @@ ro: Republika Srpska
 ru: Республика Сербская, Republika Srpska, Република Српска
 sco: Republika Srpska
 sh: Republika Srpska
-simple: Republika Srpska
 sk: Republika srbská
 sl: Republika srbska
 sr: Република Српска
@@ -34914,7 +34729,6 @@ sco: Romanie
 se: Romania
 sh: Rumunija
 si: රුමේනියාව
-simple: Romania
 sk: Rumunsko
 sl: Romunija
 sm: Romania
@@ -35186,7 +35000,6 @@ se: Ruošša
 sg: Rusïi
 sh: Rusija
 si: රුසියාව
-simple: Russia
 sk: Rusko
 sl: Rusija, Ruska federacija
 sm: Lusia
@@ -35404,7 +35217,6 @@ sg: Ruandäa
 sgs: Ruanda
 sh: Ruanda
 si: රුවන්ඩා ජනරජය
-simple: Rwanda
 sk: Rwanda
 sl: Ruanda
 sn: Rwanda
@@ -35552,7 +35364,6 @@ scn: Riunioni
 sco: Réunion
 se: Reuion
 sh: Reunion
-simple: Réunion
 sk: Réunion
 sl: Reunion
 sr: Реинион
@@ -35636,7 +35447,6 @@ pt: Saba, Ilha de Saba
 ro: Saba
 ru: Саба
 sco: Saba
-simple: Saba
 sr: Саба
 su: Saba
 sv: Saba
@@ -35689,7 +35499,6 @@ pt: Santa Helena, Ascensão e Tristão da Cunha
 pt-br:Santa Helena, Ascensão e Tristão da Cunha
 ro: Sfânta Elena, Ascension și Tristan da Cunha
 ru: Острова Святой Елены, Вознесения и Тристан-да-Кунья
-simple: Saint Helena
 sk: Svätá Helena
 sl: Saint Helena
 sr: Света Јелена, Асенсион и Тристан да Куња
@@ -35831,7 +35640,6 @@ sco: Saunt Kitts an Nevis
 se: Saint Christopher ja Nevis
 sh: Sveti Kristofor i Nevis
 si: ශාන්ත කිට්ස් සහ නෙවිස්
-simple: Saint Kitts and Nevis
 sk: Svätý Krištof a Nevis
 sl: Saint Kitts in Nevis
 sq: Shën Kits dhe Nevis
@@ -35979,7 +35787,6 @@ sah: Сент Лусия
 scn: Santa Lucia
 sco: Saunt Lucia
 sh: Sveta Lucija
-simple: Saint Lucia
 sk: Svätá Lucia
 sl: Saint Lucia
 sq: Shën Luçia
@@ -36060,7 +35867,6 @@ pt: São Martinho, Saint Martin, Saint-Martin, Coletividade de São Martinho, St
 ro: Saint Martin
 ru: Сен-Мартен
 sh: Saint Martin, Sveti Martin, Saint Martin (francuska teritorija
-simple: Saint Martin
 su: Saint-Martin, Koléktivitas Saint Martin, Saint Martin
 tl: San Martin
 tr: Saint Martin
@@ -36155,7 +35961,6 @@ ro: Saint Pierre și Miquelon, Saint-Pierre şi Miquelon, Saint Pierre şi Mique
 ru: Сен-Пьер и Микелон, Сент-Пьер и Микелон
 rw: Mutagatifu Petero na Mikeloni
 sh: Saint-Pierre i Miquelon, Saint Pierre i Miquelon, Sent-Pjer i Mikelon, Saint-Pierre i Miqeulon, Sveti Petar i Mikelon, Sveti Pjer i Mikelon
-simple: Saint Pierre and Miquelon
 sk: Saint Pierre a Miquelon, Saint-Pierre a Miquelon, Ostrovy Saint Pierre a Miquelon
 sl: Saint Pierre in Miquelon, Saint-Pierre in Miquelon, Saint-Pierre-et-Miquelon
 sq: Shën Pierre dhe Miquelon
@@ -36289,7 +36094,6 @@ sah: Сент Винсент уонна Гренадиннар
 scn: Saint Vincent e Grenadine
 sco: Saunt Vincent an the Grenadines
 sh: Sveti Vincent i Grenadini
-simple: Saint Vincent and the Grenadines
 sk: Svätý Vincent a Grenadíny
 sl: Sveti Vincent in Grenadini
 sq: Shën Vincenti dhe Grenadinet
@@ -36374,7 +36178,6 @@ pt: Coletividade de São Bartolomeu, Saint-barthélemy, São Bartolomeu, Saint B
 ro: Saint Barthélemy, Saint Barthelemy, Saint-Barthélemy
 ru: Сен-Бартелеми, Сен-Бартельми
 sh: Saint Barthélemy, Saint-Barthélemy, Sveti Bartolomej, Saint Barthelemy, Ostvro Sveti Bartolomej
-simple: Saint-Barthélemy
 sk: Svätý Bartolomej, Saint Barthélemy, Saint-Barthélemy
 sq: Shën Barthélemy, Shën Barth, Shën Barthelemy
 sr: Острво Свети Бартоломеј, Saint-Barthélemy
@@ -36511,7 +36314,6 @@ scn: Samoa
 sco: Samoa
 se: Samoa
 sh: Samoa
-simple: Samoa
 sk: Samoa
 sl: Samoa
 sm: Sāmoa
@@ -36712,7 +36514,6 @@ sco: San Marino
 se: San Marino
 sgs: San Marėns, San Marins
 sh: San Marino
-simple: San Marino
 sk: San Maríno
 sl: San Marino
 so: San Marino
@@ -36892,7 +36693,6 @@ sco: São Tomé an Príncipe
 se: São Tomé ja Príncipe
 sg: Sâô Tömê na Prinsîpe
 sh: Sao Tome i Principe
-simple: São Tomé and Príncipe
 sk: Svätý Tomáš a Princov ostrov
 sl: Sao Tome in Principe
 sn: Sao Tome and Principe
@@ -37098,7 +36898,6 @@ sco: Saudi Arabie
 se: Saudi-Arábia
 sh: Saudijska Arabija
 si: සවුදි අරාබියාව
-simple: Saudi Arabia
 sk: Saudská Arábia
 sl: Saudova Arabija
 so: Sacuudi Carabiya
@@ -37287,7 +37086,6 @@ sco: Senegal
 se: Senegal
 sg: Senegäle
 sh: Senegal
-simple: Senegal
 sk: Senegal
 sl: Senegal
 sn: Senegal
@@ -37504,7 +37302,6 @@ sco: Serbie
 se: Serbia
 sgs: Serbėjė
 sh: Srbija
-simple: Serbia
 sk: Srbsko
 sl: Srbija
 sm: Serbia
@@ -37689,7 +37486,6 @@ sco: Seychelles
 se: Seychellsullot
 sg: Sëyshêle
 sh: Sejšeli
-simple: Seychelles
 sk: Seychely
 sl: Sejšeli
 sn: Seychelles
@@ -37864,7 +37660,6 @@ sg: Sierä-Leône
 sgs: Sėira Leuonė
 sh: Sijera Leone
 si: සියෙරා ලියෝන්
-simple: Sierra Leone
 sk: Sierra Leone
 sl: Sierra Leone
 sn: Sierra Leone
@@ -38078,7 +37873,6 @@ se: Singapore
 sg: Sïngäpûru
 sgs: Singapūrs
 sh: Singapur
-simple: Singapore
 sk: Singapur
 sl: Singapur
 sm: Sigapoa
@@ -38175,7 +37969,6 @@ pnb: سنت ایوستیتیس
 pt: Santo Eustáquio, Sint eustatius, Saint eustatius, St. Eustatius
 ro: Sint Eustatius
 ru: Синт-Эстатиус, Остров Святого Евстафия, Синт-Эустатиус
-simple: Sint Eustatius
 sr: Свети Еустахије, Sint Eustatius
 su: Sint Eustatius
 sv: Sint Eustatius
@@ -38242,7 +38035,6 @@ pt: Sint maarten, Saint Marteen, St. Maarten
 pt-br:São Martinho, Sint Maarten
 ro: Sint Maarten
 ru: Синт-Мартен, Синт-Маартен
-simple: Saint Martin
 sr: Свети Мартин
 srn: Sint Maarten
 su: Sint Maarten
@@ -38426,7 +38218,6 @@ sco: Slovakie
 se: Slovakia
 sgs: Sluovakėjė, Slovakėjė, Slovakėjės Respoblėka, Slovakia, Sluovakėjės respoblėka
 sh: Slovačka
-simple: Slovakia
 sk: Slovensko, Slovenská republika
 sl: Slovaška
 sma: Slovaakia
@@ -38651,7 +38442,6 @@ sco: Slovenie
 se: Slovenia
 sgs: Slovienėjė, Slovėnėjė, Sluovienėjė
 sh: Slovenija
-simple: Slovenia
 sk: Slovinsko
 sl: Slovenija, Republika Slovenija
 sm: Slovenia
@@ -38827,7 +38617,6 @@ sco: Solomon Islands
 se: Salomonsullot
 sh: Solomonski Otoci
 si: සොලමන් දුපත්
-simple: Solomon Islands
 sk: Šalamúnove ostrovy
 sl: Salomonovi otoki
 sm: Solomon Islands
@@ -39001,7 +38790,6 @@ se: Somália
 sg: Somalïi
 sh: Somalija
 si: සෝමාලියාව
-simple: Somalia
 sk: Somálsko
 sl: Somalija
 sm: Somalia
@@ -39231,7 +39019,6 @@ se: Lulli-Afrihkká
 sg: Afrîka-Mbongo
 sgs: Pėitū Afrėkas Respoblėka, PAR
 sh: Južna Afrika
-simple: South Africa
 sk: Južná Afrika
 sl: Republika Južna Afrika
 sn: South Africa
@@ -39370,7 +39157,6 @@ rw: Geworugiya y’Epfo n’Ibirwa bya Sanduwice y’Epfo
 sah: Соҕуруу Георгия уонна Соҕуруу Сэндуич арыылара
 se: Lulli Georgia ja Lulli Sandwich-sullot
 sh: Južna Georgija i otočje Sandwich, Južna Džordžija i Južni Sendvič Otoci, Južna Georgia i Južni Otoci Sandwich, Južna Džordžija i Južna Sendvička Ostrva, Južna Džordžija i Južna Sendvič Ostrva
-simple: South Georgia and the South Sandwich Islands
 sk: Južná Georgia a Južné Sandwichove ostrovy
 sl: Južna Georgia in Južni Sandwichevi otoki, Južno Sandwichevo otočje, Otoki South Georgia in South Sandwich, South Georgia and the South Sandwich Islands, Južna Georgija in Južni Sandwichevi otoki, Južna Georgija, Južna Georgija in Južno Sandwichevo otočje, Južna Georgia
 so: Koonfur Joorjiya iyo Koonfurta Jasiiradaha Sanwij
@@ -39560,7 +39346,6 @@ sco: Sooth Korea
 se: Mátta-Korea
 sh: Južna Koreja
 si: දකුණු කොරියාව
-simple: South Korea
 sk: Kórejská republika
 sl: Južna Koreja
 sm: Kolea i Saute
@@ -39734,7 +39519,6 @@ sco: Sooth Sudan
 se: Lulli-Sudan
 sg: Sudäan-Mbongo
 sh: Južni Sudan
-simple: South Sudan
 sk: Južný Sudán
 sl: Južni Sudan
 sn: South Sudan
@@ -39910,7 +39694,6 @@ sco: Soviet Union
 se: Sovjetlihttu
 sh: Sovjetski Savez
 si: සෝවියට් සංගමය
-simple: Soviet Union
 sk: Sovietsky zväz
 sl: Sovjetska zveza
 so: Midowga Sofiyet
@@ -40145,7 +39928,6 @@ scn: Spagna
 sco: Spain
 se: Spánia
 sh: Španija
-simple: Spain
 sk: Španielsko
 sl: Španija
 sm: Spania
@@ -40360,7 +40142,6 @@ sco: Sri Lanka
 se: Sri Lanka
 sh: Šri Lanka
 si: ශ් රී ලංකාව, සිතියම
-simple: Sri Lanka
 sk: Srí Lanka
 sl: Šrilanka
 sm: Sri Lanka
@@ -40639,7 +40420,6 @@ sco: Sudan
 se: Sudan
 sg: Sudäan
 sh: Sudan
-simple: Sudan
 sk: Sudán
 sl: Sudan
 sm: Sudan
@@ -40832,7 +40612,6 @@ scn: Surinami
 sco: Suriname
 se: Surinam
 sh: Surinam
-simple: Suriname
 sk: Surinam
 sl: Surinam
 so: Surinam
@@ -41043,7 +40822,6 @@ sco: Swaziland
 se: Svazieana
 sg: Swäzïlânde
 sh: Svazilend
-simple: Swaziland
 sk: Svazijsko
 sl: Svazi
 sn: Swaziland
@@ -41278,7 +41056,6 @@ scn: Svezzia
 sco: Swaden
 se: Ruoŧŧa
 sh: Švedska
-simple: Sweden
 sk: Švédsko
 sl: Švedska
 sm: Sweden
@@ -41524,7 +41301,6 @@ sco: Swisserland
 se: Šveica
 sh: Švajcarska
 si: ස්විට්සර්ලන්තය
-simple: Switzerland
 sk: Švajčiarsko
 sl: Švica
 so: Iswisarland
@@ -41742,7 +41518,6 @@ scn: Siria
 sco: Sirie
 se: Syria
 sh: Sirija
-simple: Syria
 sk: Sýria
 sl: Sirija
 so: Suuriya
@@ -41933,7 +41708,6 @@ sco: Tajikistan
 se: Tažikistan
 sh: Tadžikistan
 si: ටජිකිස්ථාන්
-simple: Tajikistan
 sk: Tadžikistan
 sl: Tadžikistan
 so: Tadsjikistan
@@ -42133,7 +41907,6 @@ sco: Tanzanie
 se: Tanzánia
 sg: Tanzanïi
 sh: Tanzanija
-simple: Tanzania
 sk: Tanzánia
 sl: Tanzanija
 sn: Tanzania
@@ -42341,7 +42114,6 @@ sco: Thailand
 se: Thaieana
 sg: Tailânde
 sh: Tajland
-simple: Thailand
 sk: Thajsko
 sl: Tajska
 so: Tayland
@@ -42529,7 +42301,6 @@ sco: The Bahamas
 se: Bahama
 sh: Bahami
 si: බහමාස්
-simple: The Bahamas
 sk: Bahamy
 sl: Bahami
 so: Bahamas
@@ -42711,7 +42482,6 @@ sco: East Timor
 se: Nuorta-Timor
 sg: Timôro tî Tö
 sh: Istočni Timor
-simple: East Timor
 sk: Východný Timor
 sl: Vzhodni Timor
 so: Bariga Timor
@@ -42894,7 +42664,6 @@ se: Togo
 sg: Togö
 sh: Togo
 si: ටෝගෝ
-simple: Togo
 sk: Togo
 sl: Togo
 sn: Togo
@@ -43007,7 +42776,6 @@ ro: Tokelau
 ru: Токелау
 rw: Tokelawu
 sh: Tokelau
-simple: Tokelau
 sk: Tokelau
 sl: Tokelau, Zvezni otoki
 sm: To'elau
@@ -43152,7 +42920,6 @@ scn: Tonga
 sco: Tonga
 se: Tonga
 sh: Tonga
-simple: Tonga
 sk: Tonga
 sl: Tonga
 sm: Toga
@@ -43306,7 +43073,6 @@ sah: Тринидад уонна Тобаго
 scn: Trinidad e Tobagu
 sco: Trinidad an Tobago
 sh: Trinidad i Tobago
-simple: Trinidad and Tobago
 sk: Trinidad a Tobago
 sl: Trinidad in Tobago
 sm: Trindad ma Tobacco
@@ -43493,7 +43259,6 @@ sco: Tunisie
 se: Tunisia
 sg: Tunizïi
 sh: Tunis
-simple: Tunisia
 sk: Tunisko
 sl: Tunizija
 sn: Tunisia
@@ -43738,7 +43503,6 @@ sco: Turkey
 se: Durka
 sh: Turska
 si: තුර්කිය
-simple: Turkey
 sk: Turecko
 sl: Turčija
 so: Turki
@@ -43951,7 +43715,6 @@ scn: Turkmenistan
 sco: Turkmenistan
 se: Turkmenistan
 sh: Turkmenistan
-simple: Turkmenistan
 sk: Turkménsko
 sl: Turkmenistan
 so: Turkmenistan
@@ -44081,7 +43844,6 @@ ro: Insulele Turks și Caicos
 ru: Тёркс и Кайкос
 rw: Ibirwa bya Takisi na Kayikosi
 sh: Turks i Caicos Otoci
-simple: Turks and Caicos Islands
 sk: Turks a Caicos
 sq: Turks dhe Kaikos
 sr: Туркс и Кајкос
@@ -44229,7 +43991,6 @@ scn: Tuvalu
 sco: Tuvalu
 se: Tuvalu
 sh: Tuvalu
-simple: Tuvalu
 sk: Tuvalu
 sl: Tuvalu
 sm: Tuvalu
@@ -44412,7 +44173,6 @@ sco: Uganda
 se: Uganda
 sg: Ugandäa
 sh: Uganda
-simple: Uganda
 sk: Uganda
 sl: Uganda
 sn: Uganda
@@ -44647,7 +44407,6 @@ scn: Ucraina
 sco: Ukraine
 se: Ukraina
 sh: Ukrajina
-simple: Ukraine
 sk: Ukrajina
 sl: Ukrajina
 sm: Ukraine
@@ -44850,7 +44609,6 @@ sco: Unitit Arab Emirates
 sd: گڏيل عرب امارات
 se: Ovttastuvvan arábaemiráhtat
 sh: Ujedinjeni Arapski Emirati
-simple: United Arab Emirates
 sk: Spojené arabské emiráty
 sl: Združeni arabski emirati
 so: Imaaraatka Carabta
@@ -45086,7 +44844,6 @@ sco: Unitit Kinrick
 se: Ovttastuvvan gonagasriika
 sh: Ujedinjeno Kraljevstvo
 si: එක්සත් රාජධානිය
-simple: United Kingdom
 sk: Spojené kráľovstvo
 sl: Združeno kraljestvo Velike Britanije in Severne Irske
 sma: Stoerebritannia
@@ -45192,7 +44949,6 @@ pt: Ilhas Menores Distantes dos Estados Unidos
 ro: Insulele Minore Îndepărtate ale Statelor Unite
 ru: Внешние малые острова США
 rw: Ibirwa Bito Bikikije Leta Zunze Ubumwe
-simple: United States Minor Outlying Islands
 sk: Menšie odľahlé ostrovy USA
 sv: Förenta staternas mindre öar i Oceanien och Västindien
 th: เกาะเล็กรอบนอกของสหรัฐอเมริกา
@@ -45417,7 +45173,6 @@ se: Amerihká ovttastuvvan stáhtat
 sg: ÂKödörö-ôko tî Amerîka
 sh: Sjedinjene Američke Države
 si: ඇමරිකානු එක්සත් ජනපදය
-simple: United States
 sk: Spojené štáty
 sl: Združene države Amerike
 sm: Iunaite Sitete o Amerika
@@ -45640,7 +45395,6 @@ sco: Uruguay
 se: Uruguay
 sh: Urugvaj
 si: උරුගුවායි
-simple: Uruguay
 sk: Uruguaj
 sl: Urugvaj
 so: Uruguay
@@ -45840,7 +45594,6 @@ scn: Uzbekistan
 sco: Uzbekistan
 se: Uzbekistána
 sh: Uzbekistan
-simple: Uzbekistan
 sk: Uzbekistan
 sl: Uzbekistan
 so: Usbekistan
@@ -46011,7 +45764,6 @@ scn: Vanuatu
 sco: Vanuatu
 se: Vanuatu
 sh: Vanuatu
-simple: Vanuatu
 sk: Vanuatu
 sl: Vanuatu
 sm: Vanuatu
@@ -46225,7 +45977,6 @@ sco: Vatican Ceety
 se: Vatikána
 sh: Vatikan
 si: වතිකානුව
-simple: Vatican City
 sk: Vatikán
 sl: Vatikan
 so: Faatikan
@@ -46440,7 +46191,6 @@ sco: Venezuela
 se: Venezuela
 sgs: Venesoela
 sh: Venezuela
-simple: Venezuela
 sk: Venezuela
 sl: Venezuela
 sm: Venesuela
@@ -46687,7 +46437,6 @@ se: Vietnam
 sgs: Vietnams
 sh: Vijetnam
 si: වියට්නාමය
-simple: Vietnam
 sk: Vietnam
 sl: Vietnam
 sm: Vietnam
@@ -46831,7 +46580,6 @@ rue: Америцькы Паненьскы островы
 rw: Ibirwa bya Virigini bya Leta Zunze Ubumwe
 scn: U.S. Virgin Islands
 sh: Američki Djevičanski otoci
-simple: United States Virgin Islands
 sk: Americké Panenské ostrovy
 sl: Ameriški Deviški otoki
 sq: Ishujt e Virgjër të Shteteve të Bashkuara
@@ -46922,7 +46670,6 @@ ru: Уоллис и Футуна, Острова Валлис, Острова У
 rw: Walisi na Fatuna
 se: Wallis ja Futuna
 sh: Wallis i Futuna, Ostrva Valis i Futuna, Volis i Futuna ostrva, Valis i Futuna, Volis i Futuna
-simple: Wallis and Futuna
 sk: Wallis a Futuna
 sl: Wallis in Futuna, Wallis and Futuna, Wallis in Futuna otoki
 sm: Wallis and Futuna
@@ -47051,7 +46798,6 @@ sc: Sahara Otzidentale
 scn: Sahara Uccidintali
 se: Oarje-Sahára
 sh: Zapadna Sahara
-simple: Western Sahara
 sk: Západná Sahara
 sl: Zahodna Sahara
 sr: Западна Сахара
@@ -47233,7 +46979,6 @@ scn: Yemen
 sco: Yemen
 se: Jemen
 sh: Jemen
-simple: Yemen
 sk: Jemen
 sl: Jemen
 so: Yemen
@@ -47360,7 +47105,6 @@ sah: Югославия
 sc: Iugoslàvia
 scn: Jugoslavia, Juguslavia, Yugoslavia
 sh: Jugoslavija, Југославија
-simple: Yugoslavia
 sk: Juhoslávia, SFRJ
 sl: Jugoslavija, Federativna republika Jugoslavija, Yugoslavia, Slovenska nararodna podporna jednota
 sr: Југославија
@@ -47521,7 +47265,6 @@ sco: Zambie
 se: Zámbia
 sg: Zambïi
 sh: Zambija
-simple: Zambia
 sk: Zambia
 sl: Zambija
 sn: Zambia
@@ -47715,7 +47458,6 @@ se: Zimbabwe
 sg: Zimbäbwe
 sh: Zimbabve
 si: සිම්බාබ්වේ, Zසිම්බාබ්වේ, Zimbabwe
-simple: Zimbabwe
 sk: Zimbabwe, Zimbabwe-Rodézia, Južná Rodézia, Zimbabwianska republika
 sl: Zimbabve, Republika Zimbabve, Južna Rodezija, Rodezija
 sn: Zimbabwe
@@ -47854,7 +47596,6 @@ rw: Ibirwa by’Alande
 sco: Åland Islands
 se: Ålánda
 sh: Åland
-simple: Åland Islands
 sk: Ålandy
 sl: Åland
 sr: Оландска острва

--- a/taxonomies/languages.txt
+++ b/taxonomies/languages.txt
@@ -81,7 +81,6 @@ scn: abcasu, lingua abcasa
 sco: Abkhaz leid
 se: Abkhasagiella
 sh: Abhaški jezik
-simple: Abkhaz language
 sk: Abcházština
 sr: абхаски језик
 sr-ec:абхаски језик
@@ -149,7 +148,6 @@ pt: Afar
 pt-br:Afar
 ru: Афарский язык
 sh: Afarski jezik
-simple: Afar language
 sk: Afarčina
 so: Af-Cafari
 sq: Gjuha afare
@@ -346,7 +344,6 @@ pt: Acã, Akan
 pt-br:Acã, Akan
 qu: Akan simi
 ru: акан, аканский язык
-simple: Akan language
 sv: Akan
 sw: Kiakan
 ta: அகன மொழி
@@ -467,7 +464,6 @@ sco: Albanie leid
 se: Albánagiella
 sgs: Albanu kalba
 sh: Albanski jezik
-simple: Albanian language
 sk: Albánčina
 sl: Albanščina
 sm: Gagana Kosovo
@@ -581,7 +577,6 @@ sco: Amharic
 se: Amharagiella
 sgs: Amharu kalba
 sh: Amharski jezik
-simple: Amharic language
 sk: Amharčina
 sl: Amharščina
 so: Amxaari
@@ -774,7 +769,6 @@ sd: عربي ٻولي
 se: Arábagiella
 sgs: Arabu kalba
 sh: Arapski jezik
-simple: Arabic language
 sk: Arabčina
 sl: Arabščina
 so: Carabi
@@ -903,7 +897,6 @@ scn: aragunisi, lingua aragunisa
 sco: Aragonese
 se: Aragoniagiella
 sh: Aragonski jezik
-simple: Aragonese language
 sr: арагонски језик
 sr-ec:арагонски језик
 sv: Aragonska
@@ -1027,7 +1020,6 @@ scn: armenu, lingua armena
 sco: Armenie leid
 se: Armeenalaš gielat
 sh: Jermenski jezik
-simple: Armenian language
 sk: arménčina
 sl: armenščina
 sq: gjuha armene
@@ -1129,7 +1121,6 @@ ru: ассамский язык
 sa: असमिया
 sco: Assamese
 sh: Asamski jezik
-simple: Assamese language
 sk: ásamčina
 sr: асамски језик
 sr-ec:асамски језик
@@ -1206,7 +1197,6 @@ pt: Avar
 pt-br:Avar
 ru: аварский язык
 sah: Аваар тыла
-simple: Avar language
 sl: Avarščina
 sv: Avariska
 szl: Awarskŏ gŏdka
@@ -1368,7 +1358,6 @@ ro: limba aimara, Limba aymara
 ru: аймара, Язык Аймара, Аймарский язык
 se: Aymaragiella
 sgs: Aimaru kalba
-simple: Aymara language
 sl: Ajmarščina, Aymara, Aimarščina
 sq: Gjuha aimare, Gjuha Aymara
 sr: ајмара
@@ -1498,7 +1487,6 @@ sco: Azerbaijani leid
 se: Aserbaižanagiella
 sgs: Azėrbaidžanėitiu kalba
 sh: Azerski jezik
-simple: Azerbaijani language
 sk: Azerbajdžančina
 sl: azerbajdžanščina
 sq: Gjuha azerbajxhane
@@ -1656,7 +1644,6 @@ sah: Башкиир тыла
 sco: Bashkir leid
 sgs: Baškėru kalba
 sh: Baškirski jezik
-simple: Bashkir language
 sk: Baškirčina
 sl: Baškirščina
 sr: башкирски језик
@@ -1775,7 +1762,6 @@ scn: bascu, lingua basca, vascu, lingua vasca
 sco: Basque leid
 se: Baskagiella
 sh: Baskijski jezik
-simple: Basque language
 sk: Baskičtina
 sl: Baskovščina
 sq: Gjuha baske
@@ -1915,7 +1901,6 @@ sco: Belaroushie leid
 se: Vilges-ruoššagiella
 sgs: Godu kalba
 sh: Bjeloruski jezik
-simple: Belarusian language
 sk: bieloruština
 sl: Beloruščina
 sq: Gjuha bjelloruse
@@ -2066,7 +2051,6 @@ sco: Bengali leid
 se: Bengalgiella
 sgs: Bengalu kalba
 sh: Bengalski jezik
-simple: Bengali language
 sk: bengálčina
 sl: bengalščina
 sq: gjuha bengali
@@ -2494,7 +2478,6 @@ scn: brètuni, lingua brètuna
 sco: Breton leid
 se: Bretonagiella
 sh: Bretonski jezik
-simple: Breton language
 sk: bretónčina
 sl: Bretonščina
 sq: Gjuha bretoneze
@@ -2632,7 +2615,6 @@ sco: Bulgarie leid
 se: Bulgáriagiella
 sgs: Bolgaru kalba
 sh: Bugarski jezik
-simple: Bulgarian language
 sk: Bulharčina
 sl: bolgarščina
 sq: gjuha bullgare
@@ -2732,7 +2714,6 @@ ro: Limba birmană
 ru: бирманский язык
 scn: birmanu, lingua birmana
 sco: Burmese leid
-simple: Burmese language
 stq: Birmanisk
 sv: Burmesiska
 ta: பருமிய மொழி
@@ -2872,7 +2853,6 @@ sco: Catalan
 se: Katalánagiella
 sgs: Kataluonu kalba
 sh: Katalonski jezik
-simple: Catalan language
 sk: Katalánčina
 sl: Katalonščina
 sm: Fa'aCatalan
@@ -3255,7 +3235,6 @@ sd: چيني ٻولي
 se: Kiinnágiella
 sgs: Kėnu kalba
 sh: Kineski jezik
-simple: Chinese language
 sk: čínština
 sl: Kitajščina
 sm: Fa'asaina
@@ -3609,7 +3588,6 @@ sc: Limba corsicana
 scn: corsu, lingua corsa
 se: Corsicagiella
 sgs: Kuorsėkėitiu kalba
-simple: Corsican language
 sl: Korziščina
 sr: Корзички језик, Корзикански језик
 sv: Korsikanska
@@ -3969,7 +3947,6 @@ sco: Czech
 se: Čeahkagiella
 sgs: Čeku kalba
 sh: Češki jezik
-simple: Czech language
 sk: čeština
 sl: Češčina
 sm: Fa'aSieki
@@ -4129,7 +4106,6 @@ sco: Dens leid
 se: Dánskkagiella
 sgs: Danu kalba
 sh: Danski jezik
-simple: Danish language
 sk: Dánčina
 sl: Danščina
 sm: Fa'atenimaka
@@ -4300,7 +4276,6 @@ scn: ulannisi, lingua ulannisa, olannisi, lingua olannisa
 sco: Dutch
 se: Hollánddagiella
 sh: Holandski jezik
-simple: Dutch language
 sk: Holandčina
 sl: Nizozemščina
 sm: Fa'aholani
@@ -4639,7 +4614,6 @@ sg: Anglëe
 sgs: Onglu kalba
 sh: engleski jezik
 si: ඉංග්‍රීසි භාෂාව
-simple: English language
 sk: Angličtina
 sl: angleščina, angleški jezik
 sm: Fa'aperetania
@@ -5014,7 +4988,6 @@ sco: Estonie leid
 se: Esttegiella
 sgs: Estu kalba
 sh: Estonski jezik
-simple: Estonian language
 sk: estónčina
 sl: Estonščina
 sq: Gjuha estoneze
@@ -5386,7 +5359,6 @@ sco: Finnish
 se: Suomagiella
 sgs: Soumiu kalba
 sh: Finski jezik
-simple: Finnish language
 sk: Fínčina
 sl: Finščina
 sm: Fa'afinelani
@@ -5615,7 +5587,6 @@ se: Fránskkagiella
 sgs: Prancūzu kalba
 sh: Francuski jezik
 si: ප් රංශ භාෂාව
-simple: French language
 sk: francúzština
 sl: francoščina
 sm: Fa'afarani
@@ -5942,7 +5913,6 @@ scn: giurgianu, lingua giurgiana
 sco: Georgie leid
 sgs: Grozėnu kalba
 sh: Грузијски језик
-simple: Georgian language
 sk: Gruzínčina
 sl: Gruzinščina
 sm: Faasiaosiana
@@ -6152,7 +6122,6 @@ sco: German
 se: Duiskkagiella
 sgs: Vuokītiu kalba
 sh: Nemački jezik, Njemački jezik
-simple: German language
 sk: Nemčina
 sl: nemščina, nemški jezik
 sm: Fa'asiamani
@@ -6319,7 +6288,6 @@ qu: Kalalit simi, Kalaallisut
 ru: гренландский язык, Гренландский, Kalaallisut
 scn: groenlannisi, groenlannisi, lingua groenlannisa, groenlandisi, lingua groenlanisa
 sh: Grenlandski jezik, Kalaallisut jezik
-simple: Greenlandic language
 sk: Grónčina
 sl: Grenlandščina
 sr: гренландски језик, Kalaallisut
@@ -6507,7 +6475,6 @@ scn: gujarati, lingua gujarati
 sco: Gujarati
 se: Gujaratagiella
 sh: Gudžarati jezik
-simple: Gujarati language
 sl: gudžaratščina
 sr: гуџарати језик
 sr-ec:гуџарати језик
@@ -6579,7 +6546,6 @@ pt: Crioulo haitiano
 pt-br:Crioulo haitiano
 ro: limba creolă haitiană, Creola haitiană
 ru: гаитянский креольский язык, Гаитянский язык, Аисьен, Гаитийский креольский язык, Гаитянский креольский
-simple: Haitian Creole language
 sv: Haitisk kreol, Haitisk kreolska, Haitisk kreolfranska
 ta: ஐத்தி கிரியோல் மொழி
 tokipona: toki Awisi
@@ -6813,7 +6779,6 @@ sco: Ebreu
 sgs: Hebraju kalba
 sh: Hebrejski jezik
 si: හීබෲ භාෂාව
-simple: Hebrew language
 sk: Hebrejčina
 sl: Hebrejščina
 so: Af-Hebrow
@@ -7034,7 +6999,6 @@ sco: Hindi
 se: Hindigiella
 sgs: Hindi
 sh: Hindi
-simple: Hindi language
 sk: hindčina
 sl: hindijščina
 sq: hindi
@@ -7231,7 +7195,6 @@ sco: Hungarian leid
 se: Ungárgiella
 sgs: Vengru kalba
 sh: Mađarski jezik
-simple: Hungarian language
 sk: Maďarčina
 sl: Madžarščina
 sm: Gagana Hungary
@@ -7374,7 +7337,6 @@ sco: Icelandic leid
 se: Islánddagiella
 sgs: Islandu kalba, Ėslandu kalba, Ėslandū ruoda, Ėslandu ruoda
 sh: Islandski jezik
-simple: Icelandic language
 sk: Islandčina
 sl: Islandščina
 sq: Gjuha islandeze
@@ -7668,7 +7630,6 @@ sah: Индонезия тыла
 scn: innunisianu, lingua innunisiana, indunisianu, lingua indunisiana
 sco: Indonesian leid
 sh: Indonežanski jezik
-simple: Indonesian language
 sk: Indonézština
 sl: indonezijščina, indonezijski jezik, bahasa Indonesia
 sq: Gjuha indoneziane
@@ -8064,7 +8025,6 @@ scn: irlandisi, lingua irlandisi, irlannisi, lingua irlannisi
 sco: Erse leid
 se: Iirragiella
 sh: Irski jezik
-simple: Irish language
 sk: Írčina
 sl: Irska gelščina
 sq: Gjuha irlandeze
@@ -8251,7 +8211,6 @@ sco: Italian leid
 se: Itáliagiella
 sgs: Italu kalba
 sh: Italijanski jezik
-simple: Italian language
 sk: Taliančina
 sl: Italijanščina
 sm: Fa'aitaliani
@@ -8449,7 +8408,6 @@ sco: Japanese leid, Japanese
 se: Japánagiella, Jáhpángiella
 sgs: Japuonu kalba, Japuonū ruoda, Japuonu ruoda
 sh: Japanski jezik, Јапански језик, Japanski
-simple: Japanese language
 sk: japončina
 sl: Japonščina, 日本語
 sm: Fa'aiapani
@@ -8572,7 +8530,6 @@ sah: Дьааба тыла
 scn: giavanisi, lingua giavanisi
 sco: Javanese
 sh: Javanski jezik
-simple: Javanese language
 sr: јавански језик
 su: Basa Jawa
 sv: javanesiska
@@ -8995,7 +8952,6 @@ ru: кхмерский язык
 scn: khmer, lingua khmer
 sco: Khmer leid
 sh: Kmerski jezik
-simple: Khmer language
 sr: кмерски језик
 sv: Khmer
 ta: கெமர் மொழி
@@ -9366,7 +9322,6 @@ sco: Korean
 se: Koreagiella
 sh: Korejski jezik
 si: කොරියානු භාෂාව
-simple: Korean language
 sk: kórejčina
 sl: Korejščina
 sm: Fa'aKolea
@@ -9491,7 +9446,6 @@ ru: курдские языки, Kurdî, курдский, курдский яз
 scn: Lingua curda
 sco: Kurdish leid
 sh: Kurdski jezik
-simple: Kurdish language
 sk: kurdčina, Kurdský jazyk
 sq: Gjuha kurde
 sr: курдски језик
@@ -9706,7 +9660,6 @@ ru: лаосский язык
 scn: lautianu, lingua lautiana, lao, lingua lao
 sco: Lao leid
 sh: Laoski jezik
-simple: Lao language
 sk: laoština
 sr: лаоски језик
 sv: Lao
@@ -9899,7 +9852,6 @@ se: Láhtengiella
 sgs: Luotīnu kalba
 sh: Latinski jezik
 si: ලතින්
-simple: Latin language
 sk: latinčina
 sl: Latinščina
 so: Af-Laatiin
@@ -10045,7 +9997,6 @@ sco: Latvian leid
 se: Látviagiella
 sgs: Latviu kalba
 sh: Letonski jezik
-simple: Latvian language
 sk: lotyština
 sl: Latvijščina
 sq: Gjuha letoneze
@@ -10311,7 +10262,6 @@ sco: Lithuanie leid
 se: Liettuvagiella
 sgs: Lietoviu kalba
 sh: Litvanski jezik
-simple: Lithuanian language
 sk: litovčina
 sl: Litovščina
 sm: Gagana Lufiana
@@ -10501,7 +10451,6 @@ scn: lussimburghisi, lingua lussimburghisa
 sco: Luxembourgis
 se: Luxemburggagiella
 sh: Luksemburški jezik
-simple: Luxembourgish language
 sk: luxemburčina
 sl: Luksemburščina
 sq: Gjuha luksemburgeze
@@ -10619,7 +10568,6 @@ sco: Macedonie leid
 se: Makedoniagiella
 sgs: Makeduonu kalba
 sh: Makedonski jezik
-simple: Macedonian language
 sk: Macedónčina
 sl: Makedonščina
 sq: Gjuha sllavomaqedone
@@ -10814,7 +10762,6 @@ scn: malisi, lingua malisi
 sco: Malay leid
 sd: مالي ٻولي
 sh: Malajski jezik
-simple: Malay language
 sr: малајски језик
 sv: Malajiska
 sw: Kimalay
@@ -10986,7 +10933,6 @@ pt: Diveí, Maldivense, Maldivano, Maldiviano, Maldivo
 pt-br:Diveí, Maldivense, Maldivano, Maldiviano, Maldivo
 ru: мальдивский язык, Dhivehi, дхивехи, дивехи
 si: දිවෙහි භාෂාව
-simple: Dhivehi
 sk: Maldivčina
 sv: Divehi
 sw: Kidhivehi
@@ -11094,7 +11040,6 @@ scn: maltisi, lingua maltisi, mautisi, lingua mautisi
 sco: Maltese leid
 se: maltagiella
 sh: Malteški jezik
-simple: Maltese language
 sk: Maltčina
 sl: Malteščina
 sq: Gjuha malteze
@@ -11204,7 +11149,6 @@ scn: mannisi, lingua mannisi, manx, lingua manx
 sco: Manx Gaelic leid
 se: Manksgiella
 sh: Manski jezik
-simple: Manx language
 sk: Mančina
 sl: Manska gelščina
 sr: манкс језик
@@ -11304,7 +11248,6 @@ sa: मराठी भाषा
 scn: marathi, lingua marathi
 sco: Marathi
 sh: Marati jezik
-simple: Marathi language
 sk: máráthčina
 sr: маратхи језик
 sr-ec:маратхи језик
@@ -11473,7 +11416,6 @@ sah: Молдаваан тыла
 scn: Lingua moldava
 sgs: Muoldavu kalba
 sh: Moldavski jezik
-simple: Moldovan language
 sk: Moldavčina
 sl: Moldavščina
 sq: Gjuha moldave
@@ -11595,7 +11537,6 @@ sah: Монгуол тыла
 scn: mòngulu, lingua mòngula
 sco: Mongolie leid
 sh: Mongolski jezik
-simple: Mongolian language
 sk: Mongolčina
 sq: Gjuha mongoleze
 sr: монголски језик
@@ -12291,7 +12232,6 @@ sco: Norse leid
 se: Dárogiella
 sgs: Nuorvegu kalba
 sh: Norveški jezik
-simple: Norwegian language
 sk: Nórčina
 sl: Norveščina
 sq: Gjuha norvegjeze
@@ -12537,7 +12477,6 @@ sco: Occitan leid
 se: Oksitánagiella
 sgs: Uoksėtanu kalba
 sh: Oksitanski jezik
-simple: Occitan language
 sk: Okcitánčina
 sl: Okcitanščina
 sq: Gjuha oksitane
@@ -12632,7 +12571,6 @@ sa: ओडिया
 scn: oriya, lingua oriya
 sco: Odia, Oriya
 sh: Oriya, Orija, Orija jezik
-simple: Oriya language
 sr: орија језик
 sv: oriya
 sw: Kioriya
@@ -13002,7 +12940,6 @@ ro: Limba paștună, Limba paștu, Limba paştună
 ru: Пушту, Афганский язык, Язык пушту, Пашто, Пуштунский язык, Пушту язык, Авганский язык
 sco: Pashto leid
 sh: Paštunski jezik
-simple: Pashto language
 sk: Paštčina, Paštó, Afgančina
 sr: паштунски језик, Пушту, Пашто, Пашту
 su: Basa Pastun
@@ -13146,7 +13083,6 @@ sd: فارسي ٻولي
 se: Persiagiella
 sgs: Persu kalba
 sh: Perzijski jezik
-simple: Persian language
 sk: Perzské jazyky
 sl: Perzijščina
 so: Af-Faarsi
@@ -13319,7 +13255,6 @@ sco: Pols
 se: Polskkagiella
 sgs: Lėnku kalba
 sh: Poljski jezik
-simple: Polish language
 sk: Poľština
 sl: poljščina, poljski jezik
 sm: Fa'apolani
@@ -13524,7 +13459,6 @@ sco: Portuguese
 se: Portugalagiella
 sgs: Puortogalu kalba, Partugalū ruoda, Portugalu kalba, Portugalu ruoda, Partugalū kalba
 sh: Portugalski jezik, Португалски језик, Portugalski
-simple: Portuguese language
 sk: Portugalčina, Portugalský jazyk
 sl: Portugalščina
 sm: Fa'aPotukale
@@ -13646,7 +13580,6 @@ ru: панджаби, пенджаби, пенджабский язык, вос�
 sa: पञ्जाबी
 sco: Panjabi leid, Punjabi Leid
 sh: Punjabi jezik, Pandžabski jezik, Panjabi jezik, Pandžabi, Pundžabi jezik, Punjabski jezik
-simple: Punjabi language
 sk: Pandžábčina, Východná pandžábčina, Západná pandžábčina, Mírpurská pandžábčina
 sr: панџаби, Пунџаби језик, Панџабски језик, Пунџаби, Панџаби језик, Пенџаби
 sr-ec:панџаби
@@ -13750,7 +13683,6 @@ ru: кечуа
 sah: Кечуа тыла
 sco: Quechuan leids
 sh: Kečua
-simple: Quechua
 sk: kečuánčina
 sl: kečuanščina
 sq: kueçua
@@ -13888,7 +13820,6 @@ sco: Romanie leid
 se: Romániagiella
 sgs: Romonu kalba
 sh: Rumunski jezik
-simple: Romanian language
 sk: rumunčina
 sl: Romunščina
 sm: Fa'aRomania
@@ -14007,7 +13938,6 @@ sc: Limba romancia
 scn: rumanciu, lingua rumancia
 sgs: Retoruomanu kalba
 sh: Romanš
-simple: Romansh language
 sk: Švajčiarska rétorománčina
 sl: Retoromanščina
 sq: Gjuha romançe
@@ -14211,7 +14141,6 @@ sco: Roushie
 se: Ruoššagiella
 sgs: Rosu kalba
 sh: Ruski jezik
-simple: Russian language
 sk: ruština
 sl: ruščina
 sm: Gagana fa'a Lusia
@@ -14815,7 +14744,6 @@ scn: gaèlicu scuzzisi, lingua gaèlica scuzzisi
 sco: Scots Gaelic leid
 se: Gaelagiella
 sh: Škotski gelski jezik
-simple: Scottish Gaelic language
 sk: Škótska gaelčina
 sl: Škotska gelščina
 sr: шкотски гелски језик
@@ -15232,7 +15160,6 @@ scn: sindhi, lingua sindhi
 sco: Sindhi leid
 sd: سنڌي ٻولي, سنڌی ٻولی
 sh: Sindi jezik
-simple: Sindhi language
 sr: синди језик
 sr-ec:синди језик
 sr-el:sindi jezik
@@ -15438,7 +15365,6 @@ sco: Slovak leid
 se: Slovákiagiella
 sgs: Sluovaku kalba
 sh: Slovački jezik
-simple: Slovak language
 sk: slovenčina
 sl: Slovaščina
 sm: Fa'aSolovak
@@ -15572,7 +15498,6 @@ sco: Slovenie leid
 se: Slovenagiella
 sgs: Sluovienu kalba
 sh: Slovenski jezik
-simple: Slovene language
 sk: Slovinčina
 sl: slovenščina, slovenski jezik
 sm: Gagana Slovene
@@ -15667,7 +15592,6 @@ ru: сомалийский язык
 scn: sòmalu, lingua sòmala
 sco: Somali leid
 sh: Somalski jezik
-simple: Somali language
 so: Af-Soomaali
 sr: сомалски језик
 sr-ec:сомалски језик
@@ -15986,7 +15910,6 @@ sco: Spainyie
 se: Spánskagiella
 sgs: Ispanu kalba, Ėspanū kalba, Ėspanū ruoda, Ėspanu ruoda, Ėspanu kalba
 sh: Španski jezik
-simple: Spanish language
 sk: Španielčina
 sl: Španščina
 sm: Gagana spaniolo
@@ -16227,7 +16150,6 @@ sah: Суаhили
 scn: kiswahili, lingua kiswahili, swahili, lingua swahili
 sco: Swauheely leid
 sh: Svahili
-simple: Swahili language
 sk: Swahilčina
 sl: Svahili
 so: Sawaaxili
@@ -16450,7 +16372,6 @@ sco: Swadish
 se: Ruoŧagiella
 sgs: Švedu kalba
 sh: Švedski jezik
-simple: Swedish language
 sk: Švédčina
 sl: Švedščina
 sm: Fa'asuetena
@@ -16568,7 +16489,6 @@ ru: тагальский язык, Филипино, Тагальский, Та�
 scn: tagalog, lingua tagalog, tagallu, lingua tagalla
 sco: Tagalog leid
 sh: Tagaloški jezik
-simple: Tagalog language
 sr: тагалог, Тагалог језик
 sv: tagalog, Tagalogiska
 sw: Kitagalog
@@ -16843,7 +16763,6 @@ sco: Taimil leid
 sgs: Tamėlu kalba
 sh: Tamilski jezik
 si: දෙමළ
-simple: Tamil language
 sl: Tamilščina
 so: Luqada Tamil-ka
 sq: Gjuha tamile
@@ -16959,7 +16878,6 @@ sah: Татаар тыла, Татар тыла, Татар теле
 scn: tàtaru, lingua tàtara, tàrtaru, lingua tàrtara
 sco: Tatar
 sgs: Tuotuoriu kalba
-simple: Tatar language
 sk: Tatárčina
 sr: татарски језик
 sr-ec:татарски језик
@@ -17171,7 +17089,6 @@ scn: tailannisi, lingua tailannisi, siamisi, lingua siamisi, tai, lingua tai, ta
 sco: Thai
 se: Thaigiella
 sh: Tajlandski jezik
-simple: Thai language
 sk: Thajčina
 sl: tajščina, tajski jezik
 sr: тајландски језик
@@ -17461,7 +17378,6 @@ oc: Tsonga
 pl: Język tsonga, Język czitsonga, Język chitsonga
 pms: Lenga Tsonga
 ru: тсонга, шангаан, тсонга язык
-simple: Tsonga language
 sq: Gjuha tsonga
 st: Setsonga
 sv: Tsonga, Xitsonga
@@ -17684,7 +17600,6 @@ sco: Turkis
 se: Durkkagiella
 sgs: Torku kalba
 sh: Turski jezik
-simple: Turkish language
 sk: turečtina
 sl: turščina
 so: Af-Turki
@@ -17799,7 +17714,6 @@ scn: turkmenu, lingua turkmena, turcumannu, lingua turcumanna
 sco: Turkmen leid
 sgs: Torkmienu kalba
 sh: Turkmenski jezik
-simple: Turkmen language
 sk: Turkménčina
 sr: туркменски језик
 sr-ec:туркменски језик
@@ -17981,7 +17895,6 @@ sco: Ukrainian leid
 se: Ukrainagiella
 sgs: Okrainėitiu kalba
 sh: Ukrajinski jezik
-simple: Ukrainian language
 sk: Ukrajinčina
 sl: Ukrajinščina
 sm: Fa'aUkaraina
@@ -18218,7 +18131,6 @@ scn: uiguru, lingua uigura
 sco: Uyghur
 se: Uiguragiella
 sgs: Uigūru kalba
-simple: Uyghur language
 sk: Ujgurčina
 sr: ујгурски језик
 sr-ec:ујгурски језик
@@ -18323,7 +18235,6 @@ scn: usbecu, lingua usbeca, uzbecu, lingua uzbeca, uzbeku, lingua uzbeka
 sco: Uzbek leid
 sgs: Ozbėku kalba
 sh: Uzbečki jezik
-simple: Uzbek language
 sk: Uzbečtina
 sr: узбечки језик
 sr-ec:узбечки језик
@@ -18389,7 +18300,6 @@ pt-br:Venda
 ru: венда
 rw: Ikivenda
 sh: Venda jezik
-simple: Venda language
 sq: Gjuha venda
 sr: венда
 st: Sevenda
@@ -18500,7 +18410,6 @@ sa: वियतनामी भाषा
 scn: vietnamita, lingua vietnamita
 sco: Vietnamese leid
 sh: Vijetnamski jezik
-simple: Vietnamese language
 sm: Fa'aViatename
 sq: Gjuha vietnameze
 sr: вијетнамски језик
@@ -18829,7 +18738,6 @@ scn: gallisi, lingua gallisi
 sco: Welsh leid
 se: Kymragiella
 sh: Velški jezik
-simple: Welsh language
 sk: Waleština
 sl: Valižanščina
 sq: Gjuha Uelshe
@@ -19041,7 +18949,6 @@ qu: Xhosa simi
 ru: коса
 rw: Ikigisosa
 sh: Xhosa jezik
-simple: Xhosa language
 sq: Gjuha xhosa
 sr: коса
 sv: Xhosa
@@ -19228,7 +19135,6 @@ ro: Limba yoruba
 ru: йоруба, Язык йоруба, Йоруба язык
 scn: yoruba, lingua yoruba
 sco: Yoruba
-simple: Yoruba language
 sv: Yoruba, Ede Yorùbá, Yorubaspråket
 sw: Kiyoruba
 ta: யொரூபா மொழி
@@ -19372,7 +19278,6 @@ scn: zulù, lingua zulù
 sco: Zulu
 se: Zulugiella
 sh: Zulu jezik
-simple: Zulu language
 so: Af-Zulu
 sq: Gjuha zulu
 sr: зулу језик


### PR DESCRIPTION
The `simple` language entries are probably a remnant from a Wikipedia/Wikidata import, as `simple` is a Wikimedia language code used for “simplified English”. We don’t use that in OFF, so let’s drop them.

Preparation for https://github.com/openfoodfacts/openfoodfacts-server/pull/12495