### PR TITLE
taxonomy(food): fermented drink edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -10342,6 +10342,7 @@ zh: 无咖啡因茶
 < en:Fermented drinks
 < en:Teas
 en: Fermented teas
+da: Fermenterede teer
 de: Fermentierte Tees
 es: Tés fermentados
 fr: Thés sombres, Thé sombre
@@ -10349,6 +10350,7 @@ hr: Fermentirani čajevi
 hu: Fermentált teák
 lt: Fermentuotos arbatos, Raugintos arbatos
 nl: Gefermenteerde theeën, Gefermenteerde thee
+sv: Fermenterade teer
 wikidata:en: Q16241634
 
 < en:Teas
@@ -121874,19 +121876,6 @@ nl: Sushki
 ru: Сушки, Баранки
 wikidata:en: Q509835
 
-< en:Fermented drinks
-en: Kvass
-bg: Квас
-de: Kwas, Kwass
-es: Kvas
-fr: Kvass
-hr: Kvas
-lt: Gira
-nl: Kvas
-pl: Kwas chlebowy
-ru: Квас
-wikidata:en: Q173773
-
 < en:Gingerbreads
 en: Pryaniki
 de: Prjaniki
@@ -122454,15 +122443,93 @@ fr: Saucisses sèches de jambon
 < en:Fermented drinks
 < en:Tea-based beverages
 en: Kombuchas
-de: Kombucha
-es: Té kombucha, Kombucha
+xx: Kombucha
+ar: كومبوتشا
+be: Чайны квас
+bg: Комбуча
+ca: Kombutxa
+el: Κομπούχα
+eo: Kombuĉoj
+es: Té kombucha
+et: Teeseenejook
+eu: Konbutxa
+fa: کامبوچا
 fi: Kombutsat, Kombuchat
 fr: Kombuchas, combuchas
-hr: Kombucha
-it: Kombucha
+hi: कोम्बुचा
+hy: Կոմբուչա
+io: Kombucho
+is: Sveppate
 ja: 紅茶キノコ, コンブチャ
-nl: Kombucha
+ka: Ჩაის სოკო
+ko: 콤부차
+lt: Kombuča
+lv: Kombuča
+mk: Комбуча
+nl: Komboecha
+pl: Kombucza
+ru: Чайный квас
+sk: Kombuča
+sl: Kombuča
+sr: Kombusa
+tg: Замбурӯғчой
+th: คมบูชะ
+tr: Kombu Çayı
+uk: Чайний квас
+vi: Nấm thuỷ sâm
+zh: 红茶菌, 紅茶菌
 wikidata:en: Q657032
+
+< en:Fermented drinks
+< en:Plant-based beverages
+en: Kvass
+xx: Kvas, Kvass, Kwas
+ar: كفاس
+be: Квас
+bg: Квас
+ca: Kvass
+cu: Квасъ
+cv: Кăвас
+da: Kvass
+de: Kwas
+el: Κβας
+eo: Kvasoj
+et: Kali
+fa: کواس
+fi: Kvassi
+fr: Kvass
+hu: Kvasz
+hy: Կվաս
+io: Kvaso
+ja: クワス
+ka: Ბურახი
+ko: 크바스
+kv: Ырӧш
+ky: Квас
+lt: Gira
+nb: Kvass
+nn: Kvass
+os: Къуымæл
+pl: Kwas chlebowy
+ru: Квас
+sr: Квас
+sv: Kvass
+ta: குவாசு
+ug: كاۋاس
+zh: 格瓦斯, 克瓦斯
+wikidata:en: Q173773
+
+< en:Fermented drinks
+< en:Vegetable-based beverages
+en: Şalgam suyu, Turnip juices, Shalgam juices
+xx: Şalgam suyu, Şalgam, Salgam suyu, Salgam
+az: Şalğam suyu
+ja: シャルガム
+mk: Шалгам
+ru: Шалгам
+sr: Шалгам
+uk: Шалгам
+wikidata:en: Q388152
 
 < en:Dairy desserts
 fr: Oeufs au lait


### PR DESCRIPTION
- Adds new category for şalgam suyu.
- Adds `xx` entries and updates aliases/translations for kombucha and kvass.
- Groups these three fermented beverages together in the file.
- Adds “Plant-based beverages” as a parent for Kvass, since it’s a cereal (typically rye) based drink.
- Adds Danish and Swedish translations for Fermented teas category.

Needed-for: https://world.openfoodfacts.org/cgi/search.pl?search_terms=Salgam+Suyu