### PR TITLE
fix: Safari nutrition image layout rounding issue

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -1093,6 +1093,12 @@ $(function () {
             // clear the values: inputs with class nutrient_value that are inside a cell with the input_set_class
             $('.' + input_set_class + ' input.nutrient_value').val('');
         }
+        
+        
+        // Recalculate nutrition image position after table resize
+        setTimeout(update_nutrition_image_copy, 50);
+        
+        
     });
 
     $('#no_nutrition_data').on('change', function() {


### PR DESCRIPTION
### Description

Fixes nutrition image copy misalignment in Safari.

Safari was calculating element widths with fractional pixel values,
which caused incorrect positioning. This change uses
getBoundingClientRect() along with Math.ceil / Math.floor
to ensure consistent width calculations.

Fixes #13202


### Type of change
- Bug fix

### Tested on
- Safari
- Chrome
