### PR TITLE
taxonomy(food): potato categories in Danish

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -987,6 +987,7 @@ ciqual_food_name:fr: Soupe pour bébé légumes, céréales et lait
 
 < en:Main meals for babies
 en: Soup for baby with vegetables and potatoes
+da: Babysuppe med grøntsager og kartofler
 de: Suppe für Baby mit Gemüse und Kartoffeln
 es: Sopa para bebé con verduras y papas
 fr: Soupe pour bébé aux légumes et aux pommes de terre
@@ -34230,6 +34231,7 @@ ru: Растворимые напитки
 < en:Dried products to be rehydrated
 < en:Mashed potatoes
 en: Instant mashed potatoes, dehydrated mashed potatoes
+da: Kartoffelmospulvere
 de: Kartoffelpulver
 fi: perunamuusijauheet
 fr: Purées de pommes de terre en flocons, purées de pommes de terre instantanées, Purées en flocons, purées instantanées
@@ -34271,6 +34273,7 @@ ciqual_food_name:fr: Pomme de terre, purée à base de flocons, reconstituée av
 < en:Dried products to be rehydrated
 < en:Mashed potatoes
 en: Potato flakes
+da: Kartoffelflager
 fr: Flocons de pommes de terre
 agribalyse_food_code:en: 4022
 ciqual_food_code:en: 4022
@@ -42633,6 +42636,7 @@ ciqual_food_name:fr: Igname, épluchée, bouillie/cuite à l'eau
 < en:Gnocchi
 < en:Potatoes and their products
 en: Potato gnocchi, Gnocchi from potato
+da: Kartoffelgnocchier
 de: Kartoffelgnocchi
 es: Gnocchi de patata
 fi: perunagnocchi
@@ -42651,6 +42655,7 @@ wikidata:en: Q14906720
 < en:Cooked gnocchis
 < en:Potato gnocchi
 en: Cooked gnocchis from potato
+da: Kogte kartoffelgnocchier
 fr: Gnocchi de pommes de terre cuits, Gnocchis à la pomme de terre cuits
 hr: Kuhani njoki od krumpira
 nl: Gekookte aardappelgnocchis
@@ -44646,6 +44651,7 @@ nl: Linzenchips
 en: Potato crisps, potato chips
 bg: Картофен чипс
 ca: Xips de patata
+da: Kartoffelchips
 de: Kartoffelchips
 es: Chips de patatas fritas
 fi: perunalastut
@@ -44887,6 +44893,7 @@ nl: Boerenchips
 
 < en:Potato crisps
 en: Crisps of red potatoes, red potato crisps, red potatoes crisps
+da: Røde kartoffelchips, Chips af røde kartofler
 de: Rote Kartoffelchips, Chips aus roten Kartoffeln
 fr: Chips de pommes de terre rouge
 hr: Čips od crvenog krumpira
@@ -44899,6 +44906,7 @@ fr: Chips de pomme de terre reconstituée
 
 < en:Crisps
 en: Salty snacks made from potato
+da: Salte snacks lavet af kartoffel
 de: Salzige Snacks aus Kartoffeln
 es: Aperitivos salados elaborados con patata, Aperitivos salados de patata, Snacks salados de patata, Snacks salados elaborados con patata
 fi: Perunasta valmistetut suolaiset naposteltavat
@@ -44975,6 +44983,7 @@ wikidata:en: Q152088
 en: Potato wedges
 ar: بطاطا ودجز
 cs: Americké brambory
+da: Kartoffelbåde
 de: Kartoffelspalten, Kartoffelecken
 fi: Lohkoperunat
 id: Baji kentang
@@ -44994,6 +45003,7 @@ wikidata:en: Q3482613
 < en:Potato preparations
 xx: Pommes noisettes
 bg: Картофени ноазети
+da: Pommes château, Pommes noisette
 de: Schlosskartoffeln
 fr: Pommes noisettes, Pommes de terre noisettes
 ja: ポメ・ヌワゼット
