### PR TITLE
taxonomy(food): olive oil edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -60367,9 +60367,10 @@ ja: ヴァージンオリーブオイル
 lt: Gryni alyvuogių aliejai
 nl: Virgin olijfoliën
 pl: Oliwa z oliwek virgin
-sv: Jungfruolivoljor, Virgin olivoljor
+sv: Jungfruolivoljor, Virgin olivoljor, Jungfruoljor
+wikidata:en: Q57656262
 
-< en:Olive oils
+< en:Virgin olive oils
 en: Extra-virgin olive oils, Extra virgin olive oil
 bg: Маслиново масло екстра върджин, Дървено масло екстра върджин, Зехтин екстра върджин
 ca: Oli d'oliva verge extra
@@ -60386,12 +60387,27 @@ nl: Extra vierge olijfoliën
 pl: Oliwa z oliwek extra virgin
 pt: Azeites virgem extra
 ru: Оливковое масло первого отжима
+sv: Extra jungfruolivoljor, Extra jungfruoljor
 agribalyse_food_code:en: 17270
 ciqual_food_code:en: 17270
 ciqual_food_name:en: Olive oil, extra virgin
 ciqual_food_name:fr: Huile d'olive vierge extra
+description:en: Extra virgin olive oil is the highest grade of virgin olive oil derived by cold mechanical extraction without use of solvents or refining methods.
 expected_ingredients:en: en:olive-oil
 expected_nutriscore_grade:en: b
+wikidata:en: Q14789810
+
+< en:Virgin olive oils
+en: Refined olive oils
+de: Raffinierte Olivenöle, Raffiniertes Olivenöl
+es: Aceites de oliva refinados, Aceites de oliva a partir de aceites de oliva refinados y aceites de oliva vírgenes
+fr: Huiles d'olive raffinées, Huiles d'olive-composées d'huiles d'olive raffinées et d'huiles d'olive vierges
+hr: Rafinirana maslinova ulja
+hu: Finomított olívaolajok
+it: Olio d'oliva raffinato
+lt: Rafinuoti alyvuogių aliejai
+nl: Geraffineerde olijfoliën
+description:en: Refined olive oil is virgin oil refined using charcoal and other chemical and physical filters, methods which do not alter the glyceridic structure.
 
 < en:Olive oils
 en: Olive pomace oils
@@ -60403,22 +60419,11 @@ nl: Vruchtenpulp-olijfoliën
 wikidata:en: Q7087235
 
 < en:Olive oils
-en: Refined olive oils
-de: Raffinierte Olivenöle, Raffiniertes Olivenöl
-es: Aceites de oliva refinados, Aceites de oliva a partir de aceites de oliva refinados y aceites de oliva vírgenes
-fr: Huiles d'olive raffinées, Huiles d'olive-composées d'huiles d'olive raffinées et d'huiles d'olive vierges
-hr: Rafinirana maslinova ulja
-hu: Finomított olívaolajok
-it: Olio d'oliva raffinato
-lt: Rafinuoti alyvuogių aliejai
-nl: Geraffineerde olijfoliën
-
-< en:Olive oils
 en: Olive oil mixes
 fr: Mélanges de huiles d'olives
 hr: Mješavine maslinovog ulja
 nl: Olijfoliemelanges, olijfoliemixes
-#description:en:Olive oils that combine olive oils with multiple processing grades
+description:en: Olive oils that combine olive oils with multiple processing grades
 
 < en:Olive oils
 en: Olive oils from France, French olive oils, Olive oil from France, French olive oil
@@ -60509,7 +60514,7 @@ nl: Olijfoliën uit de Provence, Olijfolies uit de Provence, Provençaalse olijf
 origins:en: en:france, en:provence
 protected_name_file_number:en: PDO-FR-02421
 protected_name_type:en: pdo
-#wikidata:en:
+wikidata:en: Q3142825
 
 ############ ITALIAN OLIVE OILS
 
@@ -61329,6 +61334,11 @@ lt: Alyvuogių aliejai iš Ispanijos
 nl: Olijfoliën uit Spanje, Olijfolies uit Spanje, Spaanse olijfolies, Spaanse olijfoliën
 origins:en: en:spain
 #wikidata:en:
+
+< en:Extra-virgin olive oils
+< en:Olive oils from Spain
+en: Extra-virgin olive oils from Spain, Spanish extra-virgin olive oils
+sv: Extra jungfruolivoljor från Spanien, Spanska extra jungfruolivoljor
 
 # also a pdo hoeny from this region
 < en:Olive oils from Spain

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -15810,6 +15810,18 @@ uk: Оливкова олія
 vi: Dầu ô liu
 yi: שמן־זית
 zh: 橄欖油
+#arz: زيت زيتون
+#ast: Aceite d'oliva
+#ceb: Lana sa oliba
+#ext: Aceiti d'oliva
+#hak: Kám-lám-yù
+#lfn: Olio de oliva
+#nap: Uoglio 'e auliva
+#nds: Olivenööl
+#olo: Oliivuvoi
+#roa-rup: Untulemnu di masinu
+#sco: Olive ile
+#yue: 橄欖油
 carbon_footprint_fr_foodges_ingredient:fr: Huile d'olive
 carbon_footprint_fr_foodges_value:fr: 2.6
 #ingredient/olive-oil 26977 in 33 @2021-08-20
@@ -15825,18 +15837,6 @@ ecobalyse:en: f1b219e6-7a77-429b-b372-461e3ad0d3bd
 from_palm_oil:en: no
 nutriscore_fruits_vegetables_nuts:en: yes
 wikidata:en: Q93165
