### PR TITLE
taxonomy(food): add ginger shot categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -7440,10 +7440,11 @@ nl: Aloe Vera sappen
 pl: Napoje z aloesem, Napoje aloesowe
 #wikidata:en:
 
-< en: Fruit and vegetable juices
+< en:Fruit and vegetable juices
 en: Ginger juices
 hu: Gyömbérlevek, Gyömbérlé
 nl: Gembersappen
+wikidata:en: Q3109441
 
 < en:Fruit-based beverages
 en: Beverages with orange
@@ -7559,6 +7560,42 @@ pl: Smoothie owocowe, Owocowe smoothie
 < en:Smoothies
 fr: Smoothie kiwi pomme ananas
 nl: Smoothie kiwi appel ananas
+
+< en:Non-alcoholic beverages
+< en:Plant-based beverages
+en: Fruit and vegetable shots
+da: Frugt- og grønsagsshots
+sv: Frukt- och grönsaksshots
+description:en: Beverages of (usually perceived-to-be healthy) juices meant to be drunk in small doses, e.g. like a shot.
+
+< en:Fruit and vegetable shots
+en: Ginger shots, Ginger shot
+da: Ingefærshots
+de: Ingwershot
+sv: Ingefärsshots
+wikidata:en: Q110609991
+
+< en:Fruit and vegetable shots
+en: Turmeric shots
+da: Gurkemejeshots
+sv: Gurkmejashots
+
+< en:Ginger shots
+< en:Turmeric shots
+en: Ginger and turmeric shots, Turmeric and ginger shots
+da: Ingefær- og gurkemejeshots, Gurkemeje- og ingefærshots
+sv: Ingefärs- och gurkmejashots, Gurkmeja- och ingefärsshots
+
+< en:Ginger shots
+en: Ginger shots with apple and lemon
+da: Ingefærshots med æble og citron
+sv: Ingefärsshots med äpple och citron
+
+< en:Beverages with orange
+< en:Ginger and turmeric shots
+en: Ginger and turmeric shots with orange\, apple\, and lemon
+da: Ingefær- og gurkemejeshots med appelsin\, æble og citron
+sv: Ingefärs- och gurkmejashots med apelsin\, äpple och citron
 
 #should contain only juices (beverage with 100% fruit) and not nectars (beverage with fruit, water and eventually sugar)
 < en:Fruit-based beverages

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -65509,7 +65509,6 @@ nl: gemalen galangawortel, laos
 #                                Ginger
 #
 ###################################################################################################
-# description:en:GINGER (Zingiber officinale) is a flowering plant whose rhizome, ginger root or simply ginger, is widely used as a spice or a folk medicine
 
 # <en:root vegetable
 < en:spice
@@ -65529,7 +65528,7 @@ bs: Đumbir
 ca: gingebre
 cs: zázvor, zázvorová, zázvoru
 cy: Sinsir
-da: Ingefær, Ingefær rod
+da: ingefær, ingefær rod
 de: Ingwer
 el: Πιπερόριζα, ζιγγίβερι
 eo: zingibro
@@ -65593,7 +65592,7 @@ sk: Ďumbier, zázvor
 sl: Ingver
 sr: ћумбир
 su: Jahé
-sv: ingefära
+sv: ingefära, ingefärs
 sw: Mtangawizi
 ta: இஞ்சி
 te: అల్లం
@@ -65612,10 +65611,6 @@ wo: jinjeer
 yi: אינגבער
 za: hing
 zh: 薑
-# en:gingembre has 1506 products in 8 languages @2018-10-25
-ciqual_food_code:en: 11074
-ciqual_food_name:en: Ginger, raw
-ciqual_food_name:fr: Gingembre, racine crue
 # ace:Halia
 # ang:Gingifer
 # arc:ܚܡܣܐ
