### PR TITLE
taxonomy: add By Sainsbury's brand synonyms + Wikidata

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -862,7 +862,8 @@ wikidata:en: Q136984611
 
 xx: Saffola
 
-xx: Sainsbury's, Sainsburys
+xx: Sainsbury's, Sainsburys, By Sainsbury's, By Sainsburys
+wikidata:en: Q152096
 
 xx: Salling
 wikidata:en: Q137992460


### PR DESCRIPTION
### What

Adds `By Sainsbury's` / `By Sainsburys` as synonyms for Sainsbury's, plus the Wikidata link.

### Why

'By Sainsbury's' is how the retailer's own-brand line is printed on pack — it's not a misspelling, it's the actual on-pack branding. Product counts currently fragmented:

| tag | products |
|---|---|
| `sainsbury-s` | ~3400 |
| `by-sainsbury-s` | ~1300 |

Re-tagging after merge should consolidate.

(Didn't include `J Sainsbury` — that's the legal entity name, not something printed on packs.)