### PR TITLE
taxonomy(food): fish analogue categories synonyms

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -120264,16 +120264,22 @@ ciqual_food_name:fr: Saucisse végétale au tofu (convient aux véganes ou vég�
 
 #Meat and fish categories are separated while Fish analogues is under meat analogue. This difference is intended, since fishes are animals and therefore considered as meat by vegetarians
 < en:Meat analogues
-en: Fish analogues, Plant-based fish, Plantbased fish
+en: Fish analogues, Plant-based fish, Plantbased fish, Vegan fish
+da: Plantebaserede fisk, Veganske fisk
 hr: Analozi ribe
 nl: Plantaardige vissen
 pl: Zastępniki ryb
+sv: Växtbaserade fiskar, Veganska fiskar
 
 < en:Fish analogues
-en: Salmon analogues
+en: Salmon analogues, Vegan salmon
+da: Plantebaserede laks, Veganske laks
+sv: Växtbaserade laxar, Veganska laxar
 
 < en:Fish analogues
-en: Tuna analogues
+en: Tuna analogues, Vegan tuna
+da: Plantebaserede tun, Veganske tun
+sv: Växtbaserade tonfiskar, Veganska tonfiskar
 
 < en:Dairy substitutes
 < en:Plant-based foods


### PR DESCRIPTION
Adds some synonyms for the fish analogue categories that are already in use, and also some Danish and Swedish translations + synonyms.

Needed-for: https://world.openfoodfacts.org/facets/categories/vegan-fish
Needed-for: https://world.openfoodfacts.org/facets/categories/vegan-salmon
Needed-for: https://world.openfoodfacts.org/facets/categories/vegan-tuna