### PR TITLE
taxonomy(food): improving frozen food categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -8217,6 +8217,7 @@ hr: Ohlađeni sokovi od cijeđene naranče
 lt: Šaltai laikomos spaustos apelsinų sultys
 nl: Gekoelde verse sinaasappelsappen, Gekoelde verse sinaasappelsap
 
+< en:Frozen fruit juices
 < en:Orange juices
 en: Frozen orange juices
 fr: Jus d'orange surgelé
@@ -9161,6 +9162,7 @@ gpc_category_code:en: 10006251
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a ready to drink, non-carbonated beverage that is made exclusively from the extracted fluid content of a vegetable or a blend of vegetable and fruit juice, having vegetable as the main characteristic. These products must be refrigerated to extend their consumable life. Products include individual and blended pure juice varieties. Definition Excludes: Excludes products such as Shelf Stable and Frozen Ready to Drink Juices and Not Ready to Drink Juices, Baby and Infant Specialized Beverages as well as fruit juice and blended fruit/vegetable juice having fruit as the main characteristic.
 gpc_category_name:en: Vegetable Juice - Ready to Drink (Perishable)
 
+< en:Frozen fruit and vegetable juices
 < en:Vegetable juices
 en: Frozen vegetable juices
 da: Frosne grønsagsjuicer
@@ -34157,6 +34159,7 @@ gpc_category_code:en: 10000295
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a savoury grain-based not ready to eat, prepared/processed product, such as Rice, Polenta or Couscous with other ingredients, such as meat, eggs, dairy, fish, vegetables, and/or seasoning. An optional seasoning/flavour packet may be present. These ingredients form a valuable part of the product, such as Chicken Tandoori with Pilau Rice or Rosemary Chicken over Wild Rice Pilaf. These products may have a main component which is considered a meal without any additional components. These products must not include any Dough-Based products. They may or may not contain a sauce. These products require cooking prior to consumption. These products must be refrigerated to extend their consumable life. Includes not ready to eat perishable Ready-Made Meals where a Grain Based Product is the primary ingredient. Definition Excludes: Excludes Ready-Made Combination Meals. Specifically excludes all unprepared dried rice.Excludes products such as Shelf Stable and Frozen Not Ready-to-Eat and all Ready-to-Eat Grain-Based Prepared/Processed Products, Unprepared Grains.
 gpc_category_name:en: Grain Based Products / Meals - Not Ready to Eat - Savoury (Perishable)
 
+< en:Frozen foods
 < en:Meal kits
 en: Frozen grain based meal kits
 gpc_category_code:en: 10000296
@@ -35382,6 +35385,7 @@ nl: Gepaneerde kazen, Gepaneerde kaas
 pl: Ser panierowany
 
 < en:Breaded cheeses
+< en:Frozen foods
 en: Frozen breaded cheeses
 fr: Fromages panés surgelés
 
@@ -35412,6 +35416,7 @@ ciqual_food_code:en: 25546
 ciqual_food_name:en: Cheese and ham, breaded
 
 < en:Cheeses
+< en:Frozen foods
 en: Frozen cheeses
 fr: Fromages surgelés
 
@@ -35434,6 +35439,7 @@ en: Kroketten
 fr: Croquettes hollandaises
 nl: Kroketten
 
+< en:Frozen foods
 < en:Kroketten
 en: Frozen kroketten
 fr: Croquettes hollandaises surgelées
@@ -36179,6 +36185,7 @@ sales_format:en: weight, package
 wikidata:en: Q208172
 
 < en:Baguettes
+< en:Frozen breads
 en: Frozen baguettes
 fr: Baguettes surgelées
 
@@ -36614,6 +36621,7 @@ ciqual_food_name:en: Corn tortilla wrap, to be filled
 ciqual_food_name:fr: Tortilla souple (à garnir), à base de maïs
 
 < en:Corn flatbreads
+< en:Frozen breads
 en: Frozen corn flatbreads, Frozen corn tortilla wraps
 fr: Tortillas de maïs surgelées
 
@@ -37091,6 +37099,7 @@ it: Pane pre-cotto
 lt: Iškeptos duonos
 nl: Afbakbroden, Voorgebakken broden, Voorgebakken brood
 
+< en:Frozen breads
 < en:Pre-baked breads
 en: Frozen pre-baked breads, frozen part-baked breads
 fr: Pains précuits surgelés, pain précuit surgelé
@@ -37180,6 +37189,7 @@ ciqual_food_code:en: 7259
 ciqual_food_name:en: Rolls for hamburger/hotdog (buns), prepacked
 ciqual_food_name:fr: Pain pour hamburger ou hot dog (bun), préemballé
 
+< en:Frozen breads
 < en:Hamburger buns
 en: Frozen hamburger buns
 fr: Pains Burger surgelés, Pains pour hamburgers surgelés
@@ -37696,6 +37706,7 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Baking/Cooking Mixes (Perishable)
 
 < en:Baking Mixes
+< en:Frozen foods
 en: Frozen baking mixes
 gpc_category_code:en: 10000068
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a quantity of frozen, pre-mixed dough, batter or powder that is specifically intended to produce bread, cakes, biscuits, desserts, or other products. Products may be ready to use (where no additional ingredients need to be added to the mix prior to use) or require the addition of wet ingredients such as water, milk, oil, fat or egg. These products must be frozen to extend their consumable life. Definition Excludes: Excludes products such as Soups, Perishable or Shelf-Stable Baking Mixes, all Part Baked and Baked Products.
@@ -38058,6 +38069,7 @@ google_product_taxonomy_id:en: 1895
 intake24_category_code:en: CRUM
 wikidata:en: Q207220
 
