### PR TITLE
taxonomy: correction appetizers

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -98813,13 +98813,6 @@ ciqual_food_code:en: 25429
 ciqual_food_name:en: Sandwich made with French bread, kebab and raw vegetables
 
 < en:Sandwiches
-en: Surprise breads
-fr: Pains surprise
-hr: Kruh iznenađenja
-nl: Pain surprise
-wikidata:en: Q3360605
-
-< en:Sandwiches
 en: Monte Cristo sandwich
 wikidata:en: Q6904753
 
@@ -98884,26 +98877,6 @@ wikidata:en: Q390823
 < en:Sandwiches
 en: Breakfast sandwich
 wikidata:en: Q4959490
-
-< en:Sandwiches
-fr: Canapés
-agribalyse_proxy_food_code:en: 25523
-agribalyse_proxy_food_name:en: Canapés (toasts w various toppings)
-agribalyse_proxy_food_name:fr: Toasts ou Canapés salés, garnitures diverses
-wikidata:en: Q1032806
-
-< fr:Canapés
-en: Salted canapés
-de: Salzige Canapés
-es: Canapés salados
-fr: Canapés salés
-hr: Slani kanapei
-it: Canapé salati
-nl: Zoute canapés
-agribalyse_food_code:en: 25523
-ciqual_food_code:en: 25523
-ciqual_food_name:en: Canapés (toasts w various toppings)
-ciqual_food_name:fr: Toasts ou Canapés salés, garnitures diverses
 
 < en:Sandwiches
 en: Cheeseburgers
@@ -117720,6 +117693,21 @@ sv: Aptitretare
 th: อาหารเรียกน้ำย่อย
 food_groups:en: en:appetizers
 pnns_group_2:en: Appetizers
+
+< en:Appetizers
+en: Surprise breads
+fr: Pains surprise
+hr: Kruh iznenađenja
+nl: Pain surprise
+wikidata:en: Q3360605
+
+< en:Appetizers
+en: Canapés, Salted canapés
+fr: Canapés, Canapés salés
+agribalyse_proxy_food_code:en: 25523
+agribalyse_proxy_food_name:en: Canapés (toasts w various toppings)
+agribalyse_proxy_food_name:fr: Toasts ou Canapés salés, garnitures diverses
+wikidata:en: Q1032806
 
 < en:Appetizers
 fr: Blinis


### PR DESCRIPTION
While "surprise breads" and "canapés" are technically sandwiches (not even always true, canapés can have only one layer of bread), they are better in the category "appetizers".
I couldn't see any sweet canapés in the database, so I merged "canapés" and "salted canapés".