### PR TITLE
fix: add back missing old nutriscore details template

### DIFF
--- a/templates/web/pages/product/includes/nutriscore_details.tt.html
+++ b/templates/web/pages/product/includes/nutriscore_details.tt.html
@@ -1,0 +1,36 @@
+<!-- start templates/[% component.name %] -->
+
+<p>[% beverage_view %]</p>
+
+[% IF is_fat %]
+  <p>[% lang('nutriscore_proteins_is_added_fat') %]</p>
+[% END %]
+
+[% FOREACH group IN points_groups %]
+
+  <p> 
+    <strong>[% lang("nutriscore_${group.type}_points") %][% sep %]: [% group.points %]</strong> 
+  </p>
+
+  <ul>
+    [% FOREACH nutrient IN group.nutrients %]
+      <li>
+        <strong>[% lang("nutriscore_points_for_${nutrient.id}") %][% sep %]:
+[% nutrient.points %]&nbsp;</strong>/&nbsp;[% nutrient.maximum %][% lang("points") %]
+([% lang("nutriscore_source_value") %][% sep %]: [% nutrient.value %], 
+        [% lang('nutriscore_rounded_value') %][% sep %]: [% nutrient.rounded %])
+      </li>
+    [% END %]
+  </ul>
+
+[% END %]
+
+<p>[% nutriscore_protein_info %]</p>
+
+<p>
+  <strong>[% lang('nutriscore_score') %][% sep %]: [% score %]</strong>
+  ([% negative_points %] - [% positive_points %])
+</p>
+<p><strong>[% lang('nutriscore_grade') %][% sep %]: [% grade %]</strong></p>
+
+<!-- end templates/[% component.name %] -->


### PR DESCRIPTION
Removed by error in https://github.com/openfoodfacts/openfoodfacts-server/pull/12714/changes#top as it is still used on the pro platform.

Fixes #12961

<img width="838" height="786" alt="image" src="https://github.com/user-attachments/assets/8699099f-9880-4121-b0f9-dfa746ff6445" />
