### PR TITLE
ci: fix `taxonomy_only` check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,13 +41,9 @@ jobs:
             - '!**/*.md'   # Exclude all Markdown files
             - '!docs/**'   # Exclude docs/ folder
             any_non_taxonomy:
-            - '**/*'         # Catch everything else
-            - '!taxonomies/**' # Skip taxonomy files
+            - '**/*'           # Catch everything
+            - '!taxonomies/**' # Except taxonomy files
           predicate-quantifier: 'every'
-      - name: "Some debug output"
-        run: |
-          echo 'code: '${{ steps.filter.outputs.code }}
-          echo 'taxonomy_only: '${{ steps.filter.outputs.any_non_taxonomy == 'false' }}
 
   lint:
     name: 🕵️‍♀️ NPM lint


### PR DESCRIPTION
### What

This fixes the `taxonomy_only` check in `pull_request.yml` which is used to determine whether to run/skip some of the CI actions done on pull requests.

It does this by checking against the actual directory, `taxonomies/`, instead of the fictitious `taxonomy/` directory.

The `taxonomy_only` value is also changed to the result of an actual boolean check (`== 'false'`), rather than using inversion (with NOT/`!`) which is a bit more fragile.

Tested against this PR that `taxonomy_only` is false and all the expected actions run, and against https://github.com/openfoodfacts/openfoodfacts-server/pull/13219 that `taxonomy_only` is true and that the expected actions do not run.

### Related issue(s) and discussion

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13209