### PR TITLE
feat(taxonomy): introduce plant_alternative property with example map…

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -86016,6 +86016,7 @@ lt: Jautienos paplotėliai
 agribalyse_proxy_food_code:en: 6260
 agribalyse_proxy_food_name:en: Burger, beef based, 15% fat, raw
 agribalyse_proxy_food_name:fr: Haché à base de bœuf ou Préparation de viande hachée de boeuf, 15% MG, cru
+plant_alternative:en: Vegetable patties
 
 < en:Steaks
 en: Ground steaks


### PR DESCRIPTION
This pull request introduces a new taxonomy property plant_alternative:en: in taxonomies/food/categories.txt to map animal based products to plant based alternatives.
Example mapping added: Beef patties → Vegetable patties