@@ -45008,6 +45018,7 @@ wikidata:en: Q2244571
 < en:Frozen fried potatoes
 < xx:Pommes noisettes
 en: Frozen pommes noisettes, Frozen pre-fried mashed potato balls
+da: Frosne pommes château
 fr: Pommes noisettes surgelées, Pommes de terre noisette surgelées
 sv: Frysta pommes château
 agribalyse_food_code:en: 4013
@@ -45027,6 +45038,7 @@ wikidata:en: Q3396004
 < en:Frozen fried potatoes
 < xx:Pommes dauphines
 en: Frozen pommes dauphines, Frozen dauphine potatoes, Frozen cooked dauphine potato
+da: Frosne pommes dauphine
 fr: Pommes dauphines surgelées, Pomme de terre dauphine surgelée, Pomme de terre dauphine cuite surgelée
 hr: Smrznuti dauphine krumpir
 lt: Šaldytos dauphine bulvės
@@ -45037,6 +45049,7 @@ ciqual_food_name:fr: Pomme de terre dauphine, surgelée, cuite
 
 < en:Frozen fried potatoes
 en: Frozen duchesse potatoes, Frozen cooked duchesse potato
+da: Frosne duchesse-kartofler
 fr: Pommes duchesses surgelées, Pomme de terre duchesse surgelée, Pomme de terre duchesse cuite surgelée
 agribalyse_food_code:en: 4034
 ciqual_food_code:en: 4034
@@ -53319,6 +53332,7 @@ pt: Bebidas de espelta
 < en:Plant-based milk alternatives
 < en:Potatoes and their products
 en: Potato-based drinks, Potato milks
+da: Kartoffelbaserede drikke
 sv: Potatisbaserade dryckor
 
 < en:Plant-based barista milk alternatives
@@ -65805,6 +65819,7 @@ ciqual_food_name:fr: Blé dur précuit, entier, cru
 < en:Starches
 en: Potato starches
 bg: Картофено нишесте
+da: Kartoffelstivelser
 fr: Fécules de pomme de terre, Fécule de pomme de terre
 hr: Škrobovi krumpira
 ja: 馬鈴薯デンプン
@@ -66050,6 +66065,7 @@ wikidata:en: Q943935
 < en:Flours
 en: Potato flours, Flour of potatoes
 bg: Картофено брашно
+da: Kartoffelmel
 fi: Perunajauhot
 fr: Farines de pommes de terre
 hr: Krumpirovo brašno
@@ -66522,6 +66538,7 @@ nl: Plantaardige gevriesdroogde producten
 #generic frozen fried potatoes
 < en:Frozen foods
 en: Frozen fried potatoes
+da: Frosne stegte kartofler
 de: Gefrorene Pommes
 es: Papas fritas congeladas
 fi: Esipaistetut perunapakasteet
@@ -66542,6 +66559,7 @@ pnns_group_2:en: Potatoes
 < en:Frozen plant-based foods
 < en:Mashed potatoes
 en: Frozen mashed potatoes
+da: Frosne kartoffelmos
 fr: Purées de pommes de terre surgelée, Purée de pommes de terre surgelée
 hr: Smrznuti pire krumpir
 lt: Šaldyta bulvių košė
@@ -66554,6 +66572,7 @@ agribalyse_proxy_food_name:fr: Pomme de terre rissolée, surgelée, crue
 < en:Frozen fried potatoes
 en: Frozen fries, Frozen chips, Frozen french fries
 bg: Замразени пържени картофи
+da: Frosne pomfritter
 de: Tiefkühl-Pommes
 es: Patatas fritas congeladas
 fi: Ranskanperunapakasteet, Pakasteranskalaiset
@@ -66567,6 +66586,7 @@ who_id:en: 16
 
 < en:Frozen fries
 en: Frozen roasted French fries, Frozen baked French fries, Frozen roasted French chips
