### PR TITLE
taxonomy: snails and their products

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -117513,7 +117513,7 @@ en: Mini appetizer croissants
 fr: Mini croissants apéritifs
 
 < en:Puff pastry appetizers
-en: Sausage rolls
+en: Mini sausage rolls, Sausage rolls
 de: Wurstrollen
 fr: Roulés à la saucisse, roulés aux saucisses, feuilletés à la saucisse
 hr: Kolutići kobasica


### PR DESCRIPTION
I created "Mini appetizer puff pastries with snails" to separate them from "Snails in puff pastry" that I renamed "Large puff pastries with snails". The first one is an appetizer, the second a meal, and the difference in fat content is important. The appetizers contains around 30% fat while the large versions (only four products now) contain around 20% fat. 
Second, I created "Snails and their products" to remove "Snails preparations" from "Snails" (which is in meats). Snail puff pastries clearly don't fit in meats.
Finally I renamed "Sausage friands", "Large sausage rolls" because the English products currently in the category are called sausage rolls (e.g. https://world.openfoodfacts.org/product/5031021047410/2-pork-sausages-rolls-tesco). I renamed "Sausage rolls", "Mini sausage rolls" accordingly. I deleted the category "Frozen sausage friands" that would contain only three products.