### PR TITLE
feat: Add plant_alternative mappings for 5 animal-based categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -45433,6 +45433,7 @@ fr: Fromages apéritif
 
 < en:Fermented milk products
 en: Cheeses
+plant_alternative:en: vegan-cheese
 af: Kaas
 an: Queso
 ang: Cīese
@@ -51953,6 +51954,7 @@ intake24_category_code:en: MILK
 
 < en:Milks (liquid and powder)
 en: Milks, Milk as a drink
+plant_alternative:en: plant-milk
 af: Melk
 am: ወተት
 an: Leit
@@ -86010,6 +86012,7 @@ lt: Mėsos paplotėliai
 < en:Beef preparations
 < en:Meat patties
 en: Beef patties
+plant_alternative:en: veggie-patties
 fr: Galettes au bœuf
 hr: Goveđe pljeskavice
 lt: Jautienos paplotėliai
@@ -89407,6 +89410,7 @@ fr: Nuggets de volaille cuits
 < en:Breaded chicken
 < en:Poultry nuggets
 en: Chicken nuggets
+plant_alternative:en: plant-based-nuggets
 bg: Пилешки хапки
 de: Hähnchen-Nuggets
 es: Nugget de pollo
@@ -99614,6 +99618,7 @@ intake24_category_code:en: BRGB
 
 < en:Hamburgers
 en: Beef hamburgers
+plant_alternative:en: veggie-burger
 intake24_category_code:en: BBRG
 
 < en:Hamburgers


### PR DESCRIPTION
# Implement Issue #13248: Add `plant_alternative:en` property to taxonomy

## Description
This Pull Request introduces the `plant_alternative:en` property inside the [taxonomies/food/categories.txt](cci:7://file:///Users/saurabhkumar/Desktop/openfoodfacts-server/taxonomies/food/categories.txt:0:0-0:0) file. This new property connects animal-based food products with their plant-based analogs directly through the taxonomy, enabling dynamic mappings for end-users scanning items to suggest vegan equivalents and comparisons.

Five initial mappings have been added as proofs of concepts:
* **Beef patties** -> `veggie-patties`
* **Chicken nuggets** -> `plant-based-nuggets`
* **Milks** -> `plant-milk`
* **Cheeses** -> `vegan-cheese`
* **Beef hamburgers** -> `veggie-burger`

## Validity Checklist
- [x] Tested with existing taxonomy file schema syntax
- [x] No hierarchical indentations broken or lines stripped
- [x] All 5 base animal categories resolved to exact plant-based target names
