### PR TITLE
fix: rename 'Suffering Fingerprint' to 'Suffering Footprint'

### DIFF
--- a/po/common/aa.po
+++ b/po/common/aa.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ak.po
+++ b/po/common/ak.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/am.po
+++ b/po/common/am.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "እነዚያ ምርጫዎች የተመሰረቱት በክፍት ምግብ እውነታዎች የንጥረ ነገር ዝርዝር ግንዛቤ ላይ ነው እና ሁልጊዜም ትክክል ወይም ሙሉ ላይሆን የሚችልበት እድል አለ፣ ሁልጊዜ ምርቱን እራስዎ ያረጋግጡ።"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -7650,7 +7650,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "تعتمد هذه التفضيلات على فهم Open Food Facts لقائمة المكونات، وهناك دائمًا احتمال ألا تكون دقيقة أو كاملة، لذا تحقق دائمًا من المنتج بنفسك."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "بصمة المعاناة"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/as.po
+++ b/po/common/as.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "সেই পছন্দসমূহ Open Food Facts ৰ উপাদানৰ তালিকাখনৰ বিষয়ে বুজাৰ ওপৰত ভিত্তি কৰি কৰা হয় আৰু ই সঠিক বা সম্পূৰ্ণ নহ’বও পাৰে বুলি সদায় সম্ভাৱনা থাকে, সদায় নিজেই প্ৰডাক্টটো পৰীক্ষা কৰক।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/az.po
+++ b/po/common/az.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Bu üstünlüklər Açıq Qida Faktlarının inqrediyentlər siyahısı haqqında anlayışına əsaslanır və onun dəqiq və ya tam olmama ehtimalı həmişə var, həmişə məhsulu özünüz yoxlayın."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/be.po
+++ b/po/common/be.po
@@ -7632,7 +7632,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Гэтыя перавагі заснаваныя на разуменні Open Food Facts спісу інгрэдыентаў, і заўсёды існуе верагоднасць таго, што ён можа быць недакладным або няпоўным, заўсёды правярайце прадукт самастойна."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -7648,7 +7648,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Тези предпочитания се основават на разбирането на Open Food Facts за списъка със съставки и винаги има вероятност той да не е точен или пълен, винаги проверявайте продукта сами."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/bm.po
+++ b/po/common/bm.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "O fɛɛrɛw bɛ bɔ Open Food Facts ka faamuyali la fɛnw lisɛli kan ani a bɛ se ka kɛ tuma bɛɛ ko a tɛ tiɲɛ ye walima ko a tɛ dafa, tuma bɛɛ aw yɛrɛ ye fura in lajɛ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "এই পছন্দগুলি ওপেন ফুড ফ্যাক্টসের উপাদান তালিকার বোঝার উপর ভিত্তি করে তৈরি এবং সর্বদা এটি সঠিক বা সম্পূর্ণ নাও হতে পারে, সর্বদা নিজেই পণ্যটি পরীক্ষা করে দেখুন।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/bo.po
+++ b/po/common/bo.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Diazezet eo an dibaboù-se war gompren Open Food Facts eus roll ar c'hementadoù ha bepred ez eus ur chañs da vezañ reizh pe klok, gwiriit ar produ hoc'h-unan bepred."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/bs.po
+++ b/po/common/bs.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Te preferencije se zasnivaju na razumijevanju liste sastojaka od strane Open Food Facts i uvijek postoji mogućnost da ona nije tačna ili potpuna, uvijek sami provjerite proizvod."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -7648,7 +7648,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Aquestes preferències es basen en la comprensió que fa Open Food Facts de la llista d'ingredients i sempre hi ha la possibilitat que no sigui precisa o completa; comproveu sempre el producte vosaltres mateixos."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ce.po
+++ b/po/common/ce.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/co.po
+++ b/po/common/co.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Queste preferenze sò basate nantu à a capiscitura di Open Food Facts di a lista di l'ingredienti è ci hè sempre a pussibilità chì ùn sia micca precisa o cumpleta, verificate sempre u pruduttu voi stessu."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -7749,8 +7749,8 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
-msgstr "Suffering Fingerprint"
+msgid "Suffering Footprint"
+msgstr "Suffering Footprint"
 
 msgctxt "external_sources_empreinte_souffrance_description"
 msgid "Indicator of animal suffering computed by product"

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -7643,8 +7643,8 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Tyto preference jsou založeny na tom, jak Open Food Facts chápe seznam složek, a vždy existuje možnost, že nemusí být přesný nebo úplný, proto si vždy produkt sami zkontrolujte."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
-msgstr "Suffering Fingerprint"
+msgid "Suffering Footprint"
+msgstr "Suffering Footprint"
 
 msgctxt "external_sources_empreinte_souffrance_description"
 msgid "Indicator of animal suffering computed by product"