-# arz:زيت زيتون
-# ast:Aceite d'oliva
-# ceb:Lana sa oliba
-# ext:Aceiti d'oliva
-# hak:Kám-lám-yù
-# lfn:Olio de oliva
-# nap:Uoglio 'e auliva
-# nds:Olivenööl
-# olo:Oliivuvoi
-# roa-rup:Untulemnu di masinu
-# sco:Olive ile
-# yue:橄欖油
 wikipedia:en: https://en.wikipedia.org/wiki/Olive_oil
 
 < en:olive oil
@@ -15878,6 +15878,7 @@ no: virgin olivenolje, jomfru olivenolje
 pl: Oliwa z oliwek z pierwszego tłoczenia, Oliwa z oliwek virgin
 pt: azeite de oliva virgem, azeite virgem
 sv: jungfruolivolja, virgin olivolja
+wikidata:en: Q57656262
 
 < en:olive oil
 fr: huile d'olive extra
@@ -15905,6 +15906,13 @@ ciqual_food_code:en: 17270
 ciqual_food_name:en: Olive oil, extra virgin
 ciqual_food_name:fr: Huile d'olive vierge extra
 ecobalyse:en: fbe48b5b-62f2-4ccb-8aa6-66d08a4c7fac
+wikidata:en: Q14789810
+
+< en:extra virgin olive oil
+en: Spanish extra virgin olive oil
+da: spansk ekstra jomfruolivenolie
+sv: spansk extra jungfruolivolja, spansk extra jungfruolja
+origin:en: en:spain
 
 < en:extra virgin olive oil
 es: aceite de oliva virgen extra de Lubrín
@@ -15915,6 +15923,7 @@ fr: huile d'olive chemlali extra vierge
 < en:olive oil
 en: organic olive oil
 bg: био зехтин, био маслиново масло
+da: økologisk olivenolie
 de: Bio-Olivenöl
 fi: luomu oliiviöljy
 fr: Huile d'olive bio
@@ -15924,9 +15933,10 @@ it: Olio di oliva biologico
 nl: olie van biologische olijven
 pl: organiczna oliwa z oliwek
 pt: azeite biológico, azeite de oliva biológico
+sv: ekologisk olivolja
 # ingredient/nl:olie-van-biologische-olijven has 2 products @2019-05-24
 
-< en:olive oil
+< en:virgin olive oil
 en: refined olive oil
 bg: рафиниран зехтин, рафинирано маслиново масло
 de: raffiniertes Olivenöl, Olivenöl raffiniert
@@ -15936,17 +15946,21 @@ hr: rafinirano maslinovo ulje
 it: Olio di oliva raffinato
 pl: rafinowana oliwa z oliwek
 pt: azeite refinado, azeite de oliva refinado
+sv: raffinerad olivolja
+description:en: Refined olive oil is virgin oil refined using charcoal and other chemical and physical filters, methods which do not alter the glyceridic structure.
 
 < en:olive oil
 en: unrefined olive oil
 hr: nerafinirano maslinovo ulje
 it: olio di oliva non raffinato
 nl: ongeraffineerde olijfolie
+sv: oraffinerad olivolja
 
 < en:extra virgin olive oil
 < en:organic olive oil
 en: organic extra virgin olive oil
 bg: био екстра върджин зехтин
+da: økologisk ekstra jomfruolivenolie
 de: Natives Bio-Olivenöl Extra
 es: aceite de oliva extra virgen orgánico
 fi: luomu ekstra-neitsytoliiviöljy
@@ -15956,11 +15970,13 @@ hu: extra szűz bio olívaolaj, bio extra szűz olívaolaj
 it: Olio di oliva extra vergine biologico
 nl: biologische extra olijfolie van de eerste persing
 pt: azeite extra virgem biológico, azeite virgem extra biológico, azeite de oliva extra virgem biológico, azeite de oliva virgem extra biológico
+sv: ekologisk extra jungfruolivolja
 # ingredient/fr:huile-d'olive-vierge-extra-biologique has 25 products in 2 languages @2019-05-23
 # ingredient/fr:huile-d-olive-vierge-extra-issue-de-l-agriculture-biologique has 12 products in 2 languages @2019-05-25
 
 < en:organic olive oil
 en: Spanish organic olive oil
+da: spansk økologisk olivenolie
 de: Spanisches Bio-Olivenöl
 fi: luomu espanjalainen oliiviöljy
 fr: Huile d’olive bio d’Espagne
@@ -15968,6 +15984,7 @@ hr: španjolsko organsko maslinovo ulje
 it: olio d'oliva biologico spagnolo
 nl: olie van biologische Spaanse olijven
 pt: azeite biológico espanhol, azeite biológico de Espanha, azeite de oliva biológico espanhol, azeite de oliva biológico de Espanha
+sv: spansk ekologisk olivolja, ekologisk spansk olivolja
 # nl:olie-van-biologische-spaanse-olijven has 2 products @2019-05-24
 
 < en:olive oil


### PR DESCRIPTION
- Adds some Swedish and Danish translations/synonyms
- Adds wikidata properties
- Adds some descriptions
- Fix up a bit of formatting
- Make extra virgin and refined olive oils children of virgin olive oil
  - The ingredient extra virgin olive oil was already a child, this just transfers this relationship to categories and copies it to refined olive oil (which is also a virgin olive oil).
- Add new `en: Spanish extra virgin olive oil` ingredient and category

Needed-for: https://se.openfoodfacts.org/product/7340083463785/ekologisk-spansk-extra-jungfru-olivolja-garant