### PR TITLE
fix: Prefer shape-specific weight over default packaging weight

### DIFF
--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -494,7 +494,8 @@ sub get_checked_and_taxonomized_packaging_component_data ($tags_lc, $input_packa
 		$packaging_ref->{shape}{weight}
 	)
 	{
-		$packaging_ref->{weight_measured} = $packaging_ref->{shape}{weight};
+		$packaging_ref->{weight_measured}
+    = convert_string_to_number($input_packaging_ref->{shape}{weight});
 	}
 
 	# Shape, material and recycling


### PR DESCRIPTION
This PR ensures that when a packaging shape defines its own weight, it is preferred over the default packaging weight.
If no shape-specific weight is available, the existing default behavior remains unchanged.
This aligns the weight selection logic with expected packaging taxonomy behavior and avoids incorrect weight calculations.
<img width="1020" height="340" alt="{EEB994E2-C433-462A-8B7F-95F3B94F2D9E}" src="https://github.com/user-attachments/assets/ef0ffe0d-e941-4903-b692-64b663e2b9e9" />
@VaiTon 
- Fixes #[12696]