--- a/po/common/cv.po
+++ b/po/common/cv.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ҫав кӑмӑл-туйӑмсем Open Food Facts компанийӗн ингредиентсен списокне ӑнланни ҫинче никӗсленеҫҫӗ, ҫавӑнпа та вӑл тӗрӗс мар е тулли пулма пултараймасть, яланах продукта хӑвӑр тӗрӗслӗр."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/cy.po
+++ b/po/common/cy.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Mae'r dewisiadau hynny'n seiliedig ar ddealltwriaeth Open Food Facts o'r rhestr gynhwysion ac mae yna bob amser bosibilrwydd nad yw'n gywir nac yn gyflawn, gwiriwch y cynnyrch eich hun bob amser."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Disse præferencer er baseret på Open Food Facts' forståelse af ingredienslisten, og der er altid en mulighed for, at den ikke er nøjagtig eller fuldstændig. Tjek altid produktet selv."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Diese Präferenzen basieren auf dem Verständnis der Zutatenliste durch Open Food Facts und es besteht immer die Möglichkeit, dass diese nicht genau oder vollständig ist. Überprüfen Sie das Produkt immer selbst."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -7647,7 +7647,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Αυτές οι προτιμήσεις βασίζονται στην κατανόηση της λίστας συστατικών από το Open Food Facts και υπάρχει πάντα η πιθανότητα να μην είναι ακριβής ή πλήρης, επομένως να ελέγχετε πάντα το προϊόν μόνοι σας."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Δακτυλικό αποτύπωμα που υποφέρει"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -7742,8 +7742,8 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
-msgstr "Suffering Fingerprint"
+msgid "Suffering Footprint"
+msgstr "Suffering Footprint"
 
 msgctxt "external_sources_empreinte_souffrance_description"
 msgid "Indicator of animal suffering computed by product"

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -7648,8 +7648,8 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
-msgstr "Suffering Fingerprint"
+msgid "Suffering Footprint"
+msgstr "Suffering Footprint"
 
 msgctxt "external_sources_empreinte_souffrance_description"
 msgid "Indicator of animal suffering computed by product"

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -7648,8 +7648,8 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
-msgstr "Suffering Fingerprint"
+msgid "Suffering Footprint"
+msgstr "Suffering Footprint"
 
 msgctxt "external_sources_empreinte_souffrance_description"
 msgid "Indicator of animal suffering computed by product"

