### PR TITLE
taxonomy(food): some jeera/cumin edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -75059,19 +75059,33 @@ en: Glutamate, Monosodium glutamate
 fr: Glutamate, Glutamate monosodique
 
 < en:Spices
-en: Cumin, Cummin
+en: Cumin, Cummin, Jeera
+ar: كمون
 bg: Кимион
+ca: Comí, Comí castellà
+da: Spidskommen
 de: Kümmel, Kreuzkümmel
+eo: Oficina kuminoj
 es: Comino
 fi: juustokumina
 fr: Cumin, Jeera
+ga: Cuimín
 hr: Kim
+io: Kumino
 ja: クミン
+ku: Reşke
 la: Cuminum cyminum
 lt: Kuminas
+nb: Spisskummer
 nl: Komijn
 nl_be: Komijn
+nn: Spisskummar
+ro: Chimionul
+sv: Spiskummin
+sw: Jira
 tr: Kimyon, Boyotu
+ur: زیرہ
+zh: 孜然
 agribalyse_proxy_food_code:en: 11042
 agribalyse_proxy_food_name:en: Cumin, seed
 agribalyse_proxy_food_name:fr: Cumin, graine
@@ -75079,24 +75093,36 @@ wikidata:en: Q132624
 
 < en:Cumin
 en: Ground cumin seeds
-es: Comino molido, Comino en polvo
-fr: Cumin en poudre, Cumin moulu
+da: Malet spidskommen
+es: Comino molido
+fr: Cumin moulu
 hr: Mljevene sjemenke kimaskumin
 lt: Maltos kuminų sėklos
 nl: Gemalen komijn, Djinten
+sv: Mald spiskummin
+
+< en:Ground cumin seeds
+en: Cumin powders, Jeera powder
+da: Spidskommenpulvere
+es: Comino en polvo
+fr: Cumin en poudre
+sv: Spiskumminpulver
 
 < en:Cumin
 en: Whole cumin seeds, Cumin seeds
+da: Hele spidskommenfrø
 de: Ganze Kreuzkümmelsamen
 es: Comino en grano
 fr: Graines de cumin
 hr: Cijele sjemenke kumina
 lt: Kuminų sėklos
 nl: Komijnzaden, Grove komijn
+sv: Hela spiskumminfrön
 agribalyse_food_code:en: 11042
 ciqual_food_code:en: 11042
 ciqual_food_name:en: Cumin, seed
 ciqual_food_name:fr: Cumin, graine
+wikidata:en: Q57328174
 
 < en:Aromatic herbs
 en: Caraway seeds


### PR DESCRIPTION
- Adds “jeera” as alias for cumin (it seems to be a/the common name for cumin in India and possibly elsewhere)
- Adds new category for cumin/jeera powders
- Adds a number of translations for the `en:Cumin` category
- Adds Danish and Swedish translations for all the children of the `en:Cumin` category
- Adds `wikidata` property to cumin seeds category

Source: https://www.vegrecipesofindia.com/cumin-powder/
Needed-for: https://world.openfoodfacts.org/facets/categories/jeera-powder