### PR TITLE
ci: add additional feedback when PR action is done

### DIFF
--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -14,7 +14,8 @@ jobs:
       (github.event.comment.body == '/lint')
     runs-on: ubuntu-latest
     steps:
-    - name: Add reaction to comment
+    - &step-reaction-seen
+      name: Add “seen” reaction to comment
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ github.event.comment.id }}
@@ -61,6 +62,13 @@ jobs:
         status_options: '--untracked-files=no'
         skip_dirty_check: false
         create_branch: no
+    - &step-reaction-completed
+      name: Add “completed” reaction to comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.comment.id }}
+        reactions: rocket
+        reactions-edit-mode: replace
 
   # Action to update test results by issuing /update_tests_results
   update_test_results:
@@ -70,11 +78,7 @@ jobs:
       (github.event.comment.body == '/update_tests_results')
     runs-on: ubuntu-latest
     steps:
-    - name: Add reaction to comment
-      uses: peter-evans/create-or-update-comment@v4
-      with:
-        comment-id: ${{ github.event.comment.id }}
-        reactions: eyes
+    - *step-reaction-seen
     - name: Get repository, owner and branch name
       # see https://github.com/actions/checkout/issues/331
       id: get-branch
@@ -112,3 +116,4 @@ jobs:
         status_options: '--untracked-files=no'
         skip_dirty_check: false
         create_branch: no
+    - *step-reaction-completed


### PR DESCRIPTION
Right now there’s feedback (in the form of a reaction) when a PR action is seen (and thus begun being acted on), but there’s no feedback when it’s done being processed, esp. when there’s no resulting changes and thus no commits.

This replaces the 👀 reaction with 🚀 at the end of the action, letting the caller know the action has finished running.

(It also utilises YAML anchors to not have to repeat code.)