+< en:Frozen foods
 < en:Muffins
 en: Frozen muffins
 fr: Muffins surgelés
@@ -38208,6 +38220,7 @@ lt: Spurgos su glaistu, Glazūruotos spurgos
 nl: Geglazuurde donuts
 
 < en:Doughnuts
+< en:Frozen foods
 en: Frozen doughnuts, Frozen donuts
 fr: Donuts surgelés
 
@@ -38808,7 +38821,8 @@ en: Apple Cakes
 fr: Gâteaux aux pommes, Quatre-quarts aux pommes
 
 < en:Apple Cakes
-en: Frozen apple Cakes
+< en:Frozen desserts
+en: Frozen apple cakes
 fr: Gâteaux aux pommes surgelés, Quatre-quarts aux pommes surgelés
 
 < en:Cakes
@@ -41956,6 +41970,7 @@ zh: 鱼卵, 鱼子
 wikidata:en: Q219426
 
 < en:Fish eggs
+< en:Frozen foods
 en: Frozen fish eggs, Frozen roes
 fr: Œufs de poisson surgelés
 
@@ -42633,6 +42648,7 @@ gpc_category_name:en: Grains/Cereal - Not Ready to Eat - (Shelf Stable)
 pnns_group_2:en: Cereals
 
 < en:Cereals and their products
+< en:Frozen plant-based foods
 en: Frozen cereals and their products
 gpc_category_code:en: 10000314
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a savoury grain not ready to eat product, such as Rice, Polenta, Couscous. These products must not include any additional ingredients and are not part of a recipe prior to sale. These products are not ready to eat and require cooking prior to consumption. These products must be frozen to extend their consumable life. Definition Excludes: Specifically excludes all grain based prepared products such as Risotto and Cereal Products. Excludes products such as Perishable and Shelf Stable Not Ready to Eat and Ready to Eat Grain and all Grain Based Prepared Recipe Products.
@@ -44880,8 +44896,8 @@ google_product_taxonomy_id:en: 2392
 intake24_category_code:en: CHIP
 wikidata:en: Q152088
 
-< en: Potato preparations
 < en:Chips and fries
+< en:Potato preparations
 xx: Pommes noisettes
 bg: Картофени ноазети
 fr: Pommes noisettes
@@ -45612,6 +45628,7 @@ description:en: In genereal a highly processed product not much related to Mozza
 en: Paneer, panir
 xx: Paneer, panir
 
+< en:Frozen cheeses
 < en:Paneer
 en: Frozen Paneer, Frozen panir
 fr: Paneer surgelé, panir surgelé
@@ -49458,7 +49475,7 @@ protected_name_file_number:en: PDO-IT-0014
 protected_name_type:en: pdo
 wikidata:en: Q941068
 
-< en:Frozen foods
+< en:Frozen cheeses
 < en:Mozzarella
 en: Frozen mozzarella
 fr: Mozzarella surgelée
@@ -50869,6 +50886,7 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Cream (Perishable)
 
 < en:Creams
+< en:Frozen foods
 en: Frozen creams
 gpc_category_code:en: 10000188
 gpc_category_description:en: Definition: Includes any products that can be described/observed as frozen dairy cream (the fatty part of fresh milk that rises to the top if allowed to stand). These products must be frozen to extend their consumable life. Products include cream with added flavouring or ingredients, such as fruit and chocolate. Definition Excludes: Excludes products such as Shelf Stable and Perishable Cream and all Cream Substitutes.
@@ -55011,6 +55029,7 @@ it: Coulis di frutta
 nl: Vruchtencoulis
 wikidata:en: Q1136961
 
+< en:Frozen foods
 < en:Fruits coulis
 en: Frozen fruits coulis
 fr: Coulis de fruits surgelés
@@ -59379,6 +59398,7 @@ protected_name_type:en: pgi
 #wikidata:en:
 
 < en:Chicken eggs
+< en:Frozen foods
 en: Frozen chicken eggs
 fr: Oeufs de poules congelés
 
@@ -66404,7 +66424,8 @@ agribalyse_proxy_food_name:fr: Pomme de terre rissolée, surgelée, crue
 food_groups:en: en:potatoes
 pnns_group_2:en: Potatoes
 
-< en:Frozen foods
+< en:Frozen plant-based foods
+< en:Mashed potatoes
 en: Frozen mashed potatoes
 fr: Purées de pommes de terre surgelée, Purée de pommes de terre surgelée
 hr: Smrznuti pire krumpir
@@ -66415,6 +66436,7 @@ agribalyse_proxy_food_name:fr: Pomme de terre rissolée, surgelée, crue
 
 #frozen fried potatoes in the shape of sticks
 < en:Fries
+< en:Frozen fried potatoes
 en: Frozen fries, Frozen chips, Frozen french fries
 bg: Замразени пържени картофи
 de: Tiefkühl-Pommes
@@ -66428,7 +66450,7 @@ nl: Diepvriespatatten
 pl: Frytki mrożone
 who_id:en: 16
 
