### PR TITLE
refactor(script): optimise top-tags-per-country cursor query

### DIFF
--- a/scripts/gen_top_tags_per_country.pl
+++ b/scripts/gen_top_tags_per_country.pl
@@ -162,12 +162,9 @@ $fields_ref->{nutrition_grade_fr} = 1;
 # NB: if this query reports a "Sort exceeded memory limit" error , then that
 # could mean that it is not using the created_t index as expected - when
 # it does, it can immediately instantiate and return the cursor iterator
-my $cursor
-	= get_products_collection({timeout => 3 * 60 * 60 * 1000})
-        # ->query({'empty' => {"\$ne" => 1}})  # prevents created_t index usage; use next-if-empty in Perl instead
-	->find()
-	->sort({created_t => 1})
-	->fields($fields_ref);
+my $cursor = get_products_collection({timeout => 3 * 60 * 60 * 1000})
+	# ->query({'empty' => {"\$ne" => 1}})  # prevents created_t index usage; use next-if-empty in Perl instead
+	->find()->sort({created_t => 1})->fields($fields_ref);
 
 $cursor->immortal(1);
 


### PR DESCRIPTION
### What

Optimises a MongoDB query in the `gen_top_tags_per_country.pl` script used by OpenFoodFacts.

- Obsolete products have been migrated into a separate database collection, so we can remove filtering on the field.
  - Ref: #8277

- Querying will be (much!) more efficient if no in-memory sort is required; encourage the query to use the existing index on the `created_t` field by removing the last database filter, on the `empty` field, replacing that logic with Perl code.

:warning: This query is currently running on my laptop, and began ~5 minutes ago.  I hope to find out whether the `3h` timeout is still reasonable, or if it should be increased.

### Related issue(s) and discussion

- Resolves #12861.