### PR TITLE
taxonomy(food): rice edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -43296,14 +43296,14 @@ ciqual_food_name:en: Quinoa FR, boiled/cooked in water, unsalted
 ciqual_food_name:fr: Quinoa FR, cuit
 
 < en:Cereal grains
-en: Rices
+en: Rices, Rice
 bg: Ориз
 ca: Arrossos
 cs: Rýže
 da: Ris
 de: Reise, Reis
 es: Arroces, Arroz
-fi: riisit
+fi: Riisit
 fr: Riz
 he: אורז
 hr: riže, riža
@@ -43312,7 +43312,9 @@ it: Riso
 ja: 米
 la: Oryza sativa
 lt: Ryžiai
+nb: Ris
 nl: Rijst
+nn: Ris
 pl: Ryże
 pt: Arrozes
 ru: Рис
@@ -43336,6 +43338,7 @@ ciqual_food_name:fr: Riz complet, cru
 < en:Rices
 en: Brown rices
 bg: Кафяв ориз
+da: Brune ris
 de: Brauner Reis
 es: Arroces integrales, Arroces cargo
 fi: ruskeat riisit
@@ -43345,6 +43348,7 @@ it: Riso integrale
 ja: 玄米
 lt: Rudieji ryžiai
 nl: Zilverlvliesrijsten, Volkoren rijsten, Volkorenrijsten
+sv: Bruna ris
 agribalyse_food_code:en: 9102
 ciqual_food_code:en: 9102
 ciqual_food_name:en: Rice, brown, raw
@@ -43353,6 +43357,7 @@ wikidata:en: Q1066624
 
 < en:Brown rices
 en: Cooked brown rices
+da: Kokte brune ris
 fr: Riz complet cuit
 agribalyse_proxy_food_code:en: 9103
 agribalyse_proxy_food_name:en: Rice, brown, cooked, unsalted
@@ -43360,6 +43365,7 @@ agribalyse_proxy_food_name:fr: Riz complet, cuit, non salé
 
 < en:Cooked brown rices
 en: Unsalted cooked brown rices
+da: Usaltede kokte brune ris
 fr: Riz complet cuit non salé
 agribalyse_food_code:en: 9103
 ciqual_food_code:en: 9103
@@ -43372,10 +43378,12 @@ de: Ungedroschener Reis
 es: Arroces en cáscara, Arroces con cáscara, Arroces cáscara, Arroces paddy
 fr: Riz paddy
 hr: Neoljuštene riže
+wikidata:en: Q110461730
 
 < en:Rices
 en: Parboiled rices
 bg: Бланширан ориз
+da: Parboiled ris
 de: Gekochter Reis
 es: Arroces vaporizados, Arroces sancochados, Arroces parboiled
 fi: Parboiled-riisit
@@ -43393,6 +43401,7 @@ wikidata:en: Q732925
 < en:White rices
 en: Parboiled white rices
 bg: Бланширан бял ориз
+da: Parboiled hvide ris
 fr: Riz blanc étuvé
 hr: Prokuhana bijela riža
 agribalyse_food_code:en: 9101
@@ -43403,6 +43412,7 @@ ciqual_food_name:fr: Riz blanc étuvé, cru
 < en:Rices
 en: White rices
 bg: Бял ориз
+da: Hvide ris
 de: Weißer Reis
 es: Arroces blancos
 fi: valkoiset riisit
@@ -43413,6 +43423,7 @@ ja: 白米
 lt: Baltieji ryžiai
 nl: Witte rijst
 pl: Ryż biały
+sv: Vita ris
 agribalyse_food_code:en: 9100
 ciqual_food_code:en: 9100
 ciqual_food_name:en: Rice, raw
@@ -43462,7 +43473,7 @@ ru: Рис Индика
 wikidata:en: Q5360953
 
 < en:Rices
-en: Japonica rices
+en: Japonica rices, Sinica rices
 de: Japonica Reis
 es: Arroces de la variedad japónica
 fi: Japonica-riisit
@@ -43470,13 +43481,15 @@ fr: Riz de variété japonica
 hr: Japonica riža
 it: Risi Japonica
 ja: ジャポニカ米
+la: Oryza sativa japonica
 nl: Japonica rijst
