### PR TITLE
fix: bump trivy to 0.34.2

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -78,7 +78,7 @@ jobs:
         artifact-name: ${{ matrix.image_name }}-sbom
         dependency-snapshot: ${{ github.ref == 'refs/heads/main' }}
     - name: Trivy scan for ${{ matrix.image_name }} image
-      uses: aquasecurity/trivy-action@0.34.1
+      uses: aquasecurity/trivy-action@0.34.2
       with:
         image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image_name }}:sha-${{ github.sha }}
         format: 'sarif'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -473,7 +473,7 @@ jobs:
         artifact-name: backend-sbom
         dependency-snapshot: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     - name: Trivy scan for backend image
-      uses: aquasecurity/trivy-action@0.34.1
+      uses: aquasecurity/trivy-action@0.34.2
       with:
         image-ref: openfoodfacts-server/backend:dev
         format: 'sarif'
@@ -524,7 +524,7 @@ jobs:
         artifact-name: frontend-sbom
         dependency-snapshot: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     - name: Trivy scan for frontend image
-      uses: aquasecurity/trivy-action@0.34.1
+      uses: aquasecurity/trivy-action@0.34.2
       with:
         image-ref: openfoodfacts-server/frontend:dev
         format: 'sarif'


### PR DESCRIPTION
Because old version fetches an unpublished version of trivy
