### PR TITLE
taxonomy: add vegan/vegetarian status to amino acids, nucleotides, fix mineral orphans

### DIFF
--- a/taxonomies/amino_acids.txt
+++ b/taxonomies/amino_acids.txt
@@ -11,6 +11,19 @@
 # Commission Regulations (EC) No 41/2009 and (EC) No 953/2009
 # http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32013R0609&from=FR
 
+# description:en:Amino acids are organic compounds that combine to form proteins. In food supplements and fortified foods, amino acids are typically produced via fermentation or chemical synthesis.
+en: Amino acids
+de: Aminosäuren
+es: Aminoácidos
+fr: Acides aminés
+it: Amminoacidi
+nl: Aminozuren
+pt: Aminoácidos
+vegan:en: yes
+vegetarian:en: yes
+wikidata:en: Q8066
+
+< en:Amino acids
 en: L-alanine
 bg: L-аланин
 da: L-alanin
@@ -26,6 +39,7 @@ sl: L-alanin
 sv: L-alanin
 wikidata:en: Q218642
 
+< en:Amino acids
 en: L-arginine
 bg: L-аргинин
 cs: L-arginin
@@ -49,6 +63,7 @@ sl: L-arginin
 sv: L-arginin
 wikidata:en: Q173670
 
+< en:Amino acids
 en: L-aspartic acid
 bg: L-аспарагинова киселина
 cs: L-asparagová kyselina
@@ -73,6 +88,7 @@ sl: L-asparaginska kislina
 sv: L-asparaginsyra
 wikidata:en: Q178450
 
+< en:Amino acids
 en: L-citrulline
 bg: L-цитрулин
 cs: L-citrullin
@@ -95,6 +111,7 @@ sl: L-citrulin
 sv: L-citrullin
 wikidata:en: Q408641
 
+< en:Amino acids
 en: L-cysteine
 bg: L-цистеин
 cs: L-cystein
@@ -117,8 +134,11 @@ ro: L-cisteină
 sk: L-cysteín
 sl: L-cistein
 sv: L-cystein
+vegan:en: maybe
+vegetarian:en: maybe
 wikidata:en: Q186474
 
+< en:Amino acids
 en: Cystine (4)
 bg: Цистин
 cs: Cystin
@@ -139,7 +159,10 @@ ro: cistină
 sk: Cystín
 sl: cistin
 sv: Cystin
+vegan:en: maybe
+vegetarian:en: maybe
 
+< en:Amino acids
 en: L-histidine
 bg: L-хистидин
 cs: L-histidin
@@ -161,6 +184,7 @@ sk: L-histidín
 sl: L-histidin
 sv: L-histidin
 
+< en:Amino acids
 en: L-glutamic acid
 bg: L-глутаминова киселина
 cs: L-glutamová kyselina
@@ -184,6 +208,7 @@ sk: kyselina L-glutamínová
 sl: L-glutaminska kislina
 sv: L-glutaminsyra
 
+< en:Amino acids
 en: L-glutamine
 bg: L-глутамин
 cs: L-glutamin
@@ -208,6 +233,7 @@ sv: L-glutamin
 wikidata:en: Q181619
 wikipedia:en: https://en.wikipedia.org/wiki/Glutamine
 
+< en:Amino acids
 en: glycine
 bg: Глицин
 cs: glycin
@@ -229,6 +255,7 @@ sk: glycín
 sl: glicin
 sv: glycin
 
+< en:Amino acids
 en: L-isoleucine
 bg: L-изолевцин
 cs: L-isoleucin
@@ -253,6 +280,7 @@ sv: L-isoleucin
 wikidata:en: Q484940
 wikipedia:en: https://en.wikipedia.org/wiki/Isoleucine
 
+< en:Amino acids
 en: L-leucine
 bg: L-левцин
 cs: L-leucin
@@ -275,6 +303,7 @@ sl: L-levcin
 sv: L-leucin
 wikidata:en: Q483745
 
+< en:Amino acids
 en: L-lysine
 bg: L-лизин
 cs: L-lysin
@@ -297,6 +326,7 @@ sl: L-lizin
 sv: L-lysin
 wikidata:en: Q20816880
 
+< en:Amino acids
 en: L-lysine acetate
 bg: L-лизин ацетат
 cs: L-lysin-acetát
@@ -321,6 +351,7 @@ sl: L-lizin acetat
 sv: L-lysinacetat
 wikidata:en: Q72487859
 
+< en:Amino acids
 en: L-methionine
 bg: L-метионин
 cs: L-methionin
@@ -343,6 +374,7 @@ sk: L-metionín
 sl: L-metionin
 sv: L-metionin
 
+< en:Amino acids
 en: L-ornithine
 bg: L-орнитин
 cs: L-ornithin
@@ -364,6 +396,7 @@ sk: L-ornitín
 sl: L-ornitin
 sv: L-ornitin
 
+< en:Amino acids
 en: L-phenylalanine
 bg: L-фенилаланин
 cs: L-fenylalanin
@@ -387,6 +420,7 @@ sk: L-fenylalanín
 sl: L-fenilalanin
 sv: L-fenylalanin
 
+< en:Amino acids
 en: L-proline
 bg: L-пролин
 cs: L-prolin
@@ -409,6 +443,7 @@ sl: L-prolin
 sv: L-prolin
 wikidata:en: Q20035886
 
