### PR TITLE
taxonomy(food): curry edits

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -467,6 +467,10 @@ xx: Healthy Co
 
 xx: Heinz
 
+xx: Hela
+#web:en: https://www.hela.eu/unsere-marken/hela/
+wikidata:en: Q1601652
+
 xx: HEMA
 wikidata:en: Q137799387
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -75036,19 +75036,24 @@ nl: Hele kruidnagels
 expected_ingredients:en: en:clove
 
 < en:Spices
-en: Curry powder
+en: Curry powders, Curry powder
 bg: Къри на прах
+da: Karrypulvere
 de: Curry Pulver, Curry
 es: Curry en polvo
 fr: Curry en poudre, Poudre de curry, Curry, kari
 hr: Curry prah
 ja: カレー粉
 lt: Kario milteliai
+nb: Karipulver, Karipulvere
 nl: Kerriepoeders, Kerriepoeder, Curry, Kerrie
+nn: Karipulver
+sv: Currypulver
 agribalyse_food_code:en: 11005
 ciqual_food_code:en: 11005
 ciqual_food_name:en: Curry, powder
 ciqual_food_name:fr: Curry, poudre
+wikidata:en: Q1144935
 
 < en:Spices
 en: Garam masala
@@ -77096,6 +77101,7 @@ wikidata:en: Q17082116
 
 < en:Sauces
 en: Curry sauces
+da: Karrysovser, Karrysovse, Karrysaucer
 de: Currysaucen
 es: Salsas de curry
 fi: currykastikkeet
@@ -77105,13 +77111,16 @@ hu: Curry mártások
 it: Salse al curry
 ja: カレーソース
 lt: Kario padažai
+nb: Karisauser
 nl: Kerriesauzen, Kerriesaus, Currysauzen
+nn: Karisausar
+sv: Currysåser
 agribalyse_food_code:en: 11132
 ciqual_food_code:en: 11132
 ciqual_food_name:en: Curry sauce, prepacked
 ciqual_food_name:fr: Sauce au curry, préemballée
 intake24_category_code:en: CURS
-wikidata:en: Q610794
+wikidata:en: Q115618401
 
 < en:Curry sauces
 en: Madras curry sauce
@@ -77320,8 +77329,19 @@ ciqual_food_name:en: Bearnaise sauce, prepacked
 wikidata:en: Q58265
 
 < en:Sauces
-nl: Patatje Joppiesaussmaaksauzen
-#sauce joppie (Q610794) - sauce à base de mayonnaise, oignons et poudre de curry
+en: Joppie sauces
+da: Joppiesovser, Joppiesovse, Joppiesaucer
+de: Joppie-Saucen
+eo: Jopisaŭcoj
+fa: سس یوپی
+fr: Sauce joppie
+nb: Joppiesauser
+nl: Joppiesaus
+nn: Joppiesausar
+pt: Molho Joppie
+sv: Joppiesåser
+description:fr: sauce à base de mayonnaise, oignons et poudre de curry
+wikidata:en: Q610794
 
 < en:Sauces
 en: Burger sauces, Sauce burger
@@ -77726,9 +77746,13 @@ nl: Cassismosterds
 
 < en:Mustards
 en: Curry mustards
+da: Karrysennepper
 fr: Moutardes au curry
 hr: Curry senfovi
 lt: Kario garstyčios
+nb: Karisenneper
+nn: Karisennepar
+sv: Currysenap
 
 < en:Mustards
 fr: Moutardes au noix
@@ -80112,6 +80136,25 @@ ru: Томатный кетчуп
 sv: Tomatketchup
 tr: Domates Ketçabı
 
+< en:Ketchup
+en: Curry ketchups
+ar: كَتشب الكاري
+ca: Quètxup al curri
+da: Karryketchup
+de: Curryketchup
+eo: Karekeĉupoj
+fa: کچاپ کاری
+fr: Ketchup au curry
+jv: Kari saos tomat
+ko: 커리 케첩
+nb: Kariketsjuper, Kariketchuper
+nl: Curryketchup
+nn: Kariketsjupar, Kariketchupar
+ru: Карри-кетчуп
+sv: Curryketchup
+zh: 咖哩番茄醬
+wikidata:en: Q2148721
+
 < en:Tomato sauces
 en: Neapolitan sauces
 de: Neapolitanische Saucen
@@ -80331,6 +80374,7 @@ wikidata:en: Q68437707
 
 < en:Meal sauces
 en: Curry pastes, Curry paste
+da: Karrypastaer
 de: Currypasten, Currypaste
 es: Pasta de curry
 fi: currytahnat
@@ -80338,28 +80382,39 @@ fr: Pâtes de curry, Curry paste
 hr: Curry paste
 it: Pasta di curry
 lt: Kario pasta
+nb: Karripastaer
 nl: Curry pastas
+nn: Karripastaer, Karripastaar
 pl: Pasty curry
+sv: Currypastor
 wikidata:en: Q5195232
 
 < en:Curry pastes
 en: Red curry pastes, Red curry paste
+da: Røde karrypastaer
 de: Rote Currypasten, Rote Currypaste
 fr: Pâtes de curry rouges
 hr: Crvene curry paste
 lt: Raudonojo kario pasta
+nb: Røde karripastaer
 nl: Rode currypastas
+nn: Raude karripastaer
 pl: Czerwone pasty curry
+sv: Röda currypastor
 wikidata:en: Q67201118
 
 < en:Curry pastes
 en: Green curry pastes, Green curry paste
