### PR TITLE
fix: fix unit test results for ingredients.t

### DIFF
--- a/tests/unit/expected_test_results/ingredients/en-origin-field.json
+++ b/tests/unit/expected_test_results/ingredients/en-origin-field.json
@@ -2,7 +2,7 @@
    "ingredients" : [
       {
          "ciqual_food_code" : "13014",
-         "ecobalyse_code" : "e5bf7d33-6afe-46d6-ac06-f69c5769b10e",
+         "ecobalyse_code" : "ce20da3d-0ce4-49e9-8942-6d99ff0221b1",
          "id" : "en:strawberry",
          "is_in_taxonomy" : 1,
          "origins" : "en:spain",

--- a/tests/unit/expected_test_results/ingredients/fi-origins.json
+++ b/tests/unit/expected_test_results/ingredients/fi-origins.json
@@ -2,7 +2,7 @@
    "ingredients" : [
       {
          "ciqual_food_code" : "13014",
-         "ecobalyse_code" : "e5bf7d33-6afe-46d6-ac06-f69c5769b10e",
+         "ecobalyse_code" : "ce20da3d-0ce4-49e9-8942-6d99ff0221b1",
          "id" : "en:strawberry",
          "is_in_taxonomy" : 1,
          "origins" : "en:finland",


### PR DESCRIPTION
https://github.com/openfoodfacts/openfoodfacts-server/pull/12495 added ecobalyse_is_part_of_eu:en: yes to countries.txt for Finland, which changed the ecobalyse code we assign to strawberries from Finland:

```
(  DIAG  )  job  5    +----------------------+----------------------+----+----------------------+
(  DIAG  )  job  5    | PATH                 | GOT                  | OP | CHECK                |
(  DIAG  )  job  5    +----------------------+----------------------+----+----------------------+
(  DIAG  )  job  5    | {ingredients}[0]{eco | ce20da3d-0ce4-49e9-8 | eq | e5bf7d33-6afe-46d6-a |
(  DIAG  )  job  5    | balyse_code}         | 942-6d99ff0221b1     |    | c06-f69c5769b10e     |
(  DIAG  )  job  5    +----------------------+----------------------+----+----------------------+
```