### PR TITLE
docs: fix ingredient.yaml reference in product_ingredients schema

### DIFF
--- a/docs/api/ref/schemas/product_ingredients.yaml
+++ b/docs/api/ref/schemas/product_ingredients.yaml
@@ -22,7 +22,7 @@ properties:
       type: string
 
   ingredients:
-    $ref: "./ingredient.yaml#/components/schemas/Ingredients"
+    $ref: "ingredient.yaml#/components/schemas/Ingredients"
   ingredients_analysis:
     type: object
     properties:


### PR DESCRIPTION
This PR fixes the documentation linter failure: ENOENT: no such file or directory, open '/github/workspace/docs/api/ref/ingredient.yaml'
The issue was caused by product_ingredients.yaml referencing ingredient.yaml using an incorrect relative path:
  ./ingredient.yaml
Both files are located in:  docs/api/ref/schemas/
Updated the $ref path to:  ingredient.yaml#/components/schemas/...
This resolves the invalid-ref error in CI for issue #12695.