### PR TITLE
fix: improve error message when org_id is missing in store_org

### DIFF
--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -164,7 +164,8 @@ sub store_org ($org_ref) {
 
 	$log->debug("store_org", {org_ref => $org_ref}) if $log->is_debug();
 
-	defined $org_ref->{org_id} or die("Missing org_id");
+	defined $org_ref->{org_id}
+    or die("Missing org_id in store_org(): organization reference is missing org_id");
 
 	# retrieve eventual previous values
 	my $previous_org_ref = retrieve("$BASE_DIRS{ORGS}/$org_ref->{org_id}.sto");


### PR DESCRIPTION
### Summary

Improves the error message thrown when `org_id` is missing in `store_org()`.

### Problem

The current message `Missing org_id` does not provide enough context for debugging.

### Solution

Adds additional context indicating that the error occurred inside `store_org()` and that the organization reference does not contain an `org_id`.

### Impact

Improves debugging clarity without changing runtime logic.
<img width="853" height="505" alt="Screenshot 2026-03-16 185620" src="https://github.com/user-attachments/assets/0711fa5f-f600-4b78-a3eb-6ea19813a1c8" />