-#wikidata:en:
+wikidata:en: Q1147035
 
 < en:Rices
 en: Long grain rices
 bg: Дългозърнест ориз
 ca: Arròs de gra llarg
+da: Langkornede ris
 de: Langkornreis
 es: Arroces de grano largo
 fi: pitkäjyväiset riisit
@@ -43486,6 +43499,7 @@ it: Riso a grano lungo
 lt: Ilgagrūdžiai ryžiai
 nl: Langgraanrijst
 pt: Arrozes agulha
+sv: Långkorniga ris
 incompatible_with:en: categories:en:short-grain-rices, categories:en:medium-grain-rices
 wikidata:en: Q67594028
 
@@ -43499,12 +43513,14 @@ fr: Riz pilavlik, riz pour pilaf
 
 < en:Rices
 en: Medium grain rices
+da: Mediumkornede ris
 de: Mittelkornreis
 es: Arroces de grano medio, Arroces de grano semilargo
 fr: Riz à grain médium, Riz à grain moyen
 hr: Riže srednjeg zrna
 it: Risi di grano medio
 nl: Mediumgraanrijst
+sv: Mellankorniga ris
 incompatible_with:en: categories:en:short-grain-rices, categories:en:long-grain-rices
 
 < en:Medium grain rices
@@ -43516,7 +43532,8 @@ en: Sona Masoori rices
 fr: Riz Sona Masoori, riz Sona Mahsuri
 
 < en:Rices
-en: Short grain rices
+en: Short grain rices, Round grain rices
+da: Kortkornede ris
 de: Rundkornreise
 es: Arroces de grano corto, Arroces de grano redondo
 fi: lyhytjyväiset riisit
@@ -43525,7 +43542,9 @@ hr: Riže kratkog zrna
 it: Riso a grano corto, Riso a grana corta
 lt: Trumpagrūdžiai ryžiai
 nl: Korrelrijst
+sv: Rundkorniga ris
 incompatible_with:en: categories:en:long-grain-rices, categories:en:medium-grain-rices
+wikidata:en: Q67593960
 
 < en:Short grain rices
 en: Camolino rices
@@ -43541,6 +43560,14 @@ hr: Riže za paellu
 nl: Paellarijst
 #wikidata:en:
 
+< en:Short grain rices
+en: Rices for porridge, porridge rices
+da: Grødris
+fi: Puuroriisi
+nb: Grødris
+sv: Grötris
+wikidata:en: Q78439308
+
 < en:Rices
 en: Rices for risotto
 bg: Ориз за ризото
@@ -43553,7 +43580,7 @@ it: Riso per risotto
 nl: Risottorijsten
 pl: Ryż do risotto, Ryż na risotto
 pt: Arrozes para risotto
-#wikidata:en:
+wikidata:en: Q67438406
 
 < en:Rices for risotto
 en: Sant'Andrea Rices
@@ -43562,6 +43589,7 @@ fr: Riz Sant'Andrea
 < en:Rices
 en: Sushi rice, Rices for sushi
 bg: Ориз за суши
+da: Sushiris
 de: Sushi Reis
 es: Arroces para sushi
 fr: Riz pour sushi
@@ -43569,16 +43597,9 @@ hr: Sushi riža
 it: Riso per sushi, riso da sushi
 lt: Sushi ryžiai
 nl: Sushirijsten
+sv: Sushiris
 zh: 寿司米
 wikidata:en: Q10861403
-
-< en:Rices
-en: Unsalted cooked red rice
-fr: Riz rouge cuit non salé
-agribalyse_food_code:en: 9110
-ciqual_food_code:en: 9110
-ciqual_food_name:en: Rice, red, cooked, unsalted
-ciqual_food_name:fr: Riz rouge, cuit, non salé
 
 < en:Rices
 en: Red rices, red rice
@@ -43595,6 +43616,14 @@ ciqual_food_name:en: Rice, red, raw
 ciqual_food_name:fr: Riz rouge, cru
 sales_format:en: weight, package
 wikidata:en: Q7305375
+
+< en:Red rices
+en: Unsalted cooked red rice
+fr: Riz rouge cuit non salé
+agribalyse_food_code:en: 9110
+ciqual_food_code:en: 9110
+ciqual_food_name:en: Rice, red, cooked, unsalted
+ciqual_food_name:fr: Riz rouge, cuit, non salé
 
 < en:Red rices
 fr: Riz rouge du Bhoutan
