### PR TITLE
taxonomy(food): Plant oil translations

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -59408,9 +59408,11 @@ nl: Plantaardige vetten
 pl: Tłuszcze roślinne
 pt: Gorduras vegetals
 ru: Растительные жиры, Жиры растительные
+sv: Vegetabiliska fetter
 th: ไขมันจากพืช
 tr: Bitkisel yağ
 zh: 蔬菜脂肪
+wikidata:en: Q11870297
 
 < en:Vegetable fats
 en: Shelf-stable vegetable fats
@@ -59701,6 +59703,7 @@ en: Vegetable oils, Plant-based oils
 bg: Растителни масла
 ca: Olis vegetals
 cs: Rostlinné oleje
+da: Vegetabilske olier, Planteolier
 de: Pflanzenöle
 es: Aceites vegetales, Aceites de origen vegetal
 fi: kasvisöljyt
@@ -59729,6 +59732,7 @@ wikidata:en: Q4739805
 
 < en:Vegetable oils
 en: Flavoured oils
+da: Olier med smag
 de: Aromatisierte Öle
 es: Aceites aromatizados
 fr: Huiles aromatisées
@@ -59798,6 +59802,7 @@ wikidata:en: Q4944279
 
 < en:Vegetable oils
 en: Frying oil
+da: Fritureolier
 fr: Huile pour friture
 hr: Ulje za prženje
 ja: 揚げ油
@@ -59897,6 +59902,7 @@ wikidata:en: Q175933
 
 < en:Cereal oils
 en: Sesame oils
+da: Sesamolier
 de: Sesamöle
 es: Aceites de sésamo
 fi: seesamiöljyt
@@ -59949,6 +59955,7 @@ wikidata:en: Q811663
 
 < en:Vegetable oils
 en: Fruit and fruit seed oils
+da: Frugt- og frugtfrøolier
 de: Frucht- und Fruchtsamenöle, Öle aus Früchten oder Fruchtsamen
 es: Aceites de frutas y semillas de frutas
 fi: Hedelmä- ja hedelmänsiemenöljyt
@@ -60056,6 +60063,7 @@ wikidata:en: Q3819066
 
 < en:Vegetable oils
 en: Hemp oils, Hempseed oils
+da: Hampolier, Hampfrøolier
 de: Hanföle
 es: Aceites de cáñamo
 fi: Hamppuöljyt, Hampunsiemenöljyt
@@ -60082,6 +60090,7 @@ zh: 豆类油
 < en:Legume oils
 < en:Nut oils
 en: Peanut oils
+da: Jordnøddeolier, Jordnødolier, Peanutolier
 de: Erdnussöle
 es: Aceites de cacahuete, Aceites de maní
 fi: Maapähkinäöljyt
@@ -60102,6 +60111,7 @@ wikidata:en: Q265878
 < en:Legume oils
 en: Soybean oils, Soy oil
 bg: Соево олио
+da: Sojaolier
 de: Sojaöle, Sojabohnenöle
 es: Aceites de soja
 fr: Huile de soja
@@ -60119,6 +60129,7 @@ wikidata:en: Q926892
 
 < en:Vegetable oils
 en: Mixed vegetable oils, blended vegetable oils, combined vegetable oils, vegetable oil mixes
+da: Blandinger af vegetabilske olier
 es: Mezclas de aceites vegetales
 fi: Kasvisöljysekoitukset
 fr: Mélanges d'huiles, huiles combinées, Huile combinée, mélange d'huiles
@@ -60157,6 +60168,7 @@ wikidata:en: Q910958
 < en:Nuts and their products
 < en:Vegetable oils
 en: Nut oils
+da: Nøddeolier
 de: Nussöle
 es: Aceites de frutos de cáscara, Aceites de frutos secos
 fi: pähkinäöljyt
@@ -60171,6 +60183,7 @@ zh: 坚果油
 
 < en:Nut oils
 en: Almond oils
+da: Mandelolier
 de: Mandelöle
 es: Aceites de almendras
 fr: Huiles d'amande