+da: Frosne ristede pomfritter
 fr: Frites de pommes de terre surgelées cuites au four, Frites de pommes de terre surgelées rôties
 agribalyse_food_code:en: 4030
 ciqual_food_code:en: 4030
@@ -66575,6 +66595,7 @@ ciqual_food_name:fr: Frites de pommes de terre, surgelées, rôties/cuites au fo
 
 < en:Frozen fries
 en: Frozen French fries to roast, Frozen French fries to bake, Frozen French chips to roast, Frozen French chips to bake
+da: Frosne pomfritter til ristning, Frosne pomfritter til bagning
 fr: Frites surgelées à cuire au four, Frites de pommes de terre surgelées à rôtir, Frites de pommes de terre surgelées à cuire au four
 agribalyse_food_code:en: 4044
 ciqual_food_code:en: 4044
@@ -66583,6 +66604,7 @@ ciqual_food_name:fr: Frites de pommes de terre, surgelées, pour cuisson rôtie/
 
 < en:Fries
 en: Microwave fries
+da: Mikrobølgeovnspomfritter
 de: Mikrowellen-Pommes
 es: Papas fritas para microondas
 fi: Mikroaaltouunissa valmistettavat ranskalaiset perunat
@@ -66600,6 +66622,7 @@ agribalyse_proxy_food_name:fr: Frites de pommes de terre, surgelées, pour cuiss
 < en:Frozen fries
 < en:Microwave fries
 en: Frozen microwave fries, Frozen French fries intended to be microwaved, Frozen French chips intended to be microwaved
+da: Frosne mikrobølgeovnspomfritter
 fr: Frites surgelées micro-ondables, Frites de pommes de terre surgelées pour cuisson au micro-ondes
 agribalyse_food_code:en: 4045
 ciqual_food_code:en: 4045
@@ -66608,6 +66631,7 @@ ciqual_food_name:fr: Frites de pommes de terre, surgelées, pour cuisson micro-o
 
 < en:Frozen fries
 en: Frozen deep-fried French fries, Frozen deep-fried French chips
+da: Frosne friturestegte pomfritter
 fr: Frites de pommes de terre surgelées cuites en friteuse
 agribalyse_food_code:en: 4032
 ciqual_food_code:en: 4032
@@ -66616,6 +66640,7 @@ ciqual_food_name:fr: Frites de pommes de terre, surgelées, cuites en friteuse
 
 < en:Frozen fries
 en: Frozen French fries to deep-fry, Frozen chips to deep-fry
+da: Frosne pomfritter til friturestegning
 fr: Frites surgelées pour friteuse, Frites de pommes de terre pour cuisson en friteuse
 agribalyse_food_code:en: 4046
 ciqual_food_code:en: 4046
@@ -66625,6 +66650,7 @@ ciqual_food_name:fr: Frites de pommes de terre, surgelées, pour cuisson en frit
 < en:Fried potato cubes
 < en:Frozen fried potatoes
 en: Frozen fried potato cubes
+da: Frosne stegte kartoffeltern
 fr: Pommes de terre rissolées surgelées
 agribalyse_food_code:en: 4043
 ciqual_food_code:en: 4043
@@ -66633,6 +66659,7 @@ ciqual_food_name:fr: Pomme de terre rissolée, surgelée, crue
 
 < en:Frozen fried potato cubes
 en: Frozen cooked pre-fried potato cubes
+da: Frosne kogte forstegte kartoffeltern
 fr: Pommes rissolées surgelées cuites, Pommes de terre rissolées surgelées cuites
 agribalyse_food_code:en: 4027
 ciqual_food_code:en: 4027
@@ -66640,9 +66667,9 @@ ciqual_food_name:en: Potato, pre-fried into cubes, frozen, cooked
 ciqual_food_name:fr: Pomme de terre rissolée, surgelée, cuite
 
 < en:Frozen fried potatoes
