### PR TITLE
fix: Handle subingredients specified after their main ingredient Fixe…

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -6908,6 +6908,52 @@ sub preparse_ingredients_text ($ingredients_lc, $text) {
 	# turn & to and
 	$text =~ s/ \& /$and/g;
 
+	# Handle subingredients specified after their main ingredient #13234
+	# e.g. "skållning, surdeg (skållning och surdeg består av VETEmjöl)" -> "skållning (VETEmjöl), surdeg (VETEmjöl)"
+	my %consists_of = (
+		'en' => 'consists? of',
+		'sv' => 'består (?:av|utav)',
+		'da' => 'består af',
+		'nb' => 'består av',
+		'nn' => 'består av',
+		'de' => 'besteh(?:en|t) aus',
+		'nl' => 'bestaa[nt] uit',
+	);
+
+	if (defined $consists_of{$ingredients_lc} && $text =~ /$consists_of{$ingredients_lc}/i) {
+		my $consists = $consists_of{$ingredients_lc};
+		my $and_q = quotemeta($and_without_spaces);
+		
+		# loop to process distributive statements incrementally across nested or scattered scopes
+		while ($text =~ /(.*?)\(\s*(.+?)\s+($consists)\s+((?:[^()]+|\([^()]+\))+)\s*\)(.*)/is) {
+			my $before = $1;
+			my $subject = $2;
+			my $consists_matched = $3;
+			my $subingredients = $4;
+			my $after = $5;
+			
+			# Split on commas or "and"
+			my @subject_parts = split(/\s*,\s*|\s+$and_q\s+/i, $subject);
+			my $regex_parts = join('\s*(?:,|\s*' . $and_q . '\s*)\s*', map { quotemeta($_) } @subject_parts);
+			
+			if ($before =~ s/($regex_parts(?:(?:,|\s*$and_q\s*)\s*)?)\s*$//i) {
+				my $matched_parts = $1;
+				# Clean up the trailing comma/and from matched parts if present
+				$matched_parts =~ s/(?:,|\s*$and_q\s*)\s*$//i;
+				
+				my @actual_parts = split(/\s*,\s*|\s+$and_q\s+/i, $matched_parts);
+				my $rewritten = join(", ", map { "$_ ($subingredients)" } @actual_parts);
+				
+				# attach distributed properties back securely formatted 
+				$text = $before . $rewritten . $after;
+			} else {
+				# Could not rigidly match preceding component scope, break to avoid looping
+				$text = $before . "(" . $subject . " " . $consists_matched . " " . $subingredients . ")" . $after;
+				last;
+			}
+		}
+	}
+
 	# number + gr / grams -> g
 	$text =~ s/(\d\s*)(gr|gram|grams)\b/$1g/ig;
 	if ($ingredients_lc eq 'fr') {


### PR DESCRIPTION
This PR adds proper handling for ingredient strings where the sub‑ingredients are listed **after** the main ingredient inside parentheses, a pattern that was previously missed (e.g. `skållning, surdeg (skållning och surdeg består av VETEmjöl, RÅGmjöl, vatten, KORNmalt)`).  

### What was changed
- **lib/ProductOpener/Ingredients.pm**
  - Extended [preparse_ingredients_text](cci:1://file:///Users/saurabhkumar/Desktop/openfoodfacts-server/lib/ProductOpener/Ingredients.pm:6837:0-7329:1) with a new processing block that:
    - Detects language‑specific “consists of” phrases (`består av`, `consists of`, etc.) using a `%consists_of` map.
    - Captures the parenthesised clause, extracts the list of sub‑ingredients, and distributes them to each preceding ingredient (splitting on commas and the language‑specific “and”).
    - Works with nested parentheses and multiple languages (sv, en, da, nb, nn, de, nl).
    - Leaves the original text untouched when a match cannot be safely applied.
  - Added explanatory comments for maintainability.

### Why this is needed
Issue **#13234** reported that products such as “skållning, surdeg (skållning och surdeg består av …)” were not correctly parsed – the sub‑ingredients were ignored and the parent ingredient text was treated as a separate ingredient. The new logic ensures that each parent ingredient receives the same list of sub‑ingredients, matching the expected behavior.

### How to test
1. Run the ingredient parser on a product containing a pattern like the one above (e.g. the example used in the issue).  
2. Verify that the resulting ingredient list includes both `skållning (VETEmjöl, RÅGmjöl, vatten, KORNmalt)` and `surdeg (VETEmjöl, RÅGmjöl, vatten, KORNmalt)`.  
3. Run the full test suite (`make test` or the project's equivalent) to ensure no regressions.  

No existing tests were modified; the change has been manually verified with the example strings and passes the existing suite.

---

**Related Issue**: Closes #13234.
