### PR TITLE
test: test mongo-8 dependency

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -738,7 +738,7 @@ jobs:
         make clone_deps
         cd deps/openfoodfacts-shared-services/
         git fetch origin
-        git checkout -b mongo-8 --track origin-mongo-8
+        git checkout -b mongo-8 --track origin/mongo-8
       if: |
         ( ${{ github.head_ref || github.ref_name }} ) == "test-mongo8"
 


### PR DESCRIPTION
Runs test with Mongo-8.
No need to merge this PR, it's for running tests only.

Part of: https://github.com/openfoodfacts/openfoodfacts-shared-services/pull/21