### PR TITLE
taxonomy(food): sichuan pepper edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -76003,14 +76003,6 @@ fr: Pulla
 fr: Serrano
 
 < en:Chili peppers
-en: Sichuan pepper
-fr: Poivre du SiChuan, Poivre Sansho, Sansho
-hr: Sečuanski papar
-ja: 山椒
-pl: Pieprz syczuański
-zh: 花椒
-
-< en:Chili peppers
 en: Tasmanian Pepperberry, mountain pepper, bush pepper
 fr: Poivre de Tasmanie
 
@@ -76023,6 +76015,37 @@ nl: Grijze peper
 agribalyse_proxy_food_code:en: 11015
 agribalyse_proxy_food_name:en: Black pepper, powder
 agribalyse_proxy_food_name:fr: Poivre noir, poudre
+
+< en:Spices
+en: Sichuan pepper
+ar: فلفل سشوان
+ca: Pebre de Sichuan
+da: Sichuanpeber
+eo: Siĉuan-piproj
+et: Sichuani pipar
+fa: فلفل سیچوآن
+fi: Sichuan pippuri
+fr: Poivre du Sichuan, Poivre Sansho, Sansho
+gu: ચીરફળ
+hr: Sečuanski papar
+id: Lada sichuan
+is: Sichuanpipar
+ja: 花椒, 山椒
+jv: Mrica Sichuan
+ko: 화자오
+ml: സിഷ്വാൻ മുളക്
+ms: Lada Sichuan
+nb: Sichuanpepper
+ne: टिमुर
+pl: Pieprz syczuański
+ru: Сычуаньский перец
+sv: Sichuanpeppar
+uk: Сичуанський перець
+vt: Tiêu Tứ Xuyên
+zh: 花椒, 山椒, 四川花椒
+comment:en: Despite its name, Sichuan pepper is not closely related to black pepper or chili peppers. Instead, Zanthoxylum plants are in the same family as citrus and rue. (Wikipedia)
+description:en: Sichuan pepper is a spice made from the dried pericarp (outer shell of the fruit) of a plant of the genus Zanthoxylum in the family Rutaceae. (Wikipedia)
+wikidata:en: Q756800
 
 < en:Spices
 en: Spice Mix

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -56728,10 +56728,26 @@ fr: Poudre de piment coréen, gochugaru
 pl: papryka gochugaru
 
 < en:vegetable
-en: sichuan pepper
+en: Japanese pepper
+xx: Zanthoxylum piperitum
+ja: 山椒
+ko: 초피
+la: Zanthoxylum piperitum
+comment:en: Despite being called a pepper, it is more closely related to rues and citrus fruits and shouldn’t be a child of other peppers.
+wikidata:en: Q167881
+
+< en:spice
+en: Sichuan pepper
+ar: فلفل سشوان
+da: sichuanpeber
 hr: sečuanski papar
 it: pepe di Sichuan
+nb: sichuanpepper
 pl: pieprz syczuański
+sv: sichuanpeppar
+zh: 花椒
+description:en: Sichuan pepper is a spice made from the dried pericarp (outer shell of the fruit) of a plant of the genus Zanthoxylum in the family Rutaceae. (Wikipedia)
+wikidata:en: Q756800
 
 < en:spice
 en: paprika


### PR DESCRIPTION
Seems like Sichuan pepper was previously mixed in with chili peppers, depite them not being related. This expands on both the category and ingredient entries for Sichuan pepper and also adds one of the vegetable sources for Sichuan pepper: Japanese pepper, which is still not a pepper.

Source: https://en.wikipedia.org/wiki/Sichuan_pepper
Source: https://en.wikipedia.org/wiki/Zanthoxylum_piperitum
Needed-for: https://se.openfoodfacts.org/product/7350116923995/sichuanpeppar-eaglobe