### PR TITLE
web: point pro-register/join buttons to user profile (use requested_org)

### DIFF
--- a/tests/integration/ui_show_pro_register_join_buttons.t
+++ b/tests/integration/ui_show_pro_register_join_buttons.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use Test2::V0;
+use ProductOpener::APITest qw/:all/;
+use ProductOpener::Test qw/:all/;
+use ProductOpener::TestDefaults qw/:all/;
+use Clone qw/clone/;
+
+# Ensure application is ready
+wait_application_ready(__FILE__);
+remove_all_products();
+remove_all_users();
+remove_all_orgs();
+
+# Create a normal (non-pro) user and remain logged in
+my $ua = new_client();
+my %user_form = ( %{clone(\%default_user_form)} );
+my $resp = create_user($ua, \%user_form);
+ok(!html_displays_error($resp), "created normal user without error");
+
+# Request the producers index page
+$resp = get_page($ua, "/index-pro");
+ok($resp->is_success, "fetched index-pro page");
+my $content = $resp->decoded_content;
+
+like($content, qr/<div class="show-when-logged-in">.*?href="\/cgi\/user.pl".*?Register your organization.*?href="\/cgi\/user.pl".*?Link your user to an existing organization/s, "Register/Link buttons point to /cgi/user.pl for logged-in users");
+
+done_testing();

--- a/web-default/lang/en/texts/index-pro.html
+++ b/web-default/lang/en/texts/index-pro.html
@@ -21,8 +21,8 @@
 
 		<!-- #11867: Show register / join actions when logged in but not a producer -->
 		<div class="show-when-logged-in">
-			<a href="/cgi/org.pl" class="small button">Register your organization</a>
-			<a href="mailto:producers@openfoodfacts.org?subject=Request%20to%20join%20organization" class="small button">Link your user to an existing organization</a>
+			<a href="/cgi/user.pl" class="small button">Register your organization</a>
+			<a href="/cgi/user.pl" class="small button">Link your user to an existing organization</a>
 		</div>
 
 		<h2>Make your products visible in more than 100 apps and services</h2>


### PR DESCRIPTION
This PR updates the producers index UI to point the 'Register your organization' and 'Link your user to an existing organization' buttons to the user profile flow (/cgi/user.pl) so authenticated users can set the requested_org field. It also adds an integration test tests/integration/ui_show_pro_register_join_buttons.t asserting the buttons are visible to logged-in users and link to /cgi/user.pl.

Rationale: cgi/org.pl requires admin/pro-moderator rights; this is a minimal UX fix that avoids 403 for normal users while leaving the backend org-creation workflow to Issue #11867 for further work.

Related: openfoodfacts/openfoodfacts-server#11867