### PR TITLE
taxonomy: Puff pastry appetizers 2

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -119413,12 +119413,6 @@ wikidata:en: Q160525
 fr: mélange Sticks et Bretzels
 
 < en:Crackers(Appetizers)
-en: Puffed salty snacks, Salty snacks puff pastry
-fr: Biscuits apéritifs soufflés, Gâteaux apéritifs soufflés
-hr: Napuhane slane grickalice
-ro: Pufuleți
-
-< en:Crackers(Appetizers)
 en: Salty flaky biscuits
 fr: Biscuits apéritifs feuilletés, Biscuit apéritif feuilleté
 agribalyse_food_code:en: 38407
@@ -119451,9 +119445,15 @@ ciqual_food_code:en: 38401
 ciqual_food_name:en: Salty snacks, crackers, garnished or filled with cheese
 ciqual_food_name:fr: Biscuit apéritif, crackers, garni ou fourré, au fromage
 
+< en:Appetizers
+en: Puffed salty snacks, Salty snacks puff pastry
+fr: Snacks apéritifs soufflés, Biscuits apéritifs soufflés, Gâteaux apéritifs soufflés
+hr: Napuhane slane grickalice
+ro: Pufuleți
+
 < en:Puffed salty snacks
 en: Puffed salty snacks made from maize, Puffed salty snacks made from corn
-fr: Biscuits apéritifs soufflés à base de maïs
+fr: Snacks apéritifs soufflés à base de maïs, Biscuits apéritifs soufflés à base de maïs
 agribalyse_food_code:en: 38400
 ciqual_food_code:en: 38400
 ciqual_food_name:en: Puffed salty snacks, made from maize/corn, without peanuts
@@ -119461,7 +119461,7 @@ ciqual_food_name:fr: Biscuit apéritif soufflé, à base de maïs, sans cacahuè
 
 < en:Puffed salty snacks
 en: Puffed salty snacks made from maize with peanuts, Puffed salty snacks made from corn with peanuts
-fr: Biscuit apéritif soufflé à base de maïs à la cacahuète
+fr: Snacks apéritifs soufflés à base de maïs à la cacahuète, Biscuit apéritif soufflé à base de maïs à la cacahuète
 agribalyse_food_code:en: 38404
 ciqual_food_code:en: 38404
 ciqual_food_name:en: Puffed salty snacks, made from maize/corn, with peanuts
@@ -119469,7 +119469,7 @@ ciqual_food_name:fr: Biscuit apéritif soufflé, à base de maïs, à la cacahu�
 
 < en:Puffed salty snacks
 en: Puffed salty snacks made from potato
-fr: Biscuits apéritifs soufflés à base de pomme de terre, Biscuits apéritifs soufflés à base de pomme de terre type Monster Munch, Monster Munch
+fr: Snacks apéritifs soufflés à base de pomme de terre, Biscuits apéritifs soufflés à base de pomme de terre, Biscuits apéritifs soufflés à base de pomme de terre type Monster Munch, Monster Munch
 agribalyse_food_code:en: 38106
 ciqual_food_code:en: 38106
 ciqual_food_name:en: Puffed salty snacks, made from potato
@@ -119478,7 +119478,7 @@ ciqual_food_name:fr: Biscuit apéritif soufflé, à base de pomme de terre
 < en:Puffed salty snacks
 en: Puffed salty snacks made from potato and soy, Puffed salty snacks (potato/soy based)
 de: Gepuffte salzige Snacks (Kartoffel/Soja)
-fr: Biscuit apéritif soufflé à base de pomme de terre et de soja, Biscuits apéritifs soufflés (à base de pomme de terre/soja)
+fr: Snacks apéritifs soufflés à base de pomme de terre et de soja, Biscuit apéritif soufflé à base de pomme de terre et de soja, Biscuits apéritifs soufflés (à base de pomme de terre/soja)
 hr: Lisnate slane grickalice (na bazi krumpira/soje)
 nl: Gepofte zoutjes (aardappel/soja basis)
 agribalyse_food_code:en: 38108


### PR DESCRIPTION
I moved the category "gougères" under "puff pastry appetizers". I renamed some categories of "Puffed salty snacks" in French, and moved them directly under appetizers, they are not crackers.