### PR TITLE
feat(taxonomy): add product counts to sub-tags on facets pages (#13093)

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3347,7 +3347,7 @@ sub display_tag_and_parents_taxonomy ($tagtype, $tagid) {
 	return $html;
 }
 
-sub display_parents_and_children ($target_lc, $tagtype, $tagid) {
+sub display_parents_and_children ($target_lc, $tagtype, $tagid, $product_counts = undef) {
 
 	$target_lc =~ s/_.*//;
 	my $html = '';
@@ -3360,12 +3360,24 @@ sub display_parents_and_children ($target_lc, $tagtype, $tagid) {
 			$html .= "<p>" . lang("tag_belongs_to") . "</p>\n";
 			$html .= "<p>" . display_tag_and_parents_taxonomy($tagtype, $tagid) . "</p>\n";
 		}
-
+		
 		if ((defined $direct_children{$tagtype}) and (defined $direct_children{$tagtype}{$tagid})) {
 			$html .= "<p>" . lang("tag_contains") . "</p><ul>\n";
+
 			foreach my $childid (sort keys %{$direct_children{$tagtype}{$tagid}}) {
-				$html .= "<li>" . display_taxonomy_tag_link($target_lc, $tagtype, $childid) . "</li>\n";
+
+				# default name without count
+				my $label = display_taxonomy_tag_link($target_lc, $tagtype, $childid);
+
+				# if counts available → append
+				if ($product_counts && exists $product_counts->{$childid}) {
+					my $count = $product_counts->{$childid};
+					$label =~ s{>([^<]+)</a>}{>$1 ($count)</a>};
+				}
+
+				$html .= "<li>$label</li>\n";
 			}
+
 			$html .= "</ul>\n";
 		}
 	}


### PR DESCRIPTION
### What

This pull request adds product counts next to sub-tags in taxonomy facet pages, as requested in issue #13093.

#### Changes included:
1) Added a MongoDB aggregation in `Display.pm` to compute product counts for all direct child tags in one query.
2) Updated `display_parents_and_children()` in `Tags.pm` to optionally receive `%product_counts` and append the count to each child tag.
3)  Backward compatible: if no counts are provided, the old display remains unchanged.

Fixes #13093