### PR TITLE
fix: only display map for geo-relevant facets (countries, origins, manufacturing_places, emb_codes)

### DIFF
--- a/docs/api/ref/schemas/product_meta.yaml
+++ b/docs/api/ref/schemas/product_meta.yaml
@@ -2,6 +2,9 @@ type: object
 description: |
   Metadata of a product (author, editors, creation date, etc.)
 
+required:
+  - created_t
+
 properties:
   created_t:
     type: integer

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -2448,9 +2448,17 @@ HTML
 				. $html;
 
 		}
+		
+		my %MAP_ENABLED_FACETS = map { $_ => 1 } qw(
+			countries
+			origins
+			manufacturing_places
+			emb_codes
+		);
+		my $current_facet = $tagtype;
 
-		# countries map?
-		if (keys %{$countries_map_data} > 0) {
+		if ($MAP_ENABLED_FACETS{$current_facet} && keys %{$countries_map_data} > 0) {
+
 			my $mapData = {
 				data => $countries_map_data,
 				links => $countries_map_links,
@@ -2463,6 +2471,7 @@ HTML
 			process_template('web/pages/countries_map/map_of_countries.tt.html',
 				$map_template_data_ref, \$map_html, $request_ref)
 				|| ($map_html .= 'template error: ' . $tt->error());
+
 			$html = $map_html . $html;
 		}
 


### PR DESCRIPTION
### Summary
This pull request fixes issue #13041 where non-geographic facets  were incorrectly displaying a world map.

### Cause
The map was rendered whenever `countries_map_data` contained entries, even for non-geographic facets.

### Fix
Introduced a whitelist of geo-related facets:
- countries 
- origins 
- manufacturing_places 
- emb_codes

Maps now only render when:
1. The facet is geo-relevant, and 
3. map data exists.