### PR TITLE
fix(openapi): Require fields in product_meta schema

### DIFF
--- a/docs/api/ref/schemas/product_meta.yaml
+++ b/docs/api/ref/schemas/product_meta.yaml
@@ -1,6 +1,13 @@
 type: object
 description: |
   Metadata of a product (author, editors, creation date, etc.)
+required:
+  - created_t
+  - creator
+  - last_modified_by
+  - last_modified_t
+  - last_updated_t
+  - rev
 
 properties:
   created_t:


### PR DESCRIPTION
I'm not entirely sure if these fields are always there or not.

Fixes #12969 