### PR TITLE
fix: image tag for trivy and SBOM generation

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Generate SBOM for ${{ matrix.image_name }} image
       uses: anchore/sbom-action@v0
       with:
-        image: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:sha-${{ github.sha }}
+        image: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:${{ github.sha }}
         format: cyclonedx-json
         output-file: ${{ matrix.image_name }}-sbom.cyclonedx.json
         upload-artifact: true
@@ -79,7 +79,7 @@ jobs:
     - name: Trivy scan for ${{ matrix.image_name }} image
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:sha-${{ github.sha }}
+        image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:${{ github.sha }}
         format: 'sarif'
         output: ${{ matrix.image_name }}-trivy.sarif
         vuln-type: 'os,library'


### PR DESCRIPTION
@hangy There are errors in the build action that I think were introduced by https://github.com/openfoodfacts/openfoodfacts-server/pull/12646

https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/19302023694

[build (frontend)](https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/19302023694/job/55203735529#step:9:41)
Path does not exist: frontend-trivy.sarif

Copilot suggest this PR should fix it.


Summary
The issue was with the image reference format in the [container-build.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) workflow.

The Problem:

The Docker metadata action creates a tag with [type=sha,format=long](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → produces just the SHA (e.g., abc123...)
But the Trivy and SBOM steps were referencing sha-${{ github.sha }} → looking for sha-abc123...
This caused the Trivy scan to fail because it couldn't find the image
Since Trivy failed, no frontend-trivy.sarif file was generated
The upload step then failed with "Path does not exist: frontend-trivy.sarif"
The Fix:
I updated both the SBOM generation and Trivy scan steps to use the correct image reference:

Changed from: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:sha-${{ github.sha }}
Changed to: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:${{ github.sha }}
Now the Trivy scan will find the correct image, generate the SARIF file, and the upload will succeed. The workflow already has proper Trivy scanning configured for both frontend and backend images.