### PR TITLE
taxonomy(brands): add ICA i❤️eco

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -349,6 +349,10 @@ xx: ICA Asia
 xx: ICA Basic, ICA Bas%c
 
 #< xx:ICA
+xx: ICA i❤️eco, ICA I Love Eco, i love eco, I Love Eco ICA, ICA i♥eco, i♥eco, i❤️eco, ICA i <3 eco, i <3 eco, I Heart Eco, ICA eco
+#web:sv: https://www.ica.se/icas-egna-varor/varumarken/ica-i-love-eco/
+
+#< xx:ICA
 xx: ICA Selection
 
 xx: Ikbal


### PR DESCRIPTION
This (sub)brand has a bunch of variants in OFF currently:
https://se.openfoodfacts.org/facets/brands/i-love-eco
https://se.openfoodfacts.org/facets/brands/ica-i%E2%99%A5eco
https://se.openfoodfacts.org/facets/brands/ica-eco
https://se.openfoodfacts.org/facets/brands/ica-i-love-eco
https://se.openfoodfacts.org/facets/brands/ica-i-3-eco
https://se.openfoodfacts.org/facets/brands/i-3-eco
https://se.openfoodfacts.org/facets/brands/i%E2%99%A5eco
https://se.openfoodfacts.org/facets/brands/ica-i%E2%9D%A4%EF%B8%8Feco
https://se.openfoodfacts.org/facets/brands/i-love-eco-ica
https://se.openfoodfacts.org/facets/brands/i-heart-eco

This groups them together and marks the one closest to how it appears on packaging as the canonical form.