### PR TITLE
ci: Remove Docker ecosystem from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,11 +47,6 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 300
-  - package-ecosystem: "docker"
-    directory: "/docker/frontend"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 300
   - package-ecosystem: "pip"
     directory: "/scripts/packager-codes/non-eu/"
     schedule:


### PR DESCRIPTION
Removed old Docker package `frontend` configuration from Dependabot to avoid failing Dependabot jobs.