### PR TITLE
fix: Don't try and contact Keycloak unless editing Account parameters

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -348,7 +348,7 @@ sub process_template ($template_filename, $template_data_ref, $result_content_re
 
 	my $oidc_implementation_level = get_oidc_implementation_level();
 	$template_data_ref->{oidc_implementation_level} = $oidc_implementation_level;
-	if (    $oidc_implementation_level > 0
+	if (    $oidc_implementation_level > 4
 		and defined $template_data_ref->{user_id}
 		and defined $template_data_ref->{canon_url})
 	{


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

At OIDC Implementation Level 1 we should only be contacting Keycloak if a user edits their Account parameters.