### PR TITLE
ci: use registry cache for buildx

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -224,6 +224,7 @@ jobs:
                 echo "⚠️ Still might be tight with ${AVAIL_GB}GB available"
               else
                 echo "✅ Should have sufficient space now"
+              fi
             else
               echo "✅ Should have sufficient space"
             fi


### PR DESCRIPTION
Because we are running out of github cache otherwise