-< en:Frozen fried potatoes
+< en:Frozen fries
 en: Frozen roasted French fries, Frozen baked French fries, Frozen roasted French chips
 fr: Frites de pommes de terre surgelées cuites au four, Frites de pommes de terre surgelées rôties
 agribalyse_food_code:en: 4030
@@ -66436,7 +66458,7 @@ ciqual_food_code:en: 4030
 ciqual_food_name:en: French fries or chips, frozen, roasted/baked
 ciqual_food_name:fr: Frites de pommes de terre, surgelées, rôties/cuites au four
 
-< en:Frozen fried potatoes
+< en:Frozen fries
 en: Frozen French fries to roast, Frozen French fries to bake, Frozen French chips to roast, Frozen French chips to bake
 fr: Frites surgelées à cuire au four, Frites de pommes de terre surgelées à rôtir, Frites de pommes de terre surgelées à cuire au four
 agribalyse_food_code:en: 4044
@@ -66460,7 +66482,8 @@ agribalyse_proxy_food_code:en: 4045
 agribalyse_proxy_food_name:en: French fries or chips, frozen, raw, intended to be microwaved
 agribalyse_proxy_food_name:fr: Frites de pommes de terre, surgelées, pour cuisson micro-ondes
 
-< en:Frozen fried potatoes
+< en:Frozen fries
+< en:Microwave fries
 en: Frozen microwave fries, Frozen French fries intended to be microwaved, Frozen French chips intended to be microwaved
 fr: Frites surgelées micro-ondables, Frites de pommes de terre surgelées pour cuisson au micro-ondes
 agribalyse_food_code:en: 4045
@@ -66468,7 +66491,7 @@ ciqual_food_code:en: 4045
 ciqual_food_name:en: French fries or chips, frozen, raw, intended to be microwaved
 ciqual_food_name:fr: Frites de pommes de terre, surgelées, pour cuisson micro-ondes
 
-< en:Frozen fried potatoes
+< en:Frozen fries
 en: Frozen deep-fried French fries, Frozen deep-fried French chips
 fr: Frites de pommes de terre surgelées cuites en friteuse
 agribalyse_food_code:en: 4032
@@ -66476,7 +66499,7 @@ ciqual_food_code:en: 4032
 ciqual_food_name:en: French fries or chips, frozen, deep-fried
 ciqual_food_name:fr: Frites de pommes de terre, surgelées, cuites en friteuse
 
-< en:Frozen fried potatoes
+< en:Frozen fries
 en: Frozen French fries to deep-fry, Frozen chips to deep-fry
 fr: Frites surgelées pour friteuse, Frites de pommes de terre pour cuisson en friteuse
 agribalyse_food_code:en: 4046
@@ -68964,6 +68987,7 @@ ciqual_food_code:en: 13000
 ciqual_food_name:en: Apricot, pitted, raw
 ciqual_food_name:fr: Abricot, dénoyauté, cru
 
+< en:Frozen fruits
 < en:Pitted apricot
 en: Frozen pitted apricot
 fr: Abricot dénoyauté surgelé
@@ -70676,6 +70700,7 @@ season_in_country_fr:en: 9
 fr: Quetsches fraîches
 season_in_country_fr:en: 8,9,10
 
+< en:Frozen fruits
 < en:Plums
 en: Frozen plums
 fr: Prunes surgelées
@@ -70825,6 +70850,7 @@ nl: verse bananen
 opposite:en: en:frozen-bananas
 
 < en:Bananas
+< en:Frozen fruits
 en: Frozen bananas, Bananas (frozen)
 fr: Bananes congélés
 nl: Bananen(diepvries)
@@ -71479,6 +71505,7 @@ gpc_category_code:en: 10000204
 gpc_category_description:en: Definition: Includes any products that can be described/observed as any variety of fruit or combination of fruits, which may be whole or stoned, pitted, chopped, cored and/or peeled, and which have gone through further manufacturing processes, such as reformed, cooked or dried, however these products can also be coated, in sauce, stuffed or filled. These products must be frozen to extend their consumable life. Definition Excludes: Specifically excludes tomatoes. Excludes products such as Unprepared and Unprocessed Fruit and Prepared and Processed Shelf Stable and Perishable Fruit.
 gpc_category_name:en: Fruit - Prepared/Processed (Frozen)
 
+< en:Frozen fruits
 en: Frozen fruits with added sugar
 fr: Fruits surgelés avec sucres ajoutés
 hr: Smrznuto voće s dodatkom šećera
@@ -74675,6 +74702,7 @@ gpc_category_code:en: 10000048
 gpc_category_description:en: Definition: Includes any products that can be described/observed as an aromatic or richly flavoured vegetable or plant derivative that is typically added to season or give additional flavour to foods. These products include aromatic seasonings which are obtained from the bark, buds, fruit, roots, seeds or stems of various plants normally referred to as spices, and those, which are obtained from the leafy part of a plant and known as herbs. These products can be/must be refrigerated to extend their consumable life. Definition Excludes: Excludes products such as fresh, whole herbs classified with fresh vegetables, potted herbs classified in Lawn/Garden, Shelf Stable Herbs and Spices, Salt and Extracts.
 gpc_category_name:en: Herbs/Spices (Perishable)
 
+< en:Frozen foods
 < en:Herbs and spices
 en: Frozen Herbs and Spices
 da: Frosne urter og krydderier
@@ -76087,6 +76115,7 @@ pnns_group_2:en: Dressings and sauces
 who_id:en: 17
 wikidata:en: Q178359
 