@@ -68474,13 +68503,15 @@ protected_name_file_number:en: PGI-ES-0139
 protected_name_type:en: pgi
 #wikidata:en:
 
-< en:Vegetables from Spain
-en: Rice
+< en:Rices
+< en:Spanish cereals
+en: Rice from Valencia, Valencia rice
+da: Valencia-ris
 es: Arroz de Valencia, Arròs de València
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0151
 protected_name_type:en: pdo
-#wikidata:en:
+wikidata:en: Q8205083
 
 < en:Spanish fruits
 es: Melocotón de Calanda

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -28535,9 +28535,8 @@ it: mais estruso
 #                                                 R I C E
 #
 #################################################################################################################
-# description:en:Rice is the seed of the grass species Oryza sativa (Asian rice) or Oryza glaberrima (African rice).
 
-#<en:cereal
+#< en:cereal
 en: rice
 af: Rys
 am: ሩዝ
@@ -28665,83 +28664,84 @@ yi: רייז
 za: Haeuxbieg
 zh: 稻
 zu: ilayisi
+#aeb-arab: روز
+#arc: ܪܘܙܐ
+#arz: رز
+#ast: arroz
+#atj: Miromin
+#azb: دویو
+#bar: Reis
+#bcl: Paroy
+#be-tarask: Рыс
+#bho: चाउर
+#bjn: Banih
+#bqi: برنج
+#bxr: Тутарга
+#cdo: Dêu
+#ckb: برنج
+#crh-latn: pirinç
+#de-ch: Reis
+#din: Lop
+#dty: धान
+#en-ca: Rice
+#en-gb: Rice
+#gag: pirinç
+#gan: 禾
+#gsw: Riis
+#hak: Vò-é
+#hif: Bhaat
+#hsb: Rajs
+#ilo: bagas
+#inh: Дуга
+#jam: Rais
+#jbo: rismi
+#kbd: Прунж
+#kbp: Mɔʋ
+#krc: принч
+#lad: Arroz
+#lbe: Ппиринж
+#lez: Дуьгуь
+#lfn: Ris
+#lij: Riso
+#lmo: Ris
+#lzh: 稻
+#mai: धान
+#mzn: برنج
+#nah: Ācintli
+#nan: Tiū
+#nds: Ries
+#nds-nl: Ries
+#new: जाकि
+#ota: برنج
+#pam: Pale
+#pap: aros
+#pnb: چاول
+#pt-br: arroz
+#roa-tara: rise
+#rup: Urizu
+#sah: Рис
+#sat: ᱫᱟᱠᱟ
+#sco: Rice
+#sgs: Rīžā
+#sr-ec: пиринач
+#sr-el: pirinač
+#srn: aleysi
+#tet: hare
+#tt-cyrl: дөге
+#vec: Rixo
+#vro: Riis
+#war: Humay
+#wuu: 稻
+#xmf: ორზა
+#yue: 稻米
+#zh-hant: 米
 carbon_footprint_fr_foodges_ingredient:fr: Riz jasmin (Thaïlande)
 carbon_footprint_fr_foodges_value:fr: 1.4
 ciqual_proxy_food_code:en: 9100
 ciqual_proxy_food_name:fr: Riz blanc, cru
+description:en: Rice is the seed of the grass species Oryza sativa (Asian rice) or Oryza glaberrima (African rice).
 vegan:en: yes
 vegetarian:en: yes
