### PR TITLE
fix: add Matomo event tracking for successful signup (#13166)

### DIFF
--- a/templates/web/pages/user_form/user_form.tt.js
+++ b/templates/web/pages/user_form/user_form.tt.js
@@ -20,3 +20,9 @@ proCheckbox.addEventListener('change', function() {
 	checkboxChange(this);
 });
 [%- END -%]
+[%- IF action == 'process' AND type == 'add' -%]
+// Track successful signup event in Matomo (issue #13166)
+if (typeof trackMatomoEvent === 'function') {
+	trackMatomoEvent('User', 'Signup', 'successful');
+}
+[%- END -%]


### PR DESCRIPTION
Track signup completion events in Matomo analytics to monitor user registration.
Event format: trackMatomoEvent('User', 'Signup', 'successful')

- Fixes #13166