+da: Frosne kartoffelkroketter
 fr: Croquettes de pommes de terre surgelées
 hr: Smrznuti kroketi od krumpira
-
 
 < en:Frozen fried potatoes
 fr: Quartiers de pommes de terre surgelés
@@ -83027,6 +83054,7 @@ ciqual_food_name:fr: Soupe aux pois cassés, préemballée à réchauffer
 
 < en:Vegetable soups
 en: Leek and potato soups, Leek and potato soup
+da: Porre- og kartoffelsupper
 fr: Soupe aux poireaux et aux pommes de terre
 hr: Juha od poriluka i krumpira
 lt: Porų ir bulvių sriubos
@@ -84184,8 +84212,9 @@ ciqual_food_name:fr: Palet ou galette de légumes, préfrit, surgelé
 
 < en:Frozen foods
 < en:Rostis
-en: Frozen Rostis, Frozen Potatoes cakes, Frozen Potato cakes
-fr: Rostis surgelés, Galette de pomme de terre surgelée, Galette de pommes de terre surgelées
+en: Frozen potato rostis, Frozen Rostis, Frozen Potatoes cakes, Frozen Potato cakes
+da: Frosne røsti
+fr: Röstis de pommes de terre surgelés, Rostis surgelés, Galette de pomme de terre surgelée, Galette de pommes de terre surgelées
 
 < en:Frozen plant-based foods
 < en:Prepared vegetables
@@ -111891,6 +111920,7 @@ sales_format:en: weight, package
 
 < en:Potatoes
 en: New potatoes
+da: Nye kartofler
 fi: Tuoreet perunat
 fr: Pommes de terre nouvelles, Pommes de terre fraîches, Pommes de terre primeurs, Pommes de terre de primeur
 hr: Mladi krumpir
@@ -111905,6 +111935,7 @@ sales_format:en: weight, package
 
 < en:Potatoes
 en: Peeled potatoes
+da: Skrællede kartofler
 fr: Pommes de terre sans peau
 agribalyse_food_code:en: 4008
 ciqual_food_code:en: 4008
@@ -111915,6 +111946,7 @@ ciqual_food_name:fr: Pomme de terre, sans peau, crue
 
 < en:Potatoes
 en: Agata potatoes
+da: Agata-kartofler
 de: Agata Kartoffeln
 fr: Pommes de terre Agata
 hr: Agata krumpir
@@ -111924,6 +111956,7 @@ wikidata:en: Q373973
 
 < en:Potatoes
 en: Allians potatoes
+da: Allians-kartofler
 fr: Pommes de terre Allians
 
 < en:Potatoes
@@ -111946,6 +111979,7 @@ protected_name_type:en: pdo
 
 < en:Potatoes
 en: Amandine potatoes, Potatoes(Amandine)
+da: Amandine-kartofler
 fr: Pommes de terre amandine
 nl: Amandine aardappelen, Aardappelen(Amandine)
 ru: Картофель Амандин
@@ -111955,6 +111989,7 @@ wikidata:en: Q2841064
 
 < en:Potatoes
 en: Béa potatoes
+da: Béa-kartofler
 de: Béa Kartoffeln
 fr: Pommes de terre Béa
 hr: Béa krumpir
@@ -111986,6 +112021,7 @@ sales_format:en: weight, package
 
 < en:Potatoes
 en: Charlotte potatoes
+da: Charlotte-kartofler
 fr: Pommes de terre Charlotte
 hr: Charlotte krumpir
 nl: Charlotte aardappel
@@ -112021,10 +112057,12 @@ wikidata:en: Q864084
 
 < en:Potatoes
 en: Ostara potatoes
+da: Ostara-kartofler
 fr: Pomme de terre Ostara
 
 < en:Potatoes
 en: Grenaille potatoes, Potatoes (Grenaille)
+da: Grenaille-kartofler
 de: Grenaille Kartoffeln
 fr: Pomme de terre Grenaille
 hr: Grenaille krumpir