--- a/po/common/eo.po
+++ b/po/common/eo.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Tiuj preferoj baziĝas sur la kompreno de Open Food Facts pri la listo de ingrediencoj kaj ĉiam ekzistas ebleco, ke ĝi eble ne estas preciza aŭ kompleta, ĉiam kontrolu la produkton mem."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -7645,7 +7645,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Estas preferencias se basan en la comprensión de Open Food Facts de la lista de ingredientes y siempre existe la posibilidad de que no sea precisa o completa; siempre verifique el producto usted mismo."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Huella de sufrimiento"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/et.po
+++ b/po/common/et.po
@@ -7638,7 +7638,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Need eelistused põhinevad Open Food Factsi arusaamal koostisosade loetelust ja alati on võimalik, et see ei pruugi olla täpne või täielik, kontrollige toodet alati ise."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Lehentasun horiek Open Food Facts-ek osagaien zerrenda ulertzeko duen moduan oinarritzen dira, eta beti dago aukera zehatza edo osoa ez izateko; egiaztatu beti produktua zeuk."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -7647,7 +7647,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "این ترجیحات بر اساس درک Open Food Facts از لیست مواد تشکیل دهنده است و همیشه این احتمال وجود دارد که دقیق یا کامل نباشد، همیشه خودتان محصول را بررسی کنید."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "اثر انگشت رنج"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -7645,7 +7645,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Nämä mieltymykset perustuvat Open Food Factsin käsitykseen ainesosaluettelosta, ja on aina mahdollista, että se ei ole tarkka tai täydellinen. Tarkista aina tuote itse."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/fo.po
+++ b/po/common/fo.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -7650,7 +7650,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ces préférences sont basées sur la compréhension de la liste des ingrédients par Open Food Facts et il y a toujours une possibilité qu'elles ne soient pas exactes ou complètes, vérifiez toujours le produit vous-même."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Empreinte Souffrance"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ga.po
+++ b/po/common/ga.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Tá na roghanna sin bunaithe ar thuiscint Open Food Facts ar an liosta comhábhar agus bíonn seans ann i gcónaí nach bhfuil sé cruinn nó iomlán, seiceáil an táirge tú féin i gcónaí."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/gd.po
+++ b/po/common/gd.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Tha na roghainnean sin stèidhichte air tuigse Open Food Facts air liosta nan tàthchuid agus tha cothrom ann an-còmhnaidh nach eil e ceart no coileanta, thoir sùil air an toradh thu fhèin an-còmhnaidh."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/gl.po
+++ b/po/common/gl.po
@@ -7630,7 +7630,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Esas preferencias baséanse na comprensión que fai Open Food Facts da lista de ingredientes e sempre existe a posibilidade de que non sexa precisa ou completa; comproba sempre o produto ti mesmo."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/gu.po
+++ b/po/common/gu.po
@@ -7631,7 +7631,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "તે પસંદગીઓ ઓપન ફૂડ ફેક્ટ્સની ઘટકોની સૂચિની સમજ પર આધારિત છે અને હંમેશા એવી શક્યતા રહે છે કે તે સચોટ અથવા સંપૂર્ણ ન પણ હોય, હંમેશા ઉત્પાદન જાતે તપાસો."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ha.po
+++ b/po/common/ha.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Wadancan abubuwan da ake so sun dogara ne akan Fahimtar Fahimtar Bayanan Abinci na abubuwan sinadaran kuma koyaushe akwai yuwuwar cewa bazai yi daidai ko cikakke ba, koyaushe duba samfurin da kanka."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "העדפות אלו מבוססות על הבנת Open Food Facts את רשימת הרכיבים ותמיד קיימת אפשרות שהיא לא תהיה מדויקת או מלאה, לכן יש לבדוק תמיד את המוצר בעצמכם."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/hi.po
+++ b/po/common/hi.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ये प्राथमिकताएं ओपन फूड फैक्ट्स की सामग्री सूची की समझ पर आधारित होती हैं और हमेशा यह संभावना रहती है कि यह सटीक या पूर्ण न हो, इसलिए हमेशा उत्पाद की जांच स्वयं करें।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/hr.po
+++ b/po/common/hr.po
@@ -7648,7 +7648,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Te se preferencije temelje na razumijevanju popisa sastojaka od strane Open Food Facts i uvijek postoji mogućnost da on nije točan ili potpun, uvijek sami provjerite proizvod."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Otisak prsta koji pati"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ht.po
+++ b/po/common/ht.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Preferans sa yo baze sou konpreyansyon Open Food Facts genyen sou lis engredyan yo epi toujou gen yon posibilite ke li ka pa egzak oswa konplè, toujou verifye pwodwi a tèt ou."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -7644,7 +7644,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ezek a preferenciák az Open Food Facts összetevőlistájának értelmezésén alapulnak, és mindig fennáll annak a lehetősége, hogy az nem pontos vagy teljes, ezért mindig ellenőrizze a terméket személyesen."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/hy.po
+++ b/po/common/hy.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Այդ նախընտրությունները հիմնված են «Բաց սննդի փաստերի» կողմից բաղադրիչների ցանկի վերաբերյալ ունեցած գիտելիքների վրա, և միշտ կա հնարավորություն, որ այն ճշգրիտ կամ ամբողջական չէ, միշտ ինքներդ ստուգեք ապրանքը։"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/id.po
+++ b/po/common/id.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Preferensi tersebut didasarkan pada pemahaman Open Food Facts terhadap daftar bahan dan selalu ada kemungkinan daftar tersebut tidak akurat atau lengkap, selalu periksa sendiri produknya."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ii.po
+++ b/po/common/ii.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/is.po
+++ b/po/common/is.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Þessar óskir eru byggðar á skilningi Open Food Facts á innihaldslistanum og það er alltaf möguleiki á að hann sé ekki nákvæmur eða tæmandi, athugaðu alltaf vöruna sjálf/ur."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -7648,7 +7648,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Tali preferenze si basano sulla comprensione dell'elenco degli ingredienti da parte di Open Food Facts e c'è sempre la possibilità che non siano accurate o complete; controlla sempre personalmente il prodotto."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/iu.po
+++ b/po/common/iu.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "これらの好みは、Open Food Facts の成分リストの理解に基づいており、正確または完全ではない可能性が常にありますので、必ず自分で製品を確認してください。"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/jv.po
+++ b/po/common/jv.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Preferensi kasebut adhedhasar pemahaman Open Food Facts babagan dhaptar bahan lan mesthi ana kemungkinan ora akurat utawa lengkap, priksa produk kasebut dhewe."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ka.po
+++ b/po/common/ka.po
@@ -7643,7 +7643,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ეს პრეფერენციები ეფუძნება Open Food Facts-ის მიერ ინგრედიენტების სიის გაგებას და ყოველთვის არსებობს შესაძლებლობა, რომ ის არ იყოს ზუსტი ან სრული, ამიტომ ყოველთვის თავად შეამოწმეთ პროდუქტი."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "ტანჯვის თითის ანაბეჭდი"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/kk.po
+++ b/po/common/kk.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Бұл таңдаулар Open Food Facts компаниясының ингредиенттер тізімін түсінуіне негізделген және оның нақты немесе толық болмауы мүмкін, әрқашан өнімді өзіңіз тексеріңіз."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/km.po
+++ b/po/common/km.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ចំណូលចិត្តទាំងនោះគឺផ្អែកលើការយល់ដឹងរបស់ Open Food Facts អំពីបញ្ជីគ្រឿងផ្សំ ហើយតែងតែមានលទ្ធភាពដែលវាប្រហែលជាមិនត្រឹមត្រូវ ឬពេញលេញ សូមពិនិត្យមើលផលិតផលដោយខ្លួនឯងជានិច្ច។"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/kmr_TR.po
+++ b/po/common/kmr_TR.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ew tercîh li ser bingeha têgihîştina navnîşa pêkhateyan a Open Food Facts ne û her gav îhtîmalek heye ku ew rast an ne temam be, her gav hilberê bi xwe kontrol bikin."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/kn.po
+++ b/po/common/kn.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ಆ ಆದ್ಯತೆಗಳು ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್ಸ್‌ನ ಪದಾರ್ಥಗಳ ಪಟ್ಟಿಯ ತಿಳುವಳಿಕೆಯನ್ನು ಆಧರಿಸಿವೆ ಮತ್ತು ಅದು ನಿಖರವಾಗಿ ಅಥವಾ ಪೂರ್ಣವಾಗಿರದಿರುವ ಸಾಧ್ಯತೆ ಯಾವಾಗಲೂ ಇರುತ್ತದೆ, ಯಾವಾಗಲೂ ಉತ್ಪನ್ನವನ್ನು ನೀವೇ ಪರಿಶೀಲಿಸಿ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "이러한 선호도는 Open Food Facts가 성분 목록을 이해한 바에 따른 것이며, 정확하지 않거나 완전하지 않을 가능성이 항상 있으므로 항상 제품을 직접 확인하세요."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "고통의 지문"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/kw.po
+++ b/po/common/kw.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ky.po
+++ b/po/common/ky.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Бул артыкчылыктар Open Food Facts компаниясынын ингредиенттердин тизмесин түшүнүүсүнө негизделген жана ал так же толук эмес болушу мүмкүн, ар дайым продуктуну өзүңүз текшериңиз."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/la.po
+++ b/po/common/la.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Hae praeferentiae in intellectu indicem ingredientium ab Open Food Facts factum nituntur, et semper est possibilitas ut non sit accuratus aut completus; semper igitur ipse productum inspice."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/lb.po
+++ b/po/common/lb.po
@@ -7630,7 +7630,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Dës Virléiften baséieren op dem Verständnis vun der Zutatenlëscht vun Open Food Facts an et gëtt ëmmer d'Méiglechkeet, datt se net korrekt oder komplett ass, kontrolléiert d'Produkt ëmmer selwer."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ຄວາມມັກເຫຼົ່ານັ້ນແມ່ນອີງໃສ່ຄວາມເຂົ້າໃຈຂອງ Open Food Facts ກ່ຽວກັບບັນຊີລາຍຊື່ສ່ວນປະກອບແລະມີຄວາມເປັນໄປໄດ້ທີ່ມັນອາດຈະບໍ່ຖືກຕ້ອງຫຼືຄົບຖ້ວນ, ສະເຫມີກວດເບິ່ງຜະລິດຕະພັນດ້ວຍຕົນເອງ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/lt.po
+++ b/po/common/lt.po
@@ -7647,7 +7647,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Šie pageidavimai pagrįsti „Open Food Facts“ supratimu apie ingredientų sąrašą ir visada yra tikimybė, kad jis gali būti netikslus ar neišsamus, todėl visada patikrinkite produktą patys."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/lv.po
+++ b/po/common/lv.po
@@ -7643,7 +7643,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Šīs preferences ir balstītas uz Open Food Facts izpratni par sastāvdaļu sarakstu, un vienmēr pastāv iespēja, ka tas var nebūt precīzs vai pilnīgs, vienmēr pārbaudiet produktu pats."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Ciešanas pirkstu nospiedums"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/mg.po
+++ b/po/common/mg.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ireo safidy ireo dia mifototra amin'ny fahatakaran'ny Open Food Facts momba ny lisitry ny akora ary misy foana ny mety ho tsy marina na feno, jereo foana ny vokatra."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/mi.po
+++ b/po/common/mi.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ko aua manakohanga i ahu mai i runga i te maaramatanga o Open Food Facts ki te rarangi whakauru me te kore pea e tika, kia oti ranei, tirohia tonu te hua."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ml.po
+++ b/po/common/ml.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ആ മുൻഗണനകൾ ഓപ്പൺ ഫുഡ് ഫാക്റ്റ്സിന്റെ ചേരുവകളുടെ പട്ടികയെക്കുറിച്ചുള്ള ധാരണയെ അടിസ്ഥാനമാക്കിയുള്ളതാണ്, അത് കൃത്യമോ പൂർണ്ണമോ ആകണമെന്നില്ല എന്നതിന് എപ്പോഴും സാധ്യതയുണ്ട്, എല്ലായ്പ്പോഴും ഉൽപ്പന്നം സ്വയം പരിശോധിക്കുക."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/mn.po
+++ b/po/common/mn.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Эдгээр сонголтууд нь Open Food Facts-ийн орцын жагсаалтын талаархи ойлголт дээр үндэслэсэн бөгөөд энэ нь үнэн зөв эсвэл бүрэн биш байж болзошгүй тул бүтээгдэхүүнийг өөрөө шалгаж үзээрэй."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/mr.po
+++ b/po/common/mr.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "त्या पसंती ओपन फूड फॅक्ट्सच्या घटक यादीच्या आकलनावर आधारित आहेत आणि ती अचूक किंवा पूर्ण नसण्याची शक्यता नेहमीच असते, नेहमी उत्पादन स्वतः तपासा."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Keutamaan tersebut adalah berdasarkan pemahaman Open Food Facts tentang senarai ramuan dan sentiasa ada kemungkinan ia mungkin tidak tepat atau lengkap, sentiasa semak produk itu sendiri."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/mt.po
+++ b/po/common/mt.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Dawk il-preferenzi huma bbażati fuq il-fehim ta' Open Food Facts tal-lista tal-ingredjenti u dejjem hemm il-possibbiltà li din ma tkunx preċiża jew kompluta, dejjem iċċekkja l-prodott int stess."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/my.po
+++ b/po/common/my.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "အဆိုပါ ဦးစားပေးများသည် ပါဝင်ပစ္စည်းစာရင်းကို Open Food Facts ၏ နားလည်မှုအပေါ် အခြေခံပြီး ၎င်းသည် တိကျခြင်း သို့မဟုတ် ပြည့်စုံခြင်းမဟုတ်ပါ၊ ထုတ်ကုန်ကို သင်ကိုယ်တိုင် အမြဲစစ်ဆေးရန် ဖြစ်နိုင်ခြေအမြဲရှိပါသည်။"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/nb.po
+++ b/po/common/nb.po
@@ -7644,7 +7644,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Disse innstillingene er basert på Open Food Facts' forståelse av ingredienslisten og det er alltid en mulighet for at det ikke kan være nøyaktig eller fullstendig, kontroller produktet selv selv."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ne.po
+++ b/po/common/ne.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ती प्राथमिकताहरू ओपन फूड फ्याक्ट्सको सामग्री सूचीको बुझाइमा आधारित हुन्छन् र यो सही वा पूर्ण नहुन सक्ने सम्भावना सधैं रहन्छ, सधैं उत्पादन आफैं जाँच गर्नुहोस्।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -7645,7 +7645,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Deze voorkeuren zijn gebaseerd op de interpretatie van Open Food Facts van de ingrediëntenlijst. Er bestaat altijd een mogelijkheid dat deze interpretatie niet nauwkeurig of volledig is. Controleer daarom altijd zelf het product."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Lijdende vingerafdruk"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Deze voorkeuren zijn gebaseerd op de interpretatie van Open Food Facts van de ingrediëntenlijst. Er bestaat altijd een mogelijkheid dat deze interpretatie niet nauwkeurig of volledig is. Controleer daarom altijd zelf het product."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Lijdende vingerafdruk"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/nn.po
+++ b/po/common/nn.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Disse preferansene er basert på Open Food Facts' forståelse av ingredienslisten, og det er alltid en mulighet for at den ikke er nøyaktig eller fullstendig. Sjekk alltid produktet selv."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/no.po
+++ b/po/common/no.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Disse preferansene er basert på Open Food Facts' forståelse av ingredienslisten, og det er alltid en mulighet for at den ikke er nøyaktig eller fullstendig. Sjekk alltid produktet selv."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/oc.po
+++ b/po/common/oc.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Aquelas preferéncias son basadas sus la compreneson de la lista d'ingredients per Open Food Facts e i a totjorn la possibilitat qu'es pas precisa o completa, verificatz totjorn lo produch vos-meteis."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/or.po
+++ b/po/common/or.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ସେହି ପସନ୍ଦଗୁଡ଼ିକ ଓପନ ଫୁଡ୍ ଫ୍ୟାକ୍ଟସର ଉପାଦାନ ତାଲିକାର ବୁଝାମଣା ଉପରେ ଆଧାରିତ ଏବଂ ସର୍ବଦା ଏକ ସମ୍ଭାବନା ରହିଥାଏ ଯେ ଏହା ସଠିକ୍ କିମ୍ବା ସମ୍ପୂର୍ଣ୍ଣ ନ ହୋଇପାରେ, ସର୍ବଦା ନିଜେ ଉତ୍ପାଦଟି ଯାଞ୍ଚ କରନ୍ତୁ।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/pa.po
+++ b/po/common/pa.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ਉਹ ਤਰਜੀਹਾਂ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਦੀ ਸਮੱਗਰੀ ਸੂਚੀ ਦੀ ਸਮਝ 'ਤੇ ਅਧਾਰਤ ਹਨ ਅਤੇ ਹਮੇਸ਼ਾ ਇਹ ਸੰਭਾਵਨਾ ਰਹਿੰਦੀ ਹੈ ਕਿ ਇਹ ਸਹੀ ਜਾਂ ਸੰਪੂਰਨ ਨਾ ਹੋਵੇ, ਹਮੇਸ਼ਾ ਉਤਪਾਦ ਦੀ ਖੁਦ ਜਾਂਚ ਕਰੋ।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Preferencje te opierają się na analizie listy składników przez Open Food Facts. Zawsze istnieje ryzyko, że jest ona niedokładna lub niekompletna, dlatego zawsze należy sprawdzić produkt samodzielnie."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -7645,7 +7645,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Essas preferências são baseadas no entendimento da Open Food Facts sobre a lista de ingredientes e sempre há a possibilidade de que ela não seja precisa ou completa. Verifique sempre o produto você mesmo."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Pegada de sofrimento"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -7645,7 +7645,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Estas preferências baseiam-se no entendimento da Open Food Facts sobre a lista de ingredientes e existe sempre a possibilidade de não ser precisa ou completa. Verifique sempre o produto por si."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/qu.po
+++ b/po/common/qu.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Chay munasqakuna Open Food Facts kaqpa hamut'ayninpi ingrediente lista kaqmanta ruwasqa kanku chaymanta sapa kuti huk atiy kan mana chiqan utaq hunt'asqa kanmanchu, sapa kuti qam kikiyki ruruta qhaway."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/rm.po
+++ b/po/common/rm.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -7645,7 +7645,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Aceste preferințe se bazează pe înțelegerea de către Open Food Facts a listei de ingrediente și există întotdeauna posibilitatea ca aceasta să nu fie exactă sau completă; verificați întotdeauna produsul dumneavoastră."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -7649,7 +7649,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Эти предпочтения основаны на понимании Open Food Facts списка ингредиентов, и всегда существует вероятность, что он может быть неточным или неполным, всегда проверяйте продукт самостоятельно."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Отпечаток страданий"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sa.po
+++ b/po/common/sa.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "तानि प्राधान्यानि Open Food Facts इत्यस्य घटकसूचिकायाः अवगमनस्य आधारेण भवन्ति तथा च सदैव सम्भावना वर्तते यत् सा सटीकं वा पूर्णं वा न भवेत्, सर्वदा उत्पादं स्वयमेव पश्यन्तु।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sd.po
+++ b/po/common/sd.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "اهي ترجيحون اوپن فوڊ فيڪٽس جي اجزاء جي فهرست جي سمجھ تي ٻڌل آهن ۽ هميشه اهو امڪان آهي ته اهو صحيح يا مڪمل نه هجي، هميشه پاڻ پراڊڪٽ چيڪ ڪريو."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/si.po
+++ b/po/common/si.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "එම මනාපයන් පදනම් වී ඇත්තේ අමුද්‍රව්‍ය ලැයිස්තුව පිළිබඳ Open Food Facts හි අවබෝධය මත වන අතර එය නිවැරදි හෝ සම්පූර්ණ නොවිය හැකි බවට සෑම විටම හැකියාවක් ඇත, සෑම විටම නිෂ්පාදනය ඔබම පරීක්ෂා කරන්න."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Tieto preferencie sú založené na tom, ako Open Food Facts chápe zoznam zložiek, a vždy existuje možnosť, že nemusí byť presný alebo úplný, preto si produkt vždy skontrolujte sami."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -7643,7 +7643,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Te preference temeljijo na razumevanju seznama sestavin s strani Open Food Facts in vedno obstaja možnost, da seznam ni točen ali popoln, zato izdelek vedno preverite sami."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sn.po
+++ b/po/common/sn.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Izvo zvaunofarira zvakavakirwa paOpen Food Chokwadi 'kunzwisisa kweiyo inongedzo rondedzero uye pane nguva dzose mukana wekuti inogona kunge isiri iyo chaiyo kana yakakwana, gara uchitarisa chigadzirwa iwe pachako."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/so.po
+++ b/po/common/so.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Dookhyadaas waxay ku saleysan yihiin Xaqiiqooyinka Cuntada Furan ee fahamka liiska walxaha waxaana mar walba jirta suurtagalnimada inaysan sax ahayn ama aysan dhammaystirnayn, had iyo jeer iska hubi badeecada."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sq.po
+++ b/po/common/sq.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Këto preferenca bazohen në kuptimin e listës së përbërësve nga Open Food Facts dhe gjithmonë ekziston mundësia që ajo të mos jetë e saktë ose e plotë, prandaj gjithmonë kontrolloni vetë produktin."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sr.po
+++ b/po/common/sr.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sr_CS.po
+++ b/po/common/sr_CS.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Те преференције се заснивају на разумевању листе састојака од стране Open Food Facts и увек постоји могућност да она није тачна или потпуна, увек сами проверите производ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sr_RS.po
+++ b/po/common/sr_RS.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Те преференције се заснивају на разумевању листе састојака од стране Open Food Facts и увек постоји могућност да она није тачна или потпуна, увек сами проверите производ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ss.po
+++ b/po/common/ss.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Leto tintfo letikhetsiwe tisuselwa ekuvisisekeni kwe Open Food Facts’ kweluhlu lwetitsako futsi kuhlala kunematfuba ekutsi kungenteka kungabi ngulokunembile noma lokuphelele, hlala uhlola lomkhicito wena."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/st.po
+++ b/po/common/st.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Likhetho tseo li ipapisitse le kutloisiso ea Open Food Facts mabapi le lenane la metsoako 'me ho na le monyetla oa hore e kanna ea se be e nepahetseng kapa e felletseng, hlahloba sehlahisoa ka bowena kamehla."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -7648,7 +7648,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Dessa preferenser baseras på Open Food Facts förståelse av ingredienslistan och det finns alltid en möjlighet att den inte är korrekt eller fullständig, kontrollera alltid produkten själv."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/sw.po
+++ b/po/common/sw.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Mapendeleo hayo yanatokana na uelewa wa Open Food Facts kuhusu orodha ya viambato na daima kuna uwezekano kwamba inaweza isiwe sahihi au kamili, angalia bidhaa mwenyewe kila wakati."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ta.po
+++ b/po/common/ta.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "அந்த விருப்பத்தேர்வுகள் மூலப்பொருள் பட்டியலைப் பற்றிய ஓபன் ஃபுட் ஃபேக்ட்ஸின் புரிதலை அடிப்படையாகக் கொண்டவை, மேலும் அது துல்லியமாகவோ அல்லது முழுமையாகவோ இல்லாமல் இருக்க எப்போதும் வாய்ப்பு உள்ளது, எப்போதும் தயாரிப்பை நீங்களே சரிபார்க்கவும்."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/te.po
+++ b/po/common/te.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "ఆ ప్రాధాన్యతలు ఓపెన్ ఫుడ్ ఫ్యాక్ట్స్ పదార్థాల జాబితా యొక్క అవగాహనపై ఆధారపడి ఉంటాయి మరియు అది ఖచ్చితమైనది లేదా పూర్తిగా ఉండకపోవచ్చు, ఎల్లప్పుడూ ఉత్పత్తిని మీరే తనిఖీ చేయండి."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/tg.po
+++ b/po/common/tg.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ин афзалиятҳо ба фаҳмиши Open Food Facts дар бораи рӯйхати компонентҳо асос ёфтаанд ва ҳамеша эҳтимолияти он вуҷуд дорад, ки он дақиқ ё пурра набошад, ҳамеша маҳсулотро худатон тафтиш кунед."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -7646,7 +7646,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "การตั้งค่าเหล่านี้ขึ้นอยู่กับความเข้าใจของ Open Food Facts เกี่ยวกับรายการส่วนผสม และอาจมีความเป็นไปได้เสมอที่รายการส่วนผสมอาจไม่ถูกต้องหรือครบถ้วน โปรดตรวจสอบผลิตภัณฑ์ด้วยตนเองเสมอ"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "รอยนิ้วมือที่ทุกข์ทรมาน"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ti.po
+++ b/po/common/ti.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "እቶም ምርጫታት ኣብ ርድኢት Open Food Facts ኣብ ዝርዝር ቀመማት ዝተመርኮሱ ኮይኖም ኩሉ ግዜ ቅኑዕ ወይ ምሉእ ክኸውን ዘይክእል ተኽእሎ ኣሎ፣ ኩሉ ግዜ ነቲ ፍርያት ባዕልኻ መርምሮ።"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/tl.po
+++ b/po/common/tl.po
@@ -7638,7 +7638,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ang mga kagustuhang iyon ay batay sa pag-unawa ng Open Food Facts sa listahan ng mga sangkap at palaging may posibilidad na hindi ito tumpak o kumpleto, palaging suriin ang produkto sa iyong sarili."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/tn.po
+++ b/po/common/tn.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Dikgetho tseo di thehilwe hodima kutlwisiso ya Open Food Facts ya lenane la metswako mme kamehla ho na le kgonahalo ya hore e ka nna ya se nepahetse kapa e feletseng, kamehla hlahloba sehlahiswa ka bowena."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -7644,7 +7644,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Bu tercihler Open Food Facts'in içerik listesine ilişkin anlayışına dayanmaktadır ve her zaman doğru veya eksiksiz olmama olasılığı vardır, ürünü her zaman kendiniz kontrol edin."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ts.po
+++ b/po/common/ts.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Swihlawulekisi sweswo swi seketeriwile eka ku twisisa ka Open Food Facts eka nxaxamelo wa swiaki naswona ku tshama ku ri na ku koteka ka leswaku swi nga ha va swi nga ri ntiyiso kumbe leswi heleleke, tshama u ri karhi u languta xiendliwa hi wexe."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/tt.po
+++ b/po/common/tt.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Бу өстенлекләр Ачык азык фактларының ингредиентлар исемлеген аңлавына нигезләнә һәм аның төгәл яки тулы булмавы мөмкинлеге бар, продуктны һәрвакыт үзегез тикшерегез."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/tw.po
+++ b/po/common/tw.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Saa apɛdeɛ no gyina Open Food Facts nteaseɛ a ɛwɔ nneɛma a wɔde yɛ aduane no ho so na ɛyɛ yie berɛ biara sɛ ebia ɛnyɛ pɛpɛɛpɛ anaasɛ ɛnyɛ pɛpɛɛpɛ, bere nyinaa w’ankasa hwɛ aduru no."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ty.po
+++ b/po/common/ty.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ug.po
+++ b/po/common/ug.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "بۇ ئېتىبارلار ئوچۇق يېمەكلىك پاكىتلىرىنىڭ تەركىبلەر تىزىملىكىنى چۈشىنىشىنى ئاساس قىلغان بولۇپ ، ئۇنىڭ توغرا ياكى تولۇق بولماسلىقى مۇمكىن ، ھەمىشە مەھسۇلاتنى ئۆزىڭىز تەكشۈرۈپ بېقىڭ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -7660,7 +7660,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ці уподобання ґрунтуються на розумінні Open Food Facts списку інгредієнтів, і завжди існує ймовірність того, що він може бути неточним або неповним, завжди перевіряйте продукт самостійно."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Відбиток страждань"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ur.po
+++ b/po/common/ur.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ushbu afzalliklar Open Food Facts kompaniyasining ingredientlar ro'yxatini tushunishiga asoslanadi va u har doim aniq yoki to'liq bo'lmasligi mumkin, har doim mahsulotni o'zingiz tekshirib ko'ring."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/ve.po
+++ b/po/common/ve.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -7647,7 +7647,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Những sở thích đó dựa trên sự hiểu biết của Open Food Facts về danh sách thành phần và luôn có khả năng danh sách này không chính xác hoặc không đầy đủ, hãy luôn tự mình kiểm tra sản phẩm."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "Dấu vân tay đau khổ"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/wa.po
+++ b/po/common/wa.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/wo.po
+++ b/po/common/wo.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/xh.po
+++ b/po/common/xh.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Ezo zinto zikhethwayo zisekwe kukuqonda okuVulekileyo kokutya koluhlu lwezithako kwaye kuhlala kukho ithuba lokuba ingachaneki okanye iphelele, soloko ujonga imveliso ngokwakho."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/yi.po
+++ b/po/common/yi.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "יענע פּרעפֿערענצן זענען באַזירט אויף Open Food Facts' פֿאַרשטאַנד פֿון דער אינגרעדיענטן־ליסטע און עס איז שטענדיק פֿאַראַן אַ מעגלעכקייט אַז זי איז נישט פּינקטלעך אָדער פֿולשטענדיק, קאָנטראָלירט שטענדיק דעם פּראָדוקט אַליין."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/yo.po
+++ b/po/common/yo.po
@@ -7629,7 +7629,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Awọn ayanfẹ wọnyẹn da lori oye Awọn Otitọ Ounjẹ Ṣiṣii ti atokọ eroja ati pe o ṣeeṣe nigbagbogbo pe o le ma jẹ deede tabi pipe, nigbagbogbo ṣayẹwo ọja funrararẹ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -7642,7 +7642,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "这些偏好基于 Open Food Facts 对成分表的理解，并且始终存在不准确或不完整的可能性，请务必亲自检查产品。"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr "动物受苦评分轨迹"
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -7637,7 +7637,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -7643,7 +7643,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "這些偏好是基於 Open Food Facts 對成分錶的理解，並且始終存在不準確或不完整的可能性，請務必親自檢查產品。"
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/po/common/zu.po
+++ b/po/common/zu.po
@@ -7628,7 +7628,7 @@ msgid "Those preferences are based on Open Food Facts' understanding of the ingr
 msgstr "Lokho okuthandwayo kusekelwe ekuqondeni kwe-Open Food Facts yohlu lwesithako futhi kuhlale kunethuba lokuthi kungase kungabi nembayo noma kuphelele, hlala uhlole umkhiqizo ngokwakho."
 
 msgctxt "external_sources_empreinte_souffrance_name"
