### PR TITLE
taxonomy: fix: Fold `zh-min-nan` into `nan`

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -498,7 +498,6 @@ zh-classical:阿富汗
 zh-cn:阿富汗
 zh-hans:阿富汗
 zh-hant:阿富汗
-zh-min-nan:Afghanistan
 zh-yue:阿富汗
 zu: I-Afganistani
 country_code_2:en: AF
@@ -739,7 +738,6 @@ zh-cn:阿尔巴尼亚
 zh-hans:阿尔巴尼亚
 zh-hant:阿爾巴尼亞
 zh-hk:阿爾巴尼亞
-zh-min-nan:Shqipëria
 zh-mo:阿爾巴尼亞
 zh-my:阿尔巴尼亚
 zh-sg:阿尔巴尼亚
@@ -1030,7 +1028,6 @@ zh-cn:阿尔及利亚
 zh-hans:阿尔及利亚
 zh-hant:阿爾及利亞
 zh-hk:阿爾及利亞
-zh-min-nan:Algeria
 zh-mo:阿爾及利亞
 zh-my:阿尔及利亚
 zh-sg:阿尔及利亚
@@ -1105,6 +1102,7 @@ mk: Американска Самоа
 ml: അമേരിക്കൻ സമോവ
 mr: अमेरिकन सामोआ
 ms: Samoa Amerika
+nan: Bí-kok Samoa
 nb: Amerikansk Samoa
 ne: अमेरिकी सामोआ
 nl: Amerikaans-Samoa
@@ -1148,7 +1146,6 @@ yi: אמעריקאנישער סאמאא
 yo: Sàmóà Amẹ́ríkà
 yue: 美屬薩摩亞
 zh: 美屬薩摩亞
-zh-min-nan:Bí-kok Samoa
 zh-yue:美屬薩摩亞
 country_code_2:en: AS
 country_code_3:en: ASM
@@ -1390,7 +1387,6 @@ zh-cn:安道尔, 安道尔公国
 zh-hans:安道尔, 安道尔公国
 zh-hant:安道爾, 安道爾公國
 zh-hk:安道爾, 安道爾公國
-zh-min-nan:Andorra
 zh-mo:安道爾, 安道爾公國
 zh-my:安道尔, 安道尔公国
 zh-sg:安道尔, 安道尔公国
@@ -1610,7 +1606,6 @@ zh-classical:安哥拉
 zh-cn:安哥拉
 zh-hans:安哥拉
 zh-hant:安哥拉
-zh-min-nan:Angola
 zh-yue:安哥拉
 zu: I-Angola
 country_code_2:en: AO
@@ -1723,7 +1718,6 @@ wo: Angila, Anguilla
 yo: Àngúíllà, Anguilla
 yue: 安圭拉
 zh: 安圭拉, 英屬安圭拉, 安圭拉岛
-zh-min-nan:Anguilla
 zh-yue:安圭拉
 country_code_2:en: AI
 country_code_3:en: AIA
@@ -1979,7 +1973,6 @@ zh-cn:南极洲
 zh-hans:南极洲
 zh-hant:南极洲
 zh-hk:南极洲
-zh-min-nan:Lâm-ke̍k Tāi-lio̍k
 zh-mo:南极洲
 zh-my:南极洲
 zh-sg:南极洲
@@ -2148,7 +2141,6 @@ zh: 安提瓜和巴布达
 zh-cn:安提瓜和巴布达
 zh-hans:安提瓜和巴布达
 zh-hant:安提瓜和巴布达
-zh-min-nan:Antigua kap Barbuda
 zh-yue:安提瓜巴布達
 country_code_2:en: AG
 country_code_3:en: ATG
@@ -2382,7 +2374,6 @@ zea: Arhentinië
 zh: 阿根廷
 zh-classical:阿根廷
 zh-hans:阿根廷
-zh-min-nan:Argentina
 zh-yue:阿根廷
 country_code_2:en: AR
 country_code_3:en: ARG
@@ -2614,7 +2605,6 @@ yo: Arméníà
 yue: 亞美尼亞, Ayastani Hanrapetutyun, Հայաստան, Հայաստանի Հանրապետություն, Hayastan, Armenia, Republic of Armenia, 亞美尼亞共和國
 zea: Armenië
 zh: 亞美尼亞
-zh-min-nan:Hayastan
 zh-yue:亞美尼亞
 country_code_2:en: AM
 country_code_3:en: ARM
@@ -2751,7 +2741,6 @@ zh: 阿魯巴, 阿鲁巴岛, 阿魯巴島, 阿盧巴, 阿鲁巴
 zh-cn:阿魯巴
 zh-hans:阿魯巴
 zh-hant:阿魯巴
-zh-min-nan:Aruba
 zh-yue:阿魯巴島
 country_code_2:en: AW
 country_code_3:en: ABW
@@ -3075,7 +3064,6 @@ zea: Australië
 zh: 澳大利亚
 zh-classical:澳大利亞
 zh-hans:澳大利亚
-zh-min-nan:Australia
 zh-yue:澳洲
 zu: I-Ostreliya
 country_code_2:en: AU
@@ -3331,7 +3319,6 @@ zh-cn:奥地利, 奥地利共和国
 zh-hans:奥地利, 奥地利共和国
 zh-hant:奧地利, 奧地利共和國
 zh-hk:奧地利, 奧地利共和國
-zh-min-nan:Ò-tē-lī, Austria, Österreich, Tang-kok
 zh-mo:奧地利, 奧地利共和國
 zh-my:奥地利, 奥地利共和国
 zh-sg:奥地利, 奥地利共和国
@@ -3569,7 +3556,6 @@ za: Ahsehbaiqgyangh
 zea: Aâzerbeidzjan
 zh: 阿塞拜疆
 zh-hans:阿塞拜疆
-zh-min-nan:Azerbaijan
 zh-yue:阿塞拜疆
 zu: Azerbaijan
 country_code_2:en: AZ
@@ -3768,7 +3754,6 @@ zea: Bahrein
 zh: 巴林
 zh-classical:巴林
 zh-hans:巴林
-zh-min-nan:Bahrain
 zh-yue:巴林
 country_code_2:en: BH
 country_code_3:en: BHR
@@ -3978,7 +3963,6 @@ yue: 孟加拉國
 zea: Bangladesh
 zh: 孟加拉国
 zh-hans:孟加拉国
-zh-min-nan:Bangladesh
 zh-yue:孟加拉國
 country_code_2:en: BD
 country_code_3:en: BGD
@@ -4159,7 +4143,6 @@ yo: Bárbádọ̀s
 yue: 巴巴多斯
 zea: Barbados
 zh: 巴巴多斯
-zh-min-nan:Barbados
 zh-yue:巴巴多斯
 country_code_2:en: BB
 country_code_3:en: BRB
@@ -4301,6 +4284,7 @@ mt: Belarus
 my: ဘီလာရုဇ်နိုင်ငံ
 na: Berarut
 nah: Belarus
+nan: Belarus
 nap: Bielorussia
 nb: Hviterussland, Republikken Hviterussland
 nds: Wittrussland
@@ -4388,7 +4372,6 @@ zea: Wit-Rusland
 zh: 白俄罗斯
 zh-classical:白俄羅斯
 zh-hans:白俄罗斯
-zh-min-nan:Belarus
 zh-yue:白俄羅斯
 zu: IBelarusi
 country_code_2:en: BY
@@ -4635,7 +4618,6 @@ zh-cn:比利时, 比利时王国
 zh-hans:比利时, 比利时王国
 zh-hant:比利時, 比利時王國
 zh-hk:比利時, 比利時王國
-zh-min-nan:Belgien
 zh-mo:比利時, 比利時王國
 zh-my:比利时, 比利时王国
 zh-sg:比利时, 比利时王国
@@ -4825,7 +4807,6 @@ yo: Bẹ̀lísè
 yue: 伯利茲
 zea: Belize
 zh: 伯利兹
-zh-min-nan:Belize
 zh-yue:伯利茲
 zu: Belize
 country_code_2:en: BZ
@@ -5027,7 +5008,6 @@ zh: 贝宁
 zh-cn:贝宁
 zh-hans:贝宁
 zh-hant:贝宁
-zh-min-nan:Bénin
 zh-yue:貝寧
 zu: IBenini
 country_code_2:en: BJ
@@ -5151,7 +5131,6 @@ xmf: ბერმუდაშ კოკეფი
 yo: Bẹ̀rmúdà, Bermuda
 yue: 百慕達
 zh: 百慕大, 百慕達群島, Bermuda, 百慕達, 百慕大群岛, 百幕達
-zh-min-nan:Bermuda
 zh-yue:百慕達
 country_code_2:en: BM
 country_code_3:en: BMU
@@ -5346,7 +5325,6 @@ zh-cn:不丹, 不丹王国
 zh-hans:不丹, 不丹王国
 zh-hant:不丹, 不丹王國
 zh-hk:不丹, 不丹王國
-zh-min-nan:Bhutan
 zh-mo:不丹, 不丹王國
 zh-my:不丹, 不丹王国
 zh-sg:不丹, 不丹王国
@@ -5558,7 +5536,6 @@ zh-classical:玻利維亞
 zh-cn:玻利維亞
 zh-hans:玻利維亞
 zh-hant:玻利維亞
-zh-min-nan:Bolivia
 zh-yue:玻利維亞
 country_code_2:en: BO
 country_code_3:en: BOL
@@ -5855,7 +5832,6 @@ yo: Bósníà àti Hẹrjẹgòfínà
 yue: 波斯尼亞, Bosna, Босна и Херцеговина, Bosnia, 波斯尼亞-黑塞哥維那, Bosna i Hercegovina, 波斯尼亞同黑塞哥維那, 波斯尼亞黑塞哥維那, 波斯尼亞和黑塞哥維那, Bosnia and Herzegovina
 zea: Bosnië-Hercegovina
 zh: 波斯尼亚和黑塞哥维那
-zh-min-nan:Bosna kap Hercegovina
 zh-yue:波斯尼亞
 country_code_2:en: BA
 country_code_3:en: BIH
@@ -6062,7 +6038,6 @@ zh-classical:波札那
 zh-cn:波札那
 zh-hans:波札那
 zh-hant:波札那
-zh-min-nan:Botswana
 zh-yue:波茨華拿
 zu: IButswana
 country_code_2:en: BW
@@ -6293,6 +6268,7 @@ my: ဘရာဇီးနိုင်ငံ
 mzn: برزیل
 na: Bradir
 nah: Brasil
+nan: Pa-se
 nap: Brasile
 nb: Brasil, Forbundsrepublikken Brasil
 nds: Brasilien
@@ -6392,7 +6368,6 @@ zh-cn:巴西
 zh-hans:巴西
 zh-hant:巴西
 zh-hk:巴西
-zh-min-nan:Pa-se
 zh-mo:巴西
 zh-my:巴西
 zh-sg:巴西
@@ -6580,7 +6555,6 @@ wo: Duni Virgin, Virgin Islands
 yo: Àwọn Erékùṣù Wúndíá Brítánì, The British Virgin Islands, British Virgin Islands, Àwọn Erékùṣù Wúndíá ti Brítánì
 yue: 英屬處女羣島
 zh: 英屬維爾京群島, 英屬維京群島, 英屬處女群島, 英属维尔京群岛, 托托拉岛, 英屬處女島
-zh-min-nan:Britain Virgin Kûn-tó
 zh-yue:英屬處女羣島
 country_code_2:en: VG
 country_code_3:en: VGB
@@ -6773,7 +6747,6 @@ yo: Brunei
 yue: 汶萊
 zea: Brunei
 zh: 文莱
-zh-min-nan:Brunei
 zh-yue:汶萊
 country_code_2:en: BN
 country_code_3:en: BRN
@@ -7027,7 +7000,6 @@ zea: Bulharije, Bulgarije
 zh: 保加利亚
 zh-classical:保加利亞
 zh-hans:保加利亚
-zh-min-nan:Bulgariya
 zh-yue:保加利亞
 zu: IBulgariya
 country_code_2:en: BG
@@ -7223,7 +7195,6 @@ zh: 布吉納法索
 zh-cn:布吉納法索
 zh-hans:布吉納法索
 zh-hant:布吉納法索
-zh-min-nan:Burkina Faso
 zh-yue:布基納法索
 zu: IBukhina Faso
 country_code_2:en: BF
@@ -7422,7 +7393,6 @@ zh: 蒲隆地
 zh-cn:蒲隆地
 zh-hans:蒲隆地
 zh-hant:蒲隆地
-zh-min-nan:Burundi
 zh-yue:布隆迪
 zu: IBurundi
 country_code_2:en: BI
@@ -7546,6 +7516,7 @@ mt: Kambodja
 my: ကမ္ဘောဒီးယားနိုင်ငံ
 na: Kambodja
 nah: Camboya
+nan: Kampuchea
 nap: Cambogia
 nb: Kambodsja
 nds: Kambodscha
@@ -7614,7 +7585,6 @@ yue: 柬埔寨
 zea: Cambodja
 zh: 柬埔寨
 zh-classical:柬埔寨
-zh-min-nan:Kampuchea
 zh-yue:柬埔寨
 country_code_2:en: KH
 country_code_3:en: KHM
@@ -7817,7 +7787,6 @@ zh: 喀麦隆
 zh-cn:喀麦隆
 zh-hans:喀麦隆
 zh-hant:喀麦隆
-zh-min-nan:Cameroon
 zh-yue:喀麥隆
 zu: IKamerooni
 country_code_2:en: CM
@@ -8080,7 +8049,6 @@ zh-cn:加拿大
 zh-hans:加拿大
 zh-hant:加拿大
 zh-hk:加拿大
