### PR TITLE
fix: fix delete_user integration test (multiple delete_user minion jobs)

### DIFF
--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -1130,8 +1130,7 @@ sub get_minion_jobs ($task_name, $created_after_ts, $max_waiting_time = 60) {
 		while (my $job = $jobs->next) {
 			next if (defined $run_jobs{$job->{id}});
 			# only those who were created after the timestamp
-			# Reduce test time by two seconds to account for small clock differences
-			if ($job->{created} >= ($created_after_ts - 2)) {
+			if ($job->{created} >= $created_after_ts) {
 				# retrieving the job id
 				my $job_id = $job->{id};
 				# retrieving the job state

--- a/lib/ProductOpener/Test.pm
+++ b/lib/ProductOpener/Test.pm
@@ -282,6 +282,7 @@ sub remove_all_users () {
 	# Wait for minion jobs triggered by Redis complete as otherwise can get race conditions with the main test
 	if ($keycloak_users_affected and get_oidc_implementation_level() > 1) {
 		my $jobs_ref = get_minion_jobs("delete_user", $before_delete_ts);
+		# print STDERR "[" . localtime() . "] Delete jobs: " . JSON::encode_json($jobs_ref) . "\n";
 	}
 
 	return;

--- a/tests/integration/delete_user.t
+++ b/tests/integration/delete_user.t
@@ -12,10 +12,6 @@ use ProductOpener::Auth qw/get_oidc_implementation_level/;
 
 use Clone qw/clone/;
 use Minion::Job;
-use Data::Dumper;
-$Data::Dumper::Terse = 1;
-$Data::Dumper::Indent = 1;
-$Data::Dumper::Sortkeys = 1;
 
 wait_application_ready(__FILE__);
 remove_all_users();
@@ -73,9 +69,8 @@ if (get_oidc_implementation_level() < 5) {
 
 	#waiting the deletion task to be done (weirdly enough it is not useful anymore..)
 	my $jobs_ref = get_minion_jobs("delete_user", $before_delete_ts);
-	my $delete_users_job_triggered = scalar @{$jobs_ref} ? 1 : 0;
 
-	is($delete_users_job_triggered, 1, "One ore more delete_user was triggered") or diag Dumper $jobs_ref;
+	is(scalar @{$jobs_ref}, 1, "One delete_user was triggered");
 	my $delete_job_state = $jobs_ref->[0]{state};
 	is($delete_job_state, "finished", "delete_user finished without errors");
 }


### PR DESCRIPTION
I think there is a race condition that makes one of the delete_users.t test fail: I'm getting 2 delete_user minion jobs instead of the expected one.

I think one minin job is triggered first by delete_user_task(), then Redis gets an event and queues a second delete_user job through _process_deleted_users_stream

I'm not sure if we should try to prevent that 2nd delete (e.g. by having the initial flavor in the delete_user message so that the initial flavor does not act on delete_user messages it initiated)

e.g. on the new-nutrition-branch, I'm consistently getting failures like:
https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/21281321904/job/61252395122?pr=12500#step:11:2237

```
One delete_user was triggered
[  DEBUG ]  job  4    tests/integration/delete_user.t line 79
(  DIAG  )  job  4    +-----+----+-------+
(  DIAG  )  job  4    | GOT | OP | CHECK |
(  DIAG  )  job  4    +-----+----+-------+
(  DIAG  )  job  4    | 2   | eq | 1     |
(  DIAG  )  job  4    +-----+----+-------+
(  DIAG  )  job  4    [
(  DIAG  )  job  4      {
(  DIAG  )  job  4        'args' => [
(  DIAG  )  job  4          {
(  DIAG  )  job  4            'newuserid' => 'anonymous-aaags42cjq7wi',
(  DIAG  )  job  4            'userid' => 'tests'
(  DIAG  )  job  4          }
(  DIAG  )  job  4        ],
(  DIAG  )  job  4        'attempts' => 1,
(  DIAG  )  job  4        'children' => [],
(  DIAG  )  job  4        'created' => '1769161292.133548',
(  DIAG  )  job  4        'delayed' => '1769161292.133548',
(  DIAG  )  job  4        'expires' => undef,
(  DIAG  )  job  4        'finished' => '1769161292.276340',
(  DIAG  )  job  4        'id' => 10,
(  DIAG  )  job  4        'lax' => 0,
(  DIAG  )  job  4        'notes' => {},
(  DIAG  )  job  4        'parents' => [],
(  DIAG  )  job  4        'priority' => 0,
(  DIAG  )  job  4        'queue' => 'openfoodfacts.localhost',
(  DIAG  )  job  4        'result' => 'done',
(  DIAG  )  job  4        'retried' => undef,
(  DIAG  )  job  4        'retries' => 0,
(  DIAG  )  job  4        'started' => '1769161292.134975',
(  DIAG  )  job  4        'state' => 'finished',
(  DIAG  )  job  4        'task' => 'delete_user',
(  DIAG  )  job  4        'time' => '1769161294.320926',
(  DIAG  )  job  4        'worker' => 1
(  DIAG  )  job  4      },
(  DIAG  )  job  4      {
(  DIAG  )  job  4        'args' => [
(  DIAG  )  job  4          {
(  DIAG  )  job  4            'newuserid' => 'anonymous-aaags42cj2ftw',
(  DIAG  )  job  4            'userid' => 'tests'
(  DIAG  )  job  4          }
(  DIAG  )  job  4        ],
(  DIAG  )  job  4        'attempts' => 1,
(  DIAG  )  job  4        'children' => [],
(  DIAG  )  job  4        'created' => '1769161294.296368',
(  DIAG  )  job  4        'delayed' => '1769161294.296368',
(  DIAG  )  job  4        'expires' => undef,
(  DIAG  )  job  4        'finished' => '1769161294.418464',
(  DIAG  )  job  4        'id' => 13,
(  DIAG  )  job  4        'lax' => 0,
(  DIAG  )  job  4        'notes' => {},
(  DIAG  )  job  4        'parents' => [],
(  DIAG  )  job  4        'priority' => 0,
(  DIAG  )  job  4        'queue' => 'openfoodfacts.localhost',
(  DIAG  )  job  4        'result' => 'done',
(  DIAG  )  job  4        'retried' => undef,
(  DIAG  )  job  4        'retries' => 0,
(  DIAG  )  job  4        'started' => '1769161294.298346',
(  DIAG  )  job  4        'state' => 'finished',
(  DIAG  )  job  4        'task' => 'delete_user',
(  DIAG  )  job  4        'time' => '1769161295.324520',
(  DIAG  )  job  4        'worker' => 1
(  DIAG  )  job  4      }
(  DIAG  )  job  4    ]
```