### PR TITLE
taxonomy(food): sweet potato category groups

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -44629,6 +44629,7 @@ lt: Pasternoko traškučiai
 nl: Pastinaakchips
 
 < en:Crisps
+< en:Sweet potatoes and their products
 en: Sweet potato crisps
 de: Süßkartoffelchips
 fi: Bataattilastut
@@ -44971,12 +44972,13 @@ wikidata:en: Q1524389
 en: Flavoured corn crisps, Flavoured corn chips, Flavoured tortilla chips
 fr: Chips de maïs aromatisées
 
-< en:Cereals and potatoes
 < en:Chips and fries
+< en:Sweet potatoes and their products
 en: Sweet potato fries
-Fr: Frites de patate douce
+fr: Frites de patate douce
+wikidata:en: Q17105567
 
-< en:Cereals and potatoes
+< en:Sweet potatoes and their products
 en: Mashed sweet potatoes, Sweet potato puree cooked with cream
 fr: Purées de patates douces, Purée de patates douces cuisinée à la crème, Purée de patate douce cuisinée à la crème
 agribalyse_food_code:en: 4103
@@ -81359,6 +81361,11 @@ en: Krögarpytt
 sv: Krögarpytt
 
 < en:Meals
+en: Sweet potato dishes
+intake24_category_code:en: POTD
+wikidata:en: Q138773658
+
+< en:Meals
 en: Chop suey
 xx: Chop suey
 fr: Chop suey
@@ -82758,8 +82765,10 @@ fr: Soupes de crevettes
 nl: Erwtensoepen
 
 < en:Soups
+< en:Sweet potato dishes
 en: Sweet potato soups
 nl: Zoete aardappelsoepen
+wikidata:en: Q1012556
 
 < en:Reheatable soups
 < en:Soups
@@ -84735,6 +84744,7 @@ ciqual_food_name:fr: Légume cuit (aliment moyen)
 en: Prepared carrots
 
 < en:Prepared vegetables
+< en:Sweet potatoes and their products
 en: Prepared sweet potatoes
 nl: Geprepareerde zoete aardappelen
 
@@ -107042,7 +107052,9 @@ hr: Baba ghanoush
 nl: Baba ghanoush, Baba ganush
 wikidata:en: Q1072192
 
+< en:Plant-based spreads
 < en:Salted spreads
+< en:Sweet potato dishes
 en: Sweet potato spreads
 de: Süßkartoffel-Aufstriche, Süßkartoffel-Aufstrich
 fr: Tartinades de patates douces
@@ -113154,7 +113166,12 @@ ciqual_food_name:en: Spinach w cream sauce
 ciqual_food_name:fr: Épinards à la crème
 
 < en:Cereals and potatoes
+en: Sweet potatoes and their products
+food_groups:en: en:potatoes
+pnns_group_2:en: Potatoes
+
 < en:Root vegetables
+< en:Sweet potatoes and their products
 en: Sweet potatoes, Sweet potato
 bg: Сладки картофи
 de: Süßkartoffeln


### PR DESCRIPTION
As I’ve been pouring over the potato categories, I’ve noted that we have a number of sweet potato (which are not potatoes!) categories that are not grouped together like the potato categories are. This is an attempt at doing this grouping.

Adds new `en:Sweet potatoes and their products` and `en:Sweet potato dishes` mirroring already existing non-sweet potato analogues, and moves some inheritances around to fit into these new categories.

Also adds a few `wikidata` properties.