### PR TITLE
fix: Typo in gen_users_emails_list.pl

### DIFF
--- a/scripts/gen_users_emails_list.pl
+++ b/scripts/gen_users_emails_list.pl
@@ -75,7 +75,7 @@ my @userids;
 my $arg = $ARGV[0] || "";
 
 if (scalar $#userids < 0) {
-	@userids = retrieve_preference_userids();
+	@userids = retrieve_user_preference_ids();
 }
 
 foreach my $userid (@userids) {


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
Function name was mis-spelled during Keycloak work
