### PR TITLE
fix: Remove unused Action::CircuitBreaker and Action::Retry dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,8 +111,6 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
         #
         # cpan dependencies that can be satisfied by apt even if the package itself can't:
         #
-        # Action::Retry
-        libmath-fibonacci-perl \
         # EV - event loop
         libev-perl \
         # Algorithm::CheckDigits

--- a/cpanfile
+++ b/cpanfile
@@ -87,8 +87,6 @@ requires 'Log::Log4perl', '>= 1.54, < 2.0'; # liblog-log4perl-perl
 requires 'Log::Any::Adapter::Log4perl', '>= 0.09'; # liblog-any-adapter-log4perl-perl
 
 # Retry
-requires 'Action::CircuitBreaker';
-requires 'Action::Retry'; # deps: libmath-fibonacci-perl
 requires 'LWP::UserAgent::Plugin';
 requires 'LWP::UserAgent::Plugin::Retry';
 

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -75,11 +75,7 @@ use JSON::MaybeXS;
 use CGI ':cgi-lib';
 use Log::Any qw($log);
 
-use Action::CircuitBreaker;
-use Action::Retry;
-
 my $client;
-my $action = Action::CircuitBreaker->new();
 
 =head1 FUNCTIONS
 
@@ -182,14 +178,7 @@ eval {
 =cut
 
 sub execute_query ($sub) {
-
-	return Action::Retry->new(
-		attempt_code => sub {$action->run($sub)},
-		on_failure_code => sub {my ($error, $h) = @_; die $error;},    # by default Action::Retry would return undef
-			# If we didn't get results from MongoDB, the server is probably overloaded
-			# Do not retry the query, as it will make things worse
-		strategy => {Fibonacci => {max_retries_number => 0,}},
-	)->run();
+	return $sub->();
 }
 
 sub execute_aggregate_tags_query ($query) {


### PR DESCRIPTION
### What

`Action::Retry` and `Action::CircuitBreaker` were essentially unused due to `max_retries_number` being set to `0`. We should just remove them.

### Screenshot

N/A

### Related issue(s) and discussion

N/A