### PR TITLE
fix: use canonical "prepared" instead of "_prepared" in old-style nutrition API handler

### DIFF
--- a/lib/ProductOpener/Nutrition.pm
+++ b/lib/ProductOpener/Nutrition.pm
@@ -74,6 +74,7 @@ BEGIN {
 		&get_nutrient_from_nutrient_set_in_default_unit
 		&default_unit_for_nid
 		&add_misc_tags_for_input_nutrition_data_pers
+		&sort_sets_by_priority
 
 	);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);

--- a/lib/ProductOpener/ProductSchemaChanges.pm
+++ b/lib/ProductOpener/ProductSchemaChanges.pm
@@ -594,8 +594,10 @@ sub convert_schema_1003_to_1002_refactor_product_nutrition_schema ($product_ref,
 
 	else {
 		my $nutrient_set_ref = $product_ref->{nutrition}{aggregated_set};
-		my $preparation_state = ($nutrient_set_ref->{preparation} eq "prepared"
-			or $nutrient_set_ref->{preparation} eq "_prepared") ? "_prepared" : "";
+		my $preparation_state = (
+				   $nutrient_set_ref->{preparation} eq "prepared"
+				or $nutrient_set_ref->{preparation} eq "_prepared"
+		) ? "_prepared" : "";
 		# if per is 100ml then 1002 product version nutrient per field is 100g
 		my $per = $nutrient_set_ref->{per} eq "100ml" ? "_100g" : "_" . $nutrient_set_ref->{per};
 

--- a/tests/unit/nutrition.t
+++ b/tests/unit/nutrition.t
@@ -2101,18 +2101,18 @@ compare_to_expected_results(
 		"get_nutrition_input_sets_in_a_hash normalizes _prepared to prepared in the hash key");
 	ok(!defined $input_sets_hash_ref->{packaging}{_prepared},
 		"get_nutrition_input_sets_in_a_hash does not keep _prepared as a key");
-	is($input_sets_hash_ref->{packaging}{prepared}{"100g"}{nutrients}{sugars}{value}, 5.0,
-		"get_nutrition_input_sets_in_a_hash normalizes _prepared: nutrient value is preserved");
+	is($input_sets_hash_ref->{packaging}{prepared}{"100g"}{nutrients}{sugars}{value},
+		5.0, "get_nutrition_input_sets_in_a_hash normalizes _prepared: nutrient value is preserved");
 
 	# The preparation field inside the set should also be normalized
-	is($input_sets_hash_ref->{packaging}{prepared}{"100g"}{preparation}, "prepared",
-		"get_nutrition_input_sets_in_a_hash normalizes _prepared in the set's preparation field");
+	is($input_sets_hash_ref->{packaging}{prepared}{"100g"}{preparation},
+		"prepared", "get_nutrition_input_sets_in_a_hash normalizes _prepared in the set's preparation field");
 
 	# The as_sold set should be unaffected
 	ok(defined $input_sets_hash_ref->{packaging}{as_sold},
 		"get_nutrition_input_sets_in_a_hash keeps as_sold unchanged");
-	is($input_sets_hash_ref->{packaging}{as_sold}{"100g"}{nutrients}{sugars}{value}, 10.0,
-		"get_nutrition_input_sets_in_a_hash: as_sold nutrient value is preserved");
+	is($input_sets_hash_ref->{packaging}{as_sold}{"100g"}{nutrients}{sugars}{value},
+		10.0, "get_nutrition_input_sets_in_a_hash: as_sold nutrient value is preserved");
 }
 
 # Test that sort_sets_by_priority correctly handles both "prepared" and previously stored "_prepared"
@@ -2131,8 +2131,8 @@ compare_to_expected_results(
 		},
 	);
 	my @sorted = sort_sets_by_priority(\@input_sets);
-	is($sorted[0]->{preparation}, "prepared",
-		"sort_sets_by_priority: prepared (priority 0) sorts before as_sold (priority 1)");
+	is($sorted[0]->{preparation},
+		"prepared", "sort_sets_by_priority: prepared (priority 0) sorts before as_sold (priority 1)");
 }
 
 done_testing();


### PR DESCRIPTION
## Summary

The old-style API parameter handler (`assign_nutrition_values_from_old_request_parameters`) stored `preparation: "_prepared"` instead of the canonical `preparation: "prepared"`, causing multiple downstream bugs.

## What's broken

In `Nutrition.pm:1366`, the loop iterates over `("as_sold", "_prepared")`:

```perl
foreach my $preparation ("as_sold", "_prepared") {
```

But the canonical preparation values (used everywhere else) are `"as_sold"` and `"prepared"`. This mismatch causes:

1. **Wrong sort priority**: `sort_sets_by_priority()` has `prepared => 0` in `%preparation_priority`, but `"_prepared"` falls through to `_default => 2` (lowest priority). This means prepared nutrition data sorts **last** instead of **first**.

2. **Schema downgrade failure**: `ProductSchemaChanges.pm:597` checks `$preparation eq "prepared"` — so `"_prepared"` data doesn't get recognized as prepared when reading back via API v2, and its nutrient fields get written without the `_prepared` suffix.

3. **Inconsistency**: The CSV import handler (`Nutrition.pm:1815`) and the new-style API handler (which uses `get_preparations_for_product_type()`) both correctly use `"prepared"`.

## The fix

Three changes, all minimal:

1. **`Nutrition.pm:1366`** — Change `"_prepared"` to `"prepared"` in the foreach loop. The `$preparation_suffix` computation on the next line remains unchanged (it maps `"as_sold"` → `""` and anything else → `"_prepared"` for CGI param names).

2. **`Nutrition.pm:get_nutrition_input_sets_in_a_hash()`** — Add normalization that converts `"_prepared"` → `"prepared"` when loading input sets from storage. This ensures old products written with the buggy value are handled correctly by all downstream code.

3. **`ProductSchemaChanges.pm:597`** — Accept both `"prepared"` and `"_prepared"` in the schema downgrade check, as a belt-and-suspenders defense for any aggregated sets that might still contain the old value.

## Backwards compatibility

- **Old products with `preparation: "_prepared"` in storage**: Handled by the normalization in `get_nutrition_input_sets_in_a_hash()`. When loaded, `"_prepared"` is rewritten to `"prepared"` both in the hash key and in the set's `preparation` field, so all downstream code sees the canonical value.
- **New writes**: Will correctly use `"prepared"` going forward.
- **Schema downgrade**: Handles both values explicitly.

## Tests added

- Verifies `get_nutrition_input_sets_in_a_hash()` normalizes `"_prepared"` → `"prepared"` in both the hash structure and the set's internal field
- Verifies `sort_sets_by_priority()` correctly sorts `"prepared"` (priority 0) before `"as_sold"` (priority 1)