### PR TITLE
fix: API crash on some products when asking for specific nutrients

### DIFF
--- a/lib/ProductOpener/API.pm
+++ b/lib/ProductOpener/API.pm
@@ -1054,7 +1054,7 @@ sub customize_response_for_product ($request_ref, $product_ref, $fields_comma_se
 	api_compatibility_for_product_response($customized_product_ref, $request_ref->{api_version});
 
 	# Handle old requested nutrients from API V2
-	if (scalar @old_requested_nutrients > 0) {
+	if ((scalar @old_requested_nutrients > 0) and (defined $customized_product_ref->{nutriments})) {
 		# The new nutrition structure has been converted to the old nutriments hash
 		# we now need to filter the nutriments hash to keep only the requested nutrients
 		# Copy the nutriments hash and delete it, then re-add only the requested nutrients

--- a/tests/integration/api_v2_product_read.t
+++ b/tests/integration/api_v2_product_read.t
@@ -71,6 +71,17 @@ my @products = (
 			nutriment_fat => 8.5,
 		)
 	},
+	# Product with no nutrition data and no ingredients (so nutrition won't be estimated)
+	{
+		(
+			lc => "en",
+			lang => "en",
+			code => '200000000036',
+			product_name => "Some product 3 with no nutrition data and no ingredients",
+			generic_name => "Tester 3",
+			categories => "cookies",
+		)
+	},
 );
 
 foreach my $product_form_override (@products) {
@@ -247,6 +258,14 @@ my $tests_ref = [
 		test_case => 'get-salt-100g',
 		method => 'GET',
 		path => '/api/v2/product/200000000034',
+		query_string => '?fields=salt_100g',
+		expected_status_code => 200,
+	},
+	# bug when a product has no nutrients but we request a specific nutrient with v2
+	{
+		test_case => 'get-salt-100g-no-nutrients',
+		method => 'GET',
+		path => '/api/v2/product/200000000036',
 		query_string => '?fields=salt_100g',
 		expected_status_code => 200,
 	},

--- a/tests/integration/expected_test_results/api_v2_product_read/get-salt-100g-no-nutrients.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-salt-100g-no-nutrients.json
@@ -1,0 +1,6 @@
+{
+   "code" : "0200000000036",
+   "product" : {},
+   "status" : 1,
+   "status_verbose" : "product found"
+}


### PR DESCRIPTION
Related to the new nutrition schema, an API v2 requests that asks for specific nutrients for a product that has no nutrition data currently crashes.