### PR TITLE
fix: enable unwanted ingredients attributes for cosmetics on OBF

### DIFF
--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -569,8 +569,10 @@ $options{import_export_fields_groups} = [
 
 # Used to generate the list of possible product attributes, which is
 # used to display the possible choices for user preferences
-$options{attribute_groups}
-	= [["ingredients_analysis", ["vegan", "palm_oil_free", "unwanted_ingredients"]], ["labels", ["labels_organic", "labels_fair_trade"]],];
+$options{attribute_groups} = [
+	["ingredients_analysis", ["vegan", "palm_oil_free", "unwanted_ingredients"]],
+	["labels", ["labels_organic", "labels_fair_trade"]],
+];
 
 # default preferences for attributes
 $options{attribute_default_preferences} = {


### PR DESCRIPTION
This PR enables the unwanted ingredients attribute for cosmetics on Open Beauty Facts. (see also PRs  https://github.com/openfoodfacts/openfoodfacts-server/pull/12321 and https://github.com/openfoodfacts/openfoodfacts-server/pull/12383 )

e.g. to get warnings when products contain specfic ingredients like BHT:

<img width="1063" height="656" alt="image" src="https://github.com/user-attachments/assets/f0149777-e6c7-44bd-95da-7598593112fc" />

Result:

<img width="1302" height="1266" alt="image" src="https://github.com/user-attachments/assets/5ef2c291-1bb1-4d67-94dd-78946f4c32c1" />