@@ -65648,7 +65643,13 @@ ciqual_food_name:fr: Gingembre, racine crue
 # xmf:ginger
 # yue:薑
 # zh-tw:薑
+ciqual_food_code:en: 11074
+ciqual_food_name:en: Ginger, raw
+ciqual_food_name:fr: Gingembre, racine crue
+description:en: GINGER (Zingiber officinale) is a flowering plant whose rhizome, ginger root or simply ginger, is widely used as a spice or a folk medicine
+wikidata:en: Q35625
 wikipedia:en: https://en.wikipedia.org/wiki/Ginger
+# en:gingembre has 1506 products in 8 languages @2018-10-25
 
 #<en:ginger
 #en:organic ginger
@@ -86753,18 +86754,17 @@ de: färbende Frucht- und Pflanzenkonzentrate
 # <en:compound
 de: färbende Gemüsekonzentrate
 
-# description:en:CONCENTRATE is the form of substance which has had the majority of its base component (in the case of a liquid: the solvent) removed
-
 # TODO: improve parsing so this can live in processing only.
 # See comments on https://github.com/openfoodfacts/openfoodfacts-server/pull/12031
 en: concentrate
 hr: koncentrat
 nb: konsentrat
 sv: koncentrat
-# ingredients/en:concentrate has 288 products @2025-06-15
+description:en: CONCENTRATE is the form of substance which has had the majority of its base component (in the case of a liquid: the solvent) removed
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q1355665
+# ingredients/en:concentrate has 288 products @2025-06-15
 
 # <en:part
 < en:extract

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1161,7 +1161,6 @@ nl: vloeibaar, vloeibare
 pl: płyn, płyn z, masa z, masa, w płynie, płynny, płynna
 uk: рідкий
 
-# en:description:To increase the strength and diminish the bulk of, as of a liquid or an ore; to intensify, by getting rid of useless material.
 en: concentrated, concentrate, concentrates
 ar: مركز
 bg: концентрат, концентрат от
@@ -1192,6 +1191,7 @@ sr: Концентрат
 sv: koncentrerad, koncentrat, koncentrat från
 uk: концентрат, концентрований, концентрована, концентроване, концентровані, концентрати
 # en:wiktionary:concentrated
+description:en: To increase the strength and diminish the bulk of, as of a liquid or an ore; to intensify, by getting rid of useless material.
 wikidata:en: Q1355665
 
 #< en:for color
@@ -1261,7 +1261,6 @@ ja: ペースト, 練
 de: eingekochter
 nl: ingekookt
 
-#en:description:Water has been added to concentrate
 en: from concentrate
 bg: от концентрат
 ca: a base de concentrat, a partir de concentrat
@@ -1281,8 +1280,9 @@ pl: z koncentratu, z zagęszczonego, z zagęszczonych, z koncentratu z
 pt: a partir de concentrado, à base de concentrado
 ro: din concentrat
 sk: z koncentrátu
-sv: från koncentrat
+sv: från koncentrat, delvis från koncentrat
 uk: з концентрату
+description:en: Water has been added to concentrate
 
 #en:description:Dehydration by artificial or natural processes
 # anhydrous: No water, dehydrated: Water removed, dried: Less water.


### PR DESCRIPTION
This adds a parent “Fruit and vegetable shots” category, with “Ginger shots” and “Turmeric shots” as immediate children with additional grandchildren represented by some of the current ginger shot products in the database.

Includes some ginger shot related ingredient and processing edits.

Needed-for: https://se.openfoodfacts.org/product/7311043000517/shot-ingef%C3%A4ra-gurkmeja-apelsin-%C3%A4pple-citron-garant
Needed-for: https://se.openfoodfacts.org/product/7340083497803/shot-%C3%A4pple-ingef%C3%A4ra-citron-garant
Needed-for: https://world.openfoodfacts.org/facets/categories/en:ginger-shots
Needed-for: https://world.openfoodfacts.org/facets/categories/en:ginger-shot