### PR TITLE
taxonomy: reorganization potato categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -44151,8 +44151,8 @@ en: Lentil Crisps
 fr: Chips de lentilles
 nl: Linzenchips
 
-< en:Potatoes and their products
 < en:Crisps
+< en:Potatoes and their products
 en: Potato crisps, potato chips
 bg: Картофен чипс
 ca: Xips de patata
@@ -44480,8 +44480,8 @@ google_product_taxonomy_id:en: 2392
 intake24_category_code:en: CHIP
 wikidata:en: Q152088
 
-< en:Chips and fries
 < en: Potato preparations
+< en:Chips and fries
 xx: Pommes noisettes
 bg: Картофени ноазети
 fr: Pommes noisettes


### PR DESCRIPTION
* I put "potato preparations", "prepared potatoes" and "potato crisps" under "potatoes and their products".
* I removed some categories of mashed potatoes from "Cereals and potatoes" -> they are already under this category via Cereals and potatoes > potatoes and their products > potato preparations > mashed potatoes
* I merged the different categories of frozen pommes dauphines (and did the same for the pommes noisettes). Those separated categories originated in from the ciqual categories "Dauphine potato, frozen, cooked" and "Pomme de terre dauphine, surgelée, crue". However, their are no raw frozen dauphine potatoes in OFF database, they are all cooked. I removed this category.
* I separared mashed sweet potatoes from mashed potatoes
* I created sweet potato fries

