### PR TITLE
taxonomy: Flans patissiers

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -97918,6 +97918,7 @@ ja: コーヒーエクレア
 nl: Koffie-eclairs
 
 < en:Pastries
+en: Flan tarts, Flan tart with eggs
 xx: Flans pâtissiers
 fr: Flans pâtissiers, flan pâtissier, Flan pâtissier aux oeufs, Flan à la parisienne
 agribalyse_food_code:en: 23525


### PR DESCRIPTION
I removed the translations of "flans pâtissiers" and added "xx: Flans pâtissiers". There probably has been a mistake, flan pâtissier refers to a very specific pastry in French made of egs, milk, cream and sugar, while open pie in English refers to any pie with no dough on top. It is better to have no translation at all than really approximate translations. We are not gonna translate "Pasteis de nata" or "Mochi".