@@ -112033,6 +112071,7 @@ sales_format:en: weight, package
 
 < en:Potatoes
 en: Jersey Royal potatoes
+da: Jersey Royal-kartofler
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0027
 protected_name_type:en: pdo
@@ -112040,6 +112079,7 @@ wikidata:en: Q3177530
 
 < en:Potatoes
 en: Lady Christl potatoes
+da: Lady Christl-kartofler
 de: Lady Christl Kartoffeln
 fr: Pomme de terre Lady Christl
 hr: Lady christl krumpir
@@ -112047,14 +112087,17 @@ nl: Lady Christl aardappelen
 
 < en:Potatoes
 en: Louisiana potatoes
+da: Louisiana-kartofler
 fr: Pommes de terre Louisiana
 
 < en:Potatoes
 en: Nazca potatoes
+da: Nazca-kartofler
 fr: Pommes de terre Nazca
 
 < en:Potatoes
 en: Red potatoes
+da: Røde kartofler
 fr: Pommes de terres rouges
 nl: Rode aardappelen
 sales_format:en: package, weight
@@ -112063,12 +112106,14 @@ sales_format:en: package, weight
 
 < en:Potatoes
 en: Potatoes for steaming
+da: Kartofler til dampning
 es: Patatas para cocinar al vapor
 fr: Pommes de terre vapeur, Pommes de terre spéciales vapeur
 hr: Krumpir za kuhanje na pari
 
 < en:Potatoes
 en: Potatoes for gratin
+da: Kartofler til gratin
 fr: Pomme de terre gratin
 sales_format:en: weight, package
 
@@ -112107,6 +112152,7 @@ de: Speisekartoffeln
 
 < en:Potatoes
 en: Potatoes from Italy, Italian potatoes
+da: Kartofler fra Italien, Italienske kartofler
 de: Kartoffeln aus Italien
 fr: Pommes de terre d'Italie
 hr: Krompir iz italije
@@ -112116,6 +112162,7 @@ origins:en: en:italy
 
 < en:Potatoes from Italy
 en: Potatoes from Fucino
+da: Kartofler fra Fucino
 it: Patata del Fucino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01217-AM01, en: PGI-IT-01217
@@ -112149,6 +112196,7 @@ wikidata:en: Q3368654
 
 < en:Potatoes from Italy
 en: Potatoes from Sila
+da: Kartofler fra Sila
 it: Patata della Sila
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0643
@@ -112157,6 +112205,7 @@ wikidata:en: Q647212
 
 < en:Potatoes from Italy
 en: Potatoes from Alto Viterbese
+da: Kartofler fra Alto Viterbese
 it: Patata dell'Alto Viterbese
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1038
@@ -112165,6 +112214,7 @@ wikidata:en: Q3368640
 
 < en:Potatoes
 en: Potatoes from Spain, Spanish potatoes
+da: Kartofler fra Spanien, Spanske kartofler
 de: Kartoffeln aus Spanien
 fr: Pommes de terre d'Espagne
 hr: Krumpir iz Španjolske
@@ -112174,6 +112224,7 @@ origins:en: en:spain
 
 < en:Potatoes from Spain
 en: Potatoes from Val de Picones
+da: Kartofler fra Val de Picones
 de: Kartoffeln aus Val de Picones
 fr: Pommes de terre de Val de Picones
 hr: Krumpir iz val de picones
@@ -112202,6 +112253,7 @@ nl: Aardappelen uit Val de Picones
 
 < en:Potatoes
 en: Potatoes from France, French potatoes
+da: Kartofler fra Frankrig, Franske kartofler
 de: Kartoffeln aus Frankreich
 fr: Pommes de terre françaises
 hr: Krumpir iz Francuske
@@ -112213,6 +112265,7 @@ sales_format:en: weight, package
 
 < en:Potatoes from France
 en: Potatoes from Île de Ré
