### PR TITLE
taxonomy(food): add ground chili category+brand

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -306,6 +306,9 @@ wikidata:en: Q2189294
 
 xx: Délisse
 
+xx: EAGLOBE, 鷹球牌
+zh: 鷹球牌
+
 xx: EasiYo
 
 xx: Egelykke

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -75852,6 +75852,13 @@ gpc_category_name:en: Chilli Peppers
 sales_format:en: weight, package
 
 < en:Chili peppers
+en: Ground chili
+fi: Jauhettu chili
+nb: Kvernet chili
+sv: Mald chili
+zh: 磨碎辣椒
+
+< en:Chili peppers
 en: Chili powders
 hr: Čili u prahu
 lt: Čili milteliai


### PR DESCRIPTION
Needed-for: https://se.openfoodfacts.org/product/7350116924008/mald-chili-eaglobe
Needed-for: https://world.openfoodfacts.org/facets/brands/eaglobe
Needed-for: https://world.openfoodfacts.org/facets/brands/鷹球牌