### PR TITLE
taxonomy(food): sv:Krispsallad category+ingredient

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -110320,6 +110320,10 @@ agribalyse_proxy_food_name:fr: Laitue iceberg, crue
 ciqual_food_code:en: 20123
 ciqual_food_name:fr: Batavia, crue
 
+< en:Lettuces
+en: Frillice iceberg lettuces, Frillice lettuces
+sv: Krispsallader, Krispsallad
+
 < en:Culinary plants
 < en:Onions and their products
 #<en:ingredient:en:vegetable

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -49397,11 +49397,10 @@ ciqual_food_name:fr: Pissenlit, cru
 #100 @2021-10-06
 eurocode_2_group_3:en: 8.10.44
 
-#description:en:Frillice iceberg lettuce is a cross of curly endive and iceberg lettuce, with the taste and texture of iceberg and the frilly top of the curly endive.
-
 < en:lettuce
 en: frillice iceberg lettuce, frillice lettuce
-sv: krispsallad
+sv: krispsallad, kripsallad
+description:en: Frillice iceberg lettuce is a cross of curly endive and iceberg lettuce, with the taste and texture of iceberg and the frilly top of the curly endive.
 
 < en:frillice iceberg lettuce
 en: green frillice iceberg lettuce


### PR DESCRIPTION
This adds sv:Krispsallader as a category in addition to it being an ingredient. Additionally, it adds the apparently _very_ common misspelling/typo “kripsallad”[1] as a synonym.

Reference product (which also has the typo in its ingredients):
https://se.openfoodfacts.org/product/7311043021598/krispsallad-garant

[1] https://duckduckgo.com/?q=%22Kripsallad%22