### PR TITLE
fix(csv-export): compute energy-kj from energy-kcal when missing

### DIFF
--- a/lib/ProductOpener/Nutrition.pm
+++ b/lib/ProductOpener/Nutrition.pm
@@ -2443,7 +2443,19 @@ sub add_nutrition_fields_from_product_to_populated_fields(
 						and ref($input_set_ref->{nutrients}) eq 'HASH')
 					{
 						my $nutrients_ref = $input_set_ref->{nutrients};
+						# Ensure energy-kj exists if energy-kcal is present
+						if (exists $nutrients_ref->{"energy-kcal"}
+							&& ref($nutrients_ref->{"energy-kcal"}) eq 'HASH'
+							&& !exists $nutrients_ref->{"energy-kj"}) {
+							my $kcal = $nutrients_ref->{"energy-kcal"}{"value"};
 
+							if (defined $kcal) {
+								$nutrients_ref->{"energy-kj"} = {
+									value => $kcal * 4.184,
+									unit  => "kJ"
+								};
+							}
+						}
 						# We go through nutrients in the order of the off_europe nutrients table
 						# Go through the nutriment table
 						my $nutrient_number = 0;


### PR DESCRIPTION
Some products contain energy-kcal but not energy-kj in the nutrition input sets. Since CSV export only exports nutrients that exist in the dataset, energy-kj fields may be missing from exports. This patch computes energy-kj from energy-kcal when missing so that energy values are consistently included in CSV exports.
- Fixes #13274