### PR TITLE
feat: add Matomo event when deleting a product page (#13218)

### DIFF
--- a/templates/web/pages/product_edit/product_edit_form_display_user-moderator.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display_user-moderator.tt.html
@@ -16,4 +16,12 @@
 
 </form>
 
+<script>
+document.getElementById("product_form").addEventListener("submit", function () {
+  if (typeof _paq !== "undefined") {
+    _paq.push(['trackEvent', 'Product', 'Delete product page']);
+  }
+});
+</script>
+
 <!-- end templates/[% template.name %] -->


### PR DESCRIPTION
## What

This PR adds a Matomo tracking event when a product page is deleted.

The event is triggered when the delete confirmation form is submitted in the product edit interface.

## Why

Tracking this action helps us better understand how often product pages are deleted and provides more visibility into user interactions on the platform.

## Changes

- Added a Matomo `trackEvent` call when the delete product form is submitted.
- The event is triggered from the `product_edit_form_display_user-moderator.tt.html` template.

Fixes #13218