### PR TITLE
taxonomy: new waffle categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -116058,6 +116058,7 @@ ciqual_food_name:fr: Gaufre moelleuse (type bruxelloise ou liégeoise), nature o
 
 < en:Plain waffles
 en: Liège-style plain waffles
+fr: Gaufres de Liège nature, Gaufres liégeoises, gaufres liegeoises, gaufres de Liège, gaufre liégeoise, gaufre de Liège, Gaufre moelleuse nature liégeoise préemballée, Gaufre moelleuse sucrée liégeoise
 
 < en:Plain waffles
 en: Bruxelles-style plain waffles, Plain Brussels-style soft waffle, Brussels-style soft waffle with sugar


### PR DESCRIPTION
* There was one category called bruxelles-style waffles in English and was translated in Liège waffles in French (Gaufres de Liège). I renamed this category plain waffles anc created to children categories: Bruxelles-style plain waffles and Liège-style plain waffles
* Created a category for waffles coated with a cocoa glaze. e.g. https://world.openfoodfacts.org/product/5400101057418/carrefour-original-gaufres-de-liege-avec-fantaisie-au-cacao