### PR TITLE
docs: clean up wording and fix grammar/typos in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
 # Join the development
 
-* Before you join the development, please set up the project on your local machine, run it and go through the application completely. Press on any button you can find and see where it leads to. Explore! You'll be more familiar with what is where and might even get some cool ideas on how to improve various aspects of the app.
-* If you would like to work on an issue, drop in a comment at the issue. If it is already assigned to someone, but there is no sign of any work being done, please free to drop in a comment so that the issue can be assigned to you if the previous assignee has dropped it entirely.
+* Before you join the development, please set up the project on your local machine, run it and go through the application completely. Click any button you can find and see where it leads to. Explore! You'll be more familiar with what is where and might even get some cool ideas on how to improve various aspects of the app.
+* If you would like to work on an issue, leave a comment on the issue. If it is already assigned to someone, but there is no sign of any work being done, please feel free to drop in a comment so that the issue can be assigned to you if the previous assignee has dropped it entirely.
 
 ## Contributing
 
 [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/openfoodfacts/openfoodfacts-server)
 
-When contributing to this repository, please first discuss the change you wish to make via issue, or the official [Slack channel](https://openfoodfacts.slack.com/).
+When contributing to this repository, please first discuss the change you wish to make via an issue or the official [Slack channel](https://openfoodfacts.slack.com/).
 
 
-Get started running server in development mode, see [Dev environment quick start guide](./docs/dev/how-to-quick-start-guide.md)
+To get started running the server in development mode, see [Dev environment quick start guide](./docs/dev/how-to-quick-start-guide.md)
 
 ### Pull Request Process
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
-2. Check that there are no conflicts and your request passes [Travis](https://travis-ci.org) build. Check the log of the pass test if it fails the build.
+2. Check that there are no conflicts and your request passes [Travis](https://travis-ci.org) build. Check the logs of the failing tests if the build fails.
 3. Give the description of the issue that you want to resolve in the pull request message.
    * The format of the commit message to be fixed is
      **fix:[Description of the issue] Fixes #[issue number]**
@@ -26,30 +26,30 @@ Get started running server in development mode, see [Dev environment quick start
      with the addition of:
      * `l10n` for translations
      * `taxonomy` for PR modifying a taxonomy
-5. Wait for the maintainers to review your pull request and do the changes if requested.
+4. Wait for the maintainers to review your pull request and do the changes if requested.
 
 ## Contributions Best Practices
 
 ### Check before committing
 
-You can save you sometime by running some checks locally before committing.
+You can save yourself sometime by running some checks locally before committing.
 
 `make checks` should work.
 
 ### Commits
 
 * Write clear meaningful git commit messages (Do read [here](https://chris.beams.io/posts/git-commit/)).
-* Make sure your PR's description contains GitHub's special keyword references that automatically close the related issue when the PR is merged(For more info click [here](https://github.com/blog/1506-closing-issues-via-pull-requests)).
-* When you make very, very minor changes to a PR of yours (like for example fixing a failing Travis build or some small style corrections or minor changes requested by reviewers) make sure you squash your commits afterward so that you don't have an absurd number of commits for a very small fix(Learn how to squash at [here](https://davidwalsh.name/squash-commits-git)).
+* Make sure your PR's description contains GitHub's special keyword references that automatically close the related issue when the PR is merged (For more info, click [here](https://github.com/blog/1506-closing-issues-via-pull-requests)).
+* When you make very, very minor changes to a PR of yours (like for example fixing a failing Travis build or some small style corrections or minor changes requested by reviewers) make sure you squash your commits afterward so that you don't have an absurd number of commits for a very small fix(Learn how to squash [here](https://davidwalsh.name/squash-commits-git)).
 * When you're submitting a PR for a UI-related issue, it would be really awesome if you add a screenshot of your change or a link to a deployment where it can be tested out along with your PR. It makes it very easy for the reviewers, and you'll also get reviews quicker.
 
 ### Feature Requests and Bug Reports
 
-When you file a feature request or when you are submitting a bug report to the [issue tracker](https://github.com/openfoodfacts/openfoodfacts-server/issues), make sure you add steps to reproduce it. Especially if that bug is some weird/rare one.
+When you file a feature request or when you are submitting a bug report to the [issue tracker](https://github.com/openfoodfacts/openfoodfacts-server/issues), make sure you add steps to reproduce it, especially if the bug is rare or hard to reproduce.
 
 ## Contributing to the documentation
 
-The documentation follows the [diataxis framework](https://diataxis.fr/) which is divided into four:
+The documentation follows the [Diataxis framework](https://diataxis.fr/) which is divided into four:
 
 ### Tutorials
 
@@ -71,10 +71,10 @@ They include discussion that clarifies and illuminates a particular topic when u
 
 You can contribute to any of these sections by following these steps:
 
-* Identify a problem and [create a new issue](https://github.com/openfoodfacts/openfoodfacts-server/issues/new) to describe the fix you will like to make. (if it hasnt been created).
-* Optionally, you can join the [#api-documentation Slack Channel]( https://slack.openfoodfacts.org/) to discuss more about the task with the team and get more information to work with.
+* Identify a problem and [create a new issue](https://github.com/openfoodfacts/openfoodfacts-server/issues/new) to describe the fix you would like to make. (if it hasn't been created).
+* Optionally, you can join the [#api-documentation Slack Channel](https://slack.openfoodfacts.org/) to discuss more about the task with the team and get more information to work with.
 * Clone the project and work on a dedicated branch. Follow the [commits](#commits) guidelines to make your commit messages.
-* Make a pull request. Be decriptive and make sure the pull request describes in detail the proposed changes.
+* Make a pull request. Be descriptive and make sure the pull request describes in detail the proposed changes.
 * Wait for the maintainers to review your pull request and do the changes if requested.
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 
-[Looking for the Open Food Facts API doc ?](https://openfoodfacts.github.io/documentation/docs/Product-Opener/api/)
+[Looking for the Open Food Facts API docs?](https://openfoodfacts.github.io/documentation/docs/Product-Opener/api/)
 
 # Open Food Facts - Product Opener (Web Server)
 
@@ -36,7 +36,7 @@ It works together with [Robotoff](https://github.com/openfoodfacts/robotoff), Op
 
 ### A food product database
 
-Open Food Facts is a database of food products with ingredients, allergens, nutritional facts and all the tidbits of information that is available on various product labels.
+Open Food Facts is a database of food products with ingredients, allergens, nutritional facts and all the tidbits of information that are available on various product labels.
 
 ### Made by everyone
 
@@ -52,11 +52,11 @@ Visit the [website](https://world.openfoodfacts.org) for more info.
 ## 🎨 Design & User interface
 - We strive to thoughtfully design every feature before we move on to implementation, so that we respect Open Food Facts' graphic charter and nascent design system, while having efficient user flows.
 - [![Figma](https://img.shields.io/badge/figma-%23F24E1E.svg?logo=figma&logoColor=white) Mockups on the current app and future plans to discuss](https://www.figma.com/design/Qg9URUyrjHgYmnDHXRsTTB/Current-Website-design?m=auto&t=jNwvjRR8nIgOzzJZ-6)
-- Are you a designer ? [Join the design team](https://github.com/openfoodfacts/openfoodfacts-design)
+- Are you a designer? [Join the design team](https://github.com/openfoodfacts/openfoodfacts-design)
 <br><br>
 ## Weekly Meetings
 
-- We e-meet on Mondays at 17:00 Paris Time (Europe/Paris), which is CET (UTC+1) or CEST (UTC+2 during Daylight Saving Time). For easy conversion in local time, check [17:00 in Paris](https://time.is/1700_in_Paris).
+- We meet online on Mondays at 17:00 Paris Time (Europe/Paris), which is CET (UTC+1) or CEST (UTC+2 during Daylight Saving Time). For easy conversion in local time, check [17:00 in Paris](https://time.is/1700_in_Paris).
 - ![Google Meet](https://img.shields.io/badge/Google%20Meet-00897B?logo=google-meet&logoColor=white) Video call link: https://meet.google.com/nnw-qswu-hza
 - Join by phone: https://tel.meet/nnw-qswu-hza?pin=2111028061202
 - Add the event to your calendar by [adding the Open Food Facts community calendar to your calendar](https://wiki.openfoodfacts.org/Events).
@@ -78,7 +78,7 @@ Visit the [website](https://world.openfoodfacts.org) for more info.
 - [P1 candidates](https://github.com/openfoodfacts/openfoodfacts-server/issues?q=is%3Aopen%20label%3A%22%F0%9F%8E%AF%20P1%20candidate%22%20)
 <br><br>
 ## How do I get started?
-- Join us on slack at <https://openfoodfacts.slack.com/> in the channels: `#api`, `#productopener`, `#dev`.
+- Join us on Slack at <https://openfoodfacts.slack.com/> in the channels: `#api`, `#productopener`, `#dev`.
 - Open Food Facts API documentation:
   - [Introduction to the API](https://openfoodfacts.github.io/documentation/docs/Product-Opener/api/) and links to the full reference ([source](https://github.com/openfoodfacts/openfoodfacts-server/tree/main/docs/api))
 - Developer documentation:
@@ -112,11 +112,11 @@ Have a bug or a feature request? Please search for existing and closed issues. I
 ## Translate Open Food Facts in your language
 
 You can help translate the Open Food Facts web version and the app at:
-<https://translate.openfoodfacts.org/> (no technical knowledge required, takes a minute to signup).
+<https://translate.openfoodfacts.org/> (no technical knowledge required, takes a minute to sign up).
 <br><br>
 ## Helping with HTML and CSS
 
-We have [templatized](https://github.com/openfoodfacts/openfoodfacts-server/tree/master/templates) Product Opener, we use Gulp and NPM, but you'll need to run the Product Opener docker to be able to see the result (see the How do I get set started? section).
+We have [templatized](https://github.com/openfoodfacts/openfoodfacts-server/tree/master/templates) Product Opener, we use Gulp and NPM, but you'll need to run the Product Opener docker to be able to see the result (see the How do I get started? section).
 In particular, you can [help with issues on the new design](https://github.com/openfoodfacts/openfoodfacts-server/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22%F0%9F%8E%A8%20New%20design%22).
 <br><br>
 ## Who do I talk to?


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Improve documentation clarity and correctness in README and CONTRIBUTING.

Changes include:
- fix typos and grammar issues
- improve wording for readability
- small formatting and punctuation fixes

### Why

To make the documentation clearer, more consistent, and easier for new contributors to understand.

Documentation only — no functional changes.