### PR TITLE
fix: disable browser autocomplete on search input to prevent button o…

### DIFF
--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -227,7 +227,7 @@
 								<div class="row"><div class="small-12">
 								<div class="row collapse postfix-round">
 									<div class="columns">
-									<input type="text" placeholder="[% edq(lang('search_a_product_placeholder')) %]" name="search_terms" value="[% search_terms %]" style="background-color:white">
+									<input type="text" placeholder="[% edq(lang('search_a_product_placeholder')) %]" name="search_terms" value="[% search_terms %]" style="background-color:white" autocomplete="off">
 									<input name="search_simple" value="1" type="hidden">
 									<input name="action" value="process" type="hidden">
 									</div>
@@ -267,7 +267,7 @@
 				<form action="/cgi/search.pl">
 					<div class="row collapse">
 						<div class="small-8 columns">
-							<input type="text" placeholder="[% edq(lang('search_a_product_placeholder')) %]" name="search_terms">
+							<input type="text" placeholder="[% edq(lang('search_a_product_placeholder')) %]" name="search_terms" autocomplete="off">
 							<input name="search_simple" value="1" type="hidden">
 							<input name="action" value="process" type="hidden">
 						</div>


### PR DESCRIPTION
When users type in the search bar, browser autocomplete suggestions from previous search history can appear and overlap the turquoise barcode scanner button, causing a visual obstruction and reducing usability.

Changes:
Added autocomplete="off" to the main navigation search input (line 230)
Added autocomplete="off" to the mobile navigation search input (line 270)

Testing:
Go to the homepage
Click the search input and type previously searched text
Confirm browser autocomplete does not appear
Ensure search still works normally

Fixes #12897