@@ -60188,6 +60201,7 @@ wikidata:en: Q1164590
 
 < en:Nut oils
 en: Hazelnut oils
+da: Hasselnødolier, Hasselnøddeolier
 de: Haselnussöle
 es: Aceites de avellanas
 fi: hasselpähkinäöljyt
@@ -60220,6 +60234,7 @@ wikidata:en: Q2264972
 < en:Nut oils
 en: Pecan oils, Pecannut oils
 bg: Олио от пекан
+da: Pekannødolier, Pekannøddeolier
 es: Aceites de nuez pecana
 fr: Huiles de noix de pécan
 hr: Pekan ulja
@@ -60231,6 +60246,7 @@ wikidata:en: Q7158627
 
 < en:Nut oils
 en: Pine nut oils
+da: Pinjekerneolier
 es: Aceites de piñones
 fr: Huiles de pignons de pin
 hr: Ulja pinjola
@@ -60241,6 +60257,7 @@ wikidata:en: Q184315
 < en:Nut oils
 en: Pistachio oils
 bg: Олио от шамфъстък
+da: Pistacieolier
 de: Pistazienöle
 es: Aceites de pistacho
 fr: Huiles de pistache
@@ -60254,6 +60271,7 @@ wikidata:en: Q3820506
 < en:Nut oils
 en: Walnut oils
 bg: Орехово олио
+da: Valnødolier, Valnøddeolier
 de: Walnussöle
 es: Aceites de nueces
 fi: saksanpähkinäöljyt
@@ -60289,6 +60307,7 @@ en: Olive oil sprays
 < en:Flavoured oils
 < en:Olive tree products
 en: Flavoured olive oils
+da: Olivenolier med smag
 fr: Huiles d'olive aromatisées
 hr: Aromatizirana maslinova ulja
 nl: Gearomatiseerde olijfolies
@@ -60296,6 +60315,7 @@ nl: Gearomatiseerde olijfolies
 < en:Citrus flavoured oils
 < en:Flavoured olive oils
 en: Citrus flavoured olive oils
+da: Olivenolier med citrussmag, Olivenolier med smag af citrus
 fr: Huiles d'olive aromatisées à la citron
 hr: Maslinova ulja s okusom citrusa
 nl: Gearomatiseerde olijfolies met citrus
@@ -60326,7 +60346,7 @@ nl: Gearomatiseerde olijf olies met kruiden
 en: Olive oils
 bg: Зехтин, Дървено масло
 ca: Olis d'oliva
-da: Olivenolie
+da: Olivenolier, Olivenolie
 de: Olivenöle, Olivenöl
 es: Aceites de oliva, Aceites de oliva y de orujo de oliva
 fi: oliiviöljyt
@@ -60337,6 +60357,7 @@ hu: Olívaolajok
 it: Olio di oliva
 ja: オリーブオイル, オリーブ油
 lt: Alyvuogių aliejai
+nb: Olivenoljer
 nl: Olijfoliën, Olijfolie
 pl: Oliwa z oliwek
 pt: Azeite de oliva
@@ -60356,6 +60377,7 @@ wikidata:en: Q93165
 en: Virgin olive oils
 bg: Върджин зехтини
 ca: Olis d’oliva verge
+da: Jomfruolivenolier
 de: Native Olivenöle, Natives Olivenöl
 es: Aceites de oliva virgen, Aceites de oliva vírgenes
 fi: neitsytoliiviöljyt
@@ -60365,6 +60387,7 @@ hu: Szűz olívaolajok, Szűz olívaolaj
 it: Olio vergine di oliva
 ja: ヴァージンオリーブオイル
 lt: Gryni alyvuogių aliejai
+nb: Virgin olivenoljer
 nl: Virgin olijfoliën
 pl: Oliwa z oliwek virgin
 sv: Jungfruolivoljor, Virgin olivoljor, Jungfruoljor
@@ -60376,13 +60399,14 @@ bg: Маслиново масло екстра върджин, Дървено м
 ca: Oli d'oliva verge extra
 de: Native Olivenöle Extra, Natives Olivenöl Extra
 es: Aceites de oliva virgen extra, Aceite de oliva virgen extra
