### PR TITLE
fix: track Nutri-Score, Eco-Score, and NOVA Matomo events on product

### DIFF
--- a/html/js/matomo-events.js
+++ b/html/js/matomo-events.js
@@ -18,3 +18,35 @@ function trackMatomoEvent(category, action, name, value) {
 
     _paq.push(eventData);
 }
+
+// Track product page scores (Nutri-Score, Eco-Score, NOVA) dynamically
+document.addEventListener('DOMContentLoaded', function () {
+    if (document.body.classList.contains('product_page')) {
+        // Nutri-Score
+        var nsImg = document.querySelector('img[src*="nutriscore-"]');
+        if (nsImg) {
+            var nsMatch = nsImg.src.match(/nutriscore-([a-e])/);
+            if (nsMatch) {
+                trackMatomoEvent('product', 'has_nutriscore', nsMatch[1]);
+            }
+        }
+
+        // Eco-Score
+        var esImg = document.querySelector('img[src*="ecoscore-"]');
+        if (esImg) {
+            var esMatch = esImg.src.match(/ecoscore-([a-e])/);
+            if (esMatch) {
+                trackMatomoEvent('product', 'has_ecoscore', esMatch[1]);
+            }
+        }
+
+        // NOVA group
+        var novaImg = document.querySelector('img[src*="nova-group-"]');
+        if (novaImg) {
+            var novaMatch = novaImg.src.match(/nova-group-([1-4])/);
+            if (novaMatch) {
+                trackMatomoEvent('product', 'has_nova', novaMatch[1]);
+            }
+        }
+    }
+});


### PR DESCRIPTION
This PR tracks Matomo events for Nutri-Score, Eco-Score, and NOVA when a user views a product page. 

Since these scores are generated dynamically by Knowledge Panels, I added a small DOM script that waits for the page to load, checks which score images are being displayed, and pushes the exact grades to Matomo.

Fixes part of #8191.

### Events Tracked:
* `has_nutriscore` (e.g,  a, b, c, d, e)
* `has_ecoscore` (e.g,  a, b, c, d, e)
* `has_nova` (e.g,  1, 2, 3, 4)

I tested this locally in the browser by mocking the DOM, and all three events are successfully firing and pushing the correct values to the `_paq` array.

https://github.com/user-attachments/assets/27f04c1f-1ff8-4b6a-82e6-d317c7034e66


