### PR TITLE
taxonomy: correction acras

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -121229,16 +121229,22 @@ fr: Varenyky surgelés
 
 # TODO check the difference
 
-
 < en:Appetizers
+en: Acras, Accras
+fr: Acras, Accras
+hr: Acras
+nl: Acra
+
+< en:Acras
 < en:Fish preparations
 en: Cod acras, Cod accras
 fr: Acras de morue, Accras de morue, acras de cabillaud
 hr: Bakalar acras
 it: Frittelle di merluzzo, Frittelle di baccalà
 nl: Kabeljauwacra
-agribalyse_proxy_food_code:en: 26028
-agribalyse_proxy_food_name:en: Fish, croquette, fritter or nuggets, fried
+agribalyse_food_code:en: 25433
+ciqual_food_code:en: 25433
+ciqual_food_name:en: Caribbean-style fish fritters, fish acras
 wikidata:en: Q12860188
 
 < en:Meals
@@ -121715,15 +121721,6 @@ en: Mashed split peas
 fr: Purées de pois cassés
 hr: Pire od graška
 nl: Gepureerde spliterwten
-
-< en:Meals
-en: Acras, Accras
-fr: Acras, Accras
-hr: Acras
-nl: Acra
-agribalyse_food_code:en: 25433
-ciqual_food_code:en: 25433
-ciqual_food_name:en: Caribbean-style fish fritters, fish acras
 
 < en:Frozen vegetables
 en: Frozen raw butter beans, Frozen raw yellow beans


### PR DESCRIPTION
I moved "acras" from meals to "appetizers", put "cod acras" below "acras" and corrected the agribalyse link which was on acras while it referers to caribbean fish acras, which are the cod acras.
