### PR TITLE
fix: disable temporarily Google Vision extraction other than text

### DIFF
--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -2561,10 +2561,11 @@ sub extract_text_from_image ($product_ref, $image_type, $image_lc, $field, $requ
 	# DOCUMENT_TEXT_DETECTION does not bring significant advantages
 	# See https://github.com/openfoodfacts/openfoodfacts-server/issues/9723
 	{type => 'TEXT_DETECTION'},
-	{type => 'LOGO_DETECTION'},
-	{type => 'LABEL_DETECTION'},
-	{type => 'SAFE_SEARCH_DETECTION'},
-	{type => 'FACE_DETECTION'},
+	# Disable other Cloud Vision temporarily to save credits
+	# {type => 'LOGO_DETECTION'},
+	# {type => 'LABEL_DETECTION'},
+	# {type => 'SAFE_SEARCH_DETECTION'},
+	# {type => 'FACE_DETECTION'},
 );
 
 @CLOUD_VISION_FEATURES_TEXT = ({type => 'TEXT_DETECTION'});

--- a/tests/integration/expected_test_results/run_cloud_vision_ocr/ocr_request_body.json
+++ b/tests/integration/expected_test_results/run_cloud_vision_ocr/ocr_request_body.json
@@ -4,18 +4,6 @@
          "features" : [
             {
                "type" : "TEXT_DETECTION"
-            },
-            {
-               "type" : "LOGO_DETECTION"
-            },
-            {
-               "type" : "LABEL_DETECTION"
-            },
-            {
-               "type" : "SAFE_SEARCH_DETECTION"
-            },
-            {
-               "type" : "FACE_DETECTION"
             }
          ],
          "image" : {

--- a/tests/unit/expected_test_results/send_image_to_cloud_vision/request_body.json
+++ b/tests/unit/expected_test_results/send_image_to_cloud_vision/request_body.json
@@ -4,18 +4,6 @@
          "features" : [
             {
                "type" : "TEXT_DETECTION"
-            },
-            {
-               "type" : "LOGO_DETECTION"
-            },
-            {
-               "type" : "LABEL_DETECTION"
-            },
-            {
-               "type" : "SAFE_SEARCH_DETECTION"
-            },
-            {
-               "type" : "FACE_DETECTION"
             }
          ],
          "image" : {

--- a/tests/unit/expected_test_results/send_image_to_cloud_vision/request_body_2.json
+++ b/tests/unit/expected_test_results/send_image_to_cloud_vision/request_body_2.json
@@ -4,18 +4,6 @@
          "features" : [
             {
                "type" : "TEXT_DETECTION"
-            },
-            {
-               "type" : "LOGO_DETECTION"
-            },
-            {
-               "type" : "LABEL_DETECTION"
-            },
-            {
-               "type" : "SAFE_SEARCH_DETECTION"
-            },
-            {
-               "type" : "FACE_DETECTION"
             }
          ],
          "image" : {


### PR DESCRIPTION
As we run out of Google credits, let's disable non-critical Google Vision features.