### PR TITLE
taxonomy: fix formatting and metadata issues in containers.txt and business.txt

### DIFF
--- a/taxonomies/old/containers.txt
+++ b/taxonomies/old/containers.txt
@@ -43,7 +43,7 @@ en:Box
 bg:Кутия
 de:Kasten
 el:Κουτί
-nl:Boos
+nl:Doos
 nl_be:Doos
 fr:Boîte
 pt:Caixa
@@ -84,9 +84,8 @@ en:Tray
 bg:Тарелка
 de:Körbchen
 fr:Barquette
-nl:bakje, schaaltje
+nl:Bakje, Schaaltje
 hu:Tálca
-nlBakje, schaaltje
 pt:Tabuleiro, cuvete
 
 en:Film
@@ -115,7 +114,6 @@ fr:Emballage individuel
 nl:Individuele verpakking
 nl_be:Individuele verpakking
 el:Ατομική συσκευασία
-nl:Individuele verpakking
 pt:Embalagem individual
 hu:Egyéni csomagolás
 
@@ -131,8 +129,6 @@ hu:Dugó
 wikidata:en:Q49444
 
 fr:Puisette
-hu:Fa
-
 
 fr:Bâtonnet
 de:Stäbchen
@@ -145,7 +141,6 @@ fr:Tube
 nl:Tube
 nl_be:Tube
 hu:Cső
-nl:Tube
 pt:Bisnaga
 
 en:Can
@@ -163,7 +158,6 @@ de:Kapsel
 nl_be:Capsule
 nl:Capsule
 hu:Kapszula
-nl:Capsule
 pt:Cápsula
 
 fr:Gourde
@@ -176,13 +170,11 @@ fr:Assiette
 nl:Bord
 nl_be:Bord
 de:Teller
-nl:Bord
 pt:Prato
 
 fr:Filet
 de:Netz
 hu:Háló
-nl:Net
 pt:Rede, saco de rede
-nl:Net,Netje
-nl_be:Net,Netje
+nl:Net, Netje
+nl_be:Net, Netje

--- a/taxonomies/unused/business.txt
+++ b/taxonomies/unused/business.txt
@@ -25,7 +25,7 @@ xx: Agidra
 wikidata:en: Q137392498
 
 xx: Aguas Danone S.A.
-wikidata:en Q110888003
+wikidata:en: Q110888003
 
 xx: Albert Heijn B.V.
 wikidata:en: Q1653985
@@ -122,7 +122,7 @@ xx: Dr. Oetker B.V.
 wikidata:en: Q137476931
 
 xx: Dr. Oetker Frischeprodukte Moers KG
-code:en DE NW-303 EG
+code:en: DE NW-303 EG
 wikidata:en: Q137476948
 
 xx: Ekibio
@@ -134,7 +134,7 @@ wikidata:en: Q632030
 xx: Enrico B.V., Enrico Food
 wikidata:en: Q137428041
 
-xx:Flemmings B.V.
+xx: Flemmings B.V.
 code:en: NL 576 EU, NL 576 EG
 wikidata:en: Q137672647
 
@@ -167,7 +167,7 @@ xx: General Mills San Adrián SLU, General Mills San Adrián SLU (Spain)
 wikidata:en: Q137731201
 
 xx: Gepo Vleeswaren B.V.
-code: NL 534 EG
+code:en: NL 534 EG
 wikidata:en: Q137427861
 
 xx: Go-Tan B.V.
@@ -209,7 +209,7 @@ wikidata:en: Q2262314
 
 xx: かどや製油
 en: Kadoya Sesame Mills Inc., Kadoya Sesame Mills
-jp: かどや製油
+ja: かどや製油
 wikidata:en: Q11263994
 
 xx: Kaasmakerij Özgazi B.V.
@@ -245,7 +245,7 @@ xx: La vie est belle
 wikidata:en: Q49116253
 
 xx: Léa Nature
-wikkidata:en: Q16661663
+wikidata:en: Q16661663
 
 xx: Lidl Nederland GmbH
 wikidata:en: Q137208902
@@ -320,7 +320,7 @@ wikidata:en: Q131213649
 xx: Oatly AB
 wikidata:en: Q10605824
 
-xx: OLGA 
+xx: OLGA
 wikidata:en: Q137211129
 
 xx: Oriental Food Co. Ltd.
@@ -336,7 +336,7 @@ wikidata:en: Q137747079
 xx: Pepsico France
 wikidata:en: Q132058884
 
-xx: Perfetti van Nelle Benelux B.V., Q612524
+xx: Perfetti van Nelle Benelux B.V.
 wikidata:en: Q612524
 
 xx: Picnic
@@ -345,7 +345,7 @@ wikidata:en: Q32414703
 xx: pladis France
 wikidata:en: Q131214907
 
-xx: Plukon Processing Ommel B.V., Q135212975, NL 5056 EG
+xx: Plukon Processing Ommel B.V.
 code:en: NL 5056 EG
 wikidata:en: Q135212975
 
@@ -394,11 +394,11 @@ wikidata:en: Q55599661
 xx: Silvo
 wikidata:en: Q137552465
 
-xx: Smaakspecialist, Q136929961
+xx: Smaakspecialist
 wikidata:en: Q136929961
 
 xx: Societé Affineurs Franc-Comtois Reunis
-code: FR 25.039.003
+code:en: FR 25.039.003
 wikidata:en: Q137426255
 
 xx: Société Anonyme des Caves et des Producteurs Réunis de Roquefort, Société des Caves
@@ -461,7 +461,7 @@ code:en: NL 3119 EU
 wikidata:en: Q137399857
 
 xx: Vion Retail Groenlo
-code: NL 585 EU
+code:en: NL 585 EU
 wikidata:en: Q113486515
 
 xx: Vion Retail Nederland B.V.
@@ -485,7 +485,7 @@ xx: Walker's Shortbread Ltd
 wikidata:en: Q7962374
 
 xx: What's Cooking Ridderkerk B.V.
-code: NL 3565 EU
+code:en: NL 3565 EU
 wikidata:en: Q137840127
 
 xx: Wiha GmbH
@@ -496,5 +496,5 @@ code:en: NL 3776 EG
 wikidata:en: Q137399739
 
 xx: Zandvliet Vleeswaren II B.V.
-code NL 286 EG
+code:en: NL 286 EG
 wikidata:en: Q137476994


### PR DESCRIPTION
### What

This PR fixes formatting and metadata issues in the
`taxonomies/old/containers.txt` and `taxonomies/unused/business.txt` files.

Changes include:
- fixing typos and syntax issues
- normalizing wikidata and code fields
- correcting language tags
- removing duplicate or misplaced metadata
- minor formatting cleanup

No taxonomy meaning or structure was changed.