-fi: Ekstra-neitsytoliiviöljyt
+fi: Ekstra-neitsytoliiviöljyt, Extra-neitsytoliiviöljyt
 fr: Huiles d'olive vierges extra, Huile d'olive vierge extra
 hr: ekstra djevičanska maslinova ulja, ekstra djevičansko maslinovo ulje
 hu: Extra szűz olívaolajok, Extra szűz olívaolaj
 it: Olio extra vergine di oliva
 ja: エキストラヴァージンオリーブオイル
 lt: Pirmo spaudimo alyvuogių aliejai, ypač grynas alyvuogių aliejus
+nb: Extra virgin olivenoljer
 nl: Extra vierge olijfoliën
 pl: Oliwa z oliwek extra virgin
 pt: Azeites virgem extra
@@ -60428,6 +60452,7 @@ description:en: Olive oils that combine olive oils with multiple processing grad
 < en:Olive oils
 en: Olive oils from France, French olive oils, Olive oil from France, French olive oil
 bg: Френско дървено масло, френски зехтин
+da: Olivenolier fra Frankrig, Franske olivenolier
 de: Olivenöle aus Frankreich, Französische Olivenöle
 es: Aceites de oliva de Francia
 fi: Ranskalaiset oliiviöljyt
@@ -60521,6 +60546,7 @@ wikidata:en: Q3142825
 
 < en:Fats
 en: Italian oils and fats
+da: Italienske olier og fedtstoffer
 fr: Huiles et graisses italiennes
 sv: Italienska oljor och fetter
 
@@ -60528,6 +60554,7 @@ sv: Italienska oljor och fetter
 < en:Olive oils
 en: Olive oils from Italy, Italian olive oils, Olive oil from Italy, Italian olive oil
 bg: Италианско дървено масло, италиански зехтин
+da: Olivenolier fra Italien, Italienske olivenolier
 de: Olivenöle von Italien
 fi: Italialaiset oliiviöljyt
 fr: Huiles d'olive d'Italie
@@ -60543,6 +60570,7 @@ sv: Olivoljor från Italien, Italienska olivoljor
 < en:Extra-virgin olive oils
 < en:Olive oils from Italy
 en: Extra-virgin olive oils from Italy, Italian extra-virgin olive oils
+da: Ekstra jomfruolivenolier fra Italien, Italienske ekstra jomfruolivenolier
 sv: Extra jungfruolivoljor från Italien, Italienska extra jungfruolivoljor
 
 < en:Olive oils from Italy
@@ -61106,6 +61134,7 @@ protected_name_type:en: pdo
 
 < en:Fats
 en: Greek oils and fats
+da: Græske olier og fedtstoffer
 fr: Huiles et graisses grecques
 hr: Grčka ulja i masti
 lt: Aliejai ir riebalai iš Graikijos
@@ -61324,6 +61353,7 @@ protected_name_type:en: pgi
 
 < en:Olive oils
 en: Olive oils from Hungary, Hungarian olive oils
+da: Olivenolier fra Ungarn, Ungarnske olivenolier
 nl: Olijfolies uit Hongarije
 sv: Olivoljor från Ungern, Ungerska olivoljor
 
@@ -61337,6 +61367,7 @@ protected_name_type:en: pgi
 < en:Olive oils
 en: Olive oils from Spain, Spanish olive oils
 bg: Испанско дървено масло, испански зехтин
+da: Olivenolier fra Spanien, Spanske olivenolier
 de: Olivenöle aus Spanien
 es: Aceites de oliva de España, Aceites de oliva españoles
 fr: Huiles d'olive d'Espagne
@@ -61350,6 +61381,7 @@ origins:en: en:spain
 < en:Extra-virgin olive oils
 < en:Olive oils from Spain
 en: Extra-virgin olive oils from Spain, Spanish extra-virgin olive oils