-# aeb-arab:روز
-# arc:ܪܘܙܐ
-# arz:رز
-# ast:arroz
-# atj:Miromin
-# azb:دویو
-# bar:Reis
-# bcl:Paroy
-# be-tarask:Рыс
-# bho:चाउर
-# bjn:Banih
-# bqi:برنج
-# bxr:Тутарга
-# cdo:Dêu
-# ckb:برنج
-# crh-latn:pirinç
-# de-ch:Reis
-# din:Lop
-# dty:धान
-# en-ca:Rice
-# en-gb:Rice
-# gag:pirinç
-# gan:禾
-# gsw:Riis
-# hak:Vò-é
-# hif:Bhaat
-# hsb:Rajs
-# ilo:bagas
-# inh:Дуга
-# jam:Rais
-# jbo:rismi
-# kbd:Прунж
-# kbp:Mɔʋ
-# krc:принч
-# lad:Arroz
-# lbe:Ппиринж
-# lez:Дуьгуь
-# lfn:Ris
-# lij:Riso
-# lmo:Ris
-# lzh:稻
-# mai:धान
-# mzn:برنج
-# nah:Ācintli
-# nan:Tiū
-# nds:Ries
-# nds-nl:Ries
-# new:जाकि
-# ota:برنج
-# pam:Pale
-# pap:aros
-# pnb:چاول
-# pt-br:arroz
-# roa-tara:rise
-# rup:Urizu
-# sah:Рис
-# sat:ᱫᱟᱠᱟ
-# sco:Rice
-# sgs:Rīžā
-# sr-ec:пиринач
-# sr-el:pirinač
-# srn:aleysi
-# tet:hare
-# tt-cyrl:дөге
-# vec:Rixo
-# vro:Riis
-# war:Humay
-# wuu:稻
-# xmf:ორზა
-# yue:稻米
-# zh-hant:米
 wikidata:en: Q5090
 wikipedia:en: https://en.wikipedia.org/wiki/Rice
 
@@ -28877,29 +28877,39 @@ wikidata:en: Q115443
 en: semi-whole rice, semi-wholemeal rice
 fr: riz semi-complet
 
-#category/brown-rices
 < en:rice
-en: brown rice, full grain rice, wholegrain rice, whole rice, whole grain brown rice
+en: whole grain rice, full grain rice, wholegrain rice, whole rice
+da: fuldkornsris
+de: Vollkornreis
+fi: täysjyväriisi
+fr: riz complet
+nl: volkorenrijst
+nn: fullkornris
+sv: fullkornris
+
+#category/brown-rices
+< en:whole grain rice
+en: brown rice
 ar: أرز أسمر
-bg: кафяв пълнозърнест ориз, кафяв ориз
+bg: кафяв ориз
 ca: arròs integral
 cs: celozrnná rýže, hnědá rýže
-da: brune ris
-de: Vollkornreis, brauner Vollkornreis
+da: brunt ris, brune ris
+de: brauner Reis
 es: arroz integral
-fi: tumma riisi, täysjyväriisi, ruskea kokojyväriisi
-fr: riz complet, riz brun, riz brun complet
+fi: tumma riisi
+fr: riz brun
 hr: smeđa riža
 hu: barna rizs, barnarizs, teljes kiőrlésű rizs, teljes értékű rizs
 it: riso integrale
 ja: 玄米
-nl: zilvervliesrijst, volkorenrijst, bruine rijst
-nn: brune fullkornris
+nl: zilvervliesrijst, bruine rijst
+nn: brune ris
 pl: ryż brązowy
 pt: arroz integral
 ru: kоричневый рис
 sl: rjavi riž
-sv: brunt fullkornris, råris
+sv: brunt ris, råris
 th: ข้าวกล้อง
 ciqual_food_code:en: 9102
 ciqual_food_name:en: Rice, brown, raw
@@ -28909,11 +28919,14 @@ wikidata:en: Q1066624
 
 < en:brown rice
 en: whole grain brown rice, wholegrain brown rice
+bg: кафяв пълнозърнест ориз
 de: brauner Vollkornreis
-es: Arroz integral
-fr: Riz brun complet
+fi: ruskea kokojyväriisi
+fr: riz brun complet
 hr: integralna smeđa riža
 nl: volkoren rijst
+nn: brune fullkornris
+sv: brunt fullkornris
 
 < en:brown rice
 #<en:organic rice
@@ -28945,6 +28958,7 @@ en: white rice
 ar: أرز أبيض
 bg: бял ориз
 ca: arròs blanc
+da: hvidt ris, hvide ris
 de: weißer Reis
 el: λευκό ρύζι
 eo: blanka rizo
@@ -28962,6 +28976,7 @@ ko: 백미
 nl: witte rijst
 pl: ryż biały
 pt: arroz branco
+sv: vitt ris, vita ris
 vi: gạo trắng
 zh: 白米
 ciqual_food_code:en: 9100
