### PR TITLE
taxonomy: nutrient missing-prefix fixups

### DIFF
--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -6802,6 +6802,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Carnitine
 
 zz: melatonin
 xx: Melatonin
+en: Melatonin
 unit:en: µg
 wikidata:en: Q180912
 wikipedia:en: https://en.wikipedia.org/wiki/Melatonin


### PR DESCRIPTION
### What
Adds `en:` and `xx:` prefixes to the `nutrients.txt` taxonomy file where they are missing.

### Screenshot
N/A

### Related issue(s) and discussion
Resolves #13049.