### PR TITLE
fix: make global other_nutrients writable

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -20,7 +20,7 @@
 
 /*eslint dot-location: "off"*/
 /*eslint no-console: "off"*/
-/*global lang admin initializeTagifyInput other_nutrients*/
+/*global lang admin initializeTagifyInput other_nutrients:writable*/ // we change other_nutrients to remove nutrients when they are added
 /*exported upload_image update_image update_nutrition_image_copy*/
 
 //Polyfill, just in case


### PR DESCRIPTION
Fix lint issues:

```
/opt/product-opener/html/js/product-multilingual.js
  879:9  error  Read-only global 'other_nutrients' should not be modified  no-native-reassign
  879:9  error  Read-only global 'other_nutrients' should not be modified  no-global-assign
```