@@ -28980,8 +28995,8 @@ wikidata:en: Q2674257
 
 < en:Italian rice
 < en:parboiled rice
-< en:rice
-en: Italian Black Parboiled Brown Rice
+< en:whole grain rice
+en: parboiled Italian black whole grain rice, Italian Black Parboiled Brown Rice
 de: Italienischer Schwarzer Parboiled Vollkornreis
 es: Arroz Integral Venere Vaporizado
 fr: Riz moyen à grains noirs complet étuvé
@@ -28994,6 +29009,7 @@ pt: Arroz Integral Venere Parboiled
 < en:rice
 en: long grain rice
 bg: дългозърнест ориз
+da: langkornet ris, langkornede ris
 de: Langkornreis
 es: Arros de grano largo, arroz largo
 fi: pitkäjyväinen riisi
@@ -29003,6 +29019,8 @@ hu: hosszú szemű rizs
 it: riso a chicco lungo
 nl: Langkorrelige rijst
 pl: ryż długoziarnisty
+sv: långkornigt ris, långkorniga ris
+wikidata:en: Q67594028
 # ingredient/fr:riz-long-grain has 46 products in 4 languages @2018-12-19
 # ingredient/fr:riz-long-blanc has 9 products in french @2018-12-19
 # ingredient/fr:riz-long has 26 products in french @2018-12-19
@@ -29015,6 +29033,7 @@ fr: riz long biologique
 hr: organska riža dugog zrna
 hu: bio hosszú szemű rizs
 it: riso biologico a grani lunghi
+sv: ekologisk långkornigt ris
 
 < en:long grain rice
 en: superior quality long grain rice
@@ -29025,8 +29044,8 @@ it: riso a grani lunghi di qualità superiore
 nl: langkorrelige rijst van hoogwaardige kwaliteit
 # ingredient/fr:riz-long-grain-de-qualite-superieure has 10 products in french @2019-05-25
 
+< en:organic long grain rice
 < en:superior quality long grain rice
-#<en:organic rice
 en: superior quality organic long grain rice
 fr: riz long grain biologique de qualite superieure
 it: riso a grani lunghi biologico di qualità superiore
@@ -29042,20 +29061,18 @@ hr: bijela riža dugog zrna
 hu: hosszú szemű fehérrizs
 it: riso bianco a grani lunghi
 pl: ryż biały długoziarnisty
+sv: långkornigt vitt ris
 # ingredient/fr:riz-long-grain-blanc has 4 products @2019-05-30
 
 < en:long grain white rice
+< en:superior quality long grain rice
 en: superior quality long grain white rice
 de: Premiumqualität weißer Langkornreis
 fr: riz blanc long grain de qualite superieure
 hr: vrhunska bijela riža dugog zrna
 it: riso bianco a grani lunghi di qualità superiore
 
-< en:white rice
-en: medium grain white rice
-hr: bijela srednjezrnata riža
-it: riso bianco a grana media
-
+< en:long grain white rice
 < en:organic long grain rice
 en: organic long grain white rice
 fi: luomu pitkäjyväinen valkoinen riisi
@@ -29066,13 +29083,13 @@ it: riso bianco a grani lunghi biologico
 < en:long grain rice
 fr: riz long semi complet
 
+< en:organic long grain rice
 < fr:riz long semi complet
-#<en:organic rice
 fr: riz long semi complet issu de l'agriculture-biologique
 
 < en:brown rice
 < en:long grain rice
-en: brown long grain rice, long grain brown rice
+en: long grain brown rice, brown long grain rice
 bg: кафяв дългозърнест ориз
 de: brauner Langkornreis
 fi: pitkäjyväinen tumma riisi, pitkäjyväinen täysjyväriisi
@@ -29081,11 +29098,13 @@ hr: smeđa riža dugog zrna
 hu: hosszú szemű barnarizs
 it: riso integrale a grani lunghi
 nl: langkorrelige zilvervliesrijst
+sv: långkornigt brunt ris
+wikidata:en: Q95733958
 # ingredient/fr:riz-long-complet has 13 products @2019-05-29
 
