### PR TITLE
fix: add no_longer_exists property for historical countries

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -12207,6 +12207,7 @@ country_code_3:en: DOM
 language_codes:en: es
 
 en: East Germany, GDR, German Democratic Republic, G.D.R.
+no_longer_exists:en: yes
 af: Duitse Demokratiese Republiek
 als: Deutsche Demokratische Republik
 an: Republica Democratica Alemana
@@ -39277,6 +39278,7 @@ country_code_3:en: SSD
 language_codes:en: en
 
 en: Soviet Union, USSR, U.S.S.R., Soviets, U.S.S.R, The Union of Soviet Socialist Republics, The Soviet Union, Union of soviet socialist republics, Union of Soviet Socialist Republics, The Soviets
+no_longer_exists:en: yes
 ace: Uni Soviet
 af: Sowjetunie
 als: Sowjetunion
@@ -46692,6 +46694,7 @@ country_code_3:en: YEM
 language_codes:en: ar
 
 en: Yugoslavia, YU, YUG
+no_longer_exists:en: yes
 af: Joego-Slawië, Joegoeslawië, Joegoslawië, Joegoslawie, Jugoslawië, Joegoslavië
 als: Jugoslawien
 an: Yugoslavia


### PR DESCRIPTION
### What
This PR marks historical countries as non-existing by adding:
'no_longer_exists:en: yes'

### Why
These countries appear in the taxonomy but should not be selectable when creating a new user account.

### Changes made
- Marked "East Germany" as no longer existing
- Marked "Soviet Union (USSR)" as no longer existing
- Updated "Yugoslavia" only if present in taxonomy (search confirmed)

No localization files or unrelated modules were modified.

### Issue

- Fixes #12519


