### PR TITLE
fix(orgs): handle missing org_id error (#13282)

### DIFF
--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -164,7 +164,16 @@ sub store_org ($org_ref) {
 
 	$log->debug("store_org", {org_ref => $org_ref}) if $log->is_debug();
 
-	defined $org_ref->{org_id} or die("Missing org_id");
+	# Validate that org_ref is defined and has org_id
+	if (not defined $org_ref) {
+		$log->error("store_org called with undefined org_ref");
+		die("store_org called with undefined org_ref");
+	}
+	
+	if (not defined $org_ref->{org_id} or $org_ref->{org_id} eq "") {
+		$log->error("store_org called with missing or empty org_id", {org_ref => $org_ref});
+		die("Missing org_id in store_org call");
+	}
 
 	# retrieve eventual previous values
 	my $previous_org_ref = retrieve("$BASE_DIRS{ORGS}/$org_ref->{org_id}.sto");
@@ -543,7 +552,8 @@ Update the last import type for an organization.
 =cut
 
 sub update_last_import_type ($org_id_or_ref, $data_source) {
-	my $org_ref = retrieve_org($org_id_or_ref);
+	my $org_ref = org_id_or_ref($org_id_or_ref);
+	return if not defined $org_ref;
 	$org_ref->{last_import_type} = $data_source;
 	update_company_last_import_type($org_ref, $data_source);
 	store_org($org_ref);


### PR DESCRIPTION
### What

This PR fixes the **"Missing org_id" error** that occurs when importing CSV files through the pro platform when organization identification fields are missing or invalid.

The error occurred because the `update_last_import_type()` function in `lib/ProductOpener/Orgs.pm` used `retrieve_org()` directly instead of the `org_id_or_ref()` helper function.  
Although the function signature suggested it could accept either an `org_id` string or an `org_ref` hash reference, the implementation only worked correctly when a valid `org_id` string was provided.

When an undefined or invalid organization reference was passed, `retrieve_org()` returned `undef`, which later caused crashes when attempting to access properties or call `store_org()` with an incomplete `org_ref`.

### Changes made

**1. Fixed `update_last_import_type()` implementation**
- File: `lib/ProductOpener/Orgs.pm`
- Replaced `retrieve_org()` with the `org_id_or_ref()` helper
- Added defensive validation to safely exit if `org_ref` is undefined

This aligns the function with other similar functions such as:
- `update_import_date()`
- `update_export_date()`
- `add_user_to_org()`

**2. Improved validation in `store_org()`**
- File: `lib/ProductOpener/Orgs.pm`
- Added validation to ensure `org_ref` is defined
- Added validation to ensure `org_id` exists and is not empty
- Added clearer error logging to help diagnose invalid organization references

**3. Improved CSV import validation**
- File: `lib/ProductOpener/Import.pm`
- Added validation to ensure `org_id` is properly determined before importing products
- Skip products where the organization cannot be identified
- Added clearer error logging when required organization fields are missing

### Why these changes

- **Consistency:** Using `org_id_or_ref()` aligns `update_last_import_type()` with other functions that support both `org_id` and `org_ref`.
- **Defensive programming:** Additional validation prevents crashes caused by undefined organization references.
- **Better user experience:** Clear error messages help users understand what is wrong with their CSV imports instead of showing a cryptic `"Missing org_id"` error.

---

### Large Language Models usage disclosure

This PR description was drafted with assistance from a large language model.  
All code changes were reviewed and verified before submission.

---

### Screenshot or video

N/A – backend change with no user interface impact.

---

### Related issue(s) and discussion

Fixes: #13282 @teolemon @alexgarel 