### PR TITLE
taxonomy: correction skewers

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -85242,7 +85242,7 @@ wikidata:en: Q43669693
 < en:Quiches with vegetables
 fr: Quiches aux épinards, Quiche à l'épinard, Tartes aux épinards
 
-< en:Quiches
+< en:Meals
 en: Salted crumbles
 
 < en:Meals


### PR DESCRIPTION
Meat skewers are not meat, they are meat preparations (unless containing 100% meat, which I haven't seen).