+< en:Frozen foods
 < en:Sauces
 en: Frozen sauces, Sauces (frozen)
 gpc_category_code:en: 10000056
@@ -76276,6 +76305,7 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Dessert Sauces/Toppings/Fillings (Perishable)
 
 < en:Dessert sauces
+< en:Frozen sauces
 en: Frozen dessert sauces
 gpc_category_code:en: 10000193
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a flavoured topping/filling or a sweetened liquid typically intended for consumption as an accompaniment to a dessert. Includes products such as cream pie fillings. These products must be frozen to extend their consumable life. Definition Excludes: Excludes products such as Perishable and Shelf Stable Dessert Sauces and Toppings.
@@ -80319,6 +80349,7 @@ intake24_category_code:en: SUSH
 wikidata:en: Q46383
 wikipedia:en: https://en.wikipedia.org/wiki/Sushi
 
+< en:Frozen foods
 < en:Sushis
 en: Frozen sushis
 fr: Sushis surgelés
@@ -80434,7 +80465,8 @@ wikidata:en: Q865773
 < en:Seafood
 xx: Sashimi
 
-< xx: Sashimi
+< en:Frozen foods
+< xx:Sashimi
 en: Frozen sashimi
 fr: Sashimi surgelés
 
@@ -80701,6 +80733,7 @@ en: Zongzi
 fr: Zongzi, Zong zi
 zh: 粽子, zòngzi
 
+< en:Frozen foods
 < en:Zongzi
 en: Frozen Zongzi
 fr: Zongzi surgelés
@@ -81239,6 +81272,7 @@ sv: Rätter med kött
 zh: 肉餐
 intake24_category_code:en: MDSH
 
+< en:Frozen foods
 < en:Meals with meat
 en: Frozen meals with meat
 fr: Plats préparés surgelés à la viande
@@ -81507,6 +81541,7 @@ ciqual_food_name:en: Beef carpaccio, w marinade
 ciqual_food_name:fr: Carpaccio de bœuf, avec marinade
 
 < en:Beef carpaccio
+< en:Frozen foods
 en: Frozen beef carpaccio
 fr: Carpaccio de boeuf surgelé, Carpaccio de bœuf surgelé
 
@@ -83776,6 +83811,7 @@ fr: Flammekueches sucrées
 fr: Flammekueches aux pommes
 
 < en:Flammekueche
+< en:Frozen foods
 en: Frozen flammekueche
 fr: Flammekueches surgelées
 
@@ -83856,6 +83892,7 @@ nl: Groentenschijven
 pl: Warzywne kotlety
 #wikidata:en:
 
+< en:Frozen foods
 < en:Vegetable patties
 en: Frozen vegetable patties
 fr: Galettes de légumes surgelées
@@ -83874,7 +83911,7 @@ ciqual_food_name:fr: Palet ou galette de légumes, préfrit, surgelé
 en: Frozen Rostis, Frozen Potatoes cakes, Frozen Potato cakes
 fr: Rostis surgelés, Galette de pomme de terre surgelée, Galette de pommes de terre surgelées
 
-< en:Frozen foods
+< en:Frozen plant-based foods
 < en:Prepared vegetables
 en: Frozen pre-fried cooked vegetable rosti
 fr: Palets de légumes préfrits cuits surgelés, Galettes de légumes préfrites cuites surgelées
@@ -83889,6 +83926,7 @@ en: Breaded vegetables
 fr: Légumes panés
 
 < en:Breaded vegetables
+< en:Frozen foods
 en: Frozen breaded vegetables
 fr: Légumes panés surgelés
 
@@ -83905,6 +83943,7 @@ ciqual_food_name:en: Stuffed vegetables (excluding tomato)
 ciqual_food_name:fr: Légumes farcis (sauf tomate)
 #wikidata:en:
 
+< en:Frozen foods
 < en:Stuffed vegetables
 en: Frozen stuffed vegetables
 fr: Légumes farcis surgelés
@@ -83945,8 +83984,9 @@ ciqual_food_name:en: Vegetables au gratin (oven grilled)
 ciqual_food_name:fr: Gratin de légumes
 #wikidata:en:
 
+< en:Frozen foods
 < en:Vegetable gratins
-en: frozen-vegetable-gratins
+en: Frozen vegetable gratins
 fr: Gratins de légumes surgelés
 
 < en:Vegetable gratins
@@ -84474,12 +84514,14 @@ ciqual_food_name:en: Focaccia, filled
 ciqual_food_name:fr: Focaccia, garnie
 
 < en:Focaccia
+< en:Frozen foods
 en: Frozen focaccia
 fr: Focaccia surgelée
 
 < en:Meals
 xx: Langòs
 
+< en:Frozen foods
 < xx:Langòs
 en: Frozen langos
 fr: Langòs surgelés
@@ -85061,6 +85103,7 @@ en: Knödel
 fr: Knödel
 wikidata:en: Q158382
 
+< en:Frozen foods
 < en:Knödel
 en: Frozen knödel
 fr: Knödel surgelés
@@ -85807,6 +85850,7 @@ de: Hackfleisch
 fr: Viandes hachées
 hr: Mljeveno meso
 
+< en:Frozen meats
 < en:Ground meats
 en: Frozen ground meats
 fr: Viandes hachées surgelées
@@ -85845,6 +85889,7 @@ fr: Viandes cuites fumées, Viande cuite fumée
 en: Roasted meats
 fr: Viandes roties
 
