### PR TITLE
taxonomy: Add brands used in Sweden and/or Denmark

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -20,7 +20,17 @@ xx: Alesto
 xx: alpro
 wikidata:en: Q498666
 
+xx: anamma
+
+xx: Arla, Arla Foods
+wikidata:en: Q674575
+
 xx: Banderos
+
+xx: Barebells
+
+xx: Beauvais
+wikidata:en: Q12303007
 
 #< xx:Unilever
 xx: Best Foods
@@ -32,6 +42,17 @@ xx: Bio Village
 xx: Biscoff
 wikidata:en: Q116641741
 
+xx: Björnekulla
+wikidata:en: Q112757315
+
+xx: Blå Band
+wikidata:en: Q10431648
+
+# This seems to be different from “BSc” made by Australian(/Swedish?)
+# “Body Science International”, owned by “Humble Group Australia”,
+# which is what https://www.wikidata.org/wiki/Q18208172 is about.
+xx: Body Science
+
 xx: Bodylab
 wikidata:en: Q27530939
 
@@ -41,6 +62,8 @@ xx: Carrefour BIO
 
 xx: Chaque Jour Sans Gluten
 
+xx: chef select
+
 xx: Choice
 
 # Renamed to Kakaoarbo in 2020 or late 2019
@@ -49,6 +72,9 @@ xx: Chøkolade, Chøkolade fra Samsø
 xx: Cirio
 wikidata:en: Q3070443
 
+xx: Cloetta
+wikidata:en: Q3437039
+
 # This brand is used by different consumer cooperatives around the world
 xx: Coop
 wikidata:en: Q115764026
@@ -56,8 +82,23 @@ wikidata:en: Q115764026
 xx: Coppola Salerno, Coppola
 #web:en: https://www.coppolasalerno.com/
 
+xx: Culinea
+
+xx: Dafgårds, Gunnar Dafgård
+wikidata:en: Q5618977
+
+xx: Dahls
+
+xx: Dan Cake, DanCake
+wikidata:en: Q12307101
+
+xx: Dansukker, Dan Sukker
+#web:en: https://www.dansukker.com/
+
 xx: Dave & Jon's, Dave & Jon's Snack Factory, Dave and Jon's
 wikidata:en: Q134125853
+
+xx: Dazzley
 
 xx: De Cecco
 wikidata:en: Q931123
@@ -75,10 +116,15 @@ xx: Durra
 
 xx: Délisse
 
+xx: Egelykke
+
 xx: El Taco Truck, El Taco Truck AB, Taco Truck
 
 xx: Eldorado
 wikidata:en: Q5324313
+
+xx: Estrella
+wikidata:en: Q6303102
 
 xx: Fazer
 wikidata:en: Q996907
@@ -87,11 +133,20 @@ wikidata:en: Q996907
 # In the Nordic countries, Felix is a (human) food brand and the cat food brand is called Latz
 xx: Felix
 
+xx: Findus
+wikidata:en: Q869728
+
 xx: First Price
 wikidata:en: Q5453722
 
 xx: Flora
 wikidata:en: Q5460271
+
+xx: Fontana
+
+xx: Freshona
+
+xx: GAAM
 
 xx: Garant
 
@@ -100,6 +155,8 @@ xx: Garofalo
 
 # Axfood brand targeted at large kitchens, like restaurants
 xx: Gastrino
+
+xx: Gestus
 
 xx: Golden Sun
 
@@ -114,6 +171,13 @@ wikidata:en: Q65410727
 xx: H-E-B, HEB
 wikidata:en: Q830621
 
+xx: Hanegal
+
+xx: Haribo
+wikidata:en: Q169552
+
+xx: Healthy Co
+
 xx: Heinz
 
 #< xx:Unilever
@@ -125,6 +189,18 @@ xx: Hälsans Kök
 xx: ICA
 wikidata:en: Q10516119
 
+#< xx:ICA
+xx: ICA Asia
+
+#< xx:ICA
+xx: ICA Basic, ICA Bas%c
+
+#< xx:ICA
+xx: ICA Selection
+
+xx: IKEA
+wikidata:en: Q54078
+
 xx: innocent
 #web:en: https://www.innocentdrinks.com
 
@@ -134,7 +210,15 @@ xx: Issawi Bageri, Bageri Issawi, Issawi, مخبز العيساوي, العيس�
 xx: JOZO
 wikidata:en: Q10538850
 
+xx: Kania
+
+xx: Kavli
+wikidata:en: Q1208110
+
 xx: Kellogg's, Kelloggs, Kellogg
+
+xx: Knorr
+wikidata:en: Q313882
 
 xx: Kockens
 wikidata:en: Q10546877
@@ -147,7 +231,12 @@ xx: KOTI, KOTISINAPPI, KOTI sinappi, KOTISENAP, KOTI senap
 xx: Kung Markatta
 wikidata:en: Q10550149
 
