### PR TITLE
taxonomy(food): salmon/tuna analogue categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -120061,6 +120061,12 @@ hr: Analozi ribe
 nl: Plantaardige vissen
 pl: Zastępniki ryb
 
+< en:Fish analogues
+en: Salmon analogues
+
+< en:Fish analogues
+en: Tuna analogues
+
 < en:Dairy substitutes
 < en:Plant-based foods
 < en:Vegan products


### PR DESCRIPTION
Looking over [`en:fish-analogues`](https://world.openfoodfacts.org/facets/categories/fish-analogues) it is _almost_ entirely marketed as salmon or tuna replacements/analogues, so this adds those two categories.