+da: Kartofler fra Île de Ré
 fr: Pommes de terre de l'île de Ré, Pomme de terre de l'île de Ré
 origins:en: en:france, en:ile-de-re
 protected_name_file_number:en: PDO-FR-0065
@@ -112221,6 +112274,7 @@ wikidata:en: Q3395977
 
 < en:Potatoes from France
 en: Potatoes from Noirmoutier
+da: Kartofler fra Noirmoutier
 fr: Pomme de terre de Noirmoutier
 origins:en: en:noirmoutier
 protected_name_file_number:en: PGI-FR-02434
@@ -112228,6 +112282,7 @@ protected_name_type:en: pgi
 
 < en:Potatoes from France
 en: Potatoes from Merville
+da: Kartofler fra Merville
 fr: Pommes de terre de Merville
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0197
@@ -117836,6 +117891,7 @@ es: Parrilladas de verduras congelada, Parrillada de verduras congelada
 < en:Frozen potatoes
 < en:Roasted potatoes
 en: Frozen baked potatoes
+da: Frosne bagte kartofler
 es: Patatas panadera congeladas
 fr: Pommes de terre cuites surgelées, pommes de terre cuites congelées
 hr: Smrznuti pečeni krumpir
@@ -118387,6 +118443,7 @@ nl: Diepvriesaardappelen
 < en:Frozen potatoes
 < en:Potato wedges
 en: Frozen potato wedges
+da: Frosne kartoffelbåde
 sv: Frysta potatisklyftor, Djupfryst klyftpotatis
 
 < en:Frozen potatoes
@@ -121267,18 +121324,21 @@ wikidata:en: Q636056
 
 < en:Potatoes and their products
 en: Prepared potatoes
+da: Tilberedte kartofler
 fr: Pommes de terre préparées
 hr: Pripremljeni krumpir
 nl: Geprepareerde aardappelen
 
 < en:Prepared potatoes
 en: Precooked potatoes
+da: Forkogte karofler
 fr: Pommes de terres précuites
 hr: Prethodno kuhani krumpir
 nl: Voorgekookte aardappelen
 
 < en:Prepared potatoes
 en: Cooked potatoes, Boiled potatoes
+da: Kogte kartofler
 fr: Pommes de terre cuites
 hr: Kuhani krumpir
 nl: Gekookte aardappelen
@@ -121289,6 +121349,7 @@ intake24_category_code:en: BOLP
 
 < en:Prepared potatoes
 en: Boiled or steamed potatoes, Potatoes cooked in water or steam
+da: Kogte eller dampede kartofler
 fr: Pommes de terre bouillies ou à la vapeur, Pommes de terre cuites à l'eau ou à la vapeur
 agribalyse_proxy_food_code:en: 4014
 ciqual_proxy_food_code:en: 4014
@@ -121304,6 +121365,7 @@ ciqual_food_name:fr: Pomme de terre, bouillie/cuite à l'eau
 
 < en:Boiled or steamed potatoes
 en: Steamed potatoes, steamed cooked potatoes
+da: Dampkogte kartofler
 fr: Pommes de terre cuites à la vapeur, Pommes de terre à la vapeur
 agribalyse_proxy_food_code:en: 4014
 ciqual_proxy_food_code:en: 4014
@@ -121329,6 +121391,7 @@ ciqual_food_name:fr: Pomme de terre de conservation, sans peau, bouillie/cuite �
 
 < en:Prepared potatoes
 en: Baked peeled potatoes
+da: Bagte skrællede kartofler
 fr: Pommes de terre sans peau cuites au four
 agribalyse_food_code:en: 4002
 ciqual_food_code:en: 4002
@@ -121337,6 +121400,7 @@ ciqual_food_name:fr: Pomme de terre, sans peau, cuite au four
 
 < en:Prepared potatoes
 en: Roasted potatoes, Baked potatoes
+da: Stegte kartofler, Bagte kartofler
 fr: Pommes de terre rôties, Pommes de terre cuites au four
 agribalyse_food_code:en: 4026
 ciqual_food_code:en: 4026
