### PR TITLE
chore: add a .log to apache log

### DIFF
--- a/conf/apache-2.4/sites-available/obf.conf
+++ b/conf/apache-2.4/sites-available/obf.conf
@@ -25,8 +25,8 @@ Require all granted
 <VirtualHost *>
 DocumentRoot /srv/obf/html
 ServerName openbeautyfacts.org
-ErrorLog /srv/obf/logs/error_log_${APACHE2_PORT}
-CustomLog /srv/obf/logs/access_log_${APACHE2_PORT} proxy
+ErrorLog /srv/obf/logs/error_log_${APACHE2_PORT}.log
+CustomLog /srv/obf/logs/access_log_${APACHE2_PORT}.log proxy
 LogLevel warn
 ScriptAlias /cgi/ "/srv/obf/cgi/"
 

--- a/conf/apache-2.4/sites-available/off-pro.conf
+++ b/conf/apache-2.4/sites-available/off-pro.conf
@@ -26,8 +26,8 @@ Require all granted
 <VirtualHost *>
 DocumentRoot /srv/off-pro/html
 ServerName pro.openfoodfacts.org
-ErrorLog /srv/off-pro/logs/error_log_${APACHE2_PORT}
-CustomLog /srv/off-pro/logs/access_log_${APACHE2_PORT} proxy
+ErrorLog /srv/off-pro/logs/error_log_${APACHE2_PORT}.log
+CustomLog /srv/off-pro/logs/access_log_${APACHE2_PORT}.log proxy
 LogLevel warn
 ScriptAlias /cgi/ "/srv/off-pro/cgi/"
 

--- a/conf/apache-2.4/sites-available/opf.conf
+++ b/conf/apache-2.4/sites-available/opf.conf
@@ -25,8 +25,8 @@ Require all granted
 <VirtualHost *>
 DocumentRoot /srv/opf/html
 ServerName openproductsfacts.org
-ErrorLog /srv/opf/logs/error_log_${APACHE2_PORT}
-CustomLog /srv/opf/logs/access_log_${APACHE2_PORT} proxy
+ErrorLog /srv/opf/logs/error_log_${APACHE2_PORT}.log
+CustomLog /srv/opf/logs/access_log_${APACHE2_PORT}.log proxy
 LogLevel warn
 ScriptAlias /cgi/ "/srv/opf/cgi/"
 

--- a/conf/apache-2.4/sites-available/opff.conf
+++ b/conf/apache-2.4/sites-available/opff.conf
@@ -26,8 +26,8 @@ Require all granted
 <VirtualHost *>
 DocumentRoot /srv/opff/html
 ServerName openpetfoodfacts.org
-ErrorLog /srv/opff/logs/error_log_${APACHE2_PORT}
-CustomLog /srv/opff/logs/access_log_${APACHE2_PORT} combined
+ErrorLog /srv/opff/logs/error_log_${APACHE2_PORT}.log
+CustomLog /srv/opff/logs/access_log_${APACHE2_PORT}.log combined
 LogLevel warn
 ScriptAlias /cgi/ "/srv/opff/cgi/"
 


### PR DESCRIPTION
important because the logrotate is based upon this extension

(currently obf/opf/opff/off-pro logs are not rotated since a very long time).