### PR TITLE
taxonomy: correction vol-au vent

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -79982,6 +79982,9 @@ ciqual_food_name:en: Vol-au-vent, with meat/poultry/quenelle
 en: Vol-au-vent in sauce, Vol-au-vent
 fr: Vol-au-vent en sauce
 
+< en:Meals with meat
+fr: Garnitures pour bouchées à reine
+
 < en:Puff pastry meals
 fr: Paniers feuilletés
 nl: Bladerdeegbakjes, Bladerdeegpasteitjes


### PR DESCRIPTION
There was a huge confusion with different products with vol-au-vent in their names grouped in the category "Vol-au-vent" which was in "puff pastry meals". I separated those products in four categories:
* Puff pastry molds for vol-au-vent (e.g. https://world.openfoodfacts.org/product/8436026539651/vol-au-vent-musfi-s)
* Vol-au-vent in puff pastries, which is the equivalent of the old category under puff pastry meals. Those products are called bouchées à la reine in France (e.g. https://world.openfoodfacts.org/product/3250392486167/bouchees-a-la-reine-netto)
* Vol-au-vent in sauce, which is sold in Belgium mostly and not eaten in puff-pastry there (e.g. https://world.openfoodfacts.org/product/5400101004061/simpl-vol-au-vent or https://world.openfoodfacts.org/product/5400101077546/carrefour-the-market-traiteur-gourmet-vol-au-vent).
* fr: Garnitures pour bouchées à reine, which is similar to the Belgian vol-au-vent, but with poultry quenelles (which is a dumpling made of ground poultry, flour and eggs) instead of poultry meat. This is the filling that is put in the puff pastries.
I also merged "Puff pastries with ham and cheese" and "Ham and cheese in puffed pastry".