@@ -121346,6 +121410,7 @@ intake24_category_code:en: BKDP
 
 < en:Prepared potatoes
 en: Sautéed Potatoes, Pan-fried potatoes
+da: Sauterede kartofler, Pandestegte kartofler
 fr: Pommes de terre sautées, Pommes de terre poêlées
 agribalyse_food_code:en: 4015
 ciqual_food_code:en: 4015
@@ -121355,6 +121420,7 @@ intake24_category_code:en: ROPOT
 
 < en:Prepared potatoes
 en: Fried potato cubes
+da: Ristede kartoffeltern
 fr: Pommes de terre rissolées
 agribalyse_proxy_food_code:en: 4043
 agribalyse_proxy_food_name:en: Potato, pre-fried into cubes, frozen, raw
@@ -121371,6 +121437,7 @@ ciqual_food_name:fr: Pomme de terre sautée/poêlée à la graisse de canard
 < en:Prepared potatoes
 < en:Steamed potatoes
 en: Vacuum-packed steamed potatoes
+da: Vakuumpakkede dampede kartofler
 fr: Pommes de terre vapeur sous vide
 agribalyse_food_code:en: 4014
 ciqual_food_code:en: 4014
@@ -121379,6 +121446,7 @@ ciqual_food_name:fr: Pomme de terre vapeur, sous vide
 
 < en:Potatoes and their products
 en: Potato preparations
+da: Kartoffeltilberedninger
 de: Kartoffelzubereitungen
 fi: Perunavalmisteet
 fr: Préparations à base de pommes de terre
@@ -121390,6 +121458,7 @@ intake24_category_code:en: WFFL
 
 < en:Potato preparations
 en: Rostis, Potatoes cakes, Potato cakes
+da: Røsti, Rösti
 de: Röstis
 fr: Rostis, Galette de pomme de terre, Galette de pommes de terre
 hr: Rostis
@@ -121397,6 +121466,7 @@ agribalyse_food_code:en: 4039
 ciqual_food_code:en: 4039
 ciqual_food_name:en: Rostis or Potatoes cake
 ciqual_food_name:fr: Rostis ou Galette de pomme de terre
+wikidata:en: Q627331
 
 < en:Potato preparations
 en: Bubble and squeak
@@ -121407,15 +121477,11 @@ en: Hash Browns, hashed browns
 ja: ハッシュポテト
 wikidata:en: Q152981
 
-< en:Frozen foods
-< en:Rostis
-en: Frozen potato rostis
-fr: Röstis de pommes de terre surgelés
-
 < en:Potato preparations
 < fr:Purées
 en: Mashed potatoes
 bg: Картофено пюре
+da: Kartoffelmos
 de: Kartoffelpüree, Kartoffelpürees, Kartoffelbreie, Stampfkartoffeln, Quetschkartoffeln
 fi: perunamuusit
 fr: Purées de pommes de terre, Purée de pommes de terre
@@ -121436,6 +121502,7 @@ pnns_group_2:en: Potatoes
 # without milk, cream, butter
 < en:Mashed potatoes
 en: Pure mashed potatoes, Mashed potatoes 100%
+da: Ren kartoffelmos
 fr: Purées de pommes de terres pures, Purées de pommes de terre 100%, purée de pommes de terre 100%
 agribalyse_proxy_food_code:en: 4003
 ciqual_proxy_food_code:en: 4003


### PR DESCRIPTION
Adds Danish translations to a bunch (most?) of potato categories.

Note: This also merges the categories `en:Frozen Rostis` and `en:Frozen potato rostis` as I realised this was duplicated when I was about to add the same translation a 2nd time. :)

This will have some overlap with https://github.com/openfoodfacts/openfoodfacts-server/pull/13283 but I didn’t feel like cross-referencing every change there to leave out here. I’ll deal with any merge conflicts when either this or the other has been merged.