### PR TITLE
taxonomy: deleted croissants with almonds and pistachio

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -119068,10 +119068,6 @@ sales_format:en: package, item
 en: Croissant with almonds, Almond croissant
 fr: Croissants aux amandes
 
-< en:Croissants
-en: Croissants with almonds and pistachio
-fr: Croissants aux amandes et pistache
-
 < en:Viennoiseries
 en: Chouquettes, Sugar coated chou pastry
 de: Chouquettes


### PR DESCRIPTION
Deleted the category "croissants with almonds and pistachio", I cannot see any product in the databse which correspond to this description
