### PR TITLE
taxonomy(food): add hojiblanca olives

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -116106,6 +116106,8 @@ nl: Halfrijpe olijven
 en: Hojiblanca olives
 es: Aceitunas hojiblanca
 fr: Olives hojiblanca
+nb: Hojiblancaoliven
+
 
 < en:Olives
 en: Stuffed olives


### PR DESCRIPTION
### What
Adds `hojiblanca olives` as a food taxonomy entry under olives.

### Why
Hojiblanca is an olive variety and should be recognized independently
to improve product categorization and data quality.

Fixes #12967