### PR TITLE
fix: exclude obsolete products from CSV/RDF exports 

### DIFF
--- a/scripts/export_database.pl
+++ b/scripts/export_database.pl
@@ -272,11 +272,11 @@ XML
 	$csv =~ s/\t$/\n/;
 	print $OUT $csv;
 
-	# Get products from the products collection, plus the products_obsolete collection
-	my @collections = (
-		get_products_collection({timeout => 3 * 60 * 60 * 1000}),
-		get_products_collection({obsolete => 1, timeout => 3 * 60 * 60 * 1000})
-	);
+	# Get products only from the active products collection
+	# Note: we intentionally do NOT include the products_obsolete collection here,
+	# as obsolete products (e.g. products moved to Open Products Facts) should not
+	# appear in the public CSV/RDF exports.
+	my @collections = (get_products_collection({timeout => 3 * 60 * 60 * 1000}),);
 
 	my $count = 0;
 	my %ingredients = ();


### PR DESCRIPTION

### Discription 
The export_database.pl script was exporting products from both the products and products_obsolete MongoDB collections into the public CSV/RDF dumps. This caused deleted or transferred products (e.g. moved to Open Products Facts) to appear as active with stale data.


### Solution 
This PR removes the products_obsolete collection from the export, so only active products are included in the public dumps

Fixes #13164