### PR TITLE
ci: Add on-demand lint+test result update action

### DIFF
--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -20,7 +20,8 @@ jobs:
       with:
         comment-id: ${{ github.event.comment.id }}
         reactions: eyes
-    - name: Get repository, owner and branch name
+    - &get-repository-owner-branch
+      name: Get repository, owner and branch name
       # see https://github.com/actions/checkout/issues/331
       id: get-branch
       run: |
@@ -31,7 +32,8 @@ jobs:
         REPO: ${{ github.repository }}
         PR_NO: ${{ github.event.issue.number }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-    - name: Checkout
+    - &checkout-fork-repo
+      name: Checkout
       uses: actions/checkout@v5
       with:
         # we need to checkout the fork repository
@@ -44,11 +46,13 @@ jobs:
         # So this is a personal access token
         token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     # we need origin/main to have comparison linting work !
-    - name: Fetch origin/main
+    - &fetch-origin-main
+      name: Fetch origin/main
       run: |
         git remote set-branches --add origin main
         git fetch origin
-    - name: Run linting
+    - &run-linting
+      name: Run linting
       run: make lint front_lint
     - name: Push changes if needed
       uses: stefanzweifel/git-auto-commit-action@v7
@@ -79,35 +83,44 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - *step-reaction-seen
-    - name: Get repository, owner and branch name
-      # see https://github.com/actions/checkout/issues/331
-      id: get-branch
-      run: |
-        echo branch=$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName') >> $GITHUB_OUTPUT
-        echo owner=$(gh pr view $PR_NO --repo $REPO --json headRepositoryOwner --jq '.headRepositoryOwner.login')  >> $GITHUB_OUTPUT
-        echo repository=$(gh pr view $PR_NO --repo $REPO --json headRepositoryOwner,headRepository --jq '.headRepositoryOwner.login + "/" + .headRepository.name')  >> $GITHUB_OUTPUT
-      env:
-        REPO: ${{ github.repository }}
-        PR_NO: ${{ github.event.issue.number }}
-        GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        # we need to checkout the fork repository
-        # see https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#workflow-should-run-in-base-repository
-        fetch-depth: 1
-        repository: "${{ steps.get-branch.outputs.repository }}"
-        ref: "${{ steps.get-branch.outputs.branch }}"
-        # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
-        # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-        # So this is a personal access token
-        token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-    - name: Run update tests results
+    - *get-repository-owner-branch
+    - *checkout-fork-repo
+    - &run-update-tests-results
+      name: Run update tests results
       run: make update_tests_results
     - name: Push changes if needed
       uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "test: Update tests results"
+        branch: "${{ steps.get-branch.outputs.branch }}"
+        commit_user_name: Open Food Facts Bot
+        commit_user_email: contact@openfoodfacts.org
+        commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
+        push_options: ""
+        status_options: '--untracked-files=no'
+        skip_dirty_check: false
+        create_branch: no
+    - *step-reaction-completed
+
+  # Action to lint _and_ update test results in one go
+  lint_and_update_test_results:
+    name: "On demand linting and updating of test results"
+    if: |
+      github.event.issue.pull_request &&
+      ((github.event.comment.body == '/lint+update_test_results') ||
+      (github.event.comment.body == '/lint+update_tests_results'))
+    runs-on: ubuntu-latest
+    steps:
+    - *step-reaction-seen
+    - *get-repository-owner-branch
+    - *checkout-fork-repo
+    - *fetch-origin-main
+    - *run-linting
+    - *run-update-tests-results
+    - name: Push changes if needed
+      uses: stefanzweifel/git-auto-commit-action@v7
+      with:
+        commit_message: "chore: Linting and test results changes"
         branch: "${{ steps.get-branch.outputs.branch }}"
         commit_user_name: Open Food Facts Bot
         commit_user_email: contact@openfoodfacts.org


### PR DESCRIPTION
Instead of having to first do `/lint` and then do `/update_tests_results`, this adds a combined command `/lint+update_test_results` (`/lint+update_tests_results` will also work) that will (effectively) run both of these commands.