### PR TITLE
taxonomy(food): add ratte potato category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -112006,6 +112006,20 @@ sales_format:en: weight, package
 wikidata:en: Q1491619
 
 < en:Potatoes
+en: Ratte potatoes
+da: Aspargeskartofler
+de: Ratte Kartoffeln
+fi: Ratte (peruna)
+hr: Ratte krumpir
+ko: 라트감자
+la: Solanum tuberosum ‘Ratte’
+nb: Ratte-poteter
+nn: Ratte-potetar, Ratte-poteter
+sv: Sparrispotatisar, Ratte-potatisar, Potatisar (Ratte)
+sales_format:en: weight, package
+wikidata:en: Q1422830
+
+< en:Potatoes
 en: Bintje potatoes
 da: Bintje-kartofler
 de: Bintje Kartoffeln


### PR DESCRIPTION
Somewhat common Danish and French potato cultivar, which at least is available for purchase in (some) Danish supermarkets.