### PR TITLE
fix: remove broken Microsoft Phone link from config #13003

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -581,11 +581,6 @@ my @related_applications = (
 		'url' => 'https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner'
 	},
 	{'platform' => 'ios', 'id' => 'id588797948', 'url' => 'https://apps.apple.com/app/id588797948'},
-	{
-		'platform' => 'windows',
-		'id' => '9nblggh0dkqr',
-		'url' => 'https://www.microsoft.com/p/openfoodfacts/9nblggh0dkqr'
-	},
 );
 
 my $manifest = {


### PR DESCRIPTION
This PR addresses issue #13003 by removing the broken Microsoft Phone hyperlink from the configuration.

This is a clean submission with only the necessary changes.

Closes #13003. CC: @jayaddison