### PR TITLE
taxonomy: pickled vegetables

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -1016,3 +1016,4 @@ xx: 1de Beste
 wikidata:en: Q136929195
 
 xx: 움트리
+

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -108105,8 +108105,8 @@ fr: Épis de maïs marinés, Maïs doux mariné
 en: Turnips pickles
 fr: Navets marinés
 
-< en:bamboo shoots
 < en:Vegetable pickles
+< en:bamboo shoots
 en: Bamboo shoots pickles, marinated bamboo shoots
 fr: Pousses de bambou marinées
 


### PR DESCRIPTION
Pickles vegetables should not be in the category of their vegetable, because thew are not used in the same way. E.g one can use fresh mushrooms, canned mushrooms or frozen mushrooms to make the same recipe. Pickled mushrooms will have a very different taste and will not be adapted for the same recipes. Moreover, they can contain oil or a great quantity of salt which change substentially their nutrional values compared to fresh, canned or frozen products.