### PR TITLE
taxonomy(food): mark mycoprotein `vegan`

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -74365,6 +74365,7 @@ la: cantharellus lutescens
 pl: Pieprznik żyłkowany, pieprznik żółtawy
 wikipedia:es: https://es.wikipedia.org/wiki/Cantharellus_lutescens
 
+# <en:fungus
 en: mycoprotein
 es: micoproteína
 fi: mycoprotein
@@ -74372,6 +74373,8 @@ fr: mycoprotéine
 hr: mikoprotein
 it: micoproteina
 sv: mycoprotein
+vegan:en: yes
+vegetarian:en: yes
 wikidata:en: Q3122802
 
 < en:mycoprotein


### PR DESCRIPTION
Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13185