### PR TITLE
fix: display error message for oidc_signin_no_cookie

### DIFF
--- a/lib/ProductOpener/Auth.pm
+++ b/lib/ProductOpener/Auth.pm
@@ -155,7 +155,7 @@ The return URL after successful authentication.
 
 sub signin_callback ($request_ref) {
 	if (not(defined cookie($cookie_name))) {
-		display_error_and_exit(lang('oidc_signin_no_cookie'), 400);
+		display_error_and_exit($request_ref, lang('oidc_signin_no_cookie'), 400);
 		return;
 	}
 


### PR DESCRIPTION
Fixes "Too few arguments for subroutine 'ProductOpener::Display::display_error_and_exit' at /opt/product-opener/lib/ProductOpener/Auth.pm line 158."
