### PR TITLE
fix: support carbohydrates-total in energy value computation check

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -902,7 +902,7 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 		# We need at a minimum carbohydrates, fat and proteins to be defined to compute
 		# energy.
 		if (    (defined $specified_energy)
-			and (defined $nutriments_ref->{"carbohydrates_value"})
+			and ((defined $nutriments_ref->{"carbohydrates_value"}) or (defined $nutriments_ref->{"carbohydrates-total_value"}))
 			and (defined $nutriments_ref->{"fat_value"})
 			and (defined $nutriments_ref->{"proteins_value"}))
 		{
@@ -930,7 +930,12 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 
 					$grams -= $product_ref->{nutriments}{$nid_minus . "_value"} || 0;
 				}
-				$grams += $product_ref->{nutriments}{$nid . "_value"} || 0;
+				if ($nid eq "carbohydrates") {
+					$grams += $product_ref->{nutriments}{$nid . "_value"} // $product_ref->{nutriments}{"carbohydrates-total_value"} // 0;
+				}
+				else {
+					$grams += $product_ref->{nutriments}{$nid . "_value"} || 0;
+				}
 				$computed_energy += $grams * $energy_per_gram;
 			}
 

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -515,7 +515,39 @@ ok(
 	'energy not matching nutrient'
 ) or diag Dumper $product_ref;
 
-# en:nutrition-value-negative-$nid should be raised - for nutriments (except nutriments containing "nutrition-score") below 0
+# US-style carbohydrates-total (includes fiber) - energy matches nutrients
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 1435,
+		"carbohydrates-total_value" => 10,
+		"fat_value" => 20,
+		"proteins_value" => 30,
+		"fiber_value" => 2,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy matching nutrients with carbohydrates-total (US-style)'
+) or diag Dumper $product_ref;
+
+# US-style carbohydrates-total - energy does not match nutrients
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 5,
+		"carbohydrates-total_value" => 10,
+		"fat_value" => 20,
+		"proteins_value" => 30,
+		"fiber_value" => 2,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+is($product_ref->{nutriments}{"energy-kj_value_computed"}, 1436);
+ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrients with carbohydrates-total (US-style)')
+	or diag Dumper $product_ref;
+
+
 $product_ref = {
 	nutriments => {
 		"proteins_100g" => -1,


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST -->
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)

### What

Fix energy value computation check to support US-style `carbohydrates-total` nutrient field.

**Problem:** US products that correctly use "Total Carbohydrates" (`carbohydrates-total`) were getting false positive data quality errors:
- `en:energy-value-in-kcal-does-not-match-value-computed-from-other-nutrients`

**Root cause:** The `check_nutrition_data_energy_computation` function in `DataQualityFood.pm` only checked for `carbohydrates_value`, ignoring `carbohydrates-total_value` which is the default for US products.

**Fix:** 
1. Updated the condition to accept either `carbohydrates_value` OR `carbohydrates-total_value`
2. When computing energy from carbohydrates, use `carbohydrates-total_value` as fallback when `carbohydrates_value` is undefined

### Related issue(s) and discussion

- Fixes the issue where US products with `carbohydrates-total` field trigger incorrect energy mismatch errors
- Examples: https://world.openfoodfacts.org/product/0850077995026/prebiotic-fiber-formula-loam and https://world.openfoodfacts.org/product/0055742550832/salted-caramel-frozen-dessert-compliments
