### PR TITLE
ci: run fewer jobs on taxonomy-only changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,13 @@ name: "CodeQL"
 on:
   push:
     branches: [main]
+    paths_ignore:
+      - 'taxonomy/**'  # No need to run for taxonomy-only changes
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+    paths_ignore:
+      - 'taxonomy/**'  # No need to run for taxonomy-only changes
   schedule:
     - cron: '0 23 * * 4'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code_modified: ${{ steps.filter.outputs.code }}
+      taxonomy_only: ${{ ! steps.filter.outputs.any_non_taxonomy }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -39,13 +40,16 @@ jobs:
             - '**/*'       # Catch everything else
             - '!**/*.md'   # Exclude all Markdown files
             - '!docs/**'   # Exclude docs/ folder
+            any_non_taxonomy:
+            - '**/*'         # Catch everything
+            - '!taxonomy/**' # Except taxonomy files
           predicate-quantifier: 'every'
 
   lint:
     name: 🕵️‍♀️ NPM lint
     needs: filter
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.filter.outputs.code_modified == 'true'
+    if: github.event_name == 'pull_request' && needs.filter.outputs.code_modified == 'true' && needs.filter.outputs.taxonomy_only == 'false'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -136,7 +140,7 @@ jobs:
             ${{
               (!github.event.pull_request.head.repo.fork) &&
               format('type=registry,ref={0},mode=max', steps.registry_ref.outputs.registry_ref) ||
-              '' 
+              ''
             }}
           load: true                   # loads the image into local docker daemon
           tags: openfoodfacts-server/backend:dev
@@ -144,58 +148,58 @@ jobs:
       - name: Clean up duplicate BuildKit cache and additional space
         run: |
           echo "🧹 Cleaning up duplicate BuildKit cache before Docker save..."
-          
+
           # Show space before cleanup
           echo "Space before cleanup:"
           df -h / | tail -1
-          
+
           # Remove the old BuildKit cache (keeping the new one)
           echo "Removing old BuildKit cache..."
           time rm -rf /tmp/.buildx-cache
-          
+
           # Additional cleanup to get us over the threshold
           echo "Additional cleanup for more space..."
-          
+
           # Remove APT package cache (can be regenerated)
           time sudo apt-get clean
           time sudo rm -rf /var/cache/apt/archives/*.deb
-          
+
           # Remove large APT lists (can be regenerated)
           time sudo rm -rf /var/lib/apt/lists/*
-          
+
           # Remove any temporary files in /tmp
           time sudo find /tmp -type f -size +50M -delete 2>/dev/null || true
-          
+
           # Remove Docker build cache that's not needed for save
           time docker builder prune -af || true
-          
+
           # Show space freed
           echo "Space after cleanup:"
           time df -h / | tail -1
-          
+
           # Calculate available space
           AVAIL=$(df / | tail -1 | awk '{print $4}')
           AVAIL_GB=$((AVAIL/1024/1024))
           echo "Available space: ${AVAIL_GB}GB"
-          
+
           # Docker save will need ~12-16GB, check if we have enough
           if [ "$AVAIL_GB" -lt 16 ]; then
             echo "⚠️ Still tight on space. Available: ${AVAIL_GB}GB, needed: ~12-16GB"
             echo "Need more cleanup..."
-            
+
             # Additional aggressive cleanup - AVOID Docker image cleanup entirely
             echo "Performing aggressive system cleanup (avoiding Docker images)..."
-            
+
             # First verify our target image exists
             echo "Checking if target image exists..."
             time docker images openfoodfacts-server/backend:dev
-            
+
             # SKIP Docker cleanup entirely to preserve our image
             echo "Skipping Docker cleanup to preserve target image..."
-            
+
             # Focus on system files only
             echo "Cleaning system caches and files..."
-            
+
 
             echo "Clean up system caches (this freed the most space)"
             time sudo rm -rf /var/log/*.log /var/log/*/*.log || true
@@ -203,22 +207,22 @@ jobs:
             time sudo rm -rf /usr/share/doc/* || true
             time sudo rm -rf /usr/share/man/* || true
             time sudo rm -rf /usr/share/locale/* || true
-            
+
             echo "Clean up more system temporary files"
             time sudo rm -rf /tmp/* || true
             time sudo rm -rf /var/tmp/* || true
-            
+
             # Verify our image still exists
             echo "Verifying target image still exists..."
             time docker images openfoodfacts-server/backend:dev
-            
+
             # Final space check
             echo "Space after aggressive cleanup:"
             df -h / | tail -1
             AVAIL=$(df / | tail -1 | awk '{print $4}')
             AVAIL_GB=$((AVAIL/1024/1024))
             echo "Final available space: ${AVAIL_GB}GB"
-            
+
             if [ "$AVAIL_GB" -lt 15 ]; then
               echo "removing files at the cost of time"
 
@@ -266,7 +270,7 @@ jobs:
 
       - name: Setup Git and Restore Taxonomies
         run: ./.github/scripts/setup_git.sh
-        
+
       # Update dynamic test groups before running tests
       - name: Update dynamic test groups
         run: ./.github/scripts/update_test_groups.sh
@@ -385,10 +389,13 @@ jobs:
       run: make check_taxonomies
     - name: check perltidy
       run: make check_perltidy
+      if: needs.filter.outputs.taxonomy_only == 'false'
     - name: check perlcritic
       run: make check_critic
+      if: needs.filter.outputs.taxonomy_only == 'false'
     - name: check perl
       run: make check_perl
+      if: needs.filter.outputs.taxonomy_only == 'false'
 
   generate_perl_sbom:
     name: 📦 Generate Perl SBOM
@@ -396,7 +403,7 @@ jobs:
       contents: write
     needs: [filter, build_backend]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.code_modified == 'true'
+    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.code_modified == 'true' && needs.filter.outputs.taxonomy_only == 'false'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -441,7 +448,7 @@ jobs:
       security-events: write
     needs: [filter, build_backend]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.code_modified == 'true'
+    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.code_modified == 'true' && needs.filter.outputs.taxonomy_only == 'false'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -492,7 +499,7 @@ jobs:
       security-events: write
     needs: [build_frontend]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request')
+    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.taxonomy_only == 'false'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -548,7 +555,7 @@ jobs:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 1
-    
+
     # Cache dynamic test groups and timing data
     - uses: actions/cache@v5
       id: test_groups_cache
@@ -558,26 +565,26 @@ jobs:
         restore-keys: |
           test-groups-${{ hashFiles('tests/**/*.t') }}-
           test-groups-
-    
+
     - name: Calculate optimal test group counts
       id: matrix
       run: |
         echo "🥫 Calculating optimal test group counts..."
-        
+
         # Generate matrix configuration using the Python script
         python3 scripts/generate_matrix_config.py > matrix_config.json
-        
+
         # Extract group counts
         unit_groups=$(python3 -c "import json; data=json.load(open('matrix_config.json')); print(json.dumps(data['unit_group_range']))")
         integration_groups=$(python3 -c "import json; data=json.load(open('matrix_config.json')); print(json.dumps(data['integration_group_range']))")
-        
+
         echo "🥫 Unit test groups: $unit_groups"
         echo "🥫 Integration test groups: $integration_groups"
-        
+
         # Set outputs for the matrix
         echo "unit_test_groups=$unit_groups" >> $GITHUB_OUTPUT
         echo "integration_test_groups=$integration_groups" >> $GITHUB_OUTPUT
-        
+
         # Display the calculated matrix
         cat matrix_config.json
 
@@ -596,7 +603,7 @@ jobs:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 1
-    
+
     # Restore cached taxonomies built in build_backend job
     # This avoids rebuilding taxonomies for each test group
     - uses: actions/cache/restore@v5
@@ -605,7 +612,7 @@ jobs:
         path: ./build-cache
         key: taxonomies-${{ hashFiles('taxonomies/**') }}
         restore-keys: taxonomies-
-    
+
     # Cache dynamic test groups and timing data
     # This enables persistent learning and avoids regenerating groups unnecessarily
     - uses: actions/cache@v5
@@ -616,43 +623,43 @@ jobs:
         restore-keys: |
           test-groups-unit-${{ hashFiles('tests/unit/**/*.t') }}-
           test-groups-unit-
-    
+
     - name: Setup Git and Restore Taxonomies
       run: ./.github/scripts/setup_git.sh
-    
+
     # Update dynamic test groups before running tests
     # This ensures optimal load balancing based on historical timing data
     - name: Update dynamic test groups
       run: |
         echo "🥫 Checking and updating dynamic test groups..."
         ./.github/scripts/update_test_groups.sh
-        
+
         # Ensure .mk files are regenerated for current test discovery
         echo "🥫 Regenerating unit test groups for Makefile..."
         python3 scripts/dynamic_test_grouper.py --type=unit --force > .test_groups_cache/unit_groups.mk
-    
+
     # Download the Docker image built in build_backend job as an artifact
     # This reuses the cached Docker image instead of rebuilding it
     - name: Download backend image from artifacts
       id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.1.0
       with:
-        image: "openfoodfacts-server/backend:dev"       
-    
+        image: "openfoodfacts-server/backend:dev"
+
     # Clean up downloaded file to save GitHub Actions storage space
     # The image is already loaded into Docker daemon, file no longer needed
     - name: Remove downloaded image
       env:
         FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
       run: rm $FILE
-    
+
     # Build test-specific taxonomies and language files
     # These use the cached taxonomies from build_backend when possible
     - name: Build taxonomies for tests
       run: make DOCKER_LOCAL_DATA="$(pwd)" build_taxonomies_test GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
     - name: Build language files for tests
       run: make DOCKER_LOCAL_DATA="$(pwd)" build_lang_test GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
-    
+
     # Run unit tests for this specific test group (parallel execution)
     # Matrix strategy splits tests across 6 parallel jobs for faster execution
     # Now uses dynamically generated groups for optimal load balancing
@@ -661,7 +668,7 @@ jobs:
         echo "🥫 Running dynamically balanced unit test group ${{ matrix.test-group }}..."
         make codecov_prepare
         make COVER_OPTS='-e HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,tests/"' DOCKER_LOCAL_DATA="$(pwd)" unit_test_group TEST_GROUP=${{ matrix.test-group }} GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
-    
+
     # Update timing data after test execution for future optimization
     # This enables the system to learn and improve load balancing over time
     - name: Update test timing data
@@ -678,14 +685,14 @@ jobs:
     # Generate coverage results for this test group
     # Codecov will automatically merge coverage from all parallel test groups
     - name: Generate coverage results
-      if: always()
+      if: needs.filter.outputs.taxonomy_only == 'false'
       run: |
         make coverage_txt
         make codecov
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: always()
+      if: needs.filter.outputs.taxonomy_only == 'false'
       with:
         files: cover_db/codecov.json
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -693,7 +700,7 @@ jobs:
         name: unit-coverage-${{ matrix.test-group }}
 
     - name: Upload test results to Codecov
-      if: ${{ !cancelled() }}
+      if: ${{ needs.filter.outputs.taxonomy_only == 'false' && !cancelled() }}
       uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -713,14 +720,14 @@ jobs:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 1
-    
+
     - uses: actions/cache/restore@v5
       id: taxonomies_cache
       with:
         path: ./build-cache
         key: taxonomies-${{ hashFiles('taxonomies/**') }}
         restore-keys: taxonomies-
-    
+
     # Cache dynamic test groups and timing data for integration tests
     # Integration tests typically have more variable execution times
     - uses: actions/cache@v5
@@ -731,17 +738,17 @@ jobs:
         restore-keys: |
           test-groups-integration-${{ hashFiles('tests/integration/**/*.t') }}-
           test-groups-integration-
-    
+
     - name: Setup Git and Restore Taxonomies
       run: ./.github/scripts/setup_git.sh
-  
+
     # Update dynamic test groups before running tests
     # Integration tests benefit more from timing-based grouping due to variable execution times
     - name: Update dynamic test groups
       run: |
         echo "🥫 Checking and updating dynamic integration test groups..."
         ./.github/scripts/update_test_groups.sh
-        
+
         # Ensure .mk files are regenerated for current test discovery
         echo "🥫 Regenerating integration test groups for Makefile..."
         python3 scripts/dynamic_test_grouper.py --type=integration --force > .test_groups_cache/integration_groups.mk
@@ -750,18 +757,18 @@ jobs:
       id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.1.0
       with:
-        image: "openfoodfacts-server/backend:dev"       
-    
+        image: "openfoodfacts-server/backend:dev"
+
     - name: Remove downloaded image
       env:
         FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
       run: rm $FILE
-    
+
     - name: Build taxonomies for tests
       run: make DOCKER_LOCAL_DATA="$(pwd)" build_taxonomies_test GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
     - name: Build language files for tests
       run: make DOCKER_LOCAL_DATA="$(pwd)" build_lang_test GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
-    
+
     # Run integration tests for this specific test group (parallel execution)
     # Matrix strategy splits tests across 9 parallel jobs (more than unit tests)
     # Integration tests typically take longer and test end-to-end functionality
@@ -771,7 +778,7 @@ jobs:
         echo "🥫 Running dynamically balanced integration test group ${{ matrix.test-group }}..."
         make codecov_prepare
         make COVER_OPTS='-e HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,tests/"' DOCKER_LOCAL_DATA="$(pwd)" integration_test_group TEST_GROUP=${{ matrix.test-group }} GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
-    
+
     # Update timing data after test execution for future optimization
     # Integration test timing data is especially valuable due to higher variance
     - name: Update test timing data
@@ -788,14 +795,14 @@ jobs:
     # Generate coverage results for this test group
     # Codecov will automatically merge coverage from all parallel test groups
     - name: Generate coverage results
-      if: always()
+      if: needs.filter.outputs.taxonomy_only == 'false'
       run: |
         make coverage_txt
         make codecov
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: always()
+      if: needs.filter.outputs.taxonomy_only == 'false'
       with:
         files: cover_db/codecov.json
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -803,7 +810,7 @@ jobs:
         name: integration-coverage-${{ matrix.test-group }}
 
     - name: Upload test results to Codecov
-      if: ${{ !cancelled() }}
+      if: ${{ needs.filter.outputs.taxonomy_only == 'false' && !cancelled() }}
       uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -868,7 +875,7 @@ jobs:
     name: 🦾 Some test of deployment tools
     needs: filter
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.filter.outputs.code_modified == 'true'
+    if: github.event_name == 'pull_request' && needs.filter.outputs.code_modified == 'true' && needs.filter.outputs.taxonomy_only == 'false'
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
We current do a rough filter for whether there is any modified code, which includes the taxonomy files (as it should, as changed taxonomy files can break tests!). However, some parts of the CI do not need to run if all that has been changed are taxonomy files. E.g., there’s no need to lint Perl code, generate SBOMs, etc.

This adds a new filter `taxonomy_only` for whether a PR only touches files under the `taxonomy/` root directory and checks for it in a number of `if` checks in the jobs and tasks.

This should result both in faster turn-around for taxonomy-only changes and additionally decrease our energy/resource consumption impact by running a few less processes/having containers up for a bit shorter time.

Related: https://openfoodfacts.slack.com/archives/C02LDQDDD/p1772445237311119