### PR TITLE
fix: Ignore "Produit inconnu" placeholder in French product name

### DIFF
--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -931,6 +931,13 @@ sub clean_fields ($product_ref) {
 			$product_ref->{$field} = "";
 		}
 
+    # Ignore the placeholder "Produit inconnu" in the French product name
+    if ($field eq "product_name_fr"
+        and $product_ref->{$field} =~ /^\s*produit inconnu\s*$/i)
+    {
+        $product_ref->{$field} = '-';
+    }
+
 		# Remove "unspecified" values
 		my @unspecified_lcs = ("en");
 		if (    (defined $product_ref->{lc})


### PR DESCRIPTION
Resolves #1983

Some data sources use "Produit inconnu" as a placeholder value for the French product name.

This change detects that value in `product_name_fr` during import and converts it to "-", so it is treated as an unspecified value consistent with existing cleaning rules.