### PR TITLE
taxonomy: edits for Rügenwalder Mühle

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -872,6 +872,10 @@ xx: Royal
 xx: Royal Mediterranean
 wikidata:en: Q136984611
 
+xx: Rügenwalder Mühle
+#web:de: https://www.ruegenwalder.de/
+wikidata:en: Q2203886
+
 xx: RÅ
 #web:sv: https://drickrå.se/
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -5028,7 +5028,7 @@ label_categories:en: en:Health, en:Additives
 #instruction:en:Do NOT change the english key.
 en: No flavour enhancer
 ca: Sense potenciador de sabor
-de: Ohne Geschmacksverstärker, Ohne Zusatzstoff Geschmacksverstärker
+de: Ohne Geschmacksverstärker, Ohne Zusatz von Geschmackverstärkern, Ohne Zusatzstoff Geschmacksverstärker
 es: Sin potenciadores del sabor
 fi: ei arominvahventeita
 fr: sans exhausteur de goût, sans exhausteurs de goût


### PR DESCRIPTION
Adds Rügenwalder Mühle brand and a German variation of “no flavour enhancer” label.

Needed-for: https://de-en.openfoodfacts.org/product/4000405002285/pulled-pork-rugenwalder-muhle