+da: Grønne karrypastaer
 de: Grüne Currypasten, Grüne Currypaste
 fr: Pâtes de curry verte, Pâtes de curry vert
 hr: Zelene curry paste
 lt: Žaliojo kario pasta
+nb: Grønne karripastaer
 nl: Groene Currypastas
+nn: Grøne karripastaer
 pl: Zielone pasty curry
+sv: Gröna currypastor
 wikidata:en: Q67201120
 
 < en:Curry pastes
@@ -80379,14 +80434,17 @@ wikidata:en: Q67206116
 
 < en:Curry pastes
 en: Yellow curry pastes, Yellow curry paste
+da: Gule karrypastaer
 de: Gelbe Currypasten, Gelbe Currypaste
 fr: Pâtes de curry jaunes
 hr: Žute curry paste
 lt: Geltonojo kario pasta
+nb: Gule karripastaer
 nl: Gele Currypastas
+nn: Gule karripastaer
 pl: Żółte pasty curry
+sv: Gulor currypastor
 wikidata:en: Q67201117
-
 
 en: Meals, Prepared meals, Prepared dishes
 bg: Готови ястия

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -64603,7 +64603,6 @@ nl: cayennepeper gedroogd
 #                                Curry
 #
 ###################################################################################################
-# The wikidata item specifies the dish and not the spice mix
 
 < en:spice
 en: curry
@@ -64629,7 +64628,9 @@ it: curry
 ja: カレー
 lt: karis
 mr: कोरड्यास
+nb: karri
 nl: kerrie, curry
+nn: karri
 pa: ਰੱਸਾ
 pl: curry, mieszanka przypraw curry, curry w proszku, przyprawa curry
 pt: caril
@@ -64647,7 +64648,6 @@ ciqual_food_name:fr: Curry, poudre
 wikidata:en: Q1144935
 # 972 in 10 @2021-09-17
 
-# description:en:CURRY POWDER is a spice mix originating from the Indian subcontinent.
 # Probably curry powder is a synonym of curry
 # With the translations be careful that they refer to the powder and not plain curry
 
@@ -64684,15 +64684,15 @@ wikidata:en: Q1144935
 # en-ca:curry powder
 # en-gb:curry powder
 # yue:咖喱粉
-#wikidata:en:Q1144935
-#wikipedia:en:https://en.wikipedia.org/wiki/Curry_powder
+#description:en: CURRY POWDER is a spice mix originating from the Indian subcontinent.
+#wikidata:en: Q1144935
+#wikipedia:en: https://en.wikipedia.org/wiki/Curry_powder
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/curry-powder
 # 231 products in 8 languages @2018-10-11
 
-# description:en:CURRY PASTE usually refers to a paste used as a cooking ingredient in the preparation of a curry.
-
 < en:spice
 en: curry paste
+da: karrypasta
 de: currypaste
 es: pasta de curry
 fi: currytahna
@@ -64701,19 +64701,24 @@ hr: curry pasta
 it: pasta di curry
 ko: 커리 페이스트
 nb: karripasta
+nn: karripasta
 pl: pasta curry
 sv: currypasta, curry pasta
+description:en: CURRY PASTE usually refers to a paste used as a cooking ingredient in the preparation of a curry.
 wikidata:en: Q5195232
 wikipedia:en: https://en.wikipedia.org/wiki/Curry_paste
 # ingredient/en:curry-paste has 39 products in 1 language @2020-06-08
 
 < en:curry paste
 en: red curry paste
+da: rød karrypasta
 de: rote currypaste
 fi: punainen currytahna
 fr: pâte de curry rouge
 hr: crvena curry pasta
 it: pasta di curry rosso
+nb: rød karripasta
+nn: raud karripasta
 pl: czerwona pasta curry
 sv: röd currypasta
 wikidata:en: Q67201118
@@ -91922,7 +91927,7 @@ bs: sos
 ca: salsa
 cs: omáčka
 cy: Saws
-da: sovs
+da: sovs, sauce
 de: Sauce, Soße
 el: σάλτσα
 eo: saŭco
@@ -92045,15 +92050,20 @@ fr: sauce au vinaigre balsamique
 fr: sauce aux fruits rouges
 
 < en:sauce
-en: Curry sauce
+en: curry sauce
 ca: salsa de curry
+da: karrysovs, karrysauce
 es: salsa de curry
-fr: Sauce au curry
+fr: sauce au curry
 hr: curry umak
 it: salsa al curry
+nb: karrisaus
+nn: karrisaus
+sv: currysås
 ciqual_food_code:en: 11132
 ciqual_food_name:en: Curry sauce, prepacked
 ciqual_food_name:fr: Sauce au curry, préemballée
+wikidata:en: Q115618401
 
 < en:sauce
 fr: sauce au café


### PR DESCRIPTION
- Normalises category names to plural.
- Adds Danish, Norwegian, and Swedish translations.
- Adds `wikidata` properties.
- Replaces `nl:Patatje Joppiesaussmaaksauzen` category (with 0 products) with `en:Joppie sauces` category.
- Adds `en:Curry ketchups` category.
- Adds one of the larger curry ketchup brands.
- Un-comment-outs some `description` properties.

Needed-for: https://world.openfoodfacts.org/cgi/search.pl?search_terms=curry+ketchup
Needed-for: https://world.openfoodfacts.org/facets/brands/hela