### PR TITLE
build(deps): bump node from 22.21.1 to 22.22.0

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,7 +3,7 @@
 ARG USER_UID=1000
 ARG USER_GID=1000
 
-FROM node:22.21.1 AS builder
+FROM node:22.22.0 AS builder
 ARG USER_UID
 ARG USER_GID
 RUN usermod --uid "$USER_UID" node && \


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/december-2025-security-releases