+xx: Kungsörnen
+wikidata:en: Q6444566
+
 xx: Leader Price, Leaderprice
+
+xx: Lindahls
 
 xx: Loka
 wikidata:en: Q10568903
@@ -155,8 +244,14 @@ wikidata:en: Q10568903
 xx: Lotus, Lotus Bakeries, Lotus Since 1932
 wikidata:en: Q590113
 
+xx: Løgismose
+wikidata:en: Q6711394
+
 xx: Malaco
 wikidata:en: Q4346282
+
+xx: Marabou
+wikidata:en: Q1812718
 
 # Portuguese version of Marque Repère
 xx: Marca Guia
@@ -167,11 +262,15 @@ wikidata:en: Q714491
 xx: Marque Repère
 wikidata:en: Q3294723
 
+xx: Matriket
+
 # Swedish burger chain
 xx: Max
 wikidata:en: Q1912172
 
 xx: Maître CoQ
+
+xx: Milbona
 
 xx: Monte Castello
 
@@ -186,10 +285,19 @@ xx: Naturli'
 xx: Nestlé
 wikidata:en: Q160746
 
+xx: NOCCO
+wikidata:en: Q97225239
+
+xx: næmt, naemt
+
 xx: Oatly
 wikidata:en: Q10605824
 
+#< xx:Valio
 xx: Oddlygood, Oddly good
+
+xx: OLW, Old London Wasa
+wikidata:en: Q1775404
 
 xx: Petti
 
@@ -198,15 +306,32 @@ xx: Planti
 
 xx: Premier
 
+xx: Premieur
+
+xx: ProPud
+
 xx: Pureness
 
 xx: Pågen, Pågen AB
 wikidata:en: Q3102193
 
-xx: REMA 1000, REMA1000
+#< xx:Monde Nissin
+xx: Quorn
+wikidata:en: Q2123676
+
+xx: Rawfoodshop
+
+xx: REMA 1000, REMA1000, REMA
 wikidata:en: Q28459
 
 xx: Rice Krispies
+
+xx: Risenta
+
+xx: Rydbergs
+
+xx: Rynkeby
+wikidata:en: Q12334047
 
 xx: Récoltons l'Avenir, Récoltons l'Avenir l'agriculture durable
 
@@ -218,7 +343,11 @@ xx: salling
 # not sure if this wikidata item is fully appropriate for this
 wikidata:en: Q492820
 
-xx: Santa Maria
+xx: Saltå kvarn
+wikidata:en: Q10660794
+
+xx: Santa Maria, Santa Maria Norge AS
+#web:en: https://www.santamariaworld.com/
 
 xx: Schulstad
 wikidata:en: Q12334753
@@ -230,9 +359,22 @@ wikidata:en: Q7390267
 
 xx: Sol&Mar
 
+xx: Solevita
+
 xx: Soutenons nos agriculteurs
 
 xx: Special K
+
+xx: Star Nutrition
+
+#< xx:Scandic Food
+xx: Svansø
+
+xx: Svenskt Kosttillskott
+#web:sv: https://www.svensktkosttillskott.se/
+
+xx: Swedish Supplements
+#web:en: https://www.swedish-supplements.com/
 
 xx: Södervidinge
 wikidata:en: Q10688845
@@ -243,6 +385,10 @@ wikidata:en: Q58177342
 xx: tat, Tat Gıda
 #web:en: https://www.tatgida.com.tr/en/
 wikidata:en: Q20471706
+
+xx: Thise
+#web:da: https://thise.dk/
+#web:en: https://thise.eu/
 
 xx: Tokapi
 
@@ -257,15 +403,33 @@ wikidata:en: Q10704719
 
 xx: Turini
 
+xx: tyngre
+
 xx: Urtekram
 wikidata:en: Q12340334
+
+xx: Valio
+wikidata:en: Q2625965
+
+xx: Valrhona
+wikidata:en: Q928566
+
+xx: Valsemøllen
+wikidata:en: Q127161776
 
 xx: Valsoia
 wikidata:en: Q4008334
 
+xx: Valsølille
+
 xx: Vemondo
 
 xx: Veritas
+
+xx: Vitasia
+
+xx: wasa
+wikidata:en: Q2298302
 
 xx: Xtra, Xtra Coop
 wikidata:en: Q11902541
@@ -277,9 +441,12 @@ xx: Zeina's
 xx: Zeta
 wikidata:en: Q10724505
 
-xx: Änglamark
+xx: Änglamark, Anglemark
 wikidata:en: Q65229572
 
 xx: ØGO
 
-xx: Økolivet
+xx: Økoladen
+
+#< xx:ALDI
+xx: Økolivet, Øko Livet


### PR DESCRIPTION
A selection of some of the brands from /facets/brands of the Swedish and Danish OFFs, that were not previously in the taxonomy:
- https://se.openfoodfacts.org/facets/brands?status=unknown
- https://dk.openfoodfacts.org/facets/brands?status=unknown