### PR TITLE
fix: package write permission for build

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
   security-events: write
 
 concurrency:


### PR DESCRIPTION
https://github.com/openfoodfacts/openfoodfacts-server/pull/12646 makes push fail:

https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/19302023694

[build (frontend)](https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/19302023694/job/55203735529#step:6:302)
buildx failed with: error: failed to solve: failed to push ghcr.io/openfoodfacts/openfoodfacts-server/frontend:2.82.0: denied: installation not allowed to Write organization package

Fix suggested on Slack: https://openfoodfacts.slack.com/archives/C02LDQDDD/p1762963537961819?thread_ts=1762963267.019029&cid=C02LDQDDD