### PR TITLE
fix: treat ':' before opening bracket as nested ingredients (#3959)

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2092,6 +2092,16 @@ Text to analyze
 
 			if ($sep =~ /(:|\[|\{|\(|\N{U+FF08})/i) {
 
+				# If the separator is a colon but is immediately
+				# followed by an opening bracket, treat the
+				# bracket as the separator so the parenthesis
+				# matching logic below will run on the group.
+				# Example: "meat: (beef, pork)"
+				if ($sep eq ':' and $after =~ /^\s*(\(|\[|\{|\N{U+FF08})/i) {
+					$sep = $1;
+					$after =~ s/^\s*(?:\(|\[|\{|\N{U+FF08})\s*//;
+				}
+
 				# Single separators like commas and dashes
 				my $match = '.*?';    # non greedy match
 				my $ending = $last_separator;

--- a/tests/unit/ingredients_nesting.t
+++ b/tests/unit/ingredients_nesting.t
@@ -431,6 +431,35 @@ my @tests = (
 		]
 	],
 
+	# Issue #3959 - colon followed immediately by opening bracket should parse as nested ingredients
+	[
+		{lc => "en", ingredients_text => "meat: (beef, pork, lamb)"},
+		[
+			{
+				'id' => 'en:meat',
+				'text' => 'meat',
+				'is_in_taxonomy' => 1,
+				'ingredients' => [
+					{
+						'id' => 'en:beef-meat',
+						'is_in_taxonomy' => 1,
+						'text' => 'beef',
+					},
+					{
+						'id' => 'en:pork-meat',
+						'is_in_taxonomy' => 1,
+						'text' => 'pork',
+					},
+					{
+						'id' => 'en:lamb-meat',
+						'is_in_taxonomy' => 1,
+						'text' => 'lamb',
+					},
+				],
+			},
+		]
+	],
+
 );
 
 foreach my $test_ref (@tests) {

--- a/tests/unit/ingredients_parsing_todo.t
+++ b/tests/unit/ingredients_parsing_todo.t
@@ -115,36 +115,6 @@ my @tests = (
 	],
 
 	# ingredient group: (element1, element2, element3) needs to be parsed as ingredient group (element1, element2, element3)
-	#комплексная пищевая добавка: (порошок сыра гауда, данбо, камамбер, голубой сыр, эмульгирующая соль Е 339)
-	# using english, because the Dumper() output \x-escapes utf8.
-	[
-		"Issue #3959 - 'ingredient with colon before subingredients opening bracket' - https://github.com/openfoodfacts/openfoodfacts-server/issues/3959",
-		{
-			lc => "en",
-			ingredients_text => "meat: (beef, pork, lamb)",
-		},
-		[
-			{
-				'id' => 'en:meat',
-				'text' => 'meat',
-				'ingredients' => [
-					{
-						'id' => 'en:beef',
-						'text' => 'beef',
-					},
-					{
-						'id' => 'en:pork',
-						'text' => 'pork',
-					},
-					{
-						'id' => 'en:lamb',
-						'text' => 'lamb',
-					},
-				],
-			},
-		]
-	],
-
 	# interpret animal attribute in brackets as part of the ingredient name, instead of a separate ingredient.
 	# présure (animale) -> présure animale
 	[


### PR DESCRIPTION
Minimal parser fix to treat a colon immediately followed by an opening bracket as the bracket separator, so constructs like 'meat: (beef, pork, lamb)' are parsed as nested ingredients.

- References: #3959