### PR TITLE
taxonomy: correction E476

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -15654,14 +15654,14 @@ ar: E476, بولي غليسيرول بولي ريسينوليات
 bg: E476, Полиглицерол полирицинолеат, PGPR
 bs: E476, Poliglicerol poliricinoleat
 ca: E476, Poliricinoleat de poligliceril
-cs: E476, Polyglycerylpolyricinoleát
+cs: E476, Polyglycerolpolyricinoleát
 da: E476, Polyglycerolpolyricinoleat
 de: E476, Polyglycerin-Polyricinoleat, PGPR
 el: E476, Πολυγλυκεριδια του πολυρικινελαϊκου οξεος
 es: E476, Polirricinoleato de poliglicerol, Polyglycerol polyricinoleate, poliglicerol de polirricinoleato
 et: E476, Ritsinoolhappe polüglütseroolestrid
 fi: E476, Polyglyserolipolyrisiinioleaatti, PGPR, Polyglyserolipolyrisiinioleaatteja
-fr: E476, Esters polyglycériques d'acides gras d'huile de ricin, Polyricinoléate de polyglycérol, Esters polyglycériques de l'acide ricinoléique interesterifié, PGPR, Esters polyglycéroliques de l'acide ricinoléique interesterifié, Esters polyglycériques d'acides gras polycondensés d'huile de ricin, Esters glycériques d'acides gras condensés d'huile de ricin
+fr: E476, Polyricinoléate de polyglycérol, Esters polyglycériques d'acides gras d'huile de ricin, Esters polyglycériques de l'acide ricinoléique interesterifié, PGPR, Esters polyglycéroliques de l'acide ricinoléique interesterifié, Esters polyglycériques d'acides gras polycondensés d'huile de ricin, Esters glycériques d'acides gras condensés d'huile de ricin
 ga: E476, polairicineoláit pholaigliocróil
 he: E476, פוליגליצרול פוליריצינולאט, חומר מתחלב, PGPR
 hr: E476, poliglicerol - poliricinoleat, poliglicerol poliricinoleat


### PR DESCRIPTION
Corrected the czech translation of E476 and reordered the French translations to have most common and the direct translation of the English version as the first synonym.