-msgid "Suffering Fingerprint"
+msgid "Suffering Footprint"
 msgstr ""
 
 msgctxt "external_sources_empreinte_souffrance_description"

--- a/tests/integration/expected_test_results/external_sources/external-sources-en-moderator.json
+++ b/tests/integration/expected_test_results/external_sources/external-sources-en-moderator.json
@@ -16,7 +16,7 @@
          "icon_url" : "https://lheuredescomptes.org/logo_ES_alpha.svg",
          "id" : "empreinte_souffrance",
          "knowledge_panel_url" : "https://api.lheuredescomptes.org/off/v1/knowledge-panel/$code?lang=$lc&country=$cc",
-         "name" : "Suffering Fingerprint",
+         "name" : "Suffering Footprint",
          "privacy_policy_url" : "",
          "provider_name" : "l'Heure des Comptes",
          "provider_website" : "https://lheuredescomptes.org/",

--- a/tests/integration/expected_test_results/external_sources/external-sources-en-user.json
+++ b/tests/integration/expected_test_results/external_sources/external-sources-en-user.json
@@ -16,7 +16,7 @@
          "icon_url" : "https://lheuredescomptes.org/logo_ES_alpha.svg",
          "id" : "empreinte_souffrance",
          "knowledge_panel_url" : "https://api.lheuredescomptes.org/off/v1/knowledge-panel/$code?lang=$lc&country=$cc",