+< en:Frozen meats
 < en:Roasted meats
 en: Frozen roasted meats
 fr: Viandes roties surgelées
@@ -86050,6 +86095,7 @@ ciqual_food_code:en: 10099
 ciqual_food_name:en: Snail, without added fat, cooked
 ciqual_food_name:fr: Escargot, sans matière grasse ajoutée, cuit
 
+< en:Frozen meats
 < en:Snails
 en: Frozen snails
 fr: Escargots surgelés
@@ -86116,6 +86162,7 @@ ciqual_food_code:en: 36801
 ciqual_food_name:en: Ostrich, meat, cooked
 ciqual_food_name:fr: Autruche, viande cuite
 
+< en:Frozen meats
 < en:Ostrich
 en: Frozen ostrich meat
 fr: Viande d'autruche surgelée
@@ -86146,6 +86193,7 @@ ciqual_food_name:en: Frog, leg, raw
 ciqual_food_name:fr: Grenouille, cuisse, crue
 
 < en:Frog legs
+< en:Frozen meats
 en: Frozen frog legs
 fr: Cuisses de Grenouilles surgelées
 
@@ -86247,6 +86295,7 @@ agribalyse_proxy_food_code:en: 25589
 agribalyse_proxy_food_name:en: Plant-based ball with wheat and/or soybean, prepacked
 agribalyse_proxy_food_name:fr: Boulette végétale au soja et/ou blé, préemballée
 
+< en:Frozen plant-based foods
 < en:Vegetarian balls
 en: Frozen vegetarian balls
 fr: Boulettes végétariennes surgelées
@@ -86286,7 +86335,7 @@ it: Falafel congelato
 nl: Gekoelde falafel
 
 < en:Falafel
-< en:Frozen plant-based foods
+< en:Frozen vegetarian balls
 en: Frozen falafel
 es: Falafel congelado
 fr: Falafels surgelés, Falafel surgelé
@@ -86381,6 +86430,7 @@ ciqual_food_code:en: 25194
 ciqual_food_name:en: Meat balls, beef and lamb (kefta type), raw
 ciqual_food_name:fr: Boulettes au bœuf et à l'agneau (type kefta), crues
 
+< en:Frozen meats
 < en:Meat balls
 en: Frozen meat balls
 fr: Boulettes de viande surgelées
@@ -86666,6 +86716,7 @@ ciqual_food_name:en: Beef, knuckle, boiled/cooked in water
 ciqual_food_name:fr: Boeuf, jarret, bouilli/cuit à l'eau
 
 < en:Beef knuckle
+< en:Frozen meats
 en: Frozen beef knuckle
 fr: Jarret de boeuf surgelé
 
@@ -86674,6 +86725,7 @@ en: Beef marrowbone, beef marrow bone
 fr: Os à moelle
 
 < en:Beef marrowbone
+< en:Frozen meats
 en: Frozen beef marrowbone, Frozen beef marrow bone
 fr: Os à moelle surgelé
 
@@ -86706,6 +86758,7 @@ ciqual_food_name:en: Beef, rib steak, raw
 ciqual_food_name:fr: Boeuf, entrecôte, crue
 
 < en:Beef rib steak
+< en:Frozen meats
 en: Frozen beef rib steak
 fr: Entrecôte de boeuf surgelée
 
@@ -96884,6 +96937,7 @@ gpc_category_code:en: 10000241
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a savoury pasta, noodle or gnocchi ready to eat product. These products must not include any additional ingredients such as vegetables, protein or a sauce, and must not be part of a recipe prior to sale. These products do not require cooking prior to consumption, but some products can be reheated. These products have been treated or packaged in such a way to extend their consumable life. Definition Excludes: Specifically excludes all dough based prepared products such as Tuna Pasta Salad. Excludes products such as Perishable Ready to Eat and Not Ready to Eat Pasta and Noodles and all Dough Based Prepared Recipe Products.
 gpc_category_name:en: Pasta/Noodles - Ready to Eat (Shelf Stable)
 
+< en:Frozen foods
 < en:Pastas
 en: Frozen pasta
 fr: Pâtes surgelées
@@ -97155,6 +97209,7 @@ agribalyse_proxy_food_code:en: 25019
 < en:Meat ravioli
 xx: manti
 
+< en:Frozen foods
 < xx:manti
 en: Frozen manti
 fr: Manti surgelés
@@ -97170,6 +97225,7 @@ en: Pelmeni
 fr: Pelmeni
 ru: пельмени
 
+< en:Frozen foods
 < en:Pelmeni
 en: Frozen pelmeni
 fr: Pelmeni surgelés
@@ -98601,6 +98657,7 @@ fr: Kadayif, tel kadayif, Kadaifs
 en: Kadaif pastas, kadayif pastas, kataifi pasta
 fr: Pâtes à Kadaïf, pâtes à kadayif, pâtes à kataifi
 
+< en:Frozen foods
 < en:Kadaif pastas
 en: Frozen Kadaif pastas, frozen kadayif pastas, frozen kataifi pasta
 fr: Pâtes à Kadaïf surgelées, pâtes à kadayif surgelées, pâtes à kataifi surgelées