-zh-min-nan:Canada
 zh-mo:加拿大
 zh-my:加拿大
 zh-sg:加拿大
@@ -8275,7 +8243,6 @@ zh: 佛得角
 zh-cn:佛得角
 zh-hans:佛得角
 zh-hant:佛得角
-zh-min-nan:Chheⁿ-kak Kiōng-hô-kok
 zh-yue:維德角
 zu: IKhepi Vedhi
 country_code_2:en: CV
@@ -8391,6 +8358,7 @@ lv: Kaimanu Salas
 mk: Кајмански Острови
 mr: केमन द्वीपसमूह
 ms: Kepulauan Cayman
+nan: Cayman Kûn-tó
 nb: Caymanøyene
 nds: Kaimaninseln
 nl: Kaaimaneilanden
@@ -8428,7 +8396,6 @@ war: Kapuropud-an Cayman
 yo: Àwọn Erékùṣù Káímàn
 yue: 開曼群島
 zh: 開曼群島
-zh-min-nan:Cayman Kûn-tó
 zh-yue:開曼群島
 country_code_2:en: KY
 country_code_3:en: CYM
@@ -8614,7 +8581,6 @@ yue: 中非共和國
 zh: 中非共和國
 zh-classical:中非
 zh-hans:中非共和国, 中非
-zh-min-nan:Tiong-hui Kiōng-hô-kok
 zh-yue:中非共和國
 zu: Central African Republic
 country_code_2:en: CF
@@ -8815,7 +8781,6 @@ zh-cn:乍得
 zh-hans:乍得
 zh-hant:乍得
 zh-hk:乍得
-zh-min-nan:Tchad
 zh-mo:乍得
 zh-my:乍得
 zh-sg:乍得
@@ -9077,7 +9042,6 @@ zh: 智利
 zh-classical:智利
 zh-hans:智利
 zh-hant:智利
-zh-min-nan:Chile
 zh-yue:智利
 zu: Chili
 country_code_2:en: CL
@@ -9326,7 +9290,6 @@ zh-classical:中華人民共和國
 zh-cn:中华人民共和国
 zh-hans:中华人民共和国, 中国
 zh-hant:中華人民共和國, 中國
-zh-min-nan:Tiong-hoâ Jîn-bîn Kiōng-hô-kok
 zh-yue:中華人民共和國
 zu: IShayina
 country_code_2:en: CN
@@ -9425,7 +9388,6 @@ wuu: 圣诞岛
 yo: Erékùṣù Kérésìmesì, Christmas Island
 yue: 聖誕島
 zh: 圣诞岛, 耶誕島
-zh-min-nan:Christmas-tó
 zh-yue:聖誕島
 country_code_2:en: CX
 country_code_3:en: CXR
@@ -9488,7 +9450,7 @@ ml: കോകോസ്
 mn: Кокос (Кийлинг) Арлууд, Кокос (Кийлинг) Арал
 mr: कोकोस द्वीपसमूह, कोकोस द्वीपे
 ms: Kepulauan Cocos
-nan: Cocos (Keeling) Kûn-tó, Cocos kap Keeling Kûn-tó, Cocos (Keeling) Islands
+nan: Cocos (Keeling) Kûn-tó, Cocos kap Keeling Kûn-tó, Cocos (Keeling) Islands, Cocos
 nb: Kokosøyene, Cocos Islands, Keelingøyene, CCK
 ne: कोकोस टापु
 nl: Cocoseilanden, Cocos (Keeling) Eilanden, Keeling Eilanden, Cocos eilanden, Keelingeilanden, Keeling islands, Kokoseilanden, Cocos Islands