-         "name" : "Suffering Fingerprint",
+         "name" : "Suffering Footprint",
          "privacy_policy_url" : "",
          "provider_name" : "l'Heure des Comptes",
          "provider_website" : "https://lheuredescomptes.org/",

--- a/tests/integration/expected_test_results/external_sources/external-sources-en.json
+++ b/tests/integration/expected_test_results/external_sources/external-sources-en.json
@@ -16,7 +16,7 @@
          "icon_url" : "https://lheuredescomptes.org/logo_ES_alpha.svg",
          "id" : "empreinte_souffrance",
          "knowledge_panel_url" : "https://api.lheuredescomptes.org/off/v1/knowledge-panel/$code?lang=$lc&country=$cc",
-         "name" : "Suffering Fingerprint",
+         "name" : "Suffering Footprint",
          "privacy_policy_url" : "",
          "provider_name" : "l'Heure des Comptes",
          "provider_website" : "https://lheuredescomptes.org/",


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] ~~Code is well documented~~
- [ ] ~~Include unit tests for new functionality~~
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Renames the `Suffering Fingerprint` label in our translation string resources to `Suffering Footprint`.

This was done using the following command-line:

```
$ grep -rwl 'Suffering Fingerprint' | xargs sed -e 's#Suffering Fingerprint#Suffering Footprint#g' -i {}
```

(expanded: `grep` with options `--recursive`, `--word-regexp` and returning `--files-with-matches` (only the filenames, not the lines containing the pattern-matches) -- and then that list of files redirected to `sed`, a text stream editor, with a single command `s` pattern-matching the text `Suffering Footprint`, as indicated at the commandline by the delimiter `#` characters, globally within each file as configured by the terminating `g` character.  sed usually produces the resulting output at the command-line -- but using the `-i` flag, short for `--in-place`, means that it edits the input file on the filesystem instead of displaying the results).

### Screenshot
N/A

### Related issue(s) and discussion
- Fixes #12690.

Edit: update the checklist.
Edit: fixup for a typo in the explanation.