### PR TITLE
taxonomy(country): add more OSM ids

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -1016,3 +1016,4 @@ xx: 1de Beste
 wikidata:en: Q136929195
 
 xx: 움트리
+

--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -3296,8 +3296,8 @@ country_code_2:en: AT
 country_code_3:en: AUT
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: de
-regional_entity:en: european-union
 osm_relation:en: 16239
+regional_entity:en: european-union
 wikidata:en: Q40
 
 en: Azerbaijan, Republic of Azerbaijan, AZ, AZE
@@ -4583,8 +4583,8 @@ country_code_2:en: BE
 country_code_3:en: BEL
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: nl,fr,de
-regional_entity:en: european-union
 osm_relation:en: 52411
+regional_entity:en: european-union
 wikidata:en: Q31
 
 en: Belize, BZ, BLZ
@@ -6939,8 +6939,8 @@ country_code_2:en: BG
 country_code_3:en: BGR
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: bg
-regional_entity:en: european-union
 osm_relation:en: 186382
+regional_entity:en: european-union
 wikidata:en: Q219
 
 en: Burkina Faso, BF, BFA
@@ -10305,8 +10305,8 @@ country_code_2:en: HR
 country_code_3:en: HRV
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: hr
-regional_entity:en: european-union
 osm_relation:en: 214885
+regional_entity:en: european-union
 wikidata:en: Q224
 
 en: Cuba, Republic of Cuba, CU, CUB
@@ -10820,8 +10820,8 @@ country_code_2:en: CY
 country_code_3:en: CYP
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: el,tr
-regional_entity:en: european-union
 osm_relation:en: 307787
+regional_entity:en: european-union
 
 en: Czech Republic, Czechia, CZ, CZE
 ab: Чехиа
@@ -11058,8 +11058,8 @@ country_code_2:en: CZ
 country_code_3:en: CZE
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: cs
-regional_entity:en: european-union
 osm_relation:en: 51684
+regional_entity:en: european-union
 
 en: Côte d'Ivoire, Ivory Coast, Republic of Côte d'Ivoire, CI, CIV
 ace: Panté Gadéng
@@ -11687,8 +11687,8 @@ country_code_2:en: DK
 country_code_3:en: DNK
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: da
-regional_entity:en: european-union
 osm_relation:en: 50046
+regional_entity:en: european-union
 
 en: Djibouti, Republic of Djibouti, DJ, DJI
 ace: Djibouti
@@ -13548,8 +13548,8 @@ country_code_2:en: EE
 country_code_3:en: EST
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: et
-regional_entity:en: european-union
 osm_relation:en: 79510
+regional_entity:en: european-union
 
 en: Ethiopia, ET, ETH
 ace: Ethiopia
@@ -14809,8 +14809,8 @@ country_code_2:en: FI
 country_code_3:en: FIN
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: fi,sv
-regional_entity:en: european-union
 osm_relation:en: 54224
+regional_entity:en: european-union
 
 en: France, The Hexagon, French Republic, FR, FRA
 ace: Peurancih
@@ -15078,8 +15078,8 @@ country_code_2:en: FR
 country_code_3:en: FRA
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: fr
-regional_entity:en: european-union
 osm_relation:en: 2202162
+regional_entity:en: european-union
 
 en: French Guiana, GF, GUF
 ace: Guyana Peurancih
@@ -16299,8 +16299,8 @@ country_code_2:en: DE
 country_code_3:en: DEU
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: de
-regional_entity:en: european-union
 osm_relation:en: 51477
+regional_entity:en: european-union
 
 en: Ghana, Republic of Ghana, GH, GHA
 ace: Ghana
@@ -16898,8 +16898,8 @@ country_code_2:en: GR
 country_code_3:en: GRC
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: el
-regional_entity:en: european-union
 osm_relation:en: 192307
+regional_entity:en: european-union
 
 en: Greenland, Greenland (country), GL, GRL
 af: Groenland
@@ -19138,8 +19138,8 @@ country_code_2:en: HU
 country_code_3:en: HUN
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: hu
-regional_entity:en: european-union
 osm_relation:en: 21335
+regional_entity:en: european-union
 
 en: Iceland, Republic of Iceland, IS, ISL
 ace: Islandia
@@ -20967,8 +20967,8 @@ country_code_2:en: IT
 country_code_3:en: ITA
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: it
-regional_entity:en: european-union
 osm_relation:en: 365331
+regional_entity:en: european-union
 
 en: Jamaica, JA, Commonwealth of Jamaica, Jamdung, JM, JAM
 ace: Jamaika
@@ -23187,8 +23187,8 @@ country_code_2:en: LV
 country_code_3:en: LVA
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: lv
-regional_entity:en: european-union
 osm_relation:en: 72594
+regional_entity:en: european-union
 
 en: Lebanon, Lebanese Republic, LB, LBN
 ace: Lebanon
@@ -24443,8 +24443,8 @@ country_code_2:en: LT
 country_code_3:en: LTU
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: lt
-regional_entity:en: european-union
 osm_relation:en: 4474651
