### PR TITLE
fix(openapi): Require created_t in product_meta schema

### DIFF
--- a/docs/api/ref/schemas/product_meta.yaml
+++ b/docs/api/ref/schemas/product_meta.yaml
@@ -2,6 +2,9 @@ type: object
 description: |
   Metadata of a product (author, editors, creation date, etc.)
 
+required:
+  - created_t
+
 properties:
   created_t:
     type: integer


### PR DESCRIPTION
this pull request  marks the `created_t` field as required in the product_meta openapi schema. The field is always present in the api , but it was not included in the `required` list of  schema. Because of this, code generators  were treating it as optional and producing `number | undefined`.
updating  the schema makes the openapi spec consistent with actual api behavior.
Fixes #12970.