### PR TITLE
taxonomy(food): brand + sv translation

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -133,6 +133,10 @@ wikidata:en: Q112757315
 xx: Blå Band
 wikidata:en: Q10431648
 
+#< xx:Orkla
+xx: BOB
+#web:sv: https://www.bob.se/
+
 # This seems to be different from “BSc” made by Australian(/Swedish?)
 # “Body Science International”, owned by “Humble Group Australia”,
 # which is what https://www.wikidata.org/wiki/Q18208172 is about.

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -1086,7 +1086,7 @@ sl: Vitamin C
 sq: Vitamina C
 sr: витамин Ц
 su: Vitamin C
-sv: C-vitamin
+sv: vitamin C, C-vitamin
 sw: Vitamini C
 ta: உயிர்ச்சத்து சி
 te: విటమిన్ సి


### PR DESCRIPTION
- Adds BOB brand: https://world.openfoodfacts.org/facets/brands/bob
- Adds an additional Swedish vitamin C translation/synonym

Needed-for: https://se.openfoodfacts.org/product/7310090165538/citron-och-lime-l%C3%A4ttdryck-bob