-< en:brown long grain rice
-< en:parboiled rice
-en: parboiled brown long grain rice
+< en:long grain brown rice
+< en:long grain parboiled rice
+en: parboiled long grain brown rice, parboiled brown long grain rice
 de: brauner Parboiled Langkornreis
 fi: parboil-käsitelty pitkäjyväinen tumma riisi, parboil-käsitelty pitkäjyväinen täysjyväriisi
 fr: riz complet long grain étuvé, riz long complet etuve
@@ -29120,8 +29139,8 @@ sv: långkornigt parboil ris
 < en:parboiled long grain rice
 fr: riz long italien étuvé
 
+< en:organic long grain rice
 < en:parboiled long grain rice
-#<en:organic rice
 en: parboiled organic long grain rice
 da: økologisk parboiled langkornede ris
 de: Parboiled Bio-Langkornreis
@@ -29132,6 +29151,7 @@ it: riso parboiled biologico a grani lunghi
 nl: Witte langgraanrijst van biologische oorsprong parboiled
 
 < en:long grain parboiled rice
+< en:superior quality long grain rice
 en: superior quality long grain parboiled rice
 de: Hochwertiger langkörniger Parboiled-Reis
 es: arroz grano largo vaporizado de calidad superior
@@ -29140,8 +29160,7 @@ hr: prokuhana riža dugog zrna vrhunske kvalitete
 it: riso parboiled a grani lunghi di qualità superiore
 # ingredient/fr:riz-long-grain-étuvé-de-qualité-supérieure has 39 products in 2 languages @2018-12-19
 
-< en:brown rice
-< en:parboiled rice
+< en:parboiled long grain brown rice
 < en:superior quality long grain parboiled rice
 en: superior quality long grain parboiled brown rice
 de: brauner Spitzen-Langkornreis parboiled
@@ -29151,16 +29170,34 @@ hr: vrhunska kvaliteta parboiled smeđe riže dugog zrna
 it: riso integrale parboiled a grani lunghi di qualità superiore
 # ingredient/fr:riz-long-grain-complet-étuvé-de-qualite-superieure has 4 products @2019-05-29
 
+########################### MEDIUM GRAIN RICES #######################
+
+< en:rice
+en: medium grain rice
+da: mediumkornet ris, mediumkornede ris
+sv: mellankornigt ris, mellankorniga ris
+
+< en:medium grain rice
+< en:white rice
+en: medium grain white rice
+da: mediumkornet hvidt ris, mediumkornede hvide ris
+hr: bijela srednjezrnata riža
+it: riso bianco a grana media
+sv: mellankornigt vitt ris, mellankorniga vita ris
+
 ########################### ROUND RICES #######################
 
 < en:rice
 en: round rice
+da: kortkornet ris, kortkornede ris
 de: Rundkornreis, Milchreis
 fi: pyöreäjyväinen riisi
 fr: riz rond
 hr: okrugla riža
 hu: kerek rizs
 it: riso tondo
+sv: rundkornigt ris
+wikidata:en: Q67593960
 # ingredient/fr:riz-rond has 27 products in french @2019-05-28
 
 < en:round rice
@@ -29174,22 +29211,27 @@ it: riso tondo biologico
 # 2019-05-30
 
 < en:round rice
+< en:white rice
+en: white round rice
 fr: riz rond blanc, Riz rond blanchi
 nl: witte ronde rijst, ronde rijst wit
 # ingredient/fr:riz-rond-blanchi has 4 products @2019-05-29
 # ingredient/fr:riz-rond-blanc has 15 products @2019-05-29
 
-
-< fr:riz rond blanc
+< en:organic round rice
+< en:white round rice
+en: organic white round rice
 fr: riz rond blanc bio
 
 < en:round rice
+< en:semi-whole rice
 en: semi-whole round rice
 fr: riz rond semi-complet, riz rond complet légèrement poli
 hr: polucijela okrugla riža
 nl: halfvolkoren ronde rijst, volkoren ronde rijst lichtjes gepolijst
 
 < en:round rice
+< en:whole grain rice
 en: whole round rice
 fr: riz rond complet
 hr: cijela okrugla riža
@@ -29198,11 +29240,13 @@ nl: volkoren ronde rijst
 # ingredient/fr:riz-rond-complet has 19 products @2019-05-29
 
 < en:round rice
+en: superior quality round rice
 fr: riz rond de qualité supérieure
 # ingredient/fr:riz-rond-de-qualite-superieure has 11 products @2019-05-29
 