@@ -98686,6 +98743,7 @@ gpc_category_code:en: 10000247
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a pastry based sweet product consisting of a butter, flour and egg dough. Products may use shortcrust, puff, filo or flaky pastry and must contain a filling. Generally, these products have a high fat content. These products have been treated or packaged in such a way as to extend their consumable life. Products include pies and tarts, croissants, Danish and other breakfast pastries. Definition Excludes: Excludes products such as Perishable and Frozen Pies and Pastries, Savoury Pies and Pastries.
 gpc_category_name:en: Pies/Pastries - Sweet (Shelf Stable)
 
+< en:Frozen foods
 < en:Sweet pies
 en: Frozen sweet pies
 gpc_category_code:en: 10000245
@@ -98927,6 +98985,7 @@ ciqual_food_name:fr: Tarte Tatin aux pommes
 wikidata:en: Q1147946
 
 < en:Apple pies
+< en:Frozen pies
 en: Frozen apple pies
 de: Tiefgekühlte Apfelkuchen, Tiefgekühlter Apfelkuchen, Tiefgekühlte Apfelküchlein, Tiefgekühltes Apfelküchlein
 es: Tartas de manzana congeladas, Tarta de manzana congelada, Tartaletas de manzana congeladas, Tartaleta de manzana congelada
@@ -99063,6 +99122,7 @@ hr: Tartlete od krušaka
 it: Tortini di pera
 nl: Peertaartjes
 
+< en:Frozen foods
 < en:Fruit tartlets
 en: Frozen fruit tartlets
 fr: Tartelettes aux fruits surgelées
@@ -99184,6 +99244,7 @@ nova:en: 3
 pnns_group_2:en: Sandwiches
 wikidata:en: Q28803
 
+< en:Frozen foods
 < en:Sandwiches
 en: Frozen sandwiches
 de: Tiefkühlsandwiches
@@ -100284,6 +100345,7 @@ ciqual_food_name:fr: Wrap végétarien
 en: Vegetable wraps
 fr: Wraps aux légumes
 
+< en:Frozen sandwiches
 < en:Vegetable Wraps
 en: Frozen vegetable wraps
 fr: Wraps aux légumes surgelés
@@ -108803,6 +108865,7 @@ ciqual_food_code:en: 20133
 ciqual_food_name:en: Parsnip, cooked
 ciqual_food_name:fr: Panais, cuit
 
+< en:Frozen vegetables
 < en:Parsnip
 en: Frozen parsnip
 fr: Panais surgelés
@@ -109137,6 +109200,7 @@ hr: Smrznute šparoge
 nl: Diepvries asperges
 
 < en:Frozen asparagus
+< en:Green asparagus
 en: Frozen green asparagus
 de: Tiefgekühlter grüner Spargel, Gefrohrene grüne Spargel
 es: Espárragos verdes congelados
@@ -109160,6 +109224,7 @@ hr: Smrznute cijele zelene šparoge
 nl: Hele groene diepvriesasperges
 
 < en:Frozen asparagus
+< en:White asparagus
 en: Frozen white asparagus
 de: Tiefgekühlter weißer Spargel, Gefrohrene weiße Spargel
 es: Espárragos blancos congelados
@@ -109403,7 +109468,7 @@ opposite:en: en:frozen-aubergines
 sales_format:en: package, weight
 season_in_country_fr:en: 6,7,8,9
 
-< en: Aubergines
+< en:Aubergines
 < en:Frozen vegetables
 en: Frozen aubergines
 bg: Замразени патладжани
@@ -109531,7 +109596,7 @@ pt: Beterraba embalada a vácuo
 expected_ingredients:en: en:beetroot
 opposite:en: en:raw-beetroot, en:canned-beetroot
 
-< en:Beet
+< en:Cooked beetroots
 < en:Frozen vegetables
 en: Frozen cooked beet, Frozen cooked beetroots
 fr: Betteraves rouges cuites surgelées
@@ -109674,6 +109739,7 @@ ciqual_food_name:fr: Brocoli, surgelé, cru
 expected_ingredients:en: en:broccoli
 opposite:en: en:fresh-broccoli
 
+< en:Cooked broccoli
 < en:Frozen broccolis
 en: Frozen cooked broccoli
 fr: Brocoli surgelé cuit
@@ -109683,6 +109749,8 @@ ciqual_food_name:en: Broccoli, frozen, cooked
 ciqual_food_name:fr: Brocoli, surgelé, cuit
 
 < en:Frozen broccolis
+< en:Frozen mashed vegetables
+< en:Mashed broccoli
 en: Frozen mashed broccolis
 fr: Purée de brocoli surgelée
 
@@ -112567,6 +112635,7 @@ ciqual_food_name:en: Sweet potato, cooked
 ciqual_food_name:fr: Patate douce, cuite
 expected_ingredients:en: en:sweet-potatoes
 
+< en:Frozen vegetables
 < en:Sweet potatoes
 en: Frozen sweet potatoes
 fr: Patates douces surgelées
@@ -113042,7 +113111,6 @@ es: Mezclas de verduras y hortalizas para cocido, Mezclas de vegetales para coci
 es: Mezclas de verduras y hortalizas para sopa, Mezclas de vegetales para sopa
 fr: Mélanges de légumes pour soupes
 
-< en:Frozen foods
 < en:Frozen mixed vegetables
 en: Frozen mixed vegetables for soups
 fr: Légumes surgelés pour potage
@@ -113352,6 +113420,7 @@ fr: Cresson frais
 nl: Waterkers (vers)
 season_in_country_fr:en: 1,2,3,4,5,9,10,11,12
 
