### PR TITLE
fix: check for all $symbols_regexp not just '*'

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -622,7 +622,10 @@ sub init_percent_or_quantity_regexps($ingredients_lc) {
 			. '(\d+(?:(?:\,|\.)\d+)?)\s*'    # number, possibly with a dot or comma
 			. '(\%|g|gr|mg|kg|ml|cl|dl|l)\s*'    # % or unit
 			. '(?:' . $min_regexp . '|' . $max_regexp . '|'    # optional minimum, optional maximum
-			. $ignore_strings_after_percent . '|\s|\)|\]|\}|\*)*';    # strings that can be ignored
+			. $ignore_strings_after_percent
+			. '|\s|\)|\]|\}|(?:'
+			. $symbols_regexp
+			. '))*';    # strings that can be ignored
 	}
 
 	return;
@@ -2636,8 +2639,8 @@ Text to analyze
 				}
 
 				# remove * and other chars before and after the name of ingredients
-				$ingredient =~ s/(\s|\*|\)|\]|\}|$stops|$dashes|')+$//;
-				$ingredient =~ s/^(\s|\*|\)|\]|\}|$stops|$dashes|')+//;
+				$ingredient =~ s/(\s|$symbols_regexp|\)|\]|\}|$stops|$dashes|')+$//;
+				$ingredient =~ s/^(\s|$symbols_regexp|\)|\]|\}|$stops|$dashes|')+//;
 
 				$ingredient =~ s/\s*(\d+((\,|\.)\d+)?)\s*\%\s*$//;
 
@@ -6046,7 +6049,7 @@ sub cut_ingredients_text_for_lang ($text, $language) {
 	if (defined $phrases_after_ingredients_list{$language}) {
 
 		foreach my $regexp (@{$phrases_after_ingredients_list{$language}}) {
-			if ($text =~ /\*?\s*\b$regexp\b(.*)$/is) {
+			if ($text =~ /(?:$symbols_regexp)?\s*\b$regexp\b(.*)$/is) {
 				$text = $`;
 				$log->debug("removed phrases_after_ingredients_list", {removed => $1, kept => $text, regexp => $regexp})
 					if $log->is_debug();

--- a/tests/unit/ingredients_processing.t
+++ b/tests/unit/ingredients_processing.t
@@ -3077,6 +3077,38 @@ my @tests = (
 			}
 		],
 	],
+	# sv; two different note marks getting parsed the same
+	# https://github.com/openfoodfacts/openfoodfacts-server/issues/13024
+	[
+		{
+			lc => "sv",
+			ingredients_text => 'dadelsirap¹. ¹Från kontrollerat ekologiskt jordbruk.'
+		},
+		[
+			# This should match the below test exactly
+			{
+				'id' => 'en:date',
+				'is_in_taxonomy' => 1,
+				'processing' => 'en:syrup',
+				'text' => "dadel"
+			}
+		],
+	],
+	[
+		{
+			lc => "sv",
+			ingredients_text => 'dadelsirap*. *Från kontrollerat ekologiskt jordbruk.'
+		},
+		[
+			# This should match the above test exactly
+			{
+				'id' => 'en:date',
+				'is_in_taxonomy' => 1,
+				'processing' => 'en:syrup',
+				'text' => "dadel"
+			}
+		],
+	],
 
 );
 


### PR DESCRIPTION
In several places of the ingredients processing, we’re currently checking specifically for `*` though it can really be for any of the `$symbols_regexp` symbols. This replaces some instances of `\*` with either `$symbols_regexp` or `(?:$symbols_regexp)` to not mess with any capturing groups.

Fixes: https://github.com/openfoodfacts/openfoodfacts-server/issues/13024
Needed-for: https://se.openfoodfacts.org/product/4056489664086/kamomill-vemondo