### PR TITLE
taxonomy: translation czech ingredients

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -83443,7 +83443,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Coffea_canephora
 < en:coffee
 en: coffee beans
 bg: кафе на зърна
-de: Kaffeebohnen
+de: Kaffeebohnen, Kaffee-Bohnen
 es: Granos de café
 fi: kahvipavut
 fr: café en grains


### PR DESCRIPTION
Added and corrected some czech translation. Corrected notably hazelnut paste which translate to "lískooříšková pasta" and not "oříšková pasta" (which means nut pasta).

