### PR TITLE
taxonomy: correction tomato purée

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -80072,7 +80072,6 @@ ciqual_food_code:en: 20260
 ciqual_food_name:en: Tomato coulis, canned (tomato puree semi-reduced 11%)
 ciqual_food_name:fr: Tomate, coulis, appertisé (purée de tomates mi-réduite à 11%)
 
-< en:Mashed vegetables
 < en:Tomato sauces
 en: Tomato purées, Tomato purees, Pureed tomato
 bg: Доматено пюре


### PR DESCRIPTION
Even though "tomato purées" is technically "mashed vegetable", it doesn't suits very well in that category. Contrary to other mashed vegetables which are thick and put directly in the plate, mashed tomato is too liquid and is used as a sauce. Categories are based on usage rather than strict definition, e.g. "tomatoes" is not in "fruits", "fish" is not in "meats".