### PR TITLE
taxonomy(food): potato starchiness categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -111887,6 +111887,26 @@ intake24_category_code:en: POTS
 pnns_group_2:en: Potatoes
 sales_format:en: weight, package
 
+#################### Potato consistency/starchiness ####################
+
+< en:Potatoes
+en: Floury potatoes, Mealy potatoes, Starchy potatoes
+da: Melede kartofler
+de: Mehligkochende Kartoffeln
+sv: Mjöliga potatisar
+comment:en: Generally ca. 20-22% starch. Commonly used for baking or mashing.
+sales_format:en: weight, package
+wikidata:en: Q96603248
+
+< en:Potatoes
+en: Waxy potatoes
+da: Fastkogende kartofler
+de: Festkochende Kartoffeln
+sv: Fasta potatisar
+comment:en: Generally ca. 16-18% starch. Commonly used for boiling.
+sales_format:en: weight, package
+wikidata:en: Q96603169
+
 #################### Potato harvest ####################
 
 < en:Potatoes


### PR DESCRIPTION
Potatoes (and potato cultivars) are commonly grouped by how “waxy” or starchy they are, and are also commonly sold on this basis.

This adds the two main groupings of starchiness levels.

Needed-for: https://se.openfoodfacts.org/product/7340083475580/fast-potatis-garant
Needed-for: https://se.openfoodfacts.org/product/7340083475597/mj%C3%B6lig-potatis-garant