### PR TITLE
fix: mount node_modules volume for dynamicfront in dev environment

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -75,6 +75,7 @@ services:
       - icons_dist:/opt/product-opener/html/images/icons/dist
       - js_dist:/opt/product-opener/html/js/dist
       - css_dist:/opt/product-opener/html/css/dist
+      - node_modules:/opt/product-opener/node_modules
       # mount local folder for reload on dev changes, we follow Dockerfile.frontend COPYs
       - ./package.json:/opt/product-opener/package.json
       - ./package-lock.json:/opt/product-opener/package-lock.json


### PR DESCRIPTION
### What
- Adds missing `node_modules` volume mount to the `dynamicfront` service in `docker/dev.yml`
- Fixes CSS compilation failure that prevented stylesheets from loading in development environment
- The `dynamicfront` container needs access to `node_modules` (specifically `foundation-sites` package) to compile SCSS files, but this volume mount was only present in the main `docker-compose.yml` and missing from `docker/dev.yml`

### Why
After the `gulp-sass` upgrade to 6.0.1 (commit `eb9532f6fc`), the SCSS compilation started failing with:
<img width="297" height="45" alt="image" src="https://github.com/user-attachments/assets/b2a564cb-b64f-48ea-a7bb-f11217089fc4" />


This occurred because:
1. The `gulpfile.mjs` was updated to use `loadPaths` (breaking change in gulp-sass 6.x)
2. However, the `dynamicfront` service in dev mode couldn't access `node_modules` to resolve these imports
3. The volume mount existed in production config but was overlooked in the dev config

This bug affects **all new contributors** who clone the repository and run `make up`, resulting in a completely unstyled website and ~30-60 minutes of troubleshooting time.

### Related issue(s) and discussion
- Fixes: #13244 (CSS not generated in development environment after gulp-sass 6.0.1 upgrade)
- Related to: #13115 (CSS troubleshooting issue)
- Related to: #13116 (documented workaround for this bug)

### Additional context
- The `loadPaths` configuration in `gulpfile.mjs` was already fixed in the main branch
- This PR addresses the remaining missing piece: the volume mount in dev configuration
- Production builds are unaffected as they use pre-built images with CSS already compiled
- The fix is minimal (1 line added) and mirrors the existing volume mount structure used for other shared volumes (`icons_dist`, `js_dist`, `css_dist`)