### PR TITLE
feat: Add navigation & discovery event tracking to Matomo

### DIFF
--- a/html/js/matomo-events.js
+++ b/html/js/matomo-events.js
@@ -49,4 +49,75 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
     }
+
+    // Key page visits: track visits to important landing pages
+    const path = globalThis.location.pathname.toLowerCase();
+    const keyPages = ['nutriscore', 'nova', 'ecoscore', 'contribute', 'discover'];
+    keyPages.forEach(function (pageName) {
+        if (path.includes(pageName)) {
+            trackMatomoEvent('page_visit', 'visit', pageName);
+        }
+    });
+
+    // "Explore by" button click tracking
+    const exploreBtn = document.querySelector('button[data-dropdown="drop1"]');
+    if (exploreBtn) {
+        exploreBtn.addEventListener('click', function () {
+            trackMatomoEvent('navigation', 'explore_by');
+        });
+    }
+
+    // "Sorting by" button click tracking
+    const sortBtn = document.querySelector('button[data-dropdown="drop_sort"]');
+    if (sortBtn) {
+        sortBtn.addEventListener('click', function () {
+            trackMatomoEvent('navigation', 'sort_by');
+        });
+    }
+
+    // Google Play button click tracking
+    const googlePlayLinks = document.querySelectorAll('a[href*="play.google.com"]');
+    googlePlayLinks.forEach(function (link) {
+        link.addEventListener('click', function () {
+            trackMatomoEvent('navigation', 'click_google_play');
+        });
+    });
+
+    // App Store button click tracking
+    const appStoreLinks = document.querySelectorAll('a[href*="apps.apple.com"]');
+    appStoreLinks.forEach(function (link) {
+        link.addEventListener('click', function () {
+            trackMatomoEvent('navigation', 'click_app_store');
+        });
+    });
+
+    // Menu hover tracking on the upper navigation bar
+    const menuHoverTracked = {};
+    const upperNav = document.getElementById('upNav');
+    if (upperNav) {
+        const menuItems = upperNav.querySelectorAll('li.has-dropdown');
+        menuItems.forEach(function (menuItem) {
+            let menuName = 'tools'; // default for the hamburger/tools menu
+            if (menuItem.querySelector('.userlink')) {
+                menuName = 'user';
+            } else if (menuItem.closest('.country_language_selection') || menuItem.querySelector('#select_country')) {
+                menuName = 'language';
+            }
+
+            menuItem.addEventListener('mouseenter', function () {
+                if (!menuHoverTracked[menuName]) {
+                    menuHoverTracked[menuName] = true;
+                    trackMatomoEvent('navigation', 'menu_hover', menuName);
+                }
+            });
+        });
+    }
+
+    // "Share product" button click tracking
+    const shareButtons = document.querySelectorAll('.share_button a');
+    shareButtons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            trackMatomoEvent('product', 'share');
+        });
+    });
 });


### PR DESCRIPTION
## Description:

Adds Matomo event tracking for navigation and discovery interactions, extending matomo-events.js.

## Events added:

Key page visits — tracks visits to /nutriscore, /nova, /ecoscore, /contribute, /discover
Explore by / Sort by — tracks dropdown button clicks
App store links — tracks Google Play and App Store link clicks
Menu hover — tracks first hover on Tools, User, and Language menus (debounced per session)
Share product — tracks share button clicks

I verified this locally by creating a standalone HTML test page.

https://github.com/user-attachments/assets/dbed3d73-2686-4780-9cca-1050311327ea

Part of #8191