### PR TITLE
fix: decrease `id="donation-banner-top"`s

### DIFF
--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -4,8 +4,8 @@
 
 [% IF product_type == "food" %]
 
-  [% IF lc == "fr" %]
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  [% IF lc == "fr" %]
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -28,10 +28,7 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
-</section>
-
 [% ELSIF lc == "it" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aiutaci a promuovere la biodiversità su Open Food Facts!</h2>
@@ -53,10 +50,8 @@
       <p>DIVINFOOD è stato finanziato dal programma di ricerca e innovazione Horizon 2020 dell'Unione europea nell'ambito dell'accordo di sovvenzione n°101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "pt" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Ajude-nos a promover a biodiversidade no Open Food Facts!</h2>
@@ -78,10 +73,8 @@
       <p>O DIVINFOOD foi financiado pelo programa de pesquisa e inovação Horizon 2020 da União Europeia no âmbito do Acordo de Subvenção nº 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "es" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>¡Ayúdanos a promover la biodiversidad en Open Food Facts!</h2>
@@ -103,10 +96,8 @@
       <p>DIVINFOOD ha sido financiado por el programa de investigación e innovación Horizonte 2020 de la Unión Europea en el marco del Acuerdo de Subvención nº 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "hu" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Segítsen nekünk előmozdítani a biodiverzitást az Open Food Facts oldalon!</h2>
@@ -128,10 +119,8 @@
       <p>A DIVINFOOD az Európai Unió Horizon 2020 kutatási és innovációs programja finanszírozásában részesült az 101000383 számú támogatási megállapodás keretében</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "da" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Hjælp os med at fremme biodiversitet på Open Food Facts!</h2>
@@ -153,10 +142,8 @@
       <p>DIVINFOOD er finansieret af Den Europæiske Unions Horizon 2020 forsknings- og innovationsprogram under tilskudsaftale nr. 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "sv" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Hjälp oss att främja biologisk mångfald på Open Food Facts!</h2>
@@ -178,10 +165,8 @@
       <p>DIVINFOOD har finansierats av Europeiska unionens forsknings- och innovationsprogram Horisont 2020 enligt bidragsavtal nr 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "de" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Hilf uns, die Biodiversität auf Open Food Facts zu fördern!</h2>
@@ -203,10 +188,8 @@
       <p>DIVINFOOD wurde durch das Forschungs- und Innovationsprogramm Horizont 2020 der Europäischen Union im Rahmen des Zuschussvertrags Nr. 101000383 finanziert</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "cs" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Pomoz nám podpořit biodiverzitu na Open Food Facts!</h2>
@@ -228,10 +211,8 @@
       <p>DIVINFOOD byl financován výzkumným a inovačním programem Horizont 2020 Evropské unie na základě grantové smlouvy č. 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "ro" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Ajută-ne să promovăm biodiversitatea pe Open Food Facts!</h2>
@@ -253,10 +234,8 @@
       <p>DIVINFOOD a fost finanțat din programul de cercetare și inovare Horizon 2020 al Uniunii Europene în cadrul Acordului de Grant nr. 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "el" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Βοήθησέ μας να προωθήσουμε τη βιοποικιλότητα στο Open Food Facts!</h2>
@@ -278,10 +257,8 @@
       <p>Το DIVINFOOD χρηματοδοτήθηκε από το πρόγραμμα έρευνας και καινοτομίας Horizon 2020 της Ευρωπαϊκής Ένωσης στο πλαίσιο της Σύμβασης Επιχορήγησης αρ. 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSIF lc == "pl" %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Pomożesz nam promować bioróżnorodność na Open Food Facts?</h2>
@@ -303,10 +280,8 @@
       <p>DIVINFOOD zostało sfinansowane przez program badawczo-innowacyjny Unii Europejskiej Horyzont 2020 w ramach umowy o grant nr 101000383</p>
     </div>
   </div>
-</section>
 
 [% ELSE %]
-<section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -329,8 +304,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   [% END %]
+</section>
 
 <style>
   #donation-banner-top .survey-logo {
@@ -364,8 +339,8 @@
        <img src="/images/misc/donation-banners/off-days-2025-fr.mobile.png"
        alt="Journées Open Food Facts 2025"
        width="1280"
-       height="477" class="show-for-small-only"/>       
-  </a>  
+       height="477" class="show-for-small-only"/>
+  </a>
   [% ELSE %]
   <a href="https://connect.openfoodfacts.org/event/open-food-facts-days-2025-30/register">
     <img src="/images/misc/donation-banners/off-days-2025-en.1280x191.png"
@@ -375,7 +350,7 @@
     <img src="/images/misc/donation-banners/off-days-2025-en.mobile.png"
        alt="Open Food Facts Days 2025"
        width="1280"
-       height="477" class="show-for-small-only"/>    
+       height="477" class="show-for-small-only"/>
   </a>
   [% END %]
 [% ELSE %]

--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -339,8 +339,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -363,8 +363,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
@@ -362,8 +362,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -386,9 +386,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -339,8 +339,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -363,9 +363,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -352,8 +352,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -376,8 +376,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -366,8 +366,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -352,8 +352,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -376,8 +376,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -340,8 +340,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>¡Ayúdanos a promover la biodiversidad en Open Food Facts!</h2>
@@ -363,9 +363,9 @@
       <p>DIVINFOOD ha sido financiado por el programa de investigación e innovación Horizonte 2020 de la Unión Europea en el marco del Acuerdo de Subvención nº 101000383</p>
     </div>
   </div>
+
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -350,8 +350,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -374,8 +374,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/product_write/post-product-add-nutrition.html
+++ b/tests/integration/expected_test_results/product_write/post-product-add-nutrition.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -388,8 +388,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-off.html
+++ b/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-off.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -388,8 +388,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-on.html
+++ b/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-on.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -388,8 +388,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
+++ b/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
@@ -382,8 +382,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -406,8 +406,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -388,9 +388,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -388,9 +388,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -388,9 +388,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
+++ b/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -366,8 +366,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/upload_images/post-product-image-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/upload_images/post-product-image-bad-oauth-token.html
@@ -339,8 +339,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -363,8 +363,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>¡Ayúdanos a promover la biodiversidad en Open Food Facts!</h2>
@@ -365,9 +365,9 @@
       <p>DIVINFOOD ha sido financiado por el programa de investigación e innovación Horizonte 2020 de la Unión Europea en el marco del Acuerdo de Subvención nº 101000383</p>
     </div>
   </div>
+
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -366,9 +366,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -365,9 +365,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -366,9 +366,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -382,8 +382,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -406,9 +406,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -365,9 +365,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -366,9 +366,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -352,8 +352,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -376,9 +376,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -352,8 +352,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -376,9 +376,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -352,8 +352,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -376,9 +376,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -344,8 +344,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -368,9 +368,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -365,9 +365,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -365,9 +365,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Aidez-nous à promouvoir la biodiversité sur Open Food Facts !</h2>
@@ -365,9 +365,8 @@
       <p>DIVINFOOD a été financé par le programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de l'accord de subvention n°101000383</p>
     </div>
   </div>
+
 </section>
-
-
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/report-image-button.html
+++ b/tests/integration/expected_test_results/web_html/report-image-button.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -366,8 +366,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -366,8 +366,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -366,8 +366,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -382,8 +382,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -406,8 +406,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -364,8 +364,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -388,8 +388,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -342,8 +342,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -366,8 +366,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -352,8 +352,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -376,8 +376,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes-gs1-formats.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes-gs1-formats.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -344,8 +344,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -368,8 +368,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-search-histogram-nutrition-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-search-histogram-nutrition-sugars.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {

--- a/tests/integration/expected_test_results/web_html/world-search-scatter-plot-nutrition-sugars-fat.html
+++ b/tests/integration/expected_test_results/web_html/world-search-scatter-plot-nutrition-sugars-fat.html
@@ -341,8 +341,8 @@
 
 
 
-  
 <section id="donation-banner-top" class="row" style="position:relative;background-color:#eeffee;padding:2rem;flex-direction:column;">
+  
   <div class="row align-middle" style="margin-bottom:1rem;">
     <div class="columns small-12 medium-9">
       <h2>Help us promote biodiversity in Open Food Facts!</h2>
@@ -365,8 +365,8 @@
       <p>DIVINFOOD has been funded from the European Union’s Horizon 2020 research and innovation programme under the Grant Agreement N°101000383</p>
     </div>
   </div>
-</section>
   
+</section>
 
 <style>
   #donation-banner-top .survey-logo {


### PR DESCRIPTION
SonarQube is not happy with how many times HTML elements are given the `id` of “donation-banner-top”. This moves the `<section>` element outside of the language IF-ELSE clause.

It is still defined more than one time, but this should at least make SonarQube (and other tools?) a bit less noisy.