### PR TITLE
fix: attribute_unwanted_ingredients_tags parameter for search

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4776,7 +4776,9 @@ sub add_params_to_query ($params_ref, $query_ref) {
 		# Tags fields can be passed with taxonomy ids as values (e.g labels_tags=en:organic)
 		# or with values in a given language (e.g. labels_tags_fr=bio)
 
-		if ($field =~ /^(.*)_tags(_(\w\w))?/) {
+		# Exception: attribute_unwanted_ingredients_tags=en:water is not a filter, it is a parameter to compute attributes
+
+		if (($field !~ /^attribute_/) and ($field =~ /^(.*)_tags(_(\w\w))?/)) {
 			my $tagtype = $1;
 			my $tag_lc = $lc;
 			if (defined $3) {

--- a/tests/integration/expected_test_results/search_v1/search-attribute-unwanted-ingredients-water-cookie.json
+++ b/tests/integration/expected_test_results/search_v1/search-attribute-unwanted-ingredients-water-cookie.json
@@ -1,0 +1,2075 @@
+{
+   "count" : 6,
+   "page" : "1",
+   "page_count" : 6,
+   "page_size" : 50,
+   "products" : [
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Average nutritional quality",
+                     "grade" : "c",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 53.6666666666667,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score C"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "en:milk in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 0,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Contains: Milk"
+                  },
+                  {
+                     "debug" : "en:eggs in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 0,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Contains: Eggs"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                     "id" : "vegan",
+                     "match" : 0,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:non-vegan",
+                     "status" : "known",
+                     "title" : "Non-vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 0,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil",
+                     "status" : "known",
+                     "title" : "Palm oil"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "We did not detect: Water. We may have missed some ingredients, please always check the ingredient list.",
+                     "description_short" : "We did not detect: Water",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 100,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "No unwanted ingredients detected"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Almost no risk of deforestation",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                     "id" : "forest_footprint",
+                     "match" : 99.7025,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Very small forest footprint"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Missing data to compute the Nutri-Score",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 0,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "unknown",
+                     "title" : "Nutri-Score unknown"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "We did not detect: Water. We may have missed some ingredients, please always check the ingredient list.",
+                     "description_short" : "We did not detect: Water",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 100,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "No unwanted ingredients detected"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very good nutritional quality",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-a-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 81,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score A"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "en:milk in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 0,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Contains: Milk"
+                  },
+                  {
+                     "debug" : "en:eggs in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 0,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Contains: Eggs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                     "id" : "vegan",
+                     "match" : 0,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:non-vegan",
+                     "status" : "known",
+                     "title" : "Non-vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "We did not detect: Water. We may have missed some ingredients, please always check the ingredient list.",
+                     "description_short" : "We did not detect: Water",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 100,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "No unwanted ingredients detected"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Almost no risk of deforestation",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                     "id" : "forest_footprint",
+                     "match" : 99.4711111111111,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Very small forest footprint"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Average nutritional quality",
+                     "grade" : "c",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 45.2222222222222,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score C"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 0,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil",
+                     "status" : "known",
+                     "title" : "Palm oil"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Unwanted ingredients: Water",
+                     "description_short" : "Water",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 0,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "Contains unwanted ingredients"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very good nutritional quality",
+                     "grade" : "b",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-a-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 73.6666666666667,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score A"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Unwanted ingredients: Water",
+                     "description_short" : "Water",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 0,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "Contains unwanted ingredients"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very high environmental impact",
+                     "grade" : "d",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-e.svg",
+                     "id" : "ecoscore",
+                     "match" : 25,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "known",
+                     "title" : "Green-Score E"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very good nutritional quality",
+                     "grade" : "b",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-a-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 73.6666666666667,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score A"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Unwanted ingredients: Water",
+                     "description_short" : "Water",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 0,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "Contains unwanted ingredients"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very high environmental impact",
+                     "grade" : "d",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-e.svg",
+                     "id" : "ecoscore",
+                     "match" : 25,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "known",
+                     "title" : "Green-Score E"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      }
+   ],
+   "skip" : 0
+}

--- a/tests/integration/expected_test_results/search_v1/search-attribute-unwanted-ingredients-water.json
+++ b/tests/integration/expected_test_results/search_v1/search-attribute-unwanted-ingredients-water.json
@@ -1,0 +1,2075 @@
+{
+   "count" : 6,
+   "page" : "1",
+   "page_count" : 6,
+   "page_size" : 50,
+   "products" : [
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Average nutritional quality",
+                     "grade" : "c",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 53.6666666666667,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score C"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "en:milk in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 0,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Contains: Milk"
+                  },
+                  {
+                     "debug" : "en:eggs in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 0,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Contains: Eggs"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "4 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                     "id" : "vegan",
+                     "match" : 0,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:non-vegan",
+                     "status" : "known",
+                     "title" : "Non-vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 0,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil",
+                     "status" : "known",
+                     "title" : "Palm oil"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "We did not detect: Water. We may have missed some ingredients, please always check the ingredient list.",
+                     "description_short" : "We did not detect: Water",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 100,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "No unwanted ingredients detected"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Almost no risk of deforestation",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                     "id" : "forest_footprint",
+                     "match" : 99.7025,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Very small forest footprint"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Missing data to compute the Nutri-Score",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-unknown-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 0,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "unknown",
+                     "title" : "Nutri-Score unknown"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "We did not detect: Water. We may have missed some ingredients, please always check the ingredient list.",
+                     "description_short" : "We did not detect: Water",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 100,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "No unwanted ingredients detected"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very good nutritional quality",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-a-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 81,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score A"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "en:milk in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 0,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Contains: Milk"
+                  },
+                  {
+                     "debug" : "en:eggs in allergens",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 0,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Contains: Eggs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/non-vegan.svg",
+                     "id" : "vegan",
+                     "match" : 0,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:non-vegan",
+                     "status" : "known",
+                     "title" : "Non-vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "We did not detect: Water. We may have missed some ingredients, please always check the ingredient list.",
+                     "description_short" : "We did not detect: Water",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 100,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "No unwanted ingredients detected"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Almost no risk of deforestation",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-a.svg",
+                     "id" : "forest_footprint",
+                     "match" : 99.4711111111111,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Very small forest footprint"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Average nutritional quality",
+                     "grade" : "c",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-c-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 45.2222222222222,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score C"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "3 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-palm-oil.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 0,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil",
+                     "status" : "known",
+                     "title" : "Palm oil"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Unwanted ingredients: Water",
+                     "description_short" : "Water",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 0,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "Contains unwanted ingredients"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description_short" : "Missing a precise category",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
+                     "id" : "ecoscore",
+                     "match" : 0,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "unknown",
+                     "title" : "Green-Score not computed"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very good nutritional quality",
+                     "grade" : "b",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-a-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 73.6666666666667,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score A"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Unwanted ingredients: Water",
+                     "description_short" : "Water",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 0,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "Contains unwanted ingredients"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very high environmental impact",
+                     "grade" : "d",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-e.svg",
+                     "id" : "ecoscore",
+                     "match" : 25,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "known",
+                     "title" : "Green-Score E"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      },
+      {
+         "attribute_groups" : [
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very good nutritional quality",
+                     "grade" : "b",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutriscore-a-new-en.svg",
+                     "id" : "nutriscore",
+                     "match" : 73.6666666666667,
+                     "name" : "Nutri-Score",
+                     "panel_id" : "nutriscore_2023",
+                     "status" : "known",
+                     "title" : "Nutri-Score A"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-salt-unknown.svg",
+                     "id" : "low_salt",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Salt",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Salt in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-fat-unknown.svg",
+                     "id" : "low_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Fat in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-sugars-unknown.svg",
+                     "id" : "low_sugars",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Sugars",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Sugars in unknown quantity"
+                  },
+                  {
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nutrient-level-saturated-fat-unknown.svg",
+                     "id" : "low_saturated_fat",
+                     "missing" : "Missing nutrition facts",
+                     "name" : "Saturated fat",
+                     "panel_id" : "nutrition_facts_table",
+                     "status" : "unknown",
+                     "title" : "Saturated fat in unknown quantity"
+                  }
+               ],
+               "id" : "nutritional_quality",
+               "name" : "Nutritional quality"
+            },
+            {
+               "attributes" : [
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-gluten.svg",
+                     "id" : "allergens_no_gluten",
+                     "match" : 100,
+                     "name" : "Gluten",
+                     "status" : "known",
+                     "title" : "Does not contain: Gluten"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-milk.svg",
+                     "id" : "allergens_no_milk",
+                     "match" : 100,
+                     "name" : "Milk",
+                     "status" : "known",
+                     "title" : "Does not contain: Milk"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-eggs.svg",
+                     "id" : "allergens_no_eggs",
+                     "match" : 100,
+                     "name" : "Eggs",
+                     "status" : "known",
+                     "title" : "Does not contain: Eggs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-nuts.svg",
+                     "id" : "allergens_no_nuts",
+                     "match" : 100,
+                     "name" : "Nuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Nuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-peanuts.svg",
+                     "id" : "allergens_no_peanuts",
+                     "match" : 100,
+                     "name" : "Peanuts",
+                     "status" : "known",
+                     "title" : "Does not contain: Peanuts"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sesame-seeds.svg",
+                     "id" : "allergens_no_sesame_seeds",
+                     "match" : 100,
+                     "name" : "Sesame seeds",
+                     "status" : "known",
+                     "title" : "Does not contain: Sesame seeds"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-soybeans.svg",
+                     "id" : "allergens_no_soybeans",
+                     "match" : 100,
+                     "name" : "Soybeans",
+                     "status" : "known",
+                     "title" : "Does not contain: Soybeans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-celery.svg",
+                     "id" : "allergens_no_celery",
+                     "match" : 100,
+                     "name" : "Celery",
+                     "status" : "known",
+                     "title" : "Does not contain: Celery"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-mustard.svg",
+                     "id" : "allergens_no_mustard",
+                     "match" : 100,
+                     "name" : "Mustard",
+                     "status" : "known",
+                     "title" : "Does not contain: Mustard"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-lupin.svg",
+                     "id" : "allergens_no_lupin",
+                     "match" : 100,
+                     "name" : "Lupin",
+                     "status" : "known",
+                     "title" : "Does not contain: Lupin"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-fish.svg",
+                     "id" : "allergens_no_fish",
+                     "match" : 100,
+                     "name" : "Fish",
+                     "status" : "known",
+                     "title" : "Does not contain: Fish"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-crustaceans.svg",
+                     "id" : "allergens_no_crustaceans",
+                     "match" : 100,
+                     "name" : "Crustaceans",
+                     "status" : "known",
+                     "title" : "Does not contain: Crustaceans"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-molluscs.svg",
+                     "id" : "allergens_no_molluscs",
+                     "match" : 100,
+                     "name" : "Molluscs",
+                     "status" : "known",
+                     "title" : "Does not contain: Molluscs"
+                  },
+                  {
+                     "debug" : "2 ingredients (0 unknown)",
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
+                     "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+                     "match" : 100,
+                     "name" : "Sulphur dioxide and sulphites",
+                     "status" : "known",
+                     "title" : "Does not contain: Sulphur dioxide and sulphites"
+                  }
+               ],
+               "id" : "allergens",
+               "name" : "Allergens",
+               "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegan.svg",
+                     "id" : "vegan",
+                     "match" : 100,
+                     "name" : "Vegan",
+                     "panel_id" : "ingredients_analysis_en:vegan",
+                     "status" : "known",
+                     "title" : "Vegan"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/vegetarian.svg",
+                     "id" : "vegetarian",
+                     "match" : 100,
+                     "name" : "Vegetarian",
+                     "panel_id" : "ingredients_analysis_en:vegetarian",
+                     "status" : "known",
+                     "title" : "Vegetarian"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/palm-oil-free.svg",
+                     "id" : "palm_oil_free",
+                     "match" : 100,
+                     "name" : "Palm oil free",
+                     "panel_id" : "ingredients_analysis_en:palm-oil-free",
+                     "status" : "known",
+                     "title" : "Palm oil free"
+                  }
+               ],
+               "id" : "ingredients_analysis",
+               "name" : "Ingredients",
+               "warning" : "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Unwanted ingredients: Water",
+                     "description_short" : "Water",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/contains-unwanted-ingredients.svg",
+                     "id" : "unwanted_ingredients",
+                     "match" : 0,
+                     "name" : "Unwanted ingredients",
+                     "panel_id" : "ingredients",
+                     "status" : "known",
+                     "title" : "Contains unwanted ingredients"
+                  }
+               ],
+               "id" : "ingredients",
+               "name" : ""
+            },
+            {
+               "attributes" : [
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/nova-group-1.svg",
+                     "id" : "nova",
+                     "match" : 100,
+                     "name" : "NOVA group",
+                     "panel_id" : "nova",
+                     "status" : "known",
+                     "title" : "Unprocessed or minimally processed foods"
+                  },
+                  {
+                     "grade" : "a",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/0-additives.svg",
+                     "id" : "additives",
+                     "match" : 100,
+                     "name" : "Additives",
+                     "panel_id" : "additives",
+                     "status" : "known",
+                     "title" : "Without additives"
+                  }
+               ],
+               "id" : "processing",
+               "name" : "Food processing"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "",
+                     "description_short" : "Very high environmental impact",
+                     "grade" : "d",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-e.svg",
+                     "id" : "ecoscore",
+                     "match" : 25,
+                     "name" : "Green-Score",
+                     "panel_id" : "environmental_score",
+                     "status" : "known",
+                     "title" : "Green-Score E"
+                  },
+                  {
+                     "description" : "",
+                     "description_short" : "Currently only for products with chicken or eggs",
+                     "grade" : "e",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/forest-footprint-not-computed.svg",
+                     "id" : "forest_footprint",
+                     "match" : 0,
+                     "name" : "Forest footprint",
+                     "status" : "known",
+                     "title" : "Forest footprint not computed"
+                  }
+               ],
+               "id" : "environment",
+               "name" : "Environment"
+            },
+            {
+               "attributes" : [
+                  {
+                     "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+                     "description_short" : "Organic products promote ecological sustainability and biodiversity.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/organic-unknown.svg",
+                     "id" : "labels_organic",
+                     "name" : "Organic farming",
+                     "status" : "unknown",
+                     "title" : "Missing information: organic product?"
+                  },
+                  {
+                     "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+                     "description_short" : "Fair trade products help producers in developing countries.",
+                     "grade" : "unknown",
+                     "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/fair-trade-unknown.svg",
+                     "id" : "labels_fair_trade",
+                     "name" : "Fair trade",
+                     "status" : "unknown",
+                     "title" : "Missing information: fair trade product?"
+                  }
+               ],
+               "id" : "labels",
+               "name" : "Labels"
+            }
+         ]
+      }
+   ],
+   "skip" : 0
+}