@@ -9524,7 +9486,6 @@ yo: Àwọn Erékùṣù Kókósì, Àwọn Erékùsù Kókósì, The Cocos (Kee
 yue: 可可斯 (基林) 群島
 zh: 科科斯（基林）群島, 科科斯（基林）群岛, 可可群岛, 可可斯群島, 科科斯群岛, 科科斯群島, 科科斯(基林)群岛
 zh-classical:科科斯（基林）群島
-zh-min-nan:Cocos
 zh-yue:可可斯
 country_code_2:en: CC
 country_code_3:en: CCK
@@ -9736,7 +9697,6 @@ zh-classical:哥倫比亞
 zh-cn:哥伦比亚
 zh-hans:哥伦比亚
 zh-hant:哥伦比亚
-zh-min-nan:Colombia
 zh-yue:哥倫比亞
 zu: IKolombiya
 country_code_2:en: CO
@@ -9844,6 +9804,7 @@ mt: Komoros
 my: ကိုမိုရိုနိုင်ငံ
 na: Komorot
 nah: Comoras
+nan: Komor
 nb: Komorene
 nds: Komoren
 ne: कोमोरोस
@@ -9914,7 +9875,6 @@ zh: 葛摩
 zh-cn:葛摩
 zh-hans:葛摩
 zh-hant:葛摩
-zh-min-nan:Komor
 zh-yue:科摩羅
 zu: IsiKhomorosi
 country_code_2:en: KM
@@ -10029,7 +9989,6 @@ wo: Dunu Kook, Iil yu Cook
 yo: Àwọn Erékùṣù Cook, The Cook Islands, Cook Islands
 yue: 曲克群島
 zh: 库克群岛, 庫克群島, 科克群島, 科克群岛
-zh-min-nan:Cook Kûn-tó
 zh-yue:曲克群島
 country_code_2:en: CK
 country_code_3:en: COK
@@ -10211,7 +10170,6 @@ yue: 哥斯達黎加
 zea: Costa Rica
 zh: 哥斯达黎加
 zh-classical:哥斯大黎加
-zh-min-nan:Costa Rica
 zh-yue:哥斯達黎加
 zu: Costa Rica
 country_code_2:en: CR
@@ -10349,6 +10307,7 @@ mt: Kroazja
 my: ခရိုအေးရှားနိုင်ငံ
 na: Kroaitsiya
 nah: Croacia
+nan: Hrvatska
 nap: Croazia
 nb: Kroatia, Republikken Kroatia
 nds: Kroatien
@@ -10440,7 +10399,6 @@ yue: 克羅地亞
 za: Gwzlozdiya
 zea: Kroaotië
 zh: 克罗地亚
-zh-min-nan:Hrvatska
 zh-yue:克羅地亞
 country_code_2:en: HR
 country_code_3:en: HRV
@@ -10650,7 +10608,6 @@ zh-classical:古巴
 zh-cn:古巴
 zh-hans:古巴
 zh-hant:古巴
-zh-min-nan:Cuba
 zh-yue:古巴
 country_code_2:en: CU
 country_code_3:en: CUB
@@ -10962,7 +10919,6 @@ yo: Kíprù
 yue: 塞浦路斯
 zea: Cyprus
 zh: 賽普勒斯
-zh-min-nan:Ku-pí-lō͘
 zh-yue:塞浦路斯
 country_code_2:en: CY
 country_code_3:en: CYP
@@ -11201,7 +11157,6 @@ zea: Tsjehhië
 zh: 捷克
 zh-classical:捷克
 zh-hans:捷克
-zh-min-nan:Česko
 zh-yue:捷克
 zu: ITsheki
 country_code_2:en: CZ
@@ -11391,7 +11346,6 @@ yi: בארטן פון העלפאנדביין
 yo: Côte d'Ivoire
 yue: 象牙海岸
 zh: 科特迪瓦
-zh-min-nan:Côte d'Ivoire
 zh-yue:象牙海岸
 zu: Ugu Emhlophe
 country_code_2:en: CI
@@ -11582,7 +11536,6 @@ zh-classical:剛果民主共和國
 zh-cn:刚果民主共和国
 zh-hans:刚果民主共和国
 zh-hant:刚果民主共和国
-zh-min-nan:Congo Bîn-chú Kiōng-hô-kok
 zh-yue:剛果民主共和國
 zu: IRiphabliki Labantu weKongo
 country_code_2:en: CD
@@ -11833,7 +11786,6 @@ zh-cn:丹麦, 丹麦王国
 zh-hans:丹麦, 丹麦王国
 zh-hant:丹麥, 丹麥王國
 zh-hk:丹麥, 丹麥王國
-zh-min-nan:Tan-kok
 zh-mo:丹麥, 丹麥王國
 zh-my:丹麦, 丹麦王国
 zh-sg:丹麦, 丹麦王国
@@ -11943,6 +11895,7 @@ my: ဂျီဘူတီနိုင်ငံ
 mzn: جیبوتی
 na: Djibuti
 nah: Yibuti
+nan: Djibouti
 nb: Djibouti, Republikken Djibouti
 nds: Dschibuti
 ne: जिबुटी
@@ -12020,7 +11973,6 @@ zh-classical:吉布地
 zh-cn:吉布提
 zh-hans:吉布提
 zh-hant:吉布提
-zh-min-nan:Djibouti
 zh-yue:吉布提
 zu: IJibuthi
 country_code_2:en: DJ
@@ -12190,7 +12142,6 @@ zh: 多米尼克
 zh-cn:多米尼克
 zh-hans:多米尼克
 zh-hant:多米尼克
-zh-min-nan:Dominica
 zh-yue:多米尼克
 country_code_2:en: DM
 country_code_3:en: DMA
@@ -12365,7 +12316,6 @@ zh: 多明尼加共和國
 zh-cn:多明尼加共和國
 zh-hans:多明尼加共和國
 zh-hant:多明尼加共和國
-zh-min-nan:Dominic Kiōng-hô-kok
 zh-yue:多明尼加
 country_code_2:en: DO
 country_code_3:en: DOM
@@ -12439,6 +12389,7 @@ mr: पूर्व जर्मनी
 ms: Jerman Timur
 my: ဂျာမန်ဒီမိုကရက်တစ်သမ္မတနိုင်ငံ
 mzn: شرقی آلمان
+nan: Tang-tek
 nb: Den tyske demokratiske republikk
 nds: Düütsche Demokraatsche Republiek
 nl: Duitse Democratische Republiek, Oost-Duitsland, DDR
@@ -12481,7 +12432,6 @@ yi: מזרח דייטשלאנד
 yo: Ìlàoòrùn Jẹ́mánì
 yue: 東德
 zh: 东德, 德意志民主共和国, 民主德国
-zh-min-nan:Tang-tek
 zh-yue:東德
 language_codes:en:
 
@@ -12675,7 +12625,6 @@ zh: 厄瓜多尔
 zh-cn:厄瓜多尔
 zh-hans:厄瓜多尔
 zh-hant:厄瓜多尔
-zh-min-nan:Ecuador
 zh-yue:厄瓜多爾
 country_code_2:en: EC
 country_code_3:en: ECU
@@ -12913,7 +12862,6 @@ zh-cn:埃及, 阿拉伯埃及共和国
 zh-hans:埃及, 阿拉伯埃及共和国
 zh-hant:埃及, 阿拉伯埃及共和國
 zh-hk:埃及, 阿拉伯埃及共和國
-zh-min-nan:Ai-ki̍p
 zh-mo:埃及, 阿拉伯埃及共和國
 zh-my:埃及, 阿拉伯埃及共和国
 zh-sg:埃及, 阿拉伯埃及共和国
@@ -13093,7 +13041,6 @@ zh: 萨尔瓦多
 zh-cn:萨尔瓦多
 zh-hans:萨尔瓦多
 zh-hant:萨尔瓦多
-zh-min-nan:El Salvador
 zh-yue:薩爾瓦多
 zu: El Salvador
 country_code_2:en: SV
@@ -13202,6 +13149,7 @@ mt: Gwinea Ekwatorjali
 my: အီကွေတာဂီနီနိုင်ငံ
 na: Gini t Ekwador
 nah: Guinea Tlahcotlālticpac
+nan: Chhiah-tō Guinea
 nb: Ekvatorial-Guinea, Republikken Ekvatorial-Guinea
 nds: Äquatoriaal-Guinea
 ne: इक्वेटोरियल गिनी
@@ -13270,7 +13218,6 @@ zh-cn:赤道几内亚
 zh-hans:赤道几内亚
 zh-hant:赤道几内亚
 zh-hk:赤道几内亚
-zh-min-nan:Chhiah-tō Guinea
 zh-mo:赤道几内亚
 zh-my:赤道几内亚
 zh-sg:赤道几内亚
@@ -13468,7 +13415,6 @@ zh-cn:厄立特里亚
 zh-hans:厄立特里亚
 zh-hant:厄立特里亚
 zh-hk:厄立特里亚
-zh-min-nan:Eritrea
 zh-mo:厄立特里亚
 zh-my:厄立特里亚
 zh-sg:厄立特里亚
@@ -13712,7 +13658,6 @@ zea: Estland
 zh: 爱沙尼亚
 zh-classical:愛沙尼亞
 zh-cn:爱沙尼亚
-zh-min-nan:Eesti
 zh-yue:愛沙尼亞
 zu: I-Estoniya
 country_code_2:en: EE
@@ -13929,7 +13874,6 @@ zh: 埃塞俄比亚
 zh-classical:衣索比亞
 zh-hans:埃塞俄比亚
 zh-hant:埃塞俄比亞
-zh-min-nan:Ityop'iya
 zh-yue:埃塞俄比亞
 zu: I-Ithiopia
 country_code_2:en: ET
@@ -14050,6 +13994,7 @@ mwl: Ounion Ouropeia
 my: ဥရောပ သမဂ္ဂ
 mzn: اتحادیه اروپا
 nah: Europan Cētiliztli
+nan: Europa Liân-bêng
 nap: Aunione europea
 nb: Den europeiske union, EU, Europaunionen
 nds: Europääsche Union
@@ -14126,7 +14071,6 @@ zh-classical:歐羅巴聯盟
 zh-cn:欧洲联盟
 zh-hans:欧洲联盟
 zh-hant:欧洲联盟
-zh-min-nan:Europa Liân-bêng
 zh-yue:歐洲聯盟
 language_codes:en: en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
 
@@ -14206,6 +14150,7 @@ mr: फॉकलंड द्वीपसमूह
 mrj: Фолкленд ошмаотывлӓ
 ms: Kepulauan Falkland
 mzn: فالکلند
+nan: Falkland Kûn-tó
 nb: Falklandsøyene
 nds: Falklandinseln
 ne: फकल्याण्ड टापु
@@ -14254,7 +14199,6 @@ yo: Àwọn Erékùṣù Falkland
 yue: 福克蘭羣島
 zh: 福克兰群岛
 zh-classical:福克蘭群島
-zh-min-nan:Falkland Kûn-tó
 zh-yue:福克蘭羣島
 country_code_2:en: FK
 country_code_3:en: FLK
@@ -14402,7 +14346,6 @@ yo: Àwọn Erékùṣù Fàróè, The Faroe Islands, Àwọn Erékùsù Fàró�
 yue: 法羅群島
 zea: Faeroër
 zh: 法罗群岛, 法罗群岛行政区划, 法羅群島, 法罗群岛历史, 法罗群岛政治, 法罗群岛教育
-zh-min-nan:Mî-iûⁿ Kûn-tó
 zh-yue:法羅群島
 country_code_2:en: FO
 country_code_3:en: FRO
@@ -14497,6 +14440,7 @@ my: မိုက်ခရိုနီးရှားနိုင်ငံ
 mzn: ایالات فدرال میکرونزی
 na: Eben Oning
 nah: Micronesia
+nan: Micronesia Liân-pang-kok
 nb: Mikronesiaføderasjonen
 nds: Mikronesien
 nl: Micronesia
@@ -14550,7 +14494,6 @@ wo: Mikroneesi
 xal: Микронезин Ниицәтә Орн Нутгуд
 yo: Mikronésíà
 zh: 密克罗尼西亚群岛
-zh-min-nan:Micronesia Liân-pang-kok
 zh-yue:密克羅尼西亞聯邦
 country_code_2:en: FM
 country_code_3:en: FSM
@@ -14726,7 +14669,6 @@ zh: 斐濟
 zh-cn:斐濟
 zh-hans:斐濟
 zh-hant:斐濟
-zh-min-nan:Fiji
 zh-yue:斐濟
 zu: IFiji
 country_code_2:en: FJ
@@ -14978,7 +14920,6 @@ zh-cn:芬兰, 芬兰共和国
 zh-hans:芬兰, 芬兰共和国
 zh-hant:芬蘭, 芬蘭共和國
 zh-hk:芬蘭, 芬蘭共和國
-zh-min-nan:Suomi
 zh-mo:芬蘭, 芬蘭共和國
 zh-my:芬兰, 芬兰共和国
 zh-sg:芬兰, 芬兰共和国
@@ -15251,7 +15192,6 @@ zh-classical:法國
 zh-cn:法国
 zh-hans:法国
 zh-hant:法國
-zh-min-nan:Hoat-kok
 zh-tw:法國
 zh-yue:法國
 zu: IFulansi
@@ -15337,6 +15277,7 @@ mk: Француска Гвајана
 ml: ഫ്രഞ്ച് ഗയാന
 mr: फ्रेंच गयाना
 ms: Guiana Perancis
+nan: Guyane
 nb: Fransk Guyana, Cayenne, Guyane, Guyane française
 nds: Franzöösch-Guayana
 ne: फ्रेन्च गुयना
@@ -15390,7 +15331,6 @@ yo: Gùyánà Fránsì
 yue: 法屬圭亞那
 zea: Frans Huyana
 zh: 法屬圭亞那
-zh-min-nan:Guyane
 zh-yue:法屬圭亞那
 country_code_2:en: GF
 country_code_3:en: GUF
@@ -15502,7 +15442,6 @@ wo: Polineesi gu Faraas, Polineesi Faraañse
 yo: Polinésíà Fránsì, French Polynesia
 yue: 法屬波利尼西亞
 zh: 法屬玻里尼西亞, 法屬波利尼西亞群島, 法属玻里尼西亚, 法属玻利尼西亚, 法屬波利尼西亞, 法属波利尼西亚, 法屬波里尼西亞
-zh-min-nan:Hoat-kok Polynésie
 zh-yue:法屬波利尼西亞
 country_code_2:en: PF
 country_code_3:en: PYF
@@ -15776,7 +15715,6 @@ zh-cn:加蓬
 zh-hans:加蓬, 加彭
 zh-hant:加蓬
 zh-hk:加蓬
-zh-min-nan:Gabon
 zh-mo:加蓬
 zh-my:加蓬
 zh-sg:加蓬
@@ -15918,6 +15856,7 @@ mt: Gambja
 my: ဂမ်ဘီယာနိုင်ငံ
 na: Gambiya
 nah: Gambia
+nan: Gambia
 nb: Gambia, Republikken Gambia
 nds: Gambia
 ne: गाम्बिया
@@ -15991,7 +15930,6 @@ yi: די גאמביע
 yo: Gámbíà
 zh: 冈比亚
 zh-hans:冈比亚
-zh-min-nan:Gambia
 zh-yue:甘比亞
 zu: IGambia
 country_code_2:en: GM
@@ -16207,7 +16145,6 @@ yue: 格魯吉亞, Грузия, 格鲁吉亚, Sakartvelo, 佐治亞, Georgia, �
 zea: Georhië
 zh: 格鲁吉亚
 zh-hans:格鲁吉亚
-zh-min-nan:Sakartvelo
 zh-yue:格魯吉亞
 country_code_2:en: GE
 country_code_3:en: GEO
@@ -16482,7 +16419,6 @@ zh: 德国, 德意志, 德意志联邦, 德意志联邦共和国, 德国, 德意
 zh-classical:德國
 zh-hans:德国, 德意志, 德意志联邦, 德意志联邦共和国
 zh-hant:德國, 德意志, 德意志聯邦, 德意志聯邦共和國
-zh-min-nan:Tek-kok
 zh-tw:德國
 zh-yue:德國
 zu: IJalimani
@@ -16691,7 +16627,6 @@ zh-classical:迦納
 zh-hans:加纳
 zh-hant:迦納
 zh-hk:加納
-zh-min-nan:Ghana
 zh-tw:迦納
 zh-yue:加納
 zu: IGana
@@ -16783,6 +16718,7 @@ mn: Гибралтар
 mr: जिब्राल्टर
 ms: Gibraltar
 my: ဂျီဘရော်လ်တာ
+nan: Gibraltar
 nb: Gibraltar
 nds: Gibraltar
 nds-nl:Gibraltar
@@ -16838,7 +16774,6 @@ yi: גיבראלטאר
 yo: Gibraltar
 yue: 直布羅陀
 zh: 直布罗陀
-zh-min-nan:Gibraltar
 zh-yue:直布羅陀
 country_code_2:en: GI
 country_code_3:en: GIB
@@ -17081,7 +17016,6 @@ zh-cn:希腊, 希腊共和国
 zh-hans:希腊, 希腊共和国
 zh-hant:希臘, 希臘共和國
 zh-hk:希臘, 希臘共和國
-zh-min-nan:Hi-lia̍p
 zh-mo:希臘, 希臘共和國
 zh-my:希腊, 希腊共和国
 zh-sg:希腊, 希腊共和国
@@ -17254,7 +17188,6 @@ zh: 格陵兰
 zh-classical:格陵蘭
 zh-hans:格陵兰
 zh-hant:格陵蘭
-zh-min-nan:Chheⁿ-tē
 zh-yue:格陵蘭
 country_code_2:en: GL
 country_code_3:en: GRL
@@ -17357,6 +17290,7 @@ mt: Grenada
 my: ဂရီနေဒါနိုင်ငံ
 na: Grenada
 nah: Granada
+nan: Grenada
 nb: Grenada
 nds: Grenada
 ne: ग्रिनाडा
@@ -17417,7 +17351,6 @@ yue: 格林納達
 za: Gwzlinznazdaz
 zea: Grenada
 zh: 格林纳达
-zh-min-nan:Grenada
 zh-yue:格林納達
 country_code_2:en: GD
 country_code_3:en: GRD
@@ -17491,6 +17424,7 @@ lv: Gvadelupa
 mk: Гваделупе
 mr: ग्वादेलोप
 ms: Guadeloupe
+nan: Guadeloupe
 nb: Guadeloupe
 nds: Guadeloupe
 ne: ग्वाडलप
@@ -17533,7 +17467,6 @@ wo: Guwaadalup
 yo: Guadeloupe
 yue: 瓜德羅普
 zh: 瓜德罗普
-zh-min-nan:Guadeloupe
 zh-yue:瓜德羅普
 country_code_2:en: GP
 country_code_3:en: GLP
@@ -17604,6 +17537,7 @@ ml: ഗുവാം
 mr: ग्वॉम
 ms: Guam
 my: ဂူအမ်ကျွန်း
+nan: Guahan
 nb: Guam
 ne: ग्वाम
 nl: Guam
@@ -17647,7 +17581,6 @@ wo: Guam
 yo: Guam
 zh: 關島
 zh-hant:關島
-zh-min-nan:Guahan
 zh-yue:關島
 country_code_2:en: GU
 country_code_3:en: GUM
@@ -17828,7 +17761,6 @@ yo: Guatẹmálà
 yue: 危地馬拉
 zea: Guatemala
 zh: 危地马拉
-zh-min-nan:Guatemala
 zh-yue:危地馬拉
 zu: Guatemala
 country_code_2:en: GT
@@ -17941,7 +17873,6 @@ yo: Guernsey
 yue: 根息島
 zea: Guernsey
 zh: 根西岛, 耿西岛, 根息岛, 根西行政區, 格恩西岛, 根息島, 根息行政區, 根西行政区, 格恩西島
-zh-min-nan:Guernsey
 zh-yue:根息島
 country_code_2:en: GG
 country_code_3:en: GGY
@@ -18052,6 +17983,7 @@ ms: Guinea
 my: ဂီနီနိုင်ငံ
 na: Gini
 nah: Guinea
+nan: Guinée
 nb: Guinea, Republikken Guinea
 nds: Guinea
 ne: गिनी
@@ -18123,7 +18055,6 @@ xal: Гвинмудин Орн
 yi: גינע
 yo: Guinea
 zh: 几内亚
-zh-min-nan:Guinée
 zh-yue:畿內亞
 zu: IGini
 country_code_2:en: GN
@@ -18307,7 +18238,6 @@ yi: גינע-ביסאו
 yo: Guinea-Bissau
 yue: 畿內亞比紹
 zh: 幾內亞比索
-zh-min-nan:Guiné-Bissau
 zh-yue:畿內亞比紹
 zu: IGini Bisawu
 country_code_2:en: GW
@@ -18421,6 +18351,7 @@ mt: Gujana
 my: ဂိုင်ယာနာနိုင်ငံ
 na: Guyana
 nah: Guyana
+nan: Guyana
 nb: Guyana, Den kooperative republikk Guyana
 nds: Guyana
 ne: गुयना
@@ -18489,7 +18420,6 @@ zh: 圭亚那
 zh-cn:圭亚那
 zh-hans:圭亚那
 zh-hant:圭亞那, 蓋亞那, 圭雅那
-zh-min-nan:Guyana
 zh-yue:圭亞那
 country_code_2:en: GY
 country_code_3:en: GUY
@@ -18675,7 +18605,6 @@ zh-classical:海地
 zh-cn:海地
 zh-hans:海地
 zh-hant:海地
-zh-min-nan:Haiti
 zh-yue:海地
 country_code_2:en: HT
 country_code_3:en: HTI
@@ -18927,7 +18856,6 @@ zh: 洪都拉斯
 zh-cn:洪都拉斯
 zh-hans:洪都拉斯
 zh-hant:洪都拉斯
-zh-min-nan:Honduras
 zh-yue:洪都拉斯
 zu: Honduras
 country_code_2:en: HN
@@ -19030,6 +18958,7 @@ ms: Hong Kong
 my: ဟောင်ကောင်
 mzn: هونگ کونگ
 nah: Hong Kong
+nan: Hiong-káng
 nb: Hongkong
 nds: Hongkong
 ne: हङकङ
@@ -19096,7 +19025,6 @@ zh-cn:香港
 zh-hans:香港, 香港特别行政区
 zh-hant:香港, 香港特別行政區
 zh-hk:香港, 香港特區
-zh-min-nan:Hiong-káng
 zh-yue:香港
 country_code_2:en: HK
 country_code_3:en: HKG
@@ -19340,7 +19268,6 @@ zh-cn:匈牙利, 匈牙利共和国
 zh-hans:匈牙利, 匈牙利共和国
 zh-hant:匈牙利, 匈牙利共和國
 zh-hk:匈牙利, 匈牙利共和國
-zh-min-nan:Magyar-kok
 zh-mo:匈牙利, 匈牙利共和國
 zh-my:匈牙利, 匈牙利共和国
 zh-sg:匈牙利, 匈牙利共和国
@@ -19582,7 +19509,6 @@ zh: 冰岛
 zh-classical:冰島
 zh-hans:冰岛
 zh-hant:冰島
-zh-min-nan:Peng-tē
 zh-yue:冰島
 zu: I-Ayisilandi
 country_code_2:en: IS
@@ -19733,6 +19659,7 @@ my: အိန္ဒိယနိုင်ငံ
 mzn: هند
 na: Indjiya
 nah: India
+nan: Ìn-tō͘
 nap: Innia
 nb: India
 nds: Indien
@@ -19832,7 +19759,6 @@ zh-classical:印度
 zh-cn:印度
 zh-hans:印度, 印度共和国
 zh-hant:印度
-zh-min-nan:Ìn-tō͘
 zh-yue:印度
 zu: INdiya
 country_code_2:en: IN
@@ -20064,7 +19990,6 @@ zh: 印度尼西亚
 zh-classical:印度尼西亞
 zh-hans:印度尼西亚
 zh-hant:印度尼西亞, 印尼
-zh-min-nan:Ìn-nî
 zh-yue:印尼
 country_code_2:en: ID
 country_code_3:en: IDN
@@ -20289,7 +20214,6 @@ zh-classical:伊朗
 zh-cn:伊朗
 zh-hans:伊朗
 zh-hant:伊朗
-zh-min-nan:Iran
 zh-yue:伊朗
 zu: I-Irani
 country_code_2:en: IR
@@ -20504,7 +20428,6 @@ zh-classical:伊拉克
 zh-cn:伊拉克
 zh-hans:伊拉克
 zh-hant:伊拉克
-zh-min-nan:Iraq
 zh-yue:伊拉克
 zu: I-Iraki
 country_code_2:en: IQ
@@ -20646,6 +20569,7 @@ mk: Ман
 ml: ഐൽ ഒഫ് മാൻ
 mr: आईल ऑफ मान
 ms: Isle of Man
+nan: Mannin
 nb: Man
 nds: Isle of Man
 nds-nl:Man
@@ -20691,7 +20615,6 @@ xal: Мэнин Арл
 yo: Erékùṣù ilẹ̀ Man
 zea: Eiland Man
 zh: 曼島
-zh-min-nan:Mannin
 zh-yue:馬恩島
 country_code_2:en: IM
 country_code_3:en: IMN
@@ -20916,7 +20839,6 @@ yo: Ísráẹ́lì
 yue: 以色列, State of Israel, إسرائيل, ישראל, מדינת ישראל, 以色列國, Israel, دَوْلَةْ إِسْرَائِيل
 zea: Israël
 zh: 以色列
-zh-min-nan:Í-sek-lia̍t-kok
 zh-yue:以色列
 zu: Isreyili
 country_code_2:en: IL
@@ -21183,7 +21105,6 @@ zh-cn:意大利, 意大利共和国
 zh-hans:意大利, 意大利共和国
 zh-hant:意大利, 意大利共和國, 義大利, 義大利共和國
 zh-hk:意大利, 意大利共和國
-zh-min-nan:Italia
 zh-mo:意大利, 意大利共和國
 zh-my:意大利, 意大利共和国
 zh-sg:意大利, 意大利共和国
@@ -21301,6 +21222,7 @@ mt: Ġamajka
 my: ဂျမေကာနိုင်ငံ
 na: Djamaika
 nah: Jamaica
+nan: Jamaica
 nb: Jamaica
 nds: Jamaika
 nds-nl:Jamaika
@@ -21372,7 +21294,6 @@ zh-classical:牙買加
 zh-cn:牙买加
 zh-hans:牙买加
 zh-hant:牙买加
-zh-min-nan:Jamaica
 zh-yue:牙買加
 country_code_2:en: JM
 country_code_3:en: JAM
@@ -21430,6 +21351,7 @@ lt: Jan Majenas
 lv: Jana Majena sala
 mr: यान मायेन
 ms: Jan Mayen
+nan: Jan Mayen
 nb: Jan Mayen
 nl: Jan Mayen
 nn: Jan Mayen
@@ -21462,7 +21384,6 @@ yo: Jan Mayen
 yue: 揚馬延島
 zea: Jan Mayen
 zh: 揚馬延島
-zh-min-nan:Jan Mayen
 zh-yue:揚馬延島
 language_codes:en:
 
@@ -21609,6 +21530,7 @@ my: ဂျပန်နိုင်ငံ
 mzn: جاپون
 na: Djapan
 nah: Xapon
+nan: Ji̍t-pún
 nap: Giappone
 nb: Japan
 nds: Japan
@@ -21707,7 +21629,6 @@ zh-cn:日本, 日本国
 zh-hans:日本, 日本国
 zh-hant:日本, 日本國
 zh-hk:日本, 日本國
-zh-min-nan:Ji̍t-pún
 zh-mo:日本, 日本國
 zh-my:日本, 日本国
 zh-sg:日本, 日本国
@@ -21826,7 +21747,6 @@ zh: 澤西島
 zh-cn:澤西島
 zh-hans:澤西島
 zh-hant:澤西島
-zh-min-nan:Jersey
 zh-yue:澤西島
 country_code_2:en: JE
 country_code_3:en: JEY
@@ -22019,7 +21939,6 @@ yo: Jọ́rdánì
 yue: 約旦
 zea: Jordaonië
 zh: 约旦
-zh-min-nan:Iok-tàn
 zh-yue:約旦
 country_code_2:en: JO
 country_code_3:en: JOR
@@ -22158,6 +22077,7 @@ my: ကာဇက်စတန်နိုင်ငံ
 mzn: قزاقئون
 na: Kadaketan
 nah: Cazactlālpan
+nan: Kazakhstan
 nb: Kasakhstan, Republikken Kasakhstan
 nds: Kasachstan
 nds-nl:Kazakstan
@@ -22243,7 +22163,6 @@ zh-cn:哈萨克斯坦
 zh-hans:哈萨克斯坦
 zh-hant:哈薩克斯坦
 zh-hk:哈薩克斯坦
-zh-min-nan:Kazakhstan
 zh-mo:哈薩克斯坦
 zh-my:哈萨克斯坦
 zh-sg:哈萨克斯坦
@@ -22371,6 +22290,7 @@ mt: Kenja
 my: ကင်ညာနိုင်ငံ
 na: Keniya
 nah: Quenia
+nan: Kenya
 nap: Kenya
 nb: Kenya, Republikken Kenya
 nds: Kenia
@@ -22449,7 +22369,6 @@ yue: 肯雅
 zh: 肯尼亚
 zh-hans:肯尼亚
 zh-hant:肯尼亞
-zh-min-nan:Kenya
 zh-tw:肯亞
 zh-yue:肯雅
 zu: IKenya
@@ -22551,6 +22470,7 @@ mt: Kiribati
 my: ကီရီဘတ်စ်နိုင်ငံ
 na: Kiribat
 nah: Quiribati
+nan: Kiribati
 nb: Kiribati
 nds: Kiribati
 nl: Kiribati
@@ -22611,7 +22531,6 @@ xal: Кирибадин Орн
 yo: Kìrìbátì
 zea: Kiribati
 zh: 基里巴斯
-zh-min-nan:Kiribati
 zh-yue:基里巴斯
 country_code_2:en: KI
 country_code_3:en: KIR
@@ -22798,7 +22717,6 @@ zh-classical:科威特
 zh-cn:科威特
 zh-hans:科威特
 zh-hant:科威特
-zh-min-nan:Kuwait
 zh-yue:科威特
 country_code_2:en: KW
 country_code_3:en: KWT
@@ -22993,7 +22911,6 @@ zh-cn:吉尔吉斯斯坦, 吉尔吉斯共和国
 zh-hans:吉尔吉斯斯坦, 吉尔吉斯共和国
 zh-hant:吉爾吉斯斯坦, 吉爾吉斯共和國
 zh-hk:吉爾吉斯斯坦, 吉爾吉斯共和國
-zh-min-nan:Kyrgyzstan
 zh-mo:吉爾吉斯斯坦, 吉爾吉斯共和國
 zh-my:吉尔吉斯斯坦, 吉尔吉斯共和国
 zh-sg:吉尔吉斯斯坦, 吉尔吉斯共和国
@@ -23194,7 +23111,6 @@ zh-classical:老撾
 zh-cn:老挝
 zh-hans:老挝
 zh-hant:老挝
-zh-min-nan:Lao-kok
 zh-yue:Laos
 country_code_2:en: LA
 country_code_3:en: LAO
@@ -23421,7 +23337,6 @@ zea: Letland
 zh: 拉脫維亞
 zh-hans:拉脱维亚
 zh-hant:拉脫維亞
-zh-min-nan:Latvia
 zh-yue:拉脫維亞
 zu: ILatviya
 country_code_2:en: LV
@@ -23618,7 +23533,6 @@ zh: 黎巴嫩
 zh-cn:黎巴嫩
 zh-hans:黎巴嫩
 zh-hant:黎巴嫩
-zh-min-nan:Lī-pa-lùn
 zh-yue:黎巴嫩
 country_code_2:en: LB
 country_code_3:en: LBN
@@ -23808,7 +23722,6 @@ zh-cn:莱索托
 zh-hans:莱索托
 zh-hant:莱索托
 zh-hk:莱索托
-zh-min-nan:Lesotho
 zh-mo:莱索托
 zh-my:莱索托
 zh-sg:莱索托
@@ -23999,7 +23912,6 @@ zh: 利比里亚
 zh-cn:利比里亚
 zh-hans:利比里亚
 zh-hant:利比里亚
-zh-min-nan:Liberia
 zh-yue:利比利亞
 zu: ILiberia
 country_code_2:en: LR
@@ -24213,7 +24125,6 @@ zh-classical:利比亞
 zh-cn:利比亚
 zh-hans:利比亚
 zh-hant:利比亚
-zh-min-nan:Libya
 zh-yue:利比亞
 zu: ILibiya
 country_code_2:en: LY
@@ -24434,7 +24345,6 @@ zh-classical:列支敦士登
 zh-cn:列支敦斯登
 zh-hans:列支敦斯登
 zh-hant:列支敦斯登
-zh-min-nan:Liechtenstein
 zh-yue:列支敦士登
 country_code_2:en: LI
 country_code_3:en: LIE
@@ -24583,6 +24493,7 @@ mt: Litwanja
 my: လစ်သူယေးနီးယားနိုင်ငံ
 na: Rituainiya
 nah: Lituania
+nan: Lietuva
 nap: Lituania
 nb: Litauen, Republikken Litauen
 nds: Litauen
@@ -24683,7 +24594,6 @@ zh-cn:立陶宛, 立陶宛共和国
 zh-hans:立陶宛, 立陶宛共和国
 zh-hant:立陶宛, 立陶宛共和國
 zh-hk:立陶宛, 立陶宛共和國
-zh-min-nan:Lietuva
 zh-mo:立陶宛, 立陶宛共和國
 zh-my:立陶宛, 立陶宛共和国
 zh-sg:立陶宛, 立陶宛共和国
@@ -24928,7 +24838,6 @@ zh-cn:卢森堡, 卢森堡大公国, 卢森堡公国
 zh-hans:卢森堡, 卢森堡大公国, 卢森堡公国
 zh-hant:盧森堡, 盧森堡大公國, 盧森堡公國
 zh-hk:盧森堡, 盧森堡大公國, 盧森堡公國
-zh-min-nan:Luxembourg
 zh-mo:盧森堡, 盧森堡大公國, 盧森堡公國
 zh-my:卢森堡, 卢森堡大公国, 卢森堡公国
 zh-sg:卢森堡, 卢森堡大公国, 卢森堡公国
@@ -25022,6 +24931,7 @@ mr: मकाओ
 ms: Makau
 mwl: Macau
 my: မကာအို
+nan: Ò-mn̂g
 nb: Macao
 nl: Macau, Macao
 nn: Macao
@@ -25072,7 +24982,6 @@ zh-classical:澳門
 zh-cn:澳门
 zh-hans:澳门, 澳门特别行政区
 zh-hant:澳門, 澳門特別行政區
-zh-min-nan:Ò-mn̂g
 zh-yue:澳門
 country_code_2:en: MO
 country_code_3:en: MAC
@@ -25275,7 +25184,6 @@ zh-cn:马达加斯加
 zh-hans:马达加斯加
 zh-hant:马达加斯加
 zh-hk:马达加斯加
-zh-min-nan:Madagasikara
 zh-mo:马达加斯加
 zh-my:马达加斯加
 zh-sg:马达加斯加
@@ -25456,7 +25364,6 @@ xal: Малавудин Орн
 yi: מאלאווי
 yo: Màláwì
 zh: 马拉维
-zh-min-nan:Malaŵi
 zh-yue:馬拉維
 zu: IMalawi
 country_code_2:en: MW
@@ -25580,6 +25487,7 @@ mt: Malażja
 my: မလေးရှားနိုင်ငံ
 na: Maraidja
 nah: Malasia
+nan: Má-lâi-se-a
 nb: Malaysia
 nds: Malaysia
 ne: मलेशिया
@@ -25657,7 +25565,6 @@ zh-classical:馬來西亞
 zh-cn:马来西亚
 zh-hans:马来西亚
 zh-hant:馬來西亞
-zh-min-nan:Má-lâi-se-a
 zh-yue:馬來西亞
 country_code_2:en: MY
 country_code_3:en: MYS
@@ -25764,6 +25671,7 @@ mt: Maldivi
 my: မော်လဒိုက်နိုင်ငံ
 na: Mardib
 nah: Maldivas
+nan: Maldives
 nb: Maldivene, Republikken Maldivene
 nds: Malediven
 ne: मालदिभ्स
@@ -25830,7 +25738,6 @@ zh: 马尔代夫
 zh-cn:马尔代夫
 zh-hans:马尔代夫
 zh-hant:马尔代夫
-zh-min-nan:Maldives
 zh-yue:馬爾代夫
 country_code_2:en: MV
 country_code_3:en: MDV
@@ -26024,7 +25931,6 @@ zh: 马里共和国
 zh-cn:马里共和国
 zh-hans:马里共和国
 zh-hant:马里共和国
-zh-min-nan:Mali
 zh-yue:馬里
 zu: IMali
 country_code_2:en: ML
@@ -26250,7 +26156,6 @@ zea: Malta
 zh: 马耳他
 zh-hans:马耳他
 zh-hant:馬耳他
-zh-min-nan:Malta
 zh-yue:馬耳他
 zu: IMalta
 country_code_2:en: MT
@@ -26398,7 +26303,6 @@ xal: Маршал Арлин Орн
 xmf: მარშალიშ კოკეფი
 yo: Àwọn Erékùṣù Marshall
 zh: 馬紹爾群島
-zh-min-nan:Marshall Kûn-tó
 zh-yue:馬紹爾群島
 country_code_2:en: MH
 country_code_3:en: MHL
@@ -26474,6 +26378,7 @@ lv: Martinika
 mk: Мартиник
 mr: मार्टिनिक
 ms: Martinique
+nan: Martinique
 nb: Martinique
 nds: Martinique
 nl: Martinique
@@ -26522,7 +26427,6 @@ zh: 馬提尼克
 zh-cn:馬提尼克
 zh-hans:馬提尼克
 zh-hant:馬提尼克
-zh-min-nan:Martinique
 zh-yue:馬提尼克
 country_code_2:en: MQ
 country_code_3:en: MTQ
@@ -26720,7 +26624,6 @@ zh-cn:毛里塔尼亚
 zh-hans:毛里塔尼亚
 zh-hant:毛里塔尼亚
 zh-hk:毛里塔尼亚
-zh-min-nan:Mauritania
 zh-mo:毛里塔尼亚
 zh-my:毛里塔尼亚
 zh-sg:毛里塔尼亚
@@ -26831,6 +26734,7 @@ ms: Mauritius
 mt: Mawrizji
 my: မောရစ်ရှနိုင်ငံ
 nah: Mauricio
+nan: Mauritius
 nb: Mauritius, Republikken Mauritius
 nds: Mauritius
 nds-nl:Maurisius
@@ -26898,7 +26802,6 @@ xal: Морисин Орн
 yo: Mọ́rísì
 yue: 毛厘士
 zh: 毛里求斯
-zh-min-nan:Mauritius
 zh-yue:毛厘士
 zu: IMorishisi
 country_code_2:en: MU
@@ -26970,6 +26873,7 @@ mk: Мајот
 ml: മായോട്ടെ
 mr: मायोत
 ms: Mayotte
+nan: Mayotte
 nb: Mayotte
 nds: Mayotte
 nl: Mayotte
@@ -27014,7 +26918,6 @@ zh: 马约特
 zh-cn:马约特
 zh-hans:马约特
 zh-hant:马约特
-zh-min-nan:Mayotte
 zh-yue:馬約特
 zu: IMayotte
 country_code_2:en: YT
@@ -27250,7 +27153,6 @@ zh-cn:墨西哥, 墨西哥合众国
 zh-hans:墨西哥, 墨西哥合众国
 zh-hant:墨西哥, 墨西哥合眾國
 zh-hk:墨西哥, 墨西哥合眾國
-zh-min-nan:Be̍k-se-ko
 zh-mo:墨西哥, 墨西哥合眾國
 zh-my:墨西哥, 墨西哥合众国
 zh-sg:墨西哥, 墨西哥合众国
@@ -27471,7 +27373,6 @@ yue: 摩爾多瓦
 zea: Moldâvië
 zh: 摩尔多瓦
 zh-hans:摩尔多瓦
-zh-min-nan:Moldova
 zh-yue:摩爾多瓦
 country_code_2:en: MD
 country_code_3:en: MDA
@@ -27682,7 +27583,6 @@ yue: 摩納哥, Mónegue, Principauté de Monaco, 摩納哥大公國, Monaco, Pr
 zea: Monaco
 zh: 摩纳哥
 zh-hans:摩纳哥
-zh-min-nan:Monaco
 zh-yue:摩納哥
 country_code_2:en: MC
 country_code_3:en: MCO
@@ -27887,7 +27787,6 @@ zh: 蒙古国
 zh-cn:蒙古国
 zh-hans:蒙古国
 zh-hant:蒙古国
-zh-min-nan:Bông-kó͘
 zh-tw:蒙古國
 zh-yue:蒙古國
 country_code_2:en: MN
@@ -28096,7 +27995,6 @@ yo: Montenẹ́grò, Montenegro
 yue: 黑山, 黑山共和國
 zea: Montenehro
 zh: 蒙特內哥羅, 門的內哥羅, 门的内哥罗, 黑山共和國, 蒙特內格羅, 黑山, 蒙特尼哥羅, 蒙特尼格羅, 黑山共和国, 蒙特內哥羅共和國, 蒙地內哥羅
-zh-min-nan:O͘-soaⁿ Kiōng-hô-kok
 zh-yue:黑山
 country_code_2:en: ME
 country_code_3:en: MNE
@@ -28168,6 +28066,7 @@ lv: Montserrata
 mk: Монтсерат
 mr: माँटसेराट
 ms: Montserrat
+nan: Montserrat
 nb: Montserrat
 nds: Montserrat
 nl: Montserrat
@@ -28205,7 +28104,6 @@ wo: Montserrat
 yo: Montserrat
 yue: 蒙塞拉特島
 zh: 蒙塞拉特島
-zh-min-nan:Montserrat
 zh-yue:蒙塞拉特島
 country_code_2:en: MS
 country_code_3:en: MSR
@@ -28393,7 +28291,6 @@ yo: Mòrókò
 zea: Marokko
 zh: 摩洛哥
 zh-classical:摩洛哥
-zh-min-nan:Morocco
 zh-yue:摩洛哥
 zu: IMorokho
 country_code_2:en: MA
@@ -28584,7 +28481,6 @@ yo: Mòsámbìk
 yue: 莫三鼻給
 zh: 莫桑比克
 zh-classical:莫三比克
-zh-min-nan:Moçambique
 zh-yue:莫三鼻給
 zu: IMozambiki
 country_code_2:en: MZ
@@ -28786,7 +28682,6 @@ zh-classical:緬甸
 zh-cn:缅甸
 zh-hans:缅甸
 zh-hant:缅甸
-zh-min-nan:Myanma
 zh-yue:緬甸
 country_code_2:en: MM
 country_code_3:en: MMR
@@ -29060,7 +28955,6 @@ zh-cn:纳米比亚
 zh-hans:纳米比亚
 zh-hant:纳米比亚
 zh-hk:纳米比亚
-zh-min-nan:Namibia
 zh-mo:纳米比亚
 zh-my:纳米比亚
 zh-sg:纳米比亚
@@ -29235,7 +29129,6 @@ xal: Наурмудин Орн
 yo: Nàúrù
 yue: 瑙魯
 zh: 諾魯
-zh-min-nan:Nauru
 zh-yue:瑙魯
 country_code_2:en: NR
 country_code_3:en: NRU
@@ -29433,7 +29326,6 @@ zh: 尼泊尔
 zh-cn:尼泊尔
 zh-hans:尼泊尔
 zh-hant:尼泊尔
-zh-min-nan:Nepal
 zh-yue:尼泊爾
 country_code_2:en: NP
 country_code_3:en: NPL
@@ -29685,7 +29577,6 @@ zh-cn:荷兰, 尼德兰, 尼德兰王国
 zh-hans:荷兰, 尼德兰, 尼德兰王国
 zh-hant:荷蘭, 尼德蘭, 尼德蘭王國
 zh-hk:荷蘭, 尼德蘭, 尼德蘭王國
-zh-min-nan:Kē-tē-kok
 zh-mo:荷蘭, 尼德蘭, 尼德蘭王國
 zh-my:荷兰, 尼德兰, 尼德兰王国
 zh-sg:荷兰, 尼德兰, 尼德兰王国
@@ -29805,7 +29696,6 @@ wo: Kaledooni-Gu-Bees, Nuweel Kaledooni
 yo: Kalẹdóníà Tuntun, New Caledonia
 yue: 新喀里多尼亞
 zh: 新喀里多尼亞, 新喀爾多尼亞, 新克里多尼亞, 新喀里多尼亚群岛, 新喀里多尼亚, 新卡里多尼亞, 新喀里多尼亚岛, New Caledonia
-zh-min-nan:Sin Calédonie
 zh-yue:新喀里多尼亞
 country_code_2:en: NC
 country_code_3:en: NCL
@@ -30012,7 +29902,6 @@ zea: Nieuw-Zeêland
 zh: 新西兰
 zh-classical:紐西蘭
 zh-hans:新西兰
-zh-min-nan:Sin Jia̍t-lân-jia
 zh-yue:紐西蘭
 zu: INyuzilandi
 country_code_2:en: NZ
@@ -30123,6 +30012,7 @@ ms: Nicaragua
 mt: Nikaragwa
 my: နီကာရာဂွါနိုင်ငံ
 nah: Nicānāhuac
+nan: Nicaragua
 nb: Nicaragua, Republikken Nicaragua
 nds: Nicaragua
 ne: निकाराग्वा
@@ -30185,7 +30075,6 @@ yi: ניקאראגוא
 yo: Nikarágúà
 yue: 尼加拉瓜
 zh: 尼加拉瓜
-zh-min-nan:Nicaragua
 zh-yue:尼加拉瓜
 zu: Nicaragua
 country_code_2:en: NI
@@ -30371,7 +30260,6 @@ zh-cn:尼日尔
 zh-hans:尼日尔
 zh-hant:尼日尔
 zh-hk:尼日尔
-zh-min-nan:Niger
 zh-mo:尼日尔
 zh-my:尼日尔
 zh-sg:尼日尔
@@ -30578,7 +30466,6 @@ yue: 尼日利亞
 za: Nizywlihya
 zh: 奈及利亞
 zh-classical:尼日利亞
-zh-min-nan:Nigeria
 zh-yue:尼日利亞
 zu: INigeria
 country_code_2:en: NG
@@ -30688,7 +30575,6 @@ wo: Niwe, Niue
 yo: Niue
 zea: Niue
 zh: 紐埃, 紐埃島, 纽埃岛, 紐威島, 纽鄂岛, 纽埃, Niue, 紐威, 尼烏埃, 纽威岛
-zh-min-nan:Niue
 zh-yue:紐埃
 country_code_2:en: NU
 country_code_3:en: NIU
@@ -30787,7 +30673,6 @@ war: Puro han Norfolk, Isla Norfolk
 wo: Dunu Norfolk, Norfolk Island
 yo: Erékùṣù Norfolk, Norfolk Island, Erékùsù Nọ́rúfọ́lkì
 zh: 诺福克岛, 諾福克島
-zh-min-nan:Norfolk-tó
 zh-yue:諾福克島
 country_code_2:en: NF
 country_code_3:en: NFK
@@ -30913,6 +30798,7 @@ ms: Korea Utara
 my: ကိုရီးယား ဒီမိုကရက်တစ် ပြည်သူ့သမ္မတနိုင်ငံ
 na: Ripubrikit Engame Korea
 nah: Corea Mictlāmpa
+nan: Tiâu-sián
 nap: Corea d''o Nord
 nb: Nord-Korea, Den demokratiske folkerepublikken Korea
 nds: Noordkorea
@@ -30990,7 +30876,6 @@ zh-cn:朝鲜民主主义人民共和国, 朝鲜, 北朝鲜, 北韩
 zh-hans:朝鲜民主主义人民共和国, 朝鲜, 北朝鲜, 北韩
 zh-hant:朝鮮民主主義人民共和國, 朝鮮, 北朝鮮, 北韓
 zh-hk:朝鮮民主主義人民共和國, 朝鮮, 北朝鮮, 北韓
-zh-min-nan:Tiâu-sián
 zh-mo:朝鮮民主主義人民共和國, 朝鮮, 北朝鮮, 北韓
 zh-my:朝鲜民主主义人民共和国, 朝鲜, 北朝鲜, 北韩
 zh-sg:朝鲜民主主义人民共和国, 朝鲜, 北朝鲜, 北韩
@@ -31001,9 +30886,6 @@ country_code_3:en: PRK
 language_codes:en: ko
 
 en: North Macedonia, Republic of North Macedonia, Republic of Macedonia, FYROM, Former Yugoslav Republic of Macedonia, Macedonia, MK, MKD
-zh-hans:北马其顿
-zh-min-nan:Makedonija Kiōng-hô-kok
-zh-yue:馬其頓共和國
 xx: FYROM
 ace: Makèdonia Utara
 af: Republiek Noord-Masedonië
@@ -31127,7 +31009,7 @@ mt: Maċedonja ta' Fuq
 my: မက်စီဒိုးနီးယားနိုင်ငံ
 na: Matedoniya
 nah: Tlācatlahtohcāyōtl Macedonia
-nan: Pak Macedonia
+nan: Pak Macedonia, Makedonija Kiōng-hô-kok
 nb: Nord-Makedonia
 nds: Noordmakedonien
 nds-nl:Noord-Macedonie
@@ -31205,6 +31087,8 @@ yo: Orílẹ̀-èdè Olómìnira ilẹ̀ Makẹdóníà
 yue: 北馬其頓共和國
 zea: Noord-Macedonië
 zh: 北马其顿
+zh-hans:北马其顿
+zh-yue:馬其頓共和國
 country_code_2:en: MK
 country_code_3:en: MKD
 language_codes:en: mk
@@ -31263,6 +31147,7 @@ mk: Северни Маријански Острови
 ml: നോർതേൺ മറിയാന ദ്വീപുകൾ
 mr: उत्तर मेरियाना द्वीपसमूह
 ms: Kepulauan Mariana Utara
+nan: Pak Mariana Kûn-tó
 nb: Nord-Marianene
 nl: Noordelijke Marianen
 nn: Nord-Marianane
@@ -31299,7 +31184,6 @@ war: Amihanan Kapuropud-an Mariana
 wo: Northern Mariana Islands
 yo: Àwọn Erékùṣù Apáàríwá Mariana
 zh: 北马里亚纳群岛
-zh-min-nan:Pak Mariana Kûn-tó
 zh-yue:北馬利安納羣島
 country_code_2:en: MP
 country_code_3:en: MNP
@@ -31554,7 +31438,6 @@ zh-cn:挪威, 挪威王国
 zh-hans:挪威, 挪威王国
 zh-hant:挪威, 挪威王國
 zh-hk:挪威, 挪威王國
-zh-min-nan:Norge
 zh-mo:挪威, 挪威王國
 zh-my:挪威, 挪威王国
 zh-sg:挪威, 挪威王国
@@ -31671,6 +31554,7 @@ ms: Oman
 my: အိုမန်နိုင်ငံ
 na: Oman
 nah: Omān
+nan: Oman
 nb: Oman
 nds: Oman
 new: ओमान
@@ -31739,7 +31623,6 @@ zh: 阿曼
 zh-cn:阿曼
 zh-hans:阿曼
 zh-hant:阿曼
-zh-min-nan:Oman
 zh-yue:阿曼
 country_code_2:en: OM
 country_code_3:en: OMN
@@ -31956,7 +31839,6 @@ zh-classical:巴基斯坦
 zh-cn:巴基斯坦
 zh-hans:巴基斯坦
 zh-hant:巴基斯坦
-zh-min-nan:Pakistan
 zh-yue:巴基斯坦
 zu: IPakistani
 country_code_2:en: PK
@@ -32056,6 +31938,7 @@ mrj: Палау
 ms: Palau
 my: ပလောင်းနိုင်ငံ
 nah: Palaos
+nan: Palau
 nb: Palau
 nds: Palau
 nl: Palau
@@ -32113,7 +31996,6 @@ yo: Páláù
 yue: 帛琉
 zea: Palau
 zh: 帛琉
-zh-min-nan:Palau
 zh-yue:帛琉
 country_code_2:en: PW
 country_code_3:en: PLW
@@ -32141,6 +32023,7 @@ ka: პალესტინის ტერიტორიები
 ko: 팔레스타인 영토
 la: Territoria Palaestinensia
 mk: Палестина
+nan: Palestine
 nb: De palestinske territoriene
 nl: Palestijnse Gebieden
 pt: Territórios palestinianos
@@ -32265,6 +32148,7 @@ ms: Panama
 mt: Panama
 my: ပနားမားနိုင်ငံ
 nah: Panama
+nan: Panamá
 nb: Panama, Republikken Panama
 nds: Panama
 ne: पानामा
@@ -32339,7 +32223,6 @@ zh-cn:巴拿马
 zh-hans:巴拿马
 zh-hant:巴拿馬
 zh-hk:巴拿馬
-zh-min-nan:Panamá
 zh-mo:巴拿馬
 zh-my:巴拿马
 zh-sg:巴拿马
@@ -32510,7 +32393,6 @@ wo: Papuwaasi-Gine-Gu-Bees
 xal: Папуһасин болн Шин Гвинемудин Орн
 yo: Papua Guinea Titun
 zh: 巴布亚新几内亚
-zh-min-nan:Papua Sin Guinea
 zh-yue:巴布亞新畿內亞
 country_code_2:en: PG
 country_code_3:en: PNG
@@ -32627,6 +32509,7 @@ ms: Paraguay
 mt: Paragwaj
 my: ပါရာဂွေးနိုင်ငံ
 nah: Paraguay
+nan: Paraguay
 nap: Paraguay
 nb: Paraguay
 nds: Paraguay
@@ -32696,7 +32579,6 @@ zh: 巴拉圭
 zh-cn:巴拉圭
 zh-hans:巴拉圭
 zh-hant:巴拉圭
-zh-min-nan:Paraguay
 zh-yue:巴拉圭
 country_code_2:en: PY
 country_code_3:en: PRY
@@ -32914,7 +32796,6 @@ zea: Peru
 zh: 秘鲁
 zh-classical:祕魯
 zh-hant:秘魯
-zh-min-nan:Perú
 zh-yue:秘魯
 zu: Peru
 country_code_2:en: PE
@@ -33114,7 +32995,6 @@ zh-classical:菲律賓
 zh-cn:菲律宾
 zh-hans:菲律宾
 zh-hant:菲律賓
-zh-min-nan:Hui-li̍p-pin
 zh-yue:菲律賓
 country_code_2:en: PH
 country_code_3:en: PHL
@@ -33218,7 +33098,6 @@ wo: Pitkeern, Pitcairn
 yi: פיטקארן
 yo: Àwọn Erékùsù Pitcairn, Pitcairn Islands, The Pitcairn Islands
 zh: 皮特凯恩群岛, 匹特揆綸島, 皮特肯島, 皮特克恩島, 皮特凯恩, 皮特凯恩岛, 皮特克恩岛, 皮特开恩群岛, 皮特肯群島, 皮特凯恩行政区划, 皮特凱恩群島, 皮特康島
-zh-min-nan:Pitcairn Kûn-tó
 zh-yue:皮特凱恩群島
 country_code_2:en: PN
 country_code_3:en: PCN
@@ -33479,7 +33358,6 @@ zh-cn:波兰, 波兰共和国
 zh-hans:波兰, 波兰共和国
 zh-hant:波蘭, 波蘭共和國
 zh-hk:波蘭, 波蘭共和國
-zh-min-nan:Polska
 zh-mo:波蘭, 波蘭共和國
 zh-my:波兰, 波兰共和国
 zh-sg:波兰, 波兰共和国
@@ -33733,7 +33611,6 @@ zh-cn:葡萄牙, 葡萄牙共和国, 葡国
 zh-hans:葡萄牙, 葡萄牙共和国, 葡国
 zh-hant:葡萄牙, 葡萄牙共和國, 葡國, 葡萄牙民國
 zh-hk:葡萄牙, 葡萄牙共和國, 葡國
-zh-min-nan:Phû-tô-gâ
 zh-mo:葡萄牙, 葡萄牙共和國, 葡國, 葡萄牙民國
 zh-my:葡萄牙, 葡萄牙共和国, 葡国
 zh-sg:葡萄牙, 葡萄牙共和国, 葡国
@@ -33877,7 +33754,6 @@ wuu: 布爱勒导里高
 yo: Púẹ́rtò Ríkò
 zea: Puerto Rico
 zh: 波多黎各
-zh-min-nan:Puerto Rico
 zh-yue:波多黎各
 country_code_2:en: PR
 country_code_3:en: PRI
@@ -34070,7 +33946,6 @@ zh-classical:卡達國
 zh-cn:卡塔尔
 zh-hans:卡塔尔
 zh-hant:卡塔尔
-zh-min-nan:Qatar
 zh-yue:卡塔爾
 country_code_2:en: QA
 country_code_3:en: QAT
@@ -34256,7 +34131,6 @@ zh-classical:臺灣
 zh-cn:中華民國
 zh-hans:中华民国
 zh-hant:中華民國, 自由中國
-zh-min-nan:Tiong-hoâ Bîn-kok
 zh-tw:中華民國
 zh-yue:臺灣
 country_code_2:en: TW
@@ -34482,7 +34356,6 @@ zh-cn:爱尔兰共和国, 爱尔兰
 zh-hans:爱尔兰共和国, 爱尔兰
 zh-hant:愛爾蘭共和國, 愛爾蘭
 zh-hk:愛爾蘭共和國, 愛爾蘭
-zh-min-nan:Éire
 zh-mo:愛爾蘭共和國, 愛爾蘭
 zh-my:爱尔兰共和国, 爱尔兰
 zh-sg:爱尔兰共和国, 爱尔兰
@@ -34591,6 +34464,7 @@ ms: Republik Congo
 my: ကွန်ဂိုသမ္မတနိုင်ငံ
 na: Ripubrikin Kongo
 nah: Tlācatlahtohcāyōtl in Congo
+nan: Congo Kiōng-hô-kok
 nb: Republikken Kongo, Kongo-Brazzaville
 nds: Republiek Kongo
 nl: Congo-Brazzaville
@@ -34658,7 +34532,6 @@ zh: 刚果共和国
 zh-cn:刚果共和国
 zh-hans:刚果共和国
 zh-hant:刚果共和国
-zh-min-nan:Congo Kiōng-hô-kok
 zh-yue:剛果
 zu: IKongo
 country_code_2:en: CG
@@ -34964,7 +34837,6 @@ zea: Roemenië
 zh: 羅馬尼亞
 zh-classical:羅馬尼亞
 zh-hans:罗马尼亚
-zh-min-nan:România
 zh-yue:羅馬尼亞
 country_code_2:en: RO
 country_code_3:en: ROU
@@ -35134,6 +35006,7 @@ myv: Россия Мастор
 mzn: ئوروسیا
 na: Ratsiya
 nah: Rusia
+nan: Lō͘-se-a
 nap: Russia
 nb: Russland, Den russiske føderasjon
 nds: Russland
@@ -35251,7 +35124,6 @@ zh-classical:俄羅斯
 zh-cn:俄罗斯
 zh-hans:俄罗斯
 zh-hant:俄羅斯
-zh-min-nan:Lō͘-se-a
 zh-tw:俄羅斯
 zh-yue:俄羅斯
 zu: IRashiya
@@ -35449,7 +35321,6 @@ zh-cn:卢旺达
 zh-hans:卢旺达
 zh-hant:卢旺达
 zh-hk:卢旺达
-zh-min-nan:Rwanda
 zh-mo:卢旺达
 zh-my:卢旺达
 zh-sg:卢旺达
@@ -35529,6 +35400,7 @@ mg: La Réunion
 mk: Реинион
 mr: रेयूनियों
 ms: Réunion
+nan: Réunion
 nb: Réunion
 nds: Réunion
 nl: Réunion
@@ -35577,7 +35449,6 @@ zh: 留尼汪
 zh-cn:留尼汪
 zh-hans:留尼汪
 zh-hant:留尼汪
-zh-min-nan:Réunion
 zh-yue:留尼旺
 zu: IRiyunion
 country_code_2:en: RE
@@ -35807,6 +35678,7 @@ ms: Santo Kitts dan Nevis
 mt: Saint Kitts u Nevis
 my: စိန့်ကစ်နှင့် နီးဗစ်နိုင်ငံ
 nah: San Cristóbal īhuān Nevis
+nan: Sèng Kitts kap Nevis
 nb: Saint Kitts og Nevis
 nds: St. Kitts un Nevis
 nl: Saint Kitts en Nevis
@@ -35859,7 +35731,6 @@ zh: 聖克里斯多福與尼維斯
 zh-cn:聖克里斯多福與尼維斯
 zh-hans:聖克里斯多福與尼維斯
 zh-hant:聖克里斯多福與尼維斯
-zh-min-nan:Sèng Kitts kap Nevis
 zh-yue:聖傑氏尼維斯
 country_code_2:en: KN
 country_code_3:en: KNA
@@ -35956,6 +35827,7 @@ ms: Saint Lucia
 mt: Santa Luċija
 my: စိန့်လူစီယာနိုင်ငံ
 nah: Santa Lucía
+nan: Sèng Lucia
 nb: Saint Lucia, St. Lucia
 nds: St. Lucia
 nl: Saint Lucia
@@ -36003,7 +35875,6 @@ wo: Saint Lucia
 xal: Сенлүүсин Орн
 yo: Lùsíà Mímọ́
 zh: 圣卢西亚
-zh-min-nan:Sèng Lucia
 zh-yue:聖盧西亞
 country_code_2:en: LC
 country_code_3:en: LCA
@@ -36175,7 +36046,6 @@ war: Saint Pierre ngan Miquelon, Saint Pierre and Miquelon, Saint-Pierre and Miq
 wo: Saint Pierre ak Miquelon
 yo: Saint Pierre àti Mìkẹ́lọ̀n, Saint Pierre and Miquelon
 zh: 圣皮埃尔和密克隆群岛, 聖皮埃蘭和密克隆群島, 聖皮里和米圭隆, 聖匹及密啟倫群島, 圣皮耶和密克罗, 圣皮埃尔和密克隆, 聖皮耶與密克隆群島, 聖皮埃爾島和密克隆島
-zh-min-nan:Sèng Pierre kap Miquelon
 zh-yue:聖皮埃爾及密克隆群島
 country_code_2:en: PM
 country_code_3:en: SPM
@@ -36268,6 +36138,7 @@ ms: Saint Vincent dan Grenadines
 mt: Saint Vincent u l-Grenadini
 my: စိန့်ဗင်းဆင့်နှင့်ဂရိနေဒိုင်နိုင်ငံ
 nah: San Vicente īhuān in Granadinas
+nan: Sèng Vincent kap Grenadines
 nb: Saint Vincent og Grenadinene
 nds: St. Vincent un de Grenadinen
 nl: Saint Vincent en de Grenadines
@@ -36314,7 +36185,6 @@ yo: Saint Vincent àti àwọn Grẹnadínì
 zh: 圣文森特和格林纳丁斯
 zh-hans:圣文森特和格林纳丁斯
 zh-hant:聖文森特和格林納丁斯
-zh-min-nan:Sèng Vincent kap Grenadines
 zh-yue:聖文森特和格林納丁斯
 country_code_2:en: VC
 country_code_3:en: VCT
@@ -36484,6 +36354,7 @@ ms: Samoa
 mt: Samoa
 my: ဆမိုးအားနိုင်ငံ
 nah: Samoa
+nan: Samoa
 nb: Samoa
 nds: Samoa
 nl: Samoa
@@ -36542,7 +36413,6 @@ xal: Самомудин Орн
 yo: Sàmóà
 yue: 薩摩亞
 zh: 萨摩亚
-zh-min-nan:Samoa
 zh-yue:薩摩亞
 country_code_2:en: WS
 country_code_3:en: WSM
@@ -36754,7 +36624,6 @@ yo: San Màrínò
 yue: 聖馬連奴, 聖馬利諾, 聖馬力諾
 zea: San Marino
 zh: 圣马力诺
-zh-min-nan:San Marino
 zh-yue:聖馬連奴
 zu: USanti Marino
 country_code_2:en: SM
@@ -36929,7 +36798,6 @@ zh-cn:圣多美和普林西比
 zh-hans:圣多美和普林西比
 zh-hant:圣多美和普林西比
 zh-hk:圣多美和普林西比
-zh-min-nan:Sèng Tomé kap Príncipe
 zh-mo:圣多美和普林西比
 zh-my:圣多美和普林西比
 zh-sg:圣多美和普林西比
@@ -37140,7 +37008,6 @@ zh-classical:沙特阿拉伯
 zh-cn:沙特阿拉伯
 zh-hans:沙特阿拉伯
 zh-hant:沙特阿拉伯
-zh-min-nan:Saud ê A-la-pek
 zh-yue:沙地阿拉伯
 country_code_2:en: SA
 country_code_3:en: SAU
@@ -37328,7 +37195,6 @@ yi: סענעגאל
 yo: Sẹ̀nẹ̀gàl
 yue: 塞內加爾
 zh: 塞内加尔
-zh-min-nan:Senegal
 zh-yue:塞內加爾
 zu: ISenegal
 country_code_2:en: SN
@@ -37553,7 +37419,6 @@ zea: Servië
 zh: 塞尔维亚
 zh-classical:塞爾維亞
 zh-hans:塞尔维亚
-zh-min-nan:Srbija
 zh-yue:塞爾維亞
 zu: ISerbiya
 country_code_2:en: RS
@@ -37722,7 +37587,6 @@ xal: Сейшел Арлин Орн
 yo: Ṣèíhẹ́lẹ́sì
 yue: 塞舌爾
 zh: 塞舌尔
-zh-min-nan:Sesel
 zh-yue:塞舌爾
 zu: IsiSeyisheli
 country_code_2:en: SC
@@ -37907,7 +37771,6 @@ zh-cn:塞拉利昂
 zh-hans:塞拉利昂
 zh-hant:塞拉利昂, 獅子山
 zh-hk:塞拉利昂
-zh-min-nan:Sierra Leone
 zh-mo:塞拉利昂
 zh-my:塞拉利昂
 zh-sg:塞拉利昂
@@ -38120,7 +37983,6 @@ zh-classical:新加坡
 zh-cn:新加坡
 zh-hans:新加坡, 星加坡
 zh-hant:新加坡, 星加坡, 新加坡共和國
-zh-min-nan:Sin-ka-pho
 zh-yue:星架坡, 星加坡, 新加坡, 石叻, 新加坡共和國, 新架坡
 country_code_2:en: SG
 country_code_3:en: SGP
@@ -38474,7 +38336,6 @@ yue: 斯洛伐克, Slovenská republika, Slovensko
 zea: Slowakije
 zh: 斯洛伐克
 zh-hans:斯洛伐克
-zh-min-nan:Slovensko
 zh-yue:斯洛伐克
 zu: ISlovaki
 country_code_2:en: SK
@@ -38701,7 +38562,6 @@ yue: 斯洛文尼亞, 斯洛文尼亚, 史洛文尼亞, 史洛文尼亚
 zea: Slovenië
 zh: 斯洛文尼亚
 zh-hans:斯洛文尼亚
-zh-min-nan:Slovenia
 zh-yue:斯洛文尼亞
 country_code_2:en: SI
 country_code_3:en: SVN
@@ -38799,6 +38659,7 @@ ms: Kepulauan Solomon
 mt: Gżejjer Solomon
 my: ဆော်လမွန်အိုင်းလန်းနိုင်ငံ
 nah: Salomón Tlālhuāctli
+nan: Só͘-lô-bûn Kûn-tó
 nb: Salomonøyene
 nds: Salomonen
 ne: सोलोमन द्धीप
@@ -38856,7 +38717,6 @@ xal: Соломонин Арлс
 yo: Àwọn Erékùsù Sólómọ́nì
 yue: 所羅門群島
 zh: 所罗门群岛
-zh-min-nan:Só͘-lô-bûn Kûn-tó
 zh-yue:所羅門群島
 country_code_2:en: SB
 country_code_3:en: SLB
@@ -38965,6 +38825,7 @@ mt: Somalja
 my: ဆိုမာလီယာနိုင်ငံ
 na: Tomariya
 nah: Somalia
+nan: Somalia
 nb: Somalia, Forbundsstaten Somalia
 nds: Somalia
 new: सोमालिया
@@ -39048,7 +38909,6 @@ zh-cn:索马里
 zh-hans:索马里
 zh-hant:索马里
 zh-hk:索马里
-zh-min-nan:Somalia
 zh-mo:索马里
 zh-my:索马里
 zh-sg:索马里
@@ -39284,7 +39144,6 @@ zh-cn:南非
 zh-hans:南非
 zh-hant:南非
 zh-hk:南非
-zh-min-nan:Lâm-hui-kok
 zh-mo:南非
 zh-my:南非
 zh-sg:南非
@@ -39606,7 +39465,6 @@ zh-classical:大韓民國
 zh-cn:大韩民国
 zh-hans:大韩民国
 zh-hant:大韓民國, 韓國, 南韓
-zh-min-nan:Hân-kok
 zh-yue:大韓民國
 country_code_2:en: KR
 country_code_3:en: KOR
@@ -39708,6 +39566,7 @@ my: တောင်ဆူဒန်နိုင်ငံ
 mzn: جنوبی سودان
 na: South Sudan
 nah: Sudan Huitztlāmpa
+nan: Lâm Sudan
 nb: Sør-Sudan
 nds: Süüdsudan
 nds-nl:Zuudsoedan
@@ -39772,7 +39631,6 @@ zh-classical:南蘇丹
 zh-cn:南蘇丹
 zh-hans:南蘇丹
 zh-hant:南蘇丹
-zh-min-nan:Lâm Sudan
 zh-yue:南蘇丹
 zu: ISudan yaseNingizimu
 country_code_2:en: SS
@@ -39884,6 +39742,7 @@ mr: सोव्हियेत संघ
 ms: Kesatuan Republik Sosialis Soviet
 my: ဆိုဗီယက်ပြည်ထောင်စု သမ္မတနိုင်ငံ
 mzn: شوروی
+nan: Soviet Siā-hōe-chú-gī Kiōng-hô-kok Liân-ha̍p
 nap: Aunione Sovieteca
 nb: Sovjetunionen
 nds: Sowjetunion
@@ -39946,7 +39805,6 @@ yue: 蘇聯
 za: Suhlienz
 zh: 苏联
 zh-classical:蘇聯
-zh-min-nan:Soviet Siā-hōe-chú-gī Kiōng-hô-kok Liân-ha̍p
 zh-yue:蘇聯
 language_codes:en: ru
 
@@ -40100,6 +39958,7 @@ my: စပိန်နိုင်ငံ
 mzn: ایسپانیا
 na: Pain
 nah: Caxtillān
+nan: Se-pan-gâ
 nap: Spagna
 nb: Spania
 nds: Spanien
@@ -40204,7 +40063,6 @@ zh-cn:西班牙, 西班牙王国
 zh-hans:西班牙, 西班牙王国
 zh-hant:西班牙, 西班牙王國
 zh-hk:西班牙, 西班牙王國
-zh-min-nan:Se-pan-gâ
 zh-mo:西班牙, 西班牙王國
 zh-my:西班牙, 西班牙王国
 zh-sg:西班牙, 西班牙王国
@@ -40401,7 +40259,6 @@ zh: 斯里蘭卡
 zh-cn:斯里蘭卡
 zh-hans:斯里蘭卡
 zh-hant:斯里蘭卡
-zh-min-nan:Sri Lanka
 zh-yue:斯里蘭卡
 country_code_2:en: LK
 country_code_3:en: LKA
@@ -40685,7 +40542,6 @@ zh-cn:苏丹共和国
 zh-hans:苏丹共和国
 zh-hant:苏丹共和国
 zh-hk:苏丹共和国
-zh-min-nan:Sudan
 zh-mo:苏丹共和国
 zh-my:苏丹共和国
 zh-sg:苏丹共和国
@@ -40867,7 +40723,6 @@ yo: Sùrìnámù
 yue: 蘇里南
 zea: Surinaome
 zh: 蘇利南
-zh-min-nan:Suriname
 zh-yue:蘇里南
 country_code_2:en: SR
 country_code_3:en: SUR
@@ -41081,7 +40936,6 @@ yi: סוואזילאנד
 yo: Swásílándì
 yue: 斯威士蘭
 zh: 斯威士兰
-zh-min-nan:Swazi-tē
 zh-yue:斯威士蘭
 zu: ISwazilandi
 country_code_2:en: SZ
@@ -41333,7 +41187,6 @@ zh-cn:瑞典, 瑞典王国
 zh-hans:瑞典, 瑞典王国
 zh-hant:瑞典, 瑞典王國
 zh-hk:瑞典, 瑞典王國
-zh-min-nan:Sūi-tián
 zh-mo:瑞典, 瑞典王國
 zh-my:瑞典, 瑞典王国
 zh-sg:瑞典, 瑞典王国
@@ -41478,6 +41331,7 @@ mt: Żvizzera
 my: ဆွစ်ဇာလန်နိုင်ငံ
 na: Witsierand
 nah: Suiza
+nan: Sūi-se
 nap: Sguizzera
 nb: Sveits, Det sveitsiske edsforbund, Konføderasjonen Sveits, Confœderatio Helvetica
 nds: Swiez
@@ -41576,7 +41430,6 @@ zh-cn:瑞士, 瑞士联邦
 zh-hans:瑞士, 瑞士联邦
 zh-hant:瑞士, 瑞士聯邦
 zh-hk:瑞士, 瑞士聯邦
-zh-min-nan:Sūi-se
 zh-mo:瑞士, 瑞士聯邦
 zh-my:瑞士, 瑞士联邦
 zh-sg:瑞士, 瑞士联邦
@@ -41783,7 +41636,6 @@ zh: 叙利亚
 zh-cn:叙利亚
 zh-hans:叙利亚
 zh-hant:叙利亚
-zh-min-nan:Su-lī-a
 zh-yue:敘利亞
 country_code_2:en: SY
 country_code_3:en: SYR
@@ -41902,6 +41754,7 @@ ms: Tajikistan
 my: တာဂျစ်ကစ္စတန်နိုင်ငံ
 na: Tadjikitan
 nah: Tayictlālpan
+nan: Tajikistan
 nb: Tadsjikistan, Republikken Tadsjikistan
 nds: Tadschikistan
 nl: Tadzjikistan
@@ -41972,7 +41825,6 @@ zh: 塔吉克斯坦
 zh-cn:塔吉克斯坦
 zh-hans:塔吉克斯坦
 zh-hant:塔吉克斯坦
-zh-min-nan:Tajikistan
 zh-yue:塔吉克
 country_code_2:en: TJ
 country_code_3:en: TJK
@@ -42178,7 +42030,6 @@ zh: 坦桑尼亚
 zh-cn:坦桑尼亚
 zh-hans:坦桑尼亚
 zh-hant:坦桑尼亚
-zh-min-nan:Tanzania
 zh-yue:坦桑尼亞
 zu: ITanzania
 country_code_2:en: TZ
@@ -42306,6 +42157,7 @@ ms: Thailand
 my: ထိုင်းနိုင်ငံ
 na: Thailand
 nah: Taitlālpan
+nan: Thài-kok
 nb: Thailand, Kongeriket Thailand, Siam
 nds: Thailand
 nds-nl:Thailaand
@@ -42388,7 +42240,6 @@ zh-classical:泰國
 zh-cn:泰国
 zh-hans:泰国
 zh-hant:泰国
-zh-min-nan:Thài-kok
 zh-yue:泰國
 country_code_2:en: TH
 country_code_3:en: THA
@@ -42498,6 +42349,7 @@ mwl: Bahamas
 my: ဘဟားမားနိုင်ငံ
 na: Bahamat
 nah: Bahamas
+nan: Bahamas
 nb: Bahamas
 nds: Bahamas
 nl: Bahama's
@@ -42568,7 +42420,6 @@ zh: 巴哈马
 zh-cn:巴哈马
 zh-hans:巴哈马
 zh-hant:巴哈马
-zh-min-nan:Bahamas
 zh-yue:巴哈馬
 country_code_2:en: BS
 country_code_3:en: BHS
@@ -42682,6 +42533,7 @@ my: အရှေ့တီမောနိုင်ငံ
 mzn: شرقي تيمور
 na: East Timor
 nah: Timor Tlāpcopa
+nan: Tang Timor
 nb: Øst-Timor, Timor-Leste
 nds: Oosttimor
 ne: पूर्वी टिमोर
@@ -42751,7 +42603,6 @@ za: Doeng Divwnq
 zea: Oôst-Timor
 zh: 东帝汶
 zh-classical:東帝汶
-zh-min-nan:Tang Timor
 zh-yue:東帝汶
 country_code_2:en: TL
 country_code_3:en: TLS
@@ -42862,6 +42713,7 @@ my: တိုဂိုနိုင်ငံ
 mzn: توگو
 na: Togo
 nah: Togo
+nan: Togo
 nb: Togo
 nds: Togo
 nl: Togo
@@ -42933,7 +42785,6 @@ yi: טאגא
 yo: Tógò
 yue: 多哥
 zh: 多哥
-zh-min-nan:Togo
 zh-yue:多哥
 zu: ITogo
 country_code_2:en: TG
@@ -43028,7 +42879,6 @@ war: Tokelau
 wo: Tokelau
 yo: Tokelau
 zh: 托克劳群岛, 托克勞, 托克劳行政区划, 托克劳
-zh-min-nan:Tokelau
 zh-yue:托克勞
 country_code_2:en: TK
 country_code_3:en: TKL
@@ -43126,6 +42976,7 @@ ms: Tonga
 mt: Tonga
 my: တုံဂါနိုင်ငံ
 nah: Tonga
+nan: Tonga
 nb: Tonga
 nds: Tonga
 nl: Tonga
@@ -43183,7 +43034,6 @@ wo: Tonga
 xal: Тонһлмудин Нутг
 yo: Tóngà
 zh: 東加
-zh-min-nan:Tonga
 zh-yue:湯加
 country_code_2:en: TO
 country_code_3:en: TON
@@ -43282,6 +43132,7 @@ ms: Trinidad dan Tobago
 mt: Trinidad u Tobago
 my: ထရီနီဒတ်နှင့် တိုဘက်ဂိုနိုင်ငံ
 nah: Trinidad īhuān Tobago
+nan: Trinidad kap Tobago
 nb: Trinidad og Tobago
 nds: Trinidad un Tobago
 ne: त्रिनिडाड एंड टोबागो
@@ -43342,7 +43193,6 @@ zh-classical:千里達及托巴哥
 zh-cn:千里達及托巴哥
 zh-hans:千里達及托巴哥
 zh-hant:千里達及托巴哥
-zh-min-nan:Trinidad kap Tobago
 zh-yue:千里達
 country_code_2:en: TT
 country_code_3:en: TTO
@@ -43535,7 +43385,6 @@ zh: 突尼西亞
 zh-cn:突尼西亞
 zh-hans:突尼西亞
 zh-hant:突尼西亞
-zh-min-nan:Tunisia
 zh-yue:突尼西亞
 zu: ITunisia
 country_code_2:en: TN
@@ -43793,7 +43642,6 @@ zh-cn:土耳其, 土耳其共和国
 zh-hans:土耳其, 土耳其共和国
 zh-hant:土耳其, 土耳其共和國
 zh-hk:土耳其, 土耳其共和國
-zh-min-nan:Türkiye
 zh-mo:土耳其, 土耳其共和國
 zh-my:土耳其, 土耳其共和国
 zh-sg:土耳其, 土耳其共和国
@@ -43992,7 +43840,6 @@ zh: 土库曼斯坦
 zh-cn:土库曼斯坦
 zh-hans:土库曼斯坦
 zh-hant:土库曼斯坦
-zh-min-nan:Turkmenistan
 zh-yue:土庫曼
 country_code_2:en: TM
 country_code_3:en: TKM
@@ -44066,6 +43913,7 @@ ml: ടർക്സ്-കൈകോസ് ദ്വീപുകൾ
 mr: टर्क्स आणि कैकास द्वीपसमूह
 mrj: Тӱркс дӓ Кайкос
 ms: Kepulauan Turks dan Caicos
+nan: Turks kap Caicos Kûn-tó
 nb: Turks- og Caicosøyene
 nds: Turks- un Caicosinseln
 nl: Turks- en Caicoseilanden
@@ -44100,7 +43948,6 @@ war: Kapuropod-an Turks ngan Caicos
 wo: Turks and Caicos Islands
 yo: Àwọn Erékùṣù Turks àti Caicos
 zh: 特克斯和凯科斯群岛
-zh-min-nan:Turks kap Caicos Kûn-tó
 zh-yue:特克斯與凱科斯群島
 country_code_2:en: TC
 country_code_3:en: TCA
@@ -44202,6 +44049,7 @@ mt: Tuvalu
 my: တူဗားလူနိုင်ငံ
 na: Tubaru
 nah: Tuvalu
+nan: Tuvalu
 nb: Tuvalu
 nds: Tuvalu
 nl: Tuvalu
@@ -44261,7 +44109,6 @@ yo: Tufalu
 yue: 圖瓦盧
 zea: Tuvalu
 zh: 圖瓦盧
-zh-min-nan:Tuvalu
 zh-yue:圖瓦盧
 country_code_2:en: TV
 country_code_3:en: TUV
@@ -44455,7 +44302,6 @@ zh-cn:乌干达
 zh-hans:乌干达
 zh-hant:乌干达
 zh-hk:乌干达
-zh-min-nan:Uganda
 zh-mo:乌干达
 zh-my:乌干达
 zh-sg:乌干达
@@ -44606,6 +44452,7 @@ myv: Украина
 mzn: اوکراین
 na: Ukraine
 nah: Ucrania
+nan: Ukrayina
 nap: Ucraina
 nb: Ukraina
 nds: Ukraine
@@ -44700,7 +44547,6 @@ zh: 乌克兰
 zh-classical:烏克蘭
 zh-hans:乌克兰
 zh-hant:烏克蘭
-zh-min-nan:Ukrayina
 zh-tw:烏克蘭
 zh-yue:烏克蘭
 country_code_2:en: UA
@@ -44890,7 +44736,6 @@ zh: 阿拉伯联合酋长国
 zh-cn:阿拉伯联合酋长国
 zh-hans:阿拉伯联合酋长国
 zh-hant:阿拉伯联合酋长国
-zh-min-nan:A-la-pek Liân-ha̍p Thâu-lâng-kok
 zh-yue:阿拉伯聯合酋長國
 country_code_2:en: AE
 country_code_3:en: ARE
@@ -45140,7 +44985,6 @@ zh-cn:英国, 联合王国, 大不列颠及北爱尔兰联合王国
 zh-hans:英国, 联合王国, 大不列颠及北爱尔兰联合王国
 zh-hant:英國, 聯合王國, 大不列顛及北愛爾蘭聯合王國
 zh-hk:英國, 聯合王國, 大不列顛及北愛爾蘭聯合王國
-zh-min-nan:Liân-ha̍p Ông-kok
 zh-mo:英國, 聯合王國, 大不列顛及北愛爾蘭聯合王國
 zh-my:英国, 联合王国, 大不列颠及北爱尔兰联合王国
 zh-sg:英国, 联合王国, 大不列颠及北爱尔兰联合王国
@@ -45478,7 +45322,6 @@ zh-cn:美国, 美利坚合众国, 花旗国
 zh-hans:美国, 美利坚合众国, 花旗国
 zh-hant:美國, 美利堅合眾國, 花旗國
 zh-hk:美國, 美利堅合眾國, 花旗國
-zh-min-nan:Bí-kok
 zh-mo:美國, 美利堅合眾國, 花旗國
 zh-my:美国, 美利坚合众国, 花旗国
 zh-sg:美国, 美利坚合众国, 花旗国
@@ -45604,6 +45447,7 @@ ms: Uruguay
 mt: Urugwaj
 my: ဥရုဂွေးနိုင်ငံ
 nah: Uruguay
+nan: Uruguay
 nap: Uruguay
 nb: Uruguay
 nds: Uruguay
@@ -45681,7 +45525,6 @@ zh-cn:乌拉圭, 乌拉圭东岸共和国
 zh-hans:乌拉圭, 乌拉圭东岸共和国
 zh-hant:烏拉圭, 烏拉圭東岸共和國
 zh-hk:乌拉圭, 烏拉圭東岸共和國
-zh-min-nan:Uruguay
 zh-mo:乌拉圭, 烏拉圭東岸共和國
 zh-my:乌拉圭, 乌拉圭东岸共和国
 zh-sg:乌拉圭, 乌拉圭东岸共和国
@@ -45881,7 +45724,6 @@ zea: Oezbekistan
 zh: 乌兹别克斯坦
 zh-hans:乌兹别克斯坦, 乌兹别克
 zh-hant:烏茲別克斯坦
-zh-min-nan:Uzbekistan
 zh-yue:月即別
 country_code_2:en: UZ
 country_code_3:en: UZB
@@ -45984,6 +45826,7 @@ mt: Vanwatu
 my: ဗနွားတူနိုင်ငံ
 na: Banuatu
 nah: Vanuatu
+nan: Vanuatu
 nb: Vanuatu
 nds: Vanuatu
 ne: भानुअटु
@@ -46043,7 +45886,6 @@ yo: Fanuatu
 yue: 萬那杜
 zea: Vanuatu
 zh: 瓦努阿图
-zh-min-nan:Vanuatu
 zh-yue:萬那杜
 country_code_2:en: VU
 country_code_3:en: VUT
@@ -46271,7 +46113,6 @@ zea: Vaticaânstad
 zh: 梵蒂冈
 zh-hans:梵蒂冈
 zh-hant:梵蒂岡
-zh-min-nan:Vaticano
 zh-yue:梵蒂岡
 zu: Indolobha yaseVathikhani
 country_code_2:en: VA
@@ -46486,7 +46327,6 @@ zh-classical:委內瑞拉
 zh-cn:委內瑞拉
 zh-hans:委內瑞拉
 zh-hant:委內瑞拉
-zh-min-nan:Venezuela
 zh-yue:委內瑞拉
 zu: Venezuela
 country_code_2:en: VE
@@ -46745,7 +46585,6 @@ zh-classical:越南
 zh-cn:越南
 zh-hans:越南
 zh-hant:越南
-zh-min-nan:Oa̍t-lâm
 zh-yue:越南
 zu: IViyetnami
 country_code_2:en: VN
@@ -46814,6 +46653,7 @@ mk: Американски Девствени Острови
 ml: യുനൈറ്റഡ് സ്റ്റേറ്റ്സ് വിർജിൻ ദ്വീപുകൾ
 mr: यु.एस. व्हर्जिन द्वीपसमूह
 ms: Kepulauan Virgin Amerika Syarikat
+nan: Bí-kok Virgin Kûn-tó
 nb: De amerikanske jomfruøyene
 nds: Amerikaansche Jumferninseln
 nl: Amerikaanse Maagdeneilanden
@@ -46851,7 +46691,6 @@ vi: Quần đảo Virgin thuộc Mỹ
 war: Kapuropud-an Birhen han Estados Unidos
 yo: Àwọn Erékùṣù Wúndíá ti Amẹ́ríkà
 zh: 美屬維爾京群島
-zh-min-nan:Bí-kok Virgin Kûn-tó
 country_code_2:en: VI
 country_code_3:en: VIR
 language_codes:en: en
@@ -46943,7 +46782,6 @@ war: Wallis ngan Futuna, Wallis and Futuna
 wo: Wallis ak Futuna, Wallis and Futuna
 yo: Wallis àti Futuna, Wallis and Futuna, Wallis and Futuna Islands
 zh: 瓦利斯和富圖納群島, 瓦利斯及富圖納群島, 瓦里斯和富圖納島, 瓦利斯和富图纳, 沃里斯與伏塔那島, 瓦利斯和富图纳行政区划, 瓦利斯群島和富圖納群島
-zh-min-nan:Wallis kap Futuna
 zh-yue:瓦利斯及富圖納群島
 country_code_2:en: WF
 country_code_3:en: WLF
@@ -47029,6 +46867,7 @@ mr: पश्चिम सहारा
 mrj: Вадывел Сахара
 ms: Sahara Barat
 mt: Saħara tal-Punent
+nan: Sai Sahara
 nb: Vest-Sahara
 ne: पश्चिमी सहारा
 nl: Westelijke Sahara
@@ -47076,7 +46915,6 @@ yo: Apáìwọ̀orùn Sàhárà
 yue: 西撒哈拉
 zh: 西撒哈拉
 zh-hant:西撒哈拉
-zh-min-nan:Sai Sahara
 zh-yue:西撒哈拉
 country_code_2:en: EH
 country_code_3:en: ESH
@@ -47273,7 +47111,6 @@ yo: Yemen
 yue: 也門
 zea: Jeem’n
 zh: 也门
-zh-min-nan:Yemen
 zh-yue:也門
 zu: IYemen
 country_code_2:en: YE
@@ -47564,7 +47401,6 @@ zh-classical:尚比亞
 zh-cn:赞比亚
 zh-hans:赞比亚
 zh-hant:赞比亚
-zh-min-nan:Zambia
 zh-yue:贊比亞
 zu: IZambiya
 country_code_2:en: ZM
@@ -47761,7 +47597,6 @@ zh-classical:辛巴威
 zh-cn:辛巴威
 zh-hans:辛巴威
 zh-hant:辛巴威
-zh-min-nan:Zimbabwe
 zh-yue:津巴布韋
 zu: IZimbabwe
 country_code_2:en: ZW
@@ -47835,6 +47670,7 @@ mk: Оланд
 ml: അലാന്ദ് ദ്വീപുകൾ
 mr: ऑलंड द्वीपसमूह
 ms: Åland
+nan: Åland Kûn-tó
 nb: Åland
 nds-nl:Åland
 nl: Åland
@@ -47880,7 +47716,6 @@ yo: Àwọn Erékùṣù Åland
 yue: 亞蘭
 zea: Åland
 zh: 奥兰群岛
-zh-min-nan:Åland Kûn-tó
 zh-yue:亞蘭
 country_code_2:en: AX
 country_code_3:en: ALA


### PR DESCRIPTION
`zh-min-nan` is a code formerly used for Southern Min, `nan` is the more recent ISO 639-3 code: https://iso639-3.sil.org/code/nan

Preparation for https://github.com/openfoodfacts/openfoodfacts-server/pull/12495