+< en:Frozen vegetables
 < en:Leaf vegetables
 en: Frozen leaf vegetables
 fr: Légumes-feuilles surgelés, Légume-feuille surgelé
@@ -117194,6 +117263,7 @@ ciqual_food_code:en: 20267
 ciqual_food_name:en: Spring vegetables, frozen, raw (French beans, carrots, potatoes, green peas, onions)
 ciqual_food_name:fr: Printanière de légumes, surgelée, crue (haricots verts, carottes, pomme de terre, petits pois, oignons)
 
+< en:Frozen diced vegetables
 < en:Frozen mixed vegetables
 en: Frozen mixed diced vegetables
 fr: Macédoine de légumes surgelée
@@ -117210,7 +117280,7 @@ ciqual_food_code:en: 20265
 ciqual_food_name:en: Thinly-shredded or diced vegetables, frozen, raw
 ciqual_food_name:fr: Julienne ou brunoise de légumes, surgelée, crue
 
-< en:Frozen mixed vegetables
+< en:Frozen vegetables
 en: Frozen diced vegetables
 fr: Brunoise de légumes surgelée
 agribalyse_food_code:en: 20265
@@ -117304,6 +117374,7 @@ ciqual_food_name:en: Vegetables pan-fried or stir-fried, Asian-style, frozen, ra
 ciqual_food_name:fr: Poêlée de légumes assaisonnés à l'asiatiques ou wok de légumes, surgelée, crue
 
 < en:Frozen mixed vegetables
+< en:Pan-fried vegetables
 en: Frozen pan-fried Mediterranean-style grilled vegetables
 fr: Poêlée de légumes assaisonnés grillée méridionale surgelée, Poêlée de légumes assaisonnés grillée méditerranéenne surgelée
 agribalyse_food_code:en: 20274
@@ -117348,6 +117419,7 @@ es: Mezclas para sofrito congelada, Mezcla para sofrito congelada
 < en:Frozen plant-based foods mixes
 es: Parrilladas de verduras congelada, Parrillada de verduras congelada
 
+< en:Frozen potatoes
 < en:Roasted potatoes
 en: Frozen baked potatoes
 es: Patatas panadera congeladas
@@ -117376,6 +117448,8 @@ fr: Rondelles d'oignon panées, Onion rings panés, Onion rings
 hr: Pohani kolutići luka
 nl: Gepaneerde uienringen
 
+# “Frozen cereals and their products” as parent somehow cause a circular parent loop
+#< en:Frozen cereals and their products
 < en:Cereals and their products
 < en:Frozen plant-based foods
 en: Frozen cereals
@@ -117388,7 +117462,6 @@ gpc_category_code:en: 10000315
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a savoury grain not ready to eat product, such as Rice, Polenta, Couscous. These products must not include any additional ingredients and are not part of a recipe prior to sale. These products are not ready to eat and require cooking prior to consumption. These products must be refrigerated to extend their consumable life. Definition Excludes: Specifically excludes all grain based prepared products such as Risotto and Cereal Products. Excludes products such as Frozen and Shelf Stable Not Ready to Eat and Ready to Eat Grain and all Grain Based Prepared Recipe Products.
 gpc_category_name:en: Grains/Cereal - Not Ready to Eat - (Perishable)
 pnns_group_2:en: Cereals
-
 
 < en:Frozen cereals
 en: Frozen corn, Frozen maize, Frozen sweet corn
@@ -117938,6 +118011,7 @@ fr: Courgettes surgelées
 hr: Smrznute tikvice
 nl: Diepvriescourgettes
 
+< en:Frozen diced vegetables
 < en:Frozen zucchini
 en: Frozen diced zucchinis, Frozen diced courgettes
 de: Gefrorene gehackte Zucchini
@@ -119597,6 +119671,7 @@ it: Nugget vegetarianeìi
 nl: Vegetarische nuggets
 pl: Nuggetsy wegetariańskie
 
+< en:Frozen plant-based foods
 < en:Vegetarian nuggets
 en: Frozen vegetarian nuggets
 da: Frosne vegetariske nuggets
@@ -119648,6 +119723,7 @@ fr: Hachés végétaux
 hr: Vegetarijanska podloga
 pl: Mielone wegetariańskie, Wegetariańskie mielone
 
+< en:Frozen plant-based foods
 < en:Vegetarian grounds
 en: Frozen vegetarian grounds, frozen veggie grounds
 fr: Hachés végétaux surgelés
@@ -119723,6 +119799,7 @@ ciqual_food_code:en: 25234
 ciqual_food_name:en: Cereal patty (without soybean)
 ciqual_food_name:fr: Galette de céréales aux légumes (sans soja), préemballé
 
+< en:Frozen plant-based foods
 < en:Vegetarian patties
 en: Frozen vegetarian patties, frozen vegetarian steaks
 fr: Galettes végétariennes surgelées, Steaks végétariens surgelés
@@ -120553,6 +120630,7 @@ ciqual_food_code:en: 23402
 ciqual_food_name:en: Thin-crust pizza shell, raw
 ciqual_food_name:fr: Pâte à pizza fine, crue
 
+< en:Frozen foods
 < en:Pizza dough
 en: Frozen pizza dough
 fr: Pâtes à pizza surgelées, pâte à pizza surgelée
