### PR TITLE
taxonomy(food): translate category names to Hungarian; tune Hungary-related categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -3994,8 +3994,8 @@ hu: Szlovák gyümölcspárlatok
 
 < en:Slovakian fruit spirit
 en: Borovicka
-sk: Borovička
 hu: Borovicska
+sk: Borovička
 
 < en:Fruit brandy
 en: Medovaca
@@ -4303,8 +4303,8 @@ uk: Палінка
 zh: 帕林卡
 wikidata:en: Q782901
 
-< en:Pálinka
 < en:Hungarian fruit spirit
+< en:Pálinka
 en: Hungarian Pálinka
 hu: Magyar pálinka
 origins:en: en:hungary
@@ -6265,7 +6265,7 @@ de: Kräuterschnäppse, Kräuterliköre, Kräuterschnaps, Kräuterlikör
 es: Licor de hierbas
 fr: Liqueur herbale
 hr: Biljni liker
-hu: Fűszeres likőr, Gyógynövénylikőr,  Kräuterlikör
+hu: Fűszeres likőr, Gyógynövénylikőr, Kräuterlikör
 it: Liquori alle erbe
 nl: Kruidenlikeur
 wikidata:en: Q1883967
@@ -6541,8 +6541,8 @@ ciqual_food_name:fr: Boisson plate aux fruits, (à moins de 10% de jus), non suc
 
 < en:Still fruit soft drinks
 en: Still fruit soft drink with sugar
-hu: Szénsavmentes gyümölcsös cukros üdítőitalok
 fr: Boissons plates aux fruits sucrées, Boisson plate aux fruits sucrée
+hu: Szénsavmentes gyümölcsös cukros üdítőitalok
 agribalyse_food_code:en: 18309
 ciqual_food_code:en: 18309
 ciqual_food_name:en: Fruit soft drink, still (fruit juice content unspecified), with sugar
@@ -8623,8 +8623,8 @@ en: Tangerine juices from concentrate
 de: Mandarinensäfte aus Konzentrat
 es: Zumos de mandarina procedente de concentrado, Zumos de clementina procedente de concentrado
 fr: Jus de mandarine à base de concentré
-hu: Mandarinlé koncentrátumból
 hr: Sokovi mandarina iz koncentrata
+hu: Mandarinlé koncentrátumból
 lt: Koncentruotos mandarinų sultys, Mandarinų sultys iš koncentrato
 nl: Manderijnensappen uit concentraat, Manderijnensap uit concentraat
 
@@ -9364,8 +9364,8 @@ sv: Örtte i pås
 
 < en:Herbal teas
 en: Instant herbal teas
-nl: Instanttheebereidingen
 hu: Instant gyógynövényes teák
+nl: Instanttheebereidingen
 gpc_category_code:en: 10000210
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a fruit or herbal tea, which is prepared for consumption by the addition of hot water and/or hot milk and is derived in part or in total from one or more species of fruit, herb, spice or flower and does not require straining. Includes herbal teas of various flavours such as apple, ginseng, jasmine and cinnamon, and blends of any of these such as apple and cinnamon. Definition Excludes: Excludes products such as Teas, Fruit Herbal Infusions/Tisanes Bags or Loose, Fruit Herbal Infusions/Tisanes Capsules and Pods and Liquid Ready to Drink and Not Ready to Drink Fruit Herbal Infusions/Tisanes.
 gpc_category_name:en: Fruit Herbal Infusions/Tisanes - Instant
@@ -18752,8 +18752,8 @@ en: Medoc wines
 de: Weine aus dem Medoc
 fi: Medoc-viinit
 fr: Vins du Médoc
-hu: Medoc borok
 hr: Medočka vina
+hu: Medoc borok
 nl: Médocwijn
 wikidata:fr: Q17354961
 
@@ -26483,7 +26483,7 @@ hu: Pannon borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1380, PDO-HU-A1380-AM03
 protected_name_type:en: pdo
-wikidata:en:Q4052414
+wikidata:en: Q4052414
 
 < en:Wines from Hungary
 hu: Balatoni borok


### PR DESCRIPTION
- Hungarian translation up to line 34 000
- added category "Hungarian beers"
- moved categories of Hungarian Palinkas from "en:Hungarian fruit spirit" to "en:Hungarian Pálinka" category
- fixed names of Hungarian wines: we never use geographical names alone to name wines
