### PR TITLE
fix: compute nutrition aggregated set with IU and % DV units

### DIFF
--- a/tests/unit/expected_test_results/nutrition/normalize_vitamin_iu_dv_units.json
+++ b/tests/unit/expected_test_results/nutrition/normalize_vitamin_iu_dv_units.json
@@ -1,0 +1,45 @@
+{
+   "nutrition" : {
+      "aggregated_set" : {
+         "nutrients" : {
+            "vitamin-a" : {
+               "source" : "packaging",
+               "source_index" : 0,
+               "source_per" : "100g",
+               "unit" : "g",
+               "value" : 0.0015
+            },
+            "vitamin-d" : {
+               "source" : "packaging",
+               "source_index" : 0,
+               "source_per" : "100g",
+               "unit" : "g",
+               "value" : 1e-05
+            }
+         },
+         "per" : "100g",
+         "preparation" : "as_sold"
+      },
+      "input_sets" : [
+         {
+            "nutrients" : {
+               "vitamin-a" : {
+                  "unit" : "IU",
+                  "value" : 5000,
+                  "value_string" : "5000"
+               },
+               "vitamin-d" : {
+                  "unit" : "% DV",
+                  "value" : 50,
+                  "value_string" : "400"
+               }
+            },
+            "per" : "100g",
+            "per_quantity" : "100",
+            "per_unit" : "g",
+            "preparation" : "as_sold",
+            "source" : "packaging"
+         }
+      ]
+   }
+}

--- a/tests/unit/nutrition.t
+++ b/tests/unit/nutrition.t
@@ -845,6 +845,35 @@ my @tests = (
 			}
 		}
 	],
+	# Vitamin values in International Units (IU), e.g. Vitamin A, or %DV for Vitamin D
+	[
+		"normalize_vitamin_iu_dv_units",
+		{
+			nutrition => {
+				input_sets => [
+					{
+						preparation => "as_sold",
+						per => "100g",
+						per_quantity => "100",
+						per_unit => "g",
+						source => "packaging",
+						nutrients => {
+							"vitamin-a" => {
+								value_string => "5000",
+								value => 5000,
+								unit => "IU",
+							},
+							"vitamin-d" => {
+								value_string => "400",
+								value => 50,
+								unit => "% DV",
+							}
+						}
+					}
+				]
+			}
+		}
+	],
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
Input sets can have some nutrients in IU (international unit) or % DV (daily value) for vitamins in some countries.

In the aggregated set, we convert everything to g.