--- a/tests/integration/search_v1.t
+++ b/tests/integration/search_v1.t
@@ -144,6 +144,22 @@ my $tests_ref = [
 		path => '/cgi/search.pl?action=process&json=1&fields=code,packaging_text_en,packagings&api_version=3',
 		expected_status_code => 200,
 	},
+	# Attribute groups with unwanted ingredients
+	{
+		test_case => 'search-attribute-unwanted-ingredients-water',
+		method => 'GET',
+		path =>
+			'/cgi/search.pl?action=process&json=1&attribute_unwanted_ingredients_tags=en:water&fields=attribute_groups',
+		expected_status_code => 200,
+	},
+	# Attributes groups with unwanted ingredients using a cookie to set the language to Spanish
+	{
+		test_case => 'search-attribute-unwanted-ingredients-water-cookie',
+		method => 'GET',
+		path => '/cgi/search.pl?action=process&json=1&fields=attribute_groups',
+		cookies => [{name => "attribute_unwanted_ingredients_tags", value => "en:water"}],
+		expected_status_code => 200,
+	}
 ];
 
 execute_api_tests(__FILE__, $tests_ref);


### PR DESCRIPTION
Fixes issue found by @monsieurtanuki : https://github.com/openfoodfacts/openfoodfacts-dart/issues/1134#issuecomment-3475865815

https://fr.openfoodfacts.org/cgi/search.pl?search_terms=pizza&langs=fr&page_size=5&page=1&fields=code%2Cbrands&json=1&attribute_unwanted_ingredients_tags=en:garlic returns 0 results because the search think it is a filter on tags as the parameter ends with _tags

Also added some tests.