### PR TITLE
taxonomy: retaxonomise 'tigernut' as a tuber, not a treenut

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -54039,7 +54039,7 @@ sv: modifierad tapiokastärkelse, modifierad tapioka stärkelse
 #                                Tigernut
 #
 ###################################################################################################
-< en:tree nut
+< en:tuber
 en: tigernut
 ca: xufa, xufas
 de: Tigernuss, Erdmandel


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Relocates `tigernuts` from the tree-nuts food ingredient category to tubers.

### Related issue(s) and discussion

- Resolves #12775, which I opened in response to...
  - ...a Slack thread reporting the problem: https://openfoodfacts.slack.com/archives/C02KVRT2C/p1765123310014339