### PR TITLE
ci: fix `paths_ignore` in codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
     paths_ignore:
-      - 'taxonomy/**'  # No need to run for taxonomy-only changes
+      - 'taxonomies/**'  # No need to run for taxonomy-only changes
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
     paths_ignore:
-      - 'taxonomy/**'  # No need to run for taxonomy-only changes
+      - 'taxonomies/**'  # No need to run for taxonomy-only changes
   schedule:
     - cron: '0 23 * * 4'
 


### PR DESCRIPTION
### What

Have the `codeql-analysis.yml` workflow ignore the actually existing `taxonomies/` directory rather than the not existing `taxonomy/` directory.

### Related issue(s) and discussion

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13209
See-also: https://github.com/openfoodfacts/openfoodfacts-server/pull/13220