### PR TITLE
ci: remove `off-org` from deploy matrix

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - deploy-*
-    tags:
-      - v*.*.*
 
 # Note on secrets used for connection
 # SSH_PRIVATE_KEY is the private key (shared between VM and host)
@@ -17,7 +15,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - ${{ startsWith(github.ref, 'refs/tags/v') && 'off-org' || 'off-net' }}
+          - off-net
     environment: ${{ matrix.env }}
     concurrency: ${{ matrix.env }}
     steps:
@@ -49,12 +47,6 @@ jobs:
         echo "SSH_HOST=10.1.0.200" >> $GITHUB_ENV
         echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
         echo "SSH_USERNAME=off" >> $GITHUB_ENV
-
-    - name: Set various variable for prod (org) deployment
-      if: matrix.env == 'off-org'
-      run: |
-        # FIXME: we do not deploy to prod currently
-        false
 
     - name: Check for an eventual NO_DEPLOY file to put deployment on hold
       uses: appleboy/ssh-action@v1.2.2


### PR DESCRIPTION
Right now, every commit to `main` as well as every `v*.*.*` release will result in a red “x”/failed status, as the deploy workflow exits early for deploying to off.org.

This removes `off-org` from the build matrix entirely, to not run this. Hopefully this will lead us to not see all those red x’s all the time, only when there’s something _actually_ wrong. :)

Note that this _doesn’t_ simplify the workflow based on there only being one entry in the matrix, since this allows for a future easy reversion of this commit or otherwise re-insert `off-org` into the matrix.