### PR TITLE
fix(gulpfile): Return Promise correctly to make Gulp build fail if a file is missing

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -217,19 +217,18 @@ function copyImages() {
   return src(imagesSrc).pipe(dest("./html/css/dist"));
 }
 
-export default function buildAll() {
-  return new Promise(
-    parallel(
-      copyJs,
-      buildJs,
-      buildjQueryUi,
-      copyCss,
-      copyImages,
-      jQueryUiThemes,
-      series(icons, attributesIcons, css)
-    )
-  );
-}
+// Shared task list for build steps
+const buildTasks = [
+  copyJs,
+  buildJs,
+  buildjQueryUi,
+  copyCss,
+  copyImages,
+  jQueryUiThemes,
+  series(icons, attributesIcons, css),
+];
+
+export default parallel(...buildTasks);
 
 function watchAll() {
   watch(jsSrc, { delay: 500 }, buildJs);
@@ -240,9 +239,11 @@ function watchAll() {
 }
 export { watchAll as watch };
 
-export function dynamic() {
-  buildAll().then(() => {
+export const dynamic = series(
+  parallel(...buildTasks),
+  function startWatch(done: () => void) {
     console.log("Build succeeded start watching for css and js changes");
     watchAll();
-  });
-}
+    done();
+  }
+);


### PR DESCRIPTION
### What

Apparently, this works better if we return the `Promise` directly.

### Screenshot

N/A

### Related issue(s) and discussion

- Fixes #10709