@@ -120852,6 +120930,7 @@ en: Hash Browns, hashed browns
 ja: ハッシュポテト
 wikidata:en: Q152981
 
+< en:Frozen foods
 < en:Rostis
 en: Frozen potato rostis
 fr: Röstis de pommes de terre surgelés
@@ -120944,6 +121023,7 @@ ciqual_food_code:en: 20285
 ciqual_food_name:en: Spinach, puree
 ciqual_food_name:fr: Épinard, purée
 
+< en:Cauliflowers
 < en:Mashed vegetables
 en: Mashed cauliflower
 de: Blumenkohlbreie
@@ -120951,6 +121031,8 @@ fr: Purées de choux-fleurs
 hr: Pasiranu cvjetaču
 nl: Bloemkoolpureeën
 
+< en:Frozen cauliflowers
+< en:Frozen mashed vegetables
 < en:Mashed cauliflower
 en: Frozen mashed cauliflower
 fr: Purées de choux-fleurs surgelées
@@ -121001,6 +121083,7 @@ ciqual_food_code:en: 20258
 ciqual_food_name:en: Vegetables (3-4 types), mashed
 ciqual_food_name:fr: Légumes (3-4 sortes en mélange), purée
 
+< en:Frozen vegetables
 < en:Mashed vegetables
 en: Frozen mashed vegetables
 fr: Purées de légumes surgelées
@@ -121931,7 +122014,7 @@ ciqual_food_code:en: 20237
 ciqual_food_name:en: Salsify, frozen, raw
 ciqual_food_name:fr: Salsifis, surgelé, cru
 
-< en:Frozen vegetables
+< en:Frozen salsify
 < en:Salsifis
 en: Frozen raw salsify
 fr: Salsifis surgelés crus
@@ -122116,6 +122199,7 @@ nl: Groentetortellini
 < en:Meals
 xx: Varenyky, vareniki
 
+< en:Frozen foods
 < xx:Varenyky
 en: Frozen varenyky, frozen vareniki
 fr: Varenyky surgelés
@@ -122384,7 +122468,7 @@ ciqual_food_name:en: Puff pastry, raw
 ciqual_food_name:fr: Pâte feuilletée, matière grasse végétale, crue
 
 < en:Frozen foods
-< en:Pie dough
+< en:Raw Puff pastry
 en: Frozen raw puff pastry
 fr: Pâte feuilletée surgelée crue
 ciqual_food_code:en: 23421
@@ -122392,7 +122476,7 @@ ciqual_food_name:en: Puff pastry, frozen, raw
 ciqual_food_name:fr: Pâte feuilletée, surgelée, crue
 
 < en:Frozen foods
-< en:Pie dough
+< en:Raw puff pastry with pure butter
 en: Frozen raw puff pastry with pure butter
 fr: Pâte feuilletée pur beurre surgelée crue
 ciqual_food_code:en: 23425
@@ -122608,15 +122692,14 @@ fr: Purées de pois cassés
 hr: Pire od graška
 nl: Gepureerde spliterwten
 
-< en:Frozen vegetables
+< en:Frozen butter beans
 en: Frozen raw butter beans, Frozen raw yellow beans
 fr: Haricots beurre surgelés crus
 ciqual_food_code:en: 20203
 ciqual_food_name:en: Butter bean or yellow bean, frozen, raw
 ciqual_food_name:fr: Haricot beurre, surgelé, cru
 
-< en:Frozen vegetables
-< en:Onions
+< en:Frozen onions
 en: Frozen raw onions
 fr: Oignons surgelés crus
 ciqual_food_code:en: 20235
@@ -122679,6 +122762,7 @@ fr: farces
 hr: Punjenje
 it: Stuffing
 
+< en:Frozen foods
 < en:stuffing
 en: Frozen stuffing
 fr: farces surgelées
@@ -122694,7 +122778,7 @@ ciqual_food_code:en: 0005
 ciqual_food_name:en: Dried deffated black soldier fly protein
 ciqual_food_name:fr: Insecte (Mouche Soldat Noir)
 
-< en:fruit-juices
+< en:Fruit juices
 en: Fruit juice mixed - apple base standard
 fr: Jus multifruit - base pomme standard
 hr: Voćni sok miješani - baza jabuka standard
@@ -122704,11 +122788,20 @@ ciqual_food_code:en: 2048
 ciqual_food_name:en: Fruit juice, mixed - apple base, standard
 ciqual_food_name:fr: Jus multifruit - base pomme, standard
 
-< en:fruit-juices
+#< en:Frozen foods
+< en:Fruit and vegetable juices
+en: Frozen fruit and vegetable juices, Frozen juices
+
+< en:Frozen fruit and vegetable juices
+< en:Fruit juices
+en: Frozen fruit juices
+
+< en:Fruit juices
 en: Citrus juices
 fr: Jus d'agrumes
 
 < en:Citrus juices
+< en:Frozen fruit juices
 en: Frozen citrus juices
 fr: Jus d'agrumes surgelés
 


### PR DESCRIPTION
A number of frozen food categories are currently not children of “Frozen foods”, and thus not counted/considered for the current Open Prices community challenge: https://prices.openfoodfacts.org/challenges/10

I tried doing all the dead animal categories too, but after doing a few of them, I started feeling ill and upset, so I skipped through those, leaving those for someone else to fix.

This includes new “Frozen fruit and vegetable juices” and “Frozen fruit juices” categories separate from “Frozen foods”.