### PR TITLE
fix: Add null guards for high-impact warnings in production logs

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -939,7 +939,7 @@ Set two attributes to `request_ref`:
 =cut
 
 sub set_user_agent_request_ref_attributes ($request_ref) {
-	my $user_agent_str = user_agent();
+	my $user_agent_str = user_agent() // '';
 	$request_ref->{user_agent} = $user_agent_str;
 
 	my $is_crawl_bot = 0;
@@ -7673,7 +7673,7 @@ sub display_page ($request_ref) {
 
 	# Display a banner from users on Android or iOS
 
-	my $user_agent = $ENV{HTTP_USER_AGENT};
+	my $user_agent = $ENV{HTTP_USER_AGENT} // '';
 
 	# add a user_agent parameter so that we can test from desktop easily
 	if (defined single_param('user_agent')) {

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -3273,7 +3273,7 @@ sub process_product_edit_rules ($product_ref) {
 						}
 						else {
 							$action_log
-								= "product code $code - https://world.$server_domain/product/$code - edit rule $rule_ref->{name} - type: $type - condition: $condition \n";
+								= "product code $code - https://world.$server_domain/product/$code - edit rule $rule_ref->{name} - type: $type - condition: (none) \n";
 						}
 
 						if ($condition_ok) {

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -771,7 +771,7 @@ sub match_route ($request_ref) {
 
 	# Simple routing with fast hash key match with first component #
 	# api -> api_route
-	if (exists $routes{$request_ref->{components}[0]}) {
+	if (defined $request_ref->{components}[0] and exists $routes{$request_ref->{components}[0]}) {
 		my $route = $routes{$request_ref->{components}[0]};
 		$log->debug("route matched", {route => $request_ref->{components}[0]}) if $log->is_debug();
 		if ((not defined $route->{opt}{onlyif}) or ($route->{opt}{onlyif}($request_ref))) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -4062,6 +4062,7 @@ sub get_taxonomy_tag_synonyms ($target_lc, $tagtype, $tagid) {
 sub exists_taxonomy_tag ($tagtype, $tagid) {
 
 	my $taxonomy = $taxonomy_fields{$tagtype};
+	return 0 if not defined $taxonomy;
 
 	return (    (exists $translations_from{$taxonomy})
 			and (exists $translations_from{$taxonomy}{$tagid})


### PR DESCRIPTION
I picked the 5 most frequent warnings from the log sample and added null-safety checks to fix them.

## Changes:
Tags.pm: Added a guard clause in \`exists_taxonomy_tag\` to return early if taxonomy is undefined.
Display.pm: Defaulted \`\$user_agent\` to empty string if undefined.
Routing.pm: Checked if \`components[0]\` is defined before accessing it in the hash.
Products.pm: Replaced an interpolated string that was using an undefined \`\$condition\` with a static string.



Part of #13039