### PR TITLE
taxonomy: modification savory cakes 

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -118387,7 +118387,7 @@ en: Vegetarian savory cakes, Savoury cake with vegetables
 fr: Cakes salés végétariens, Cake salé aux légumes
 
 < en:Savory cakes
-en: Savory cakes, Savoury cake with meat
+en: Savory cakes with meat, Savoury cake with meat
 fr: Cakes salés à la viande, Cake salé à la viande
 
 < en:Appetizers


### PR DESCRIPTION
I renamed "salted savory cake" in "savory cakes". I moved it under appetizers. I changed the sub-categories, which didn't make so much sense. E.g. I deleted "Savoury cake with cheese" because savory cakes rarely contain only cheese and a distinction between the one that contain cheese and the one that don't doesn't make sense. I made two separated categories "cakes with meat" and "vegetarian cakes", which is a more useful distinction.