+regional_entity:en: european-union
 
 en: Luxembourg, Luxemburg, Grand Duchy of Luxembourg, LU, LU, LUX
 ace: Luksèmburg, Luxemburg
@@ -24686,8 +24686,8 @@ country_code_2:en: LU
 country_code_3:en: LUX
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: fr,de,lb,en
-regional_entity:en: european-union
 osm_relation:en: 2171347
+regional_entity:en: european-union
 
 en: Macau, Macao, Macau Special Administrative Region, Macau Special Administrative Region of the People's Republic of China, Aomen, MO, MAC
 ace: Makèë
@@ -25997,8 +25997,8 @@ country_code_2:en: MT
 country_code_3:en: MLT
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: en,mt
-regional_entity:en: european-union
 osm_relation:en: 365307
+regional_entity:en: european-union
 
 en: Marshall Islands, Republic of the Marshall Islands, Aolepān Aorōkin M̧ajeļ, MH, MHL
 ace: Pulo-pulo Marshall
@@ -29405,8 +29405,8 @@ country_code_2:en: NL
 country_code_3:en: NLD
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: nl
-regional_entity:en: european-union
 osm_relation:en: 2323309
+regional_entity:en: european-union
 
 en: New Caledonia, NC, NCL
 ace: Kaledonia Barô
@@ -33169,8 +33169,8 @@ country_code_2:en: PL
 country_code_3:en: POL
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: pl
-regional_entity:en: european-union
 osm_relation:en: 49715
+regional_entity:en: european-union
 
 en: Portugal, Portuguese Republic, PT, PT, PRT
 ace: Portugéh
@@ -33422,8 +33422,8 @@ country_code_2:en: PT
 country_code_3:en: PRT
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: pt
-regional_entity:en: european-union
 osm_relation:en: 295480
+regional_entity:en: european-union
 
 en: Puerto Rico, Commonwealth of Puerto Rico, PR, PRI
 af: Puerto Rico
@@ -34163,8 +34163,8 @@ country_code_2:en: IE
 country_code_3:en: IRL
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: en,ga
-regional_entity:en: european-union
 osm_relation:en: 62273
+regional_entity:en: european-union
 
 en: Republic of the Congo, Congo-Brazzaville, CG, COG, Congo Republic
 af: Republiek van die Kongo
@@ -34637,8 +34637,8 @@ country_code_2:en: RO
 country_code_3:en: ROU
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: ro
-regional_entity:en: european-union
 osm_relation:en: 90689
+regional_entity:en: european-union
 
 en: Russia, Russian Federation, Russian federation, Rossiyskaya Federatsiya, Россия, Rossijskaja Federatsija, Российская Федерация, 🇷🇺, RU, RUS
 ab: Урыстәыла
@@ -38113,8 +38113,8 @@ country_code_2:en: SK
 country_code_3:en: SVK
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: sk
-regional_entity:en: european-union
 osm_relation:en: 14296
+regional_entity:en: european-union
 
 en: Slovenia, Republic of Slovenia, Slovenija, Republika Slovenija, SI, SVN
 ace: Slovenia
@@ -38338,8 +38338,8 @@ country_code_2:en: SI
 country_code_3:en: SVN
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: sl
-regional_entity:en: european-union
 osm_relation:en: 218657
+regional_entity:en: european-union
 
 en: Solomon Islands, SB, SLB
 ace: Pulo-pulo Solomon
@@ -39839,8 +39839,8 @@ country_code_2:en: ES
 country_code_3:en: ESP
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: es,ca,eu,gl
-regional_entity:en: european-union
 osm_relation:en: 1311341
+regional_entity:en: european-union
 
 en: Sri Lanka, Democratic Socialist Republic of Sri Lanka, LK, LKA
 ace: Srilanka
@@ -40959,8 +40959,8 @@ country_code_2:en: SE
 country_code_3:en: SWE
 ecobalyse_is_part_of_eu:en: yes
 language_codes:en: sv
-regional_entity:en: european-union
 osm_relation:en: 52822
+regional_entity:en: european-union
 
 en: Switzerland, Swiss Confederation, CH, CH, CHE
 ace: Swiss
@@ -47464,3 +47464,4 @@ country_code_2:en: XK
 # Recognised regional languages	Bosnian Turkish Romani
 language_codes:en: sq,sr,bs,tr
 osm_relation:en: 2088990
+


### PR DESCRIPTION
### What

Following #10172 (cc @aleene), this PR adds more `osm_relation:en:` to countries.
- I got the list of OSM countries from the overpass query [linked here](https://wiki.openstreetmap.org/wiki/Countries_of_the_world)
- I inserted the new `osm_relation:en:` above `wikidata:en:`, but below `language_codes:en:` and `regional_entity:en:` (#12645)

### Why

- to be more exhaustive
- a bit linked to this Open Prices issue: https://github.com/openfoodfacts/open-prices-frontend/issues/1912
  - exploring ways to list all the OSM countries and easily explore prices for each of them

### Some stats

- countries.txt
  - 268 nodes
  - 256 with `country_code_2:en:`
  - 225 with `osm_relation:en:` (before: 56)
  - 40 with `wikidata:en:`
- openstreetmap overpass query result (without land_area)
  - 218 lines