### PR TITLE
taxonomy(food): pommes noisettes edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -44994,17 +44994,26 @@ wikidata:en: Q3482613
 < en:Potato preparations
 xx: Pommes noisettes
 bg: Картофени ноазети
-fr: Pommes noisettes
+de: Schlosskartoffeln
+fr: Pommes noisettes, Pommes de terre noisettes
+ja: ポメ・ヌワゼット
+nl: Krielaardappel, Pommes parisiennes
+sv: Pommes château, Châteaupotatisar, Slottspotatisar
+agribalyse_proxy_food_code:en: 4013
+ciqual_proxy_food_code:en: 4013
+ciqual_proxy_food_name:en: Noisette potato, frozen, raw
+ciqual_proxy_food_name:fr: Pomme de terre noisette, surgelée, à cuire
 wikidata:en: Q2244571
 
 < en:Frozen fried potatoes
 < xx:Pommes noisettes
 en: Frozen pommes noisettes, Frozen pre-fried mashed potato balls
 fr: Pommes noisettes surgelées, Pommes de terre noisette surgelées
+sv: Frysta pommes château
 agribalyse_food_code:en: 4013
 ciqual_food_code:en: 4013
-ciqual_food_name:en: Mashed potato balls pre-fried, frozen, raw
-ciqual_food_name:fr: Pomme de terre noisette, surgelée, crue
+ciqual_food_name:en: Noisette potato, frozen, raw
+ciqual_food_name:fr: Pomme de terre noisette, surgelée, à cuire
 
 < en:Chips and fries
 < en:Potato preparations


### PR DESCRIPTION
- Adds Swedish and some other translations.
- Updates Ciqual `food_name`s.
- Adds `proxy_food_code`s for non-frozen pommes noisettes (similar to pommes dauphines).

Needed-for: https://se.openfoodfacts.org/product/7310240073812/pommes-chateau-felix
Needed-for: https://se.openfoodfacts.org/cgi/search.pl?search_terms=pommes+chateau