### PR TITLE
fix: upgrade buildx action to v0.31.1

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        version: v0.6.0
+        version: v0.31.1
         buildkitd-flags: --debug
 
     - name: Login to DockerHub


### PR DESCRIPTION
Same fix @raphael0202 did for robotoff: https://github.com/openfoodfacts/robotoff/commit/bb77914a2df33d16462c00fe79517a266a449141

This made assets generation fail for v2.88.0 release:
https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/22142117314/job/64008887580

```
error: Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
Reference
Check build summary support
Error: buildx failed with: error: Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version

```