+da: Ekstra jomfruolivenolier fra Spanien, Spanske ekstra jomfruolivenolier
 sv: Extra jungfruolivoljor från Spanien, Spanska extra jungfruolivoljor
 
 # also a pdo hoeny from this region
@@ -61748,6 +61780,7 @@ protected_name_type:en: pdo
 < en:Olive oils
 en: Olive oils from Greece, Greek olive oils, Olive oils from Greece, Greek olive oil
 bg: Гръцко дървено масло, гръцки зехтин
+da: Olivenolier fra Grækenland, Græske olivenolier
 de: Olivenöle aus Griechenland
 el: Eλαιόλαδα από την Ελλάδα
 fr: Huiles d'olive de Grèce
@@ -61763,6 +61796,7 @@ origins:en: en:greece
 < en:Extra-virgin olive oils
 < en:Olive oils from Greece
 en: Extra-virgin olive oils from Greece, Greek extra-virgin olive oils
+da: Ekstra jomfruolivenolier fra Grækenland, Græske ekstra jomfruolivenolier
 sv: Extra jungfruolivoljor från Grekland, Grekiska extra jungfruolivoljor
 
 < en:Olive oils from Greece
@@ -62216,6 +62250,7 @@ wikipedia:pt: https://pt.wikipedia.org/wiki/Azeite_de_Trás-os-Montes
 
 < en:Olive oils
 en: Olive oils from Maroc, Maroccan olive oils
+da: Olivenolier fra Marokko, Marokkanske olivenolier
 fr: Huiles d'olive de Maroc
 hr: Marokanska maslinova ulja
 lt: Alyvuogių aliejai iš Maroko
@@ -62225,6 +62260,7 @@ origins:en: en:morocco
 
 < en:Olive oils
 en: Olive oils from Tunisia, Tunisian olive oils
+da: Olivenolier fra Tunesien, Tunesiske olivenolier
 fr: Huiles d'olive de Tunisie
 hr: Maslinovo ulje iz tunisa
 lt: Alyvuogių aliejai iš Tuniso
@@ -62234,6 +62270,7 @@ origins:en: en:tunisia
 
 < en:Olive oils
 en: Olive oils from Algeria, Algerian olive oils
+da: Olivenolier fra Algeriet, Algeriske olivenolier
 fr: Huiles d'olive d'Algerie
 hr: Maslinova ulja iz alžira
 lt: Alyvuogių aliejai iš Alžyro
@@ -62243,6 +62280,7 @@ origins:en: en:algeria
 
 < en:Olive oils
 en: Olive oils from South Africa, South African olive oils
+da: Olivenolier fra Sydafrika, Sydafrikanske olivenolier
 fr: Huiles d'olive d'Afrique du Sud
 hr: Maslinova ulja iz Južne Afrike
 lt: Alyvuogių aliejai iš Pietų Afrikos
@@ -62252,6 +62290,7 @@ origins:en: en:south-africa
 
 < en:Olive oils
 en: Olive oils from Argentina, Argentinian olive oils
+da: Olivenolier fra Argentina, Argentinske olivenolier
 fr: Huiles d'olive d'Argentine
 hr: Maslinova ulja iz argentine
 lt: Alyvuogių aliejai iš Argentinos
@@ -62262,6 +62301,7 @@ origins:en: en:argentina
 < en:Vegetable oils
 en: Palm oils
 bg: Палмово масло
+da: Palmeolier
 de: Palmöle
 es: Aceites de palma
 fr: Huiles de palme, Huiles de palme alimentaire, Huiles de palm
@@ -62462,6 +62502,7 @@ wikidata:en: Q16642513
 en: Sunflower oils, Sunflower oil
 bg: Слънчогледово олио
 ca: Oli de gira-sol
+da: Solsikkeolier
 de: Sonnenblumenöle
 es: Aceites de girasol, Aceite de girasol
 fi: Auringonkukkaöljyt


### PR DESCRIPTION
Mostly Danish translations and mostly olive oils.

Prompted-by: https://dk.openfoodfacts.org/product/5765228351000/extra-neitsytoliivi%C3%B6ljy-urtekram