### PR TITLE
fix: Load "product preferences" JS and CSS dependencies from the "static" subdomain

### DIFF
--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -9,6 +9,8 @@ let preferences; // All supported preferences + translated strings
 let use_user_product_preferences_for_ranking = JSON.parse(localStorage.getItem('use_user_product_preferences_for_ranking'));
 let reset_message;
 
+const staticBaseUri = `${document.location.protocol}//static.${document.querySelector('html').dataset.serverdomain}`;
+
 function get_user_product_preferences() {
     // Retrieve user preferences from local storage
 
@@ -271,9 +273,9 @@ function display_unwanted_ingredients_preferences() {
             // Load tagify JS and CSS
             // We use jQuery to load the CSS file dynamically
             $.when(
-                $.getScript("/js/dist/tagify.js"), // FIX ME: use static subdomain
-                $.getScript("/js/dist/tagify-init.js"), // FIX ME: use static subdomain
-                loadCSS("/css/dist/tagify.css"),
+                $.getScript(`${staticBaseUri}/js/dist/tagify.js`),
+                $.getScript(`${staticBaseUri}/js/dist/tagify-init.js`),
+                loadCSS(`${staticBaseUri}/css/dist/tagify.css`),
                 localize_unwanted_ingredients_tags()
             ).done(function() {
                 // Initialize tagify on the unwanted ingredients input field
@@ -538,7 +540,7 @@ function display_use_preferences_switch_and_edit_preferences_button(target_selec
       decide();
     } else {
       const script = document.createElement("script");
-      script.src = "/js/dist/external-knowledge-panels.js";
+      script.src = `${staticBaseUri}/js/dist/external-knowledge-panels.js`;
       script.onload = decide;
       document.body.appendChild(script);
     }
@@ -604,7 +606,7 @@ function display_use_preferences_switch_and_edit_preferences_button(target_selec
         mount();
       } else {
         const s = document.createElement("script");
-        s.src = "/js/dist/external-knowledge-panels.js";
+        s.src = `${staticBaseUri}/js/dist/external-knowledge-panels.js`;
         s.onload = mount;
         document.body.appendChild(s);
       }


### PR DESCRIPTION
### What

Closes an inline TODO comment, and fixes the script being loaded from `world.openfoodfacts.org` (or `$cc.openfoodfacts.org`).

### Screenshot

N/A

### Related issue(s) and discussion

N/A