### PR TITLE
fix: update deprecated ESLint rules to modern equivalents

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,12 +54,12 @@ module.exports = {
     "global-require": "error",
     "guard-for-in": "error",
     "handle-callback-err": "error",
-    "id-blacklist": "error",
+    "id-denylist": "error",
     "id-length": "off",
     "id-match": "error",
     "implicit-arrow-linebreak": "error",
     indent: "off",
-    "indent-legacy": "off",
+
     "init-declarations": "off",
     "jsx-quotes": "error",
     "key-spacing": "off",
@@ -76,7 +76,7 @@ module.exports = {
     "max-nested-callbacks": "error",
     "max-params": [
       "error",
-      {max: 5}
+      { max: 5 }
     ],
     "max-statements": "off",
     "max-statements-per-line": "error",
@@ -131,9 +131,9 @@ module.exports = {
     "no-multi-spaces": "off",
     "no-multi-str": "error",
     "no-multiple-empty-lines": "off",
-    "no-native-reassign": "error",
+    "no-global-assign": "error",
     "no-negated-condition": "error",
-    "no-negated-in-lhs": "error",
+    "no-unsafe-negation": "error",
     "no-nested-ternary": "error",
     "no-new": "error",
     "no-new-func": "error",


### PR DESCRIPTION
Closes #12941

I noticed that `.eslintrc.js` is using some deprecated ESLint rules that have been renamed over the years. This PR updates them to their modern equivalents.

## What Changed

Updated 4 deprecated rules:
- `no-native-reassign` → `no-global-assign`
- `no-negated-in-lhs` → `no-unsafe-negation`  
- `id-blacklist` → `id-denylist`
- Removed `indent-legacy` (no longer needed)

These were deprecated between ESLint v3-v7, so they're 

tty old and should be updated to avoid issues when upgrading ESLint in the future.

## Testing

Ran `npm run lint:js` - everything still works fine, no new errors.

## Why This Matters

- Prevents potential breakage when upgrading to ESLint v9+
- Removes deprecation warnings from console
- The new rule names work exactly the same way, just renamed