### PR TITLE
taxonomy: Updates for 7331642061009 and 7318690074175

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -13689,9 +13689,6 @@ anses_additives_of_interest:en: yes
 e_number:en: 450
 wikidata:en: Q290828
 
-
-# description:en:TETRASODIUM PYROPHOSPHATE, also called sodium pyrophosphate, tetrasodium phosphate or TSPP, is a colorless transparent crystalline chemical compound with the formula Na4P2O7.
-
 < en:E450
 en: E450(iii), Tetrasodium diphosphate, Tetrasodium pyrophosphate, Tetrasodium disphosphate, Tetrasodium diphosphate, sodium pyrophosphate, TSPP, e450iii
 xx: E450(iii)
@@ -13722,15 +13719,16 @@ sh: E450(iii), etranatrijum pirofosfat
 sk: E450(iii), Difosforečnan tetrasodný, Pyrofosforečnan tetrasodný, difosforečnan tetrasodný
 sl: E450(iii), Tetranatrijev difosfat, tetranatrijev pirofosfat, tetranatrijev difosfat
 sr: E450(iii), Tetranatrijum pirofosfat
-sv: E450(iii), Tetranatriumdifosfat, Tetranatriumpyrofosfat
+sv: E450(iii), Tetranatriumdifosfat, Tetranatriumpyrofosfat, Natriumpyrofosfat
 vi: E450(iii), Natri pyrophotphat
 zh: E450(iii), 焦磷酸钠
+# azb: تتراسدیوم پیروفوسفات
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
+description:en: TETRASODIUM PYROPHOSPHATE, also called sodium pyrophosphate, tetrasodium phosphate or TSPP, is a colorless transparent crystalline chemical compound with the formula Na4P2O7.
 e_number:en: 450
 wikidata:en: Q418504
 wikipedia:en: https://en.wikipedia.org/wiki/Tetrasodium_pyrophosphate
-# azb:تتراسدیوم پیروفوسفات
 
 < en:E450
 en: E450(iv), dipotassium dihydrogenpyrophosphate, E450iv, E-450iv

--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -228,6 +228,9 @@ xx: KOTI, KOTISINAPPI, KOTI sinappi, KOTISENAP, KOTI senap
 #web:fi: https://www.kotisinappi.fi/
 #web:sv: https://www.kotisinappi.fi/svenska
 
+xx: Kryddhuset
+#web:sv: https://kryddhusetiljung.se/
+
 xx: Kung Markatta
 wikidata:en: Q10550149
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -65395,18 +65395,40 @@ ciqual_food_name:en: Baker's yeast, compressed
 
 < en:Food additives
 en: Baking powder or raising agent
-bg: Бакпулвер
-de: Backpulver
+da: Bagepulver eller hævemiddel
 es: Levadura en polvo o gasificante
 fi: Leivinjauhe tai nostatusaine
 fr: levure chimique
 hr: Prašak za pecivo ili sredstvo za dizanje
 it: Polvere da cottura o agente lievitante
 lt: Kepimo milteliai arba kildinimo medžiaga
-nl: Bakpoeders
+sv: Bakpulver eller jäsmedel, Bakpulver eller hävmedel
 agribalyse_food_code:en: 11046
 ciqual_food_code:en: 11046
 ciqual_food_name:en: Baking powder or raising agent
+
+< en:Baking powder or raising agent
+en: Baking powders, Baking powder
+ar: ذرور الخبز
+bg: Бакпулвер
+ca: Rent químic
+da: Bagepulver
+de: Backpulver
+eo: Bakpulvoro
+et: Küpsetuspulber
+eu: Legami kimiko
+ga: Púdar bácála
+is: Lyftiduft
+ja: ベーキングパウダー
+ko: 베이킹파우더
+nb: Bakepulver
+nl: Bakpoeders
+nv: Biłʼeʼeliníʼ
+pt: Levedura química
+sv: Bakpulver
+zh: 复配膨松剂
+google_product_taxonomy_id:en: 2803
+wikidata:en: Q29476
 
 < en:Food additives
 fr: Poudres à lever
@@ -65444,16 +65466,22 @@ wikidata:en: Q726460
 
 < en:Anticaking agents
 en: Bicarbonates of soda, Sodium bicarbonates, Sodium bicarbonate, Sodium hydrogen carbonate, Baking soda, Bicarbonate of soda
+xx: NaHCO₃, NaHCO3, E500ii, E-500ii
+ar: بيكربونات الصوديوم
 bg: Сода бикарбонат
+da: Natron, Natriumhydrogencarbonat, Natriumbicarbonat
 de: Natron
+eo: Natria bikarbonato, Hidrogenkarbonato de natrio
 es: Bicarbonatos de sodio, Bicarbonato sódico, Bicarbonato de sodio
-fi: ruokasooda
+fi: Ruokasooda, Natriumvetykarbonaatti, Natriumbikarbonaatti
 fr: Bicarbonates de sodium, Bicarbonate de sodium, Bicarbonate de soude, Bicarbonate alimentaire
+ga: Hidrigincharbónáit sóidiam
 hr: Soda bikarbona
 it: Bicarbonato di sodio, Sodio bicarbonato
-la: E-500ii
-lt: Kepimo soda
+lt: Natrio hidrokarbonatas, Natrio bikarbonatas, Kepimo milteliai, Kepimo soda, Maistinė soda
+nb: Natron
 nl: Natriumbicarbonaten, Natriumwaterstofcarbonaten, Dubbelkoolzure sodas
+sv: Natriumvätekarbonater, Bikarbonater, Natriumbikarbonater
 agribalyse_food_code:en: 11507
 ciqual_food_code:en: 11507
 ciqual_food_name:en: Sodium bicarbonate


### PR DESCRIPTION
https://se.openfoodfacts.org/product/7331642061009/ren-bikarbonat-universal-kryddhuset
https://se.openfoodfacts.org/product/7318690074175/bakpulver-ica

I was adding the first, then noticed the second was wrongly categorised as a sodium bicarbonate, so that ended up getting caught up in these changes too.

Note that this breaks out “Baking powders” into its own category, as there are raising agents that are not “baking powder”, so this helps us be a bit more specific – as well as link “baking powder” to Wikidata and the Google product taxonomy. (There are also currently several products with category `en:baking-powder` that are not currently being caught: https://world.openfoodfacts.org/facets/categories/baking-powder )