### PR TITLE
taxonomy: edits for raspberry & rhubarb jam

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -49,6 +49,9 @@ wikidata:en: Q136825392
 xx: Almhof hoekje
 # a subbrand of Almhof for dessert with sprinklings in a hoekje
 
+#< xx:Lidl
+xx: Alpenfest style, Alpenfest, Alpen fest, Alpen fest style, Alpen fest style Lidl
+
 xx: alpro
 wikidata:en: Q136824379
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -104837,7 +104837,7 @@ wikidata:en: Q8752059
 #   remark: jelly = gelled mixture of sugars and the juice and/or aqueous
 #     extracts of one or more kinds of fruit.
 < en:Fruit and vegetable preserves
-en: extra jams, extra fruit jams, extra jam, extra fruit jam
+en: Extra jams, extra fruit jams, extra jam, extra fruit jam
 bg: Конфитюр екстра качество
 cs: Džemem výběrovým, Extra Džemem
 da: Marmelade ekstra
@@ -104859,7 +104859,7 @@ pt: Doce extra
 ro: Gemul de calitate superioară
 sk: Extra džem
 sl: Ekstra džem
-sv: Extra sylt
+sv: Extra sylter, Extra sylt
 expected_minimal_amount_specific_ingredients:en: en:fruit, 50, en:eu
 
 < en:Jams
@@ -105382,6 +105382,14 @@ ciqual_proxy_food_name:en: Jam, apricot
 ciqual_proxy_food_name:fr: Confiture d'abricot (extra ou classique)
 expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 wikidata:en: Q6855605
+
+< en:Mixed fruit jams
+en: Raspberry and rhubarb jams
+da: Hindbær- og rabarbersyltetøj
+es: Confitura frambuesa y ruibarbo
+fi: Vadelma-raparperihillo
+it: Confettura lamponi e rabarbaro
+sv: Hallon- och rabarbersylter
 
 < en:Jams
 en: Rhubarb jams

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -4006,11 +4006,21 @@ sh: Sanriku
 zh: 三陸
 wikidata:en: Q1318603
 
-en: outside japan
+en: outside Japan
+da: udenfor Japan
+fr: hors Japon
 ja: 外国, 輸入
+sv: utanför Japan
 
 en: Outside France
+da: udenfor Frankrig
 fr: Hors France
+sv: utanför Frankrike
+
+en: outside Germany
+da: udenfor Tyskland
+fr: hors Allemagne
+sv: utanför Tyskland, icke-Tyskland, inte Tyskland, inte från Tyskland
 
 en: Europe
 xx: Europa


### PR DESCRIPTION
Needed-for: https://se.openfoodfacts.org/product/20991159/extra-jam-raspberry-rhubarb-alpenfest-style
Needed-for: https://world.openfoodfacts.org/facets/brands/alpenfest
Needed-for: https://world.openfoodfacts.org/facets/brands/alpen-fest
Needed-for: https://world.openfoodfacts.org/facets/brands/alpen-fest-style
Needed-for: https://world.openfoodfacts.org/facets/brands/alpen-fest-style-lidl