### PR TITLE
taxonomy(food): parsley category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -73748,6 +73748,7 @@ nl: Oreganoplanten in pot
 < en:Aromatic herbs
 en: Parsley
 bg: Магданоз
+da: Persille
 de: Petersilie
 es: Perejil
 fi: persilja
@@ -73759,18 +73760,21 @@ la: Petroselinum crispum
 lt: Petražolės
 nl: Peterselie
 pl: Pietruszka
+sv: Persilja
 tr: Maydanoz
-#wikidata:en:Q65522500
 agribalyse_proxy_food_code:en: 11014
 agribalyse_proxy_food_name:en: Parsley, fresh
 agribalyse_proxy_food_name:fr: Persil, frais
+comment:en: Wikidata item Q25284 is the biological taxon where Q65522500 is for “parsley-as-a-herb”.
 sales_format:en: weight, package, unit
 wikidata:en: Q25284
+#wikidata:en: Q65522500
 
 < en:Fresh aromatic plants
 < en:Parsley
 en: Fresh parsley
 bg: Пресен магданоз
+da: Frisk persille
 de: Frische Petersilie
 es: Perejil fresco
 fr: Persil frais
@@ -73778,6 +73782,7 @@ hr: Svježi peršin
 lt: Šviežios petražolės
 nl: Verse peterselie
 pl: Pietruszka świeża
+sv: Färsk persilja
 agribalyse_food_code:en: 11014
 ciqual_food_code:en: 11014
 ciqual_food_name:en: Parsley, fresh
@@ -73786,6 +73791,7 @@ ciqual_food_name:fr: Persil, frais
 < en:Frozen aromatic plants
 < en:Parsley
 en: Frozen parsley
+da: Frossen persille
 de: Petersilie gefroren
 es: Perejil congelado
 fr: Persil surgelé
@@ -73793,14 +73799,22 @@ hr: Smrznuti peršin
 lt: Šaldytos petražolės
 nl: Bevroren peterselie
 pl: Pietruszka mrożona
+sv: Fryst persilja
+
+< en:Frozen parsley
+en: Frozen chopped parsley
+da: Frossen hakket persille
+sv: Fryst hackad persilja
 
 < en:Dried aromatic plants
 < en:Parsley
 en: Dried parsley
+da: Tørret persille
 fr: Persil séché
 hr: Sušeni peršin
 lt: Džiovintos petražolės
 pl: Pietruszka suszona
+sv: Torkad persilja
 agribalyse_food_code:en: 11024
 ciqual_food_code:en: 11024
 ciqual_food_name:en: Parsley, dried
@@ -73813,6 +73827,7 @@ expected_ingredients:en: en:flatleaf parsley
 < en:Ground dried aromatic plants
 < en:Parsley
 en: Ground dried parsley, Parsley flakes
+da: Malet tørret persille
 de: Petersilie gerebelt
 es: Perejil seco molido
 fr: Persil séché moulu
@@ -73820,10 +73835,16 @@ hr: Samljeveni suhi peršin
 lt: Džiovintis maltos petražolės
 nl: Gemalen gedroogde peterselie
 pl: Pietruszka suszona mielona
+sv: Malad torkad persilja
+agribalyse_proxy_food_code:en: 11024
+ciqual_proxy_food_code:en: 11024
+ciqual_proxy_food_name:en: Parsley, dried
+ciqual_proxy_food_name:fr: Persil, séché
 
 < en:Lyophilized aromatic plants
 < en:Parsley
 en: Lyophilized parsley, Freeze-dried parsley
+da: Frysetørret persille
 de: Gefriergetrocknete Petersilie
 es: Perejil liofilizado
 fr: Persil lyophilisée
@@ -73831,16 +73852,19 @@ hr: Liofilizirani peršin
 lt: Šalčiu džiovintos petražolės
 nl: Gevriesdroogde peterselie
 pl: Pietruszka liofilizowana
+sv: Frystorkad persilja
 
 < en:Parsley
 < en:Potted aromatic plants
 en: Potted parsley
+da: Persille i krukke
 es: Macetas de perejil, Perejil en maceta
 fr: Persil en pot
 hr: Peršin u posudi
 lt: Petražolės vazonėlyje
 nl: Peterselieplanten in pot
 pl: Pietruszka w doniczce
+sv: Persilja i kruka
 
 < en:Aromatic herbs
 en: Rosemary


### PR DESCRIPTION
Adds:
- new “Frozen chopped parsley” category.
- Danish and Swedish translations.
- `comment` about the two `wikidata` properties for `en:Parsley`.
- Ciqual/AGRIBALYSE proxy codes for ground dried parsley.

Needed-for: https://se.openfoodfacts.org/product/7340083481048/finhackad-persilja-garant