### PR TITLE
taxonomy(food): add cane sugar comment

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -30887,6 +30887,7 @@ uk: тростинний цукор
 # sr-el:šećer od šećerne trske
 carbon_footprint_fr_foodges_ingredient:fr: Sucre de canne
 carbon_footprint_fr_foodges_value:fr: 1.3
+comment:en: Cane sugar inherits vegan:maybe from sugar because some cane sugar is refined using bone char. See comment on en:sugar for more details.
 description:en: Since the 6th century BC, cane sugar producers have crushed the harvested vegetable material from sugarcane in order to collect and filter the juice. They then treat the liquid (often with lime (calcium oxide)) to remove impurities and then neutralize it. Boiling the juice then allows the sediment to settle to the bottom for dredging out, while the scum rises to the surface for skimming off.
 wikidata:en: Q165267
 wikipedia:en: https://en.wikipedia.org/wiki/Sucrose#Cane


### PR DESCRIPTION
Previously, only `en:sugar` had a `comment` about why it has `vegan:en: maybe` set. This copies part of that comment to `en:cane sugar` and refers back to `en:sugar`’s `comment` for further explanation.

This will hopefully help avoid accidental reversals à la https://github.com/openfoodfacts/openfoodfacts-server/pull/13306 going forward.

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13147
Follow-up-to: a24397a1facdd2e67f23a4ee05de759376c38396