### PR TITLE
feat(knowledge-panel): show packager code in manufacturing place map

### DIFF
--- a/templates/api/knowledge-panels/environment/manufacturing_place.tt.json
+++ b/templates/api/knowledge-panels/environment/manufacturing_place.tt.json
@@ -1,5 +1,5 @@
 {
-    "level" :"info",
+    "level": "info",
     "topics": [
         "environment"
     ],
@@ -8,16 +8,16 @@
     "title_element": {
         "title": "[% edq(lang('manufacturing_places_s')) FILTER ucfirst %]",
         [% IF panel.packager_code_data.cc == 'fr' %]
-            "subtitle": "[% panel.packager_code_data.commune %] - [% display_taxonomy_tag_name('countries', 'en:france') %]",        
+            "subtitle": "[% panel.packager_code_data.commune %] - [% display_taxonomy_tag_name('countries', 'en:france') %]",
         [% ELSIF panel.packager_code_data.cc == 'ch' %]
             "subtitle": "[% panel.packager_code_data.full_address %]",
         [% ELSIF panel.packager_code_data.cc == 'es' %]
             "subtitle": "[% panel.packager_code_data.provincia_localidad %]",
         [% ELSIF panel.packager_code_data.cc == 'uk' %]
-            "subtitle": "[% panel.packager_code_data.district %]",             
+            "subtitle": "[% panel.packager_code_data.district %]",
         [% END %]
         "icon_url": "[% static_subdomain %]/images/icons/dist/transportation.svg",
-        "icon_color_from_evaluation": true,
+        "icon_color_from_evaluation": true
     },
     "elements": [
         {
@@ -27,11 +27,17 @@
                     {
                         "geo": {
                             "lat": [% panel.lat %],
-                            "lng": [% panel.lng %],
+                            "lng": [% panel.lng %]
                         }
                     }
                 ]
             }
-        },
+        }[% IF panel.packager_code_data.code %],
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": "<strong>[% lang('packager_code_s') | ucfirst %]:</strong> <a href=\"/packager/[% panel.packager_code_data.code %]\">[% panel.packager_code_data.code %]</a>"
+            }
+        }[% END %]
     ]
 }


### PR DESCRIPTION
This PR improves the Manufacturing Place knowledge panel by displaying the packager code (with a link to the packager page) when available.
1) Keeps existing map behavior unchanged
2) Adds a small, conditional text element
3) No backend or data changes
This addresses user feedback requesting easier access to packager information from the map panel.