### PR TITLE
docs: add macOS VirtioFS guide to fix taxonomy timing issues

### DIFF
--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -119,6 +119,19 @@ If you use Docker Desktop:
 - ensure you allow enough memory for your VMs (at least 4G)
 - ensure you Enabled host networking (in Resources / Network)
 
+#### macOS Users: Use VirtioFS to Avoid File Sync Issues
+
+If you're on macOS and run into "missing taxonomy files" errors when running `make dev`, the culprit is usually Docker's file sharing being a bit slow. Switching to VirtioFS fixes this:
+
+1. Open **Docker Desktop** and go to **Settings** (the gear icon)
+2. Head to **Resources** → **File Sharing**
+3. Select **VirtioFS** under "Virtual file shares"
+4. Hit **Apply & Restart**
+
+VirtioFS is way faster than the default and should sort out any timing issues. You'll need macOS 12.5 or later for this to work.
+
+Still having trouble? Try bumping up Docker's resources—6-8 GB of memory and 4+ CPU cores usually does the trick.
+
 
 ## 2. Fork and clone the repository from GitHub
 


### PR DESCRIPTION
## What

Added a quick guide for macOS users on enabling VirtioFS in Docker Desktop to prevent "missing taxonomy files" errors during `make dev`.

## Why

On macOS, Docker's default file sharing can be slow, causing timing issues where taxonomy files aren't ready when the backend starts. VirtioFS provides near-native performance and resolves this.

## Changes

- Added new subsection "macOS Users: Use VirtioFS to Avoid File Sync Issues" under Docker Desktop Prerequisite in `docs/dev/how-to-quick-start-guide.md`
- Includes step-by-step instructions for enabling VirtioFS
- Mentions resource recommendations if issues persist

Fixes #12906