### PR TITLE
taxonomy: fix fetan -> feta (fr)

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -46201,7 +46201,7 @@ de: Feta
 el: Φέτα, Feta
 es: Feta
 fi: feta
-fr: Fetan
+fr: Feta
 hr: Feta
 hu: Feta sajtok
 it: Feta


### PR DESCRIPTION
Marie found a type "fetan" instead of "feta"