-< fr:riz rond de qualité supérieure
-#<en:organic rice
+< en:organic round rice
+< en:superior quality round rice
+en: organic superior quality round rice
 fr: riz rond biologique de qualité supérieure
 
 < en:rice
@@ -29216,6 +29260,7 @@ hr: riža za rižoto
 hu: rizottó rizs
 it: riso per risotto
 pt: arroz risotto
+wikidata:en: Q67438406
 # ingredient/fr:riz-pour-risotto has 8 products @2019-05-30
 
 < en:long grain rice
@@ -29223,7 +29268,7 @@ pt: arroz risotto
 fr: riz long pour risotto
 
 < en:parboiled rice
-< en:rice
+< en:risotto rice
 fr: riz pour risotto étuvé
 
 ########################### RICE SPECIES #######################
@@ -29242,6 +29287,7 @@ la: Zizania
 nl: wilde rijst
 pl: ryż dziki
 pt: arroz selvagem
+sv: vildris
 ciqual_food_code:en: 9108
 ciqual_food_name:en: Wild rice, raw
 ciqual_food_name:fr: Riz sauvage, cru
@@ -29327,10 +29373,8 @@ zh: 紫米
 wikidata:en: Q3434002
 wikipedia:en: https://en.wikipedia.org/wiki/Black_rice
 
-# description:en:BASMATI RICE is a variety of long, slender-grained aromatic rice which is traditionally from the Indian subcontinent.
-
 # <category:en:basmati-rices
-< en:rice
+< en:long grain rice
 en: basmati rice, basmati
 ar: بسمتي
 bg: ориз басмати, басмати
@@ -29365,20 +29409,23 @@ ta: பாசுமதி
 te: బాస్మతి బియ్యం
 th: บาสมาตี
 uk: басматі
-ciqual_food_code:en: 9119
-ciqual_food_name:en: Basmati rice, raw
-ciqual_food_name:fr: Riz thaï ou basmati, cru
-ecobalyse:en: cce078cf-3d3e-4153-a0a1-35555b2da639
-ecobalyse_labels_en_organic:en: dcdcb4d1-1793-4f1b-bd1f-7578d02e4fb1
 # bho:बासमती
 # pnb:باسمتی
 # yue:印度香米
+ciqual_food_code:en: 9119
+ciqual_food_name:en: Basmati rice, raw
+ciqual_food_name:fr: Riz thaï ou basmati, cru
+description:en: BASMATI RICE is a variety of long, slender-grained aromatic rice which is traditionally from the Indian subcontinent.
+ecobalyse:en: cce078cf-3d3e-4153-a0a1-35555b2da639
+ecobalyse_labels_en_organic:en: dcdcb4d1-1793-4f1b-bd1f-7578d02e4fb1
 wikidata:en: Q1649635
 wikipedia:en: https://en.wikipedia.org/wiki/Basmati
 # 1035 in 8 @2021-09-14
 
 < en:basmati rice
+< en:white rice
 en: white basmati rice
+da: hvidt basmatiris
 de: weißer Basmatireis
 fi: valkoinen basmatiriisi
 fr: riz basmati blanc
@@ -29386,11 +29433,14 @@ hr: bijela basmati riža
 hu: fehér basmati rizs, fehér baszmati rizs
 it: riso basmati bianco
 nl: witte basmatirijst
+sv: vitt basmatiris
 # ingredient/fr:riz-basmati-blanc has 11 products @2019-0529
 # ingredient/fr:riz-basmati-blanc has 11 products @2019-0529
 
 < en:basmati rice
+< en:brown rice
 en: brown basmati rice
+da: brunt basmatiris
 de: brauner Basmatireis
 fi: tumma basmatiriisi
 fr: riz basmati complet
@@ -29398,6 +29448,7 @@ hr: smeđa basmati riža
 hu: barna basmati rizs, barna baszmati rizs
 it: riso basmati integrale
 nl: volkoren basmati rijst
+sv: brunt basmatiris
 # ingredient/fr:riz-basmati-complet has 11 products @2019-05-29
 
 #<en:brown basmati rice
@@ -29418,11 +29469,13 @@ nl: langkorrelige basmatirijst
 # fr:riz-long-basmati has 14 products in french @2019-05-25
 
 < en:long grain basmati rice
