### PR TITLE
taxonomy: baguettes reorganization

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -35900,12 +35900,12 @@ lt: Pilno grūdo duonos
 nl: Bruine broden, Bruinbrood, Bruin brood, Volkoren broden
 ro: Pâine brună, Pâine neagră
 ru: Цельнозерновой хлеб
-intake24_category_code:en: BBRD
-sales_format:en: package, item
 agribalyse_food_code:en: 7110
 ciqual_food_code:en: 7110
 ciqual_food_name:en: Bread, wholemeal or integral bread (made with flour type 150)
 ciqual_food_name:fr: Pain complet ou intégral (à la farine T150)
+intake24_category_code:en: BBRD
+sales_format:en: package, item
 wikidata:en: Q940999
 
 < en:Breads


### PR DESCRIPTION
Some categories were wrongly under baguettes because of a faulty association with agribalyse categories. e.g. "Wholemeal bread made with flour type 150". I moved those categories directly under breads. I deleted some that will remain empty because they are not adapted for OFF products. e.g. "Country-style home-made bread with flour for bread making machine". I also translated sourdough breads in French: "pains au levain" and added the ciqual and wikidata links to it.
