### PR TITLE
ci: pull_requests.yml: ensure a checkout exists

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code_modified: ${{ steps.filter.outputs.code }}
     steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->

### What

The `push` event in GitHub Actions does not implicitly create a clone of the repository, unlike the `pull_request` event.

Since the `dorny/paths-filter` action we use to handle both event types does require a checkout, this commit adds an explicit checkout step to the job.

### Related issue(s) and discussion

- Relates to https://github.com/openfoodfacts/openfoodfacts-server/pull/12698#issuecomment-3593216264
- This is a rollforward alternative to the rollback/revert suggested by #12726.
- Fix has been tested in GitHub Actions CI using a fork at `openculinary/openfoodfacts-server`: https://github.com/openculinary/openfoodfacts-server/pull/8