### PR TITLE
taxonomy(food): more potato varieties

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -111898,17 +111898,62 @@ en: Allians potatoes
 fr: Pommes de terre Allians
 
 < en:Potatoes
+en: Almond potatoes, Mandel potatoes
+fi: Puikulaperuna
+la: Solanum tuberosum ‘Almond’
+nb: Mandelpoteter
+nn: Mandelpotetar, Mandelpoteter
+sv: Mandelpotatisar
+sales_format:en: weight, package
+wikidata:en: Q3183151
+
+< en:Almond potatoes
+en: Lapin Puikula
+xx: Lapin puikula
+fi: Lapin puikula
+origins:en: en:lapland-finland
+protected_name_file_number:en: PDO-FI-1390
+protected_name_type:en: pdo
+
+< en:Potatoes
 en: Amandine potatoes, Potatoes(Amandine)
 fr: Pommes de terre amandine
 nl: Amandine aardappelen, Aardappelen(Amandine)
+ru: Картофель Амандин
+sv: Amandinepotatisar, Potatisar (Amandine)
+sales_format:en: weight, package
+wikidata:en: Q2841064
 
 < en:Potatoes
 en: Béa potatoes
-de: Béa Kortoffeln
+de: Béa Kartoffeln
 fr: Pommes de terre Béa
 hr: Béa krumpir
 nl: Béa aardappelen
 wikidata:en: Q2929373
+
+< en:Potatoes
+en: Beate potatoes
+da: Beate-kartofler
+de: Beate Kartoffeln
+hr: Beate krumpir
+nb: Beate-poteter
+nn: Beate-potetar, Beate-poteter
+sv: Beate-potatisar, Potatisar (Beate)
+comment:en: National potato of Norway, according to Norwegian Wikipedia.
+sales_format:en: weight, package
+wikidata:en: Q10427525
+
+< en:Potatoes
+en: Carolus potatoes
+da: Carolus-kartofler
+de: Carolus Kartoffeln
+hr: Carolus krumpir
+nb: Carolus-poteter
+nn: Carolus-potetar, Carolus-poteter
+sv: Carolus-potatisar, Potatisar (Carolus)
+comment:en: https://www.potatopro.com/potato-varieties/carolus
+sales_format:en: weight, package
 
 < en:Potatoes
 en: Charlotte potatoes
@@ -111919,12 +111964,31 @@ sales_format:en: weight, package
 wikidata:en: Q1067085
 
 < en:Potatoes
+en: Gala potatoes
+da: Gala-kartofler
+de: Gala Kartoffeln
+fi: Gala (peruna)
+hr: Gala krumpir
+la: Solanum tuberosum ‘Gala’
+nb: Gala-poteter
+nn: Gala-potetar, Gala-poteter
+sv: Gala-potatisar, Potatisar (Gala)
+sales_format:en: weight, package
+wikidata:en: Q1491619
+
+< en:Potatoes
 en: Bintje potatoes
+da: Bintje-kartofler
 de: Bintje Kartoffeln
 fr: Pomme de terre Bintje
 hr: Bintje krumpir
+la: Solanum tuberosum ‘Bintje’
+nb: Bintje-poteter
 nl: Aardappelen (Bintje), Bintje aardappelen
+nn: Bintje-potetar, Bintje-poteter
+sv: Bintje-potatisar, Potatisar (Bintje)
 sales_format:en: package, weight
+wikidata:en: Q864084
 
 < en:Potatoes
 en: Ostara potatoes

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -5923,6 +5923,17 @@ da: Samsø
 wikidata:en: Q216422
 wikipedia:en: https://en.wikipedia.org/wiki/Sams%C3%B8
 
+# Finland origins
+
+< en:finland
+en: Lapland (Finland), Province of Lappi
+fi: Lapin maakunta, Lappi
+se: Lappi eanangoddi
+sv: Lappland (Finland)
+#smn: Laapi eennâmkodde
+#sms: Lappi mäddkåʹdd
+wikidata:en: Q5700
+
 # Sweden origins
 
 < en:sweden


### PR DESCRIPTION
This adds a few missing potato cultivars as well as translations/synonyms and `wikidata` properties for some existing ones.

Needed-for: https://prices.openfoodfacts.org/proofs/97300
Needed-for: https://prices.openfoodfacts.org/proofs/97301
Needed-for: https://se.openfoodfacts.org/product/7340083475566/amandinepotatis-garant
Needed-for: https://se.openfoodfacts.org/product/7340083475559/mandelpotatis-garant