### PR TITLE
ci: Add Trivy configuration to ignore specific copyleft licenses

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -89,6 +89,7 @@ jobs:
         ignore-unfixed: true
         cache: true
         skip-dirs: opt/product-opener/build-cache/,opt/product-opener/taxonomies
+        trivy-config: trivy.yaml
     - name: Upload Trivy results to GitHub Security
       uses: github/codeql-action/upload-sarif@v4
       if: always()

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -471,6 +471,7 @@ jobs:
         image-ref: openfoodfacts-server/backend:dev
         format: 'sarif'
         output: backend-trivy.sarif
+        trivy-config: trivy.yaml
         vuln-type: 'os,library'
         scanners: 'vuln,secret,config,license'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
@@ -521,6 +522,7 @@ jobs:
         image-ref: openfoodfacts-server/frontend:dev
         format: 'sarif'
         output: frontend-trivy.sarif
+        trivy-config: trivy.yaml
         vuln-type: 'os,library'
         scanners: 'vuln,secret,config,license'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,9 @@
+# Trivy configuration to ignore specific copyleft licenses
+license:
+  ignored-licenses:
+    - GPL-1.0
+    - GPL-2.0
+    - GPL-3.0
+    - AGPL-3.0
+    - LGPL-2.1
+    - LGPL-3.0


### PR DESCRIPTION
### What

This should resolve some "security" warnings in GitHub, which are just being shown because we're using copyleft licenses. As ProductOpener itself is copyleft, and most of the referenced (A)GPL projects are being used as binaries in the Dockerfile anyways, we should be good by ignoring the licenses for now.

### Screenshot

N/A

### Related issue(s) and discussion

N/A