### PR TITLE
fix: Show search terms in search results page

### DIFF
--- a/templates/web/pages/search_results/search_results.tt.html
+++ b/templates/web/pages/search_results/search_results.tt.html
@@ -4,7 +4,13 @@
 	
 <div id="preferences_selection_form" style="display:none"></div>
 [% END %]
-	
+
+[% IF search_terms.defined && search_terms != '' %]
+    <p>
+        <strong>[% l("Search results for") %]</strong>: [% search_terms | html %]
+    </p>
+[% END %]
+
 <div id="search_results" style="clear:left">
 [% lang("products_are_being_loaded_please_wait") %]
 </div>


### PR DESCRIPTION
### What

This pull request updates the search results page to display the entered search terms clearly at the top of the page.

This helps users confirm the query they searched for and improves the usability of the search results page.

### Large Language Models usage disclosure

ChatGPT (GPT-5.3) was used for guidance while preparing this contribution. The final code changes were reviewed by me.

### Screenshot or video

The change was made in the search results template to display the searched terms above the results.

### Related issue(s) and discussion

- Fixes #5172
