### PR TITLE
feat(api-v3): apply BearerAuth globally for Swagger authorizationFix/api v3 openapi cleanup

### DIFF
--- a/docs/api/ref/api-v3.yaml
+++ b/docs/api/ref/api-v3.yaml
@@ -891,7 +891,8 @@ components:
         $ref: "./schemas/external_knowledge_panel.yaml"
 
 security:
-  - userAgentAuth: [] # No authentication required by default (for read requests), but we recommend sending a User-Agent header in all requests.
+  - BearerAuth: []
+  - userAgentAuth: []
   
 tags:
   - name: Products


### PR DESCRIPTION
:::writing{variant=“standard” id=“prfinal1”}

What

This PR improves Swagger/OpenAPI authentication clarity by applying the existing BearerAuth security scheme globally.

Previously, although BearerAuth was defined in the OpenAPI schema, it was not applied using the security field. This made it unclear which endpoints required authentication and how to provide it.

This change:
	•	Applies BearerAuth globally using the security field
	•	Ensures Swagger UI shows a consistent “Authorize” flow
	•	Makes authentication requirements explicit for all endpoints

No backend logic or authentication behavior was modified. This is a documentation-level improvement only.

⸻

Large Language Models usage disclosure

I used ChatGPT (GPT-5.3) for guidance on OpenAPI best practices and structuring the YAML correctly.
All changes were manually reviewed, implemented, and tested locally.

⸻

Screenshot or video

I tested the changes locally using /docs:
	•	The “Authorize” button is visible
	•	Bearer token can be entered
	•	Requests include Authorization: Bearer <token>
Related issue(s) and discussion
	•	Fixes: #110
:::
This aligns Swagger UI behavior with standard OpenAPI security practices.