### PR TITLE
docs(events): add high-level OpenFoodFacts Events overview

### DIFF
--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -1,0 +1,29 @@
+# Open Food Facts Events
+
+Open Food Facts Events is a system used to record and expose key actions that
+occur across the Open Food Facts ecosystem, such as product edits, scans,
+contributions, and community or gamification-related actions.
+
+## Why Events?
+
+The events system makes it possible to:
+- Track user and product activity in a structured way
+- Power community, contribution, and gamification features
+- Enable external applications to consume activity data reliably
+
+## Related Project
+
+The events system is implemented in a dedicated service:
+- https://github.com/openfoodfacts/openfoodfacts-events
+
+## API Documentation
+
+The Open Food Facts Events API is documented here:
+- https://events.openfoodfacts.net/docs
+
+## Who is this for?
+
+This documentation is intended for:
+- Developers building applications on top of Open Food Facts
+- Community and gamification features
+- Analytics and activity tracking use cases


### PR DESCRIPTION
This PR adds a high-level documentation page for OpenFoodFacts Events.
It provides:
- A concise explanation of the purpose of the events system
- A link to the openfoodfacts-events repository
- A link to the public Events API documentation
This addresses issue #7748.
No existing documentation or schema files were modified.