+< fr:riz long grain naturellement parfumé
 fr: Riz basmati long grain naturellement parfumé
 # ingredient/fr:riz-basmati-long-grain-naturellement-parfume has 6 products 22019-05-29
 
 < en:long grain basmati rice
-en: high quality long grain Basmati rice
+< en:superior quality long grain rice
+en: superior quality long grain Basmati rice, high quality long grain Basmati rice
 de: Langkorn Basmatireis spitzenqualität
 fr: riz basmati long grain de qualité supérieure, riz long grain Basmati de qualité supérieure, riz long basmati de qualite superieure
 hr: visokokvalitetna basmati riža dugog zrna
@@ -29430,8 +29483,8 @@ it: riso basmati a grani lunghi di alta qualità
 nl: langkorrelige basmatirijst van hoogwaardige kwaliteit
 # ingredient/fr:riz-basmati-long-grain-de-qualite-superieure has 16 products in 3 languages @2019-05-23
 
-#<en:high quality long grain Basmati rice
-#<en:organic rice
+#< en:high quality long grain Basmati rice
+#< en:organic long grain rice
 #en:organic high quality long grain Basmati rice
 #fr:riz basmati long grain de qualite superieure issu de l'agriculture biologique
 
@@ -29443,17 +29496,17 @@ fi: parboil-käsitelty basmatiriisi
 # ingredient/fr:riz-basmati-précuit has 33 products in french @2018-12-19
 
 < en:basmati rice
-fr: riz basmati cuit
+< en:cooked rice
+en: cooked basmati rice
 de: Basmati-Reis gekocht
 fi: keitetty basmatiriisi, kypsennetty basmatiriisi
+fr: riz basmati cuit
 it: riso Basmati cotto
 nl: gekookte basmatirijst
 # ingredient/fr:riz-basmati-cuit has 93 products @2018-12-19
 
-# description:en:JASMINE RICE is a long-grain variety of fragrant rice (also known as aromatic rice). Its fragrance, reminiscent of jasmine and popcorn, results from the rice plant's natural production of aromatic compounds
-
 # <category:en:Jasmine rice
-< en:rice
+< en:long grain rice
 en: Thai rice, jasmine rice
 bg: ориз жасмин, тайландски ориз
 de: Thai-Reis, Jasmin-Reis
@@ -29465,6 +29518,7 @@ hu: jázminrizs, jázmin rizs
 it: riso tailandese, di riso tailandese, riso algelsomino
 nl: thaise rijst, jasmijnrijst
 sv: Jasminris
+description:en: JASMINE RICE is a long-grain variety of fragrant rice (also known as aromatic rice). Its fragrance, reminiscent of jasmine and popcorn, results from the rice plant's natural production of aromatic compounds
 wikidata:en: Q2733021
 wikipedia:en: https://en.wikipedia.org/wiki/Jasmine_rice
 # ingredient/fr:riz-thai has 23 products @2019-05-29


### PR DESCRIPTION
- Various Swedish, Danish, and other translations
- Taxonomy tree improvements (adding/fixing/… parent relationships)
- Adds new category for “porridge rice”
- Fixes `en:rice` actually referring to very specific rices, and not just generic “rice”
  - not keeping the synonym since most products under `en:rice` do not seem to be the Valencian kind: https://world.openfoodfacts.org/facets/categories/en:rice
- Separates out “whole grain rice” ingredient from “brown rice”
  - While all brown rice are whole grain, not all whole grain rice are brown.
- Make a new section in ingredients.txt for medium grain rice
  - Move the one medium grain rice ingredient into this section
  - Add separate “medium grain rice” ingredient
- Adds some Wikidata identifiers
- Some standardisation; e.g.,
  - position of ‘colour’ and “parboiled” in relation to “long grain” and other words
  - English translation of French “de qualité supérieure”

Source: https://sv.wikipedia.org/w/index.php?title=Gr%C3%B6tris&oldid=56936898
Source: https://sv.wikipedia.org/w/index.php?title=Ris&oldid=58670982
Source: https://da.wikipedia.org/w/index.php?title=Ris&oldid=12179019
Needed-for: https://se.openfoodfacts.org/product/20063184/gr%C3%B6tris-golden-sun