### PR TITLE
fix(search): empty csv/xlsx export when search returns no products

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5942,7 +5942,9 @@ sub search_and_export_products ($request_ref, $query_ref, $sort_by) {
 		$html .= "<p>" . lang("error_database") . "</p>";
 	}
 	elsif ($count == 0) {
-		$html .= "<p>" . lang("no_products") . "</p>";
+		# No products found: export_csv already sent headers,
+		# so we must Not render an HTML page.
+		return;
 	}
 	elsif ($count > $max_count) {
 		$html .= "<p>" . sprintf(lang("error_too_many_products_to_export"), $count, $export_limit) . "</p>";


### PR DESCRIPTION
This PR fixes an issue where exporting CSV/XLSX for searches with no results
produced files containing HTML content.

When export_csv returns 0 products, we now return early to avoid rendering
an HTML page after HTTP headers have already been sent.

Fixes #9312