### PR TITLE
build: chown xzing gpg keyring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     ca-certificates
 
 # Add backport repo
-COPY ./docker/zxing-cpp-backport.gpg /usr/share/keyrings/
-COPY ./docker/zxing-cpp-backport.sources /etc/apt/sources.list.d/
+COPY --chown=root:root ./docker/zxing-cpp-backport.gpg /usr/share/keyrings/
+COPY --chown=root:root  ./docker/zxing-cpp-backport.sources /etc/apt/sources.list.d/
 
 # END zxing-cpp 2.x backport. Can be removed after moving to trixie or later.
 


### PR DESCRIPTION
because this might lead to otherwise ignore the key, if for example it's not world readable