+< en:Amino acids
 en: L-threonine
 bg: L-треонин
 cs: L-threonin
@@ -434,6 +469,7 @@ wikidata:en: Q186521
 
 # description:en:L-tryptophan—pyruvate aminotransferase is an enzyme with systematic name L-tryptophan:pyruvate aminotransferase.
 
+< en:Amino acids
 en: L-tryptophan
 af: Triptofaan
 ar: تريبتوفان
@@ -510,6 +546,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/L-tryptophan—pyruvate_aminotransfe
 # amino-acid/l-tryptophan has 79 products @2019-03-16
 # ingredient/fr:l-tryptophane has 61 products in 4 languages @2019-03-16
 
+< en:Amino acids
 en: L-tyrosine
 bg: L-тирозин
 cs: L-thyrosin
@@ -533,6 +570,7 @@ sl: L-tirozin
 sv: L-tyrosin
 wikidata:en: Q188017
 
+< en:Amino acids
 en: L-valine
 bg: L-валин
 cs: L-valin
@@ -556,6 +594,7 @@ sl: L-valin
 sv: L-valin
 wikidata:en: Q483752
 
+< en:Amino acids
 en: L-serine
 bg: L-серин
 cs: L-serin
@@ -579,6 +618,7 @@ sl: L-serin
 sv: L-serin
 wikidata:en: Q183290
 
+< en:Amino acids
 en: L-arginine-L-aspartate
 bg: L-аргинин-L-аспартат
 cs: L-arginin-L-aspartát
@@ -602,6 +642,7 @@ sl: L-arginin-L-aspartat
 sv: L-arginin-L-aspartat
 wikidata:en: Q82004220
 
+< en:Amino acids
 en: L-lysine-L-aspartate
 bg: L-лизин-L-аспартат
 cs: L-lysin-L-aspartát
@@ -624,6 +665,7 @@ sk: L-lyzín-L-aspartát
 sl: L-lizin-L-aspartat
 sv: L-lysin-L-aspartat
 
+< en:Amino acids
 en: L-lysine-L-glutamate
 bg: L-лизин-L-глутамат
 cs: L-lysin-L-glutamát
@@ -646,6 +688,7 @@ sk: L-lyzín-L-glutaman
 sl: L-lizin-L-glutamat
 sv: L-lysin-L-glutamat
 
+< en:Amino acids
 en: N-acetyl-L-cysteine
 bg: N-ацетил-L-цистеин
 cs: N-acetyl-L-cystein
@@ -668,7 +711,10 @@ ro: N-acetil-L-cisteină
 sk: N-acetyl-L-cysteín
 sl: N-acetil-L-cistein
 sv: N-acetyl-L-cystein
+vegan:en: maybe
+vegetarian:en: maybe
 
+< en:Amino acids
 en: N-acetyl-L-methionine
 bg: N-ацетил-L-метионин
 cs: N-acetyl-L-methionin

--- a/taxonomies/minerals.txt
+++ b/taxonomies/minerals.txt
@@ -2602,6 +2602,7 @@ pl: dwufosforan żelazowy
 
 
 
+< en:Mineral
 en: phosphor
 es: fosforo
 it: fosforo
@@ -2609,6 +2610,7 @@ it: fosforo
 
 # Unspecified phosphate variety
 
+< en:Mineral
 en: phosphate
 bg: фосфат, фосфати
 de: Phosphat

--- a/taxonomies/nucleotides.txt
+++ b/taxonomies/nucleotides.txt
@@ -94,6 +94,8 @@ vi: Nucleotide
 # wuu:核苷酸
 # yue:核苷酸
 zh: 核苷酸
+vegan:en: yes
+vegetarian:en: yes
 wikidata:en: Q28745
 wikipedia:en: https://en.wikipedia.org/wiki/Nucleotide
 


### PR DESCRIPTION
## Summary

Adds missing `vegan:en` and `vegetarian:en` properties to three taxonomy files that currently have little or no coverage, enabling better ingredient classification for users checking product suitability.

**amino_acids.txt** (0% → 100% coverage):
- Added root "Amino acids" entry with translations (de, es, fr, it, nl, pt) and `vegan:en: yes` / `vegetarian:en: yes`
- Added `< en:Amino acids` parent reference to all 28 entries for property inheritance
- Overrode L-cysteine, Cystine (4), and N-acetyl-L-cysteine with `vegan:en: maybe` / `vegetarian:en: maybe` — these can be sourced from duck feathers or human hair (E920)

**nucleotides.txt** (~9% → full inheritance):
- Added `vegan:en: yes` / `vegetarian:en: yes` to root nucleotides entry
- IMP (inosine monophosphate) already correctly marked `vegan:en: no` at entry level — this is preserved via override

**minerals.txt** (orphan fix):
- Added missing `< en:Mineral` parent reference to `phosphor` and `phosphate` entries that were orphaned from the mineral hierarchy and couldn't inherit root properties

## Related issue

Relates to #10169 (vegan/vegetarian status coverage)

## Test plan

- [ ] Verify taxonomy builds without errors
- [ ] Confirm amino acid entries inherit `vegan:en: yes` / `vegetarian:en: yes` from root
- [ ] Confirm L-cysteine, Cystine, N-acetyl-L-cysteine show `vegan:en: maybe` (override)
- [ ] Confirm IMP still shows `vegan:en: no` (existing override preserved)
- [ ] Confirm phosphor/phosphate now inherit from Mineral parent