### PR TITLE
taxonomy(food): raisin category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -34603,6 +34603,7 @@ hr: Keksi s grožđicama
 lt: Sausainiai su razinomis
 nl: Rozijnenkoekjes, Rozijnenkoekje, Rozijnekoekjes, Rozijnekoekje
 ro: Biscuiți cu stafide, Fursecuri cu stafide
+sv: Småkakor med russin
 
 < en:Biscuits
 en: Almond cookies, Thin biscuits with almonds
@@ -38825,10 +38826,12 @@ oqali_family:en: fr:Biscuits et gateaux industriels - Madeleines nature
 
 < en:Madeleines
 en: Madeleines with raisin, Raisin madeleines
+da: Madeleinekager med rosiner
 de: Madeleines mit Rosinen
 fr: Madeleines aux raisins, Madeleines au raisin, Madeleine aux raisins, Madeleine au raisin
 hr: Madeleine s grožđicama
 nl: Madeleines met rozijnen
+sv: Madeleinekakor med russin
 
 < en:Madeleines
 en: Long madeleines
@@ -39397,10 +39400,12 @@ tr: Fındıklı çikolata
 < en:Chocolates
 en: Chocolates with raisins
 bg: Шоколад със стафиди
+da: Chokolader med rosiner
 fr: Chocolats aux raisins
 hr: Čokolade s grožđicama
 ja: レーズンチョコレート
 lt: Šokoladai su razinomis
+sv: Choklader med russin
 #wikidata:en:
 
 < en:Chocolates
@@ -39751,8 +39756,10 @@ ciqual_food_name:fr: Chocolat au lait aux fruits secs (noisettes, amandes, raisi
 < en:Milk chocolates
 en: Milk chocolates with raisins
 bg: Млечен шоколад със стафиди
+da: Mælkechokolader med rosiner
 hr: Mliječne čokolade s grožđicama
 lt: Pieniški šokoladai su razinomis
+sv: Mjölkchoklader med russin
 agribalyse_food_code:en: 31018
 ciqual_food_code:en: 31018
 ciqual_food_name:en: Milk chocolate bar, with dried fruits (nuts, almonds, raisins, praline)
@@ -39887,9 +39894,11 @@ agribalyse_proxy_food_name:fr: Chocolat noir aux fruits secs (noisettes, amandes
 < en:Chocolates with raisins
 < en:Dark chocolates
 en: Dark chocolates with raisins
+da: Mørke chokolader med rosiner
 fr: Chocolats noirs aux raisins
 hr: Tamne čokolade s grožđicama
 lt: Juodi šokoladai su razinomis
+sv: Mörka choklader med russin
 agribalyse_proxy_food_code:en: 31070
 agribalyse_proxy_food_name:en: Dark chocolate bar, with dried fruits (nuts, almonds, raisin, praline)
 agribalyse_proxy_food_name:fr: Chocolat noir aux fruits secs (noisettes, amandes, raisins, praline), tablette
@@ -40560,6 +40569,7 @@ wikidata:en: Q16826630
 
 < en:Chocolate covered fruits
 en: Chocolate-covered raisins
+da: Rosiner med chokoladeovertræk
 de: Schokoladenrosinen
 es: Pasas recubiertas de chocolate
 fi: Suklaarusinat
@@ -40567,6 +40577,7 @@ fr: Raisins secs enrobés de chocolat, Raisins secs au chocolat
 hr: Grožđice prelivene čokoladom
 lt: Razinos šokolade
 nl: Chocoladerozijnen
+sv: Chokladöverdragna russin, Russin med chokladöverdrag
 wikidata:en: Q5103586
 
 < en:Chocolate covered fruits
@@ -70034,6 +70045,7 @@ protected_name_type:en: pdo
 < en:Fruits
 en: Grapes
 bg: Грозде
+da: Vindruer
 de: Weintrauben
 es: Uvas
 fi: viinirypäleet
@@ -70042,9 +70054,12 @@ hr: Grožđe
 it: Uva
 ja: ブドウ, ぶどう, 葡萄
 lt: Vynuogės
+nb: Vindruer
 nl: Druiven
+nn: Vindruer
 pl: Winogrona
 ru: Виноград
+sv: Vindruvor
 agribalyse_food_code:en: 13112
 ciqual_food_code:en: 13112
 ciqual_food_name:en: Grape, raw
@@ -70076,13 +70091,17 @@ protected_name_type:en: pgi
 
 < en:Grapes
 en: Green grapes, White grapes
+da: Grønne vindruer
 de: Weiße Weintrauben, Grüne Weintrauben, Gelbe Weintrauben
 es: Uvas blancas
 fr: Raisins blancs, Raisins verts
 hr: Zeleno grožđe
 lt: Žalios vynuogės, Baltos vynuogės
+nb: Grønne vindruer
 nl: Witte druiven
+nn: Grøna vindruer
 ru: Белый виноград, зелёный виноград, зеленый виноград
+sv: Gröna vindruvor
 agribalyse_food_code:en: 13044
 ciqual_food_code:en: 13044
 ciqual_food_name:en: Grape, white, raw
@@ -70095,11 +70114,13 @@ sales_format:en: weight, package
 < en:Fresh fruits
 < en:Grapes
 en: Fresh grapes
+da: Friske vindruer
 de: Frische Trauben, Frische Weintrauben
 es: Uvas frescas
 fr: Raisins frais, Raisin frais
 hr: Svježe grožđe
 lt: Šviežios vynuogės
+sv: Färska vindruvor
 
 < en:Fresh grapes
 fr: Chasselas de Moissac
@@ -70110,12 +70131,14 @@ protected_name_type:en: pdo
 
 < en:Grapes
 en: Black grapes, Red grapes
+da: Røde vindruer
 de: Rote Weintrauben
 es: Uvas negras
 fr: Raisins noirs
 hr: Crno grožđe
 lt: JUodos vynuogės, Raudonos vynuogės
 nl: Rode druiven
+sv: Röta vindruvor
 agribalyse_food_code:en: 13045
 ciqual_food_code:en: 13045
 ciqual_food_name:en: Grape, red, raw
@@ -72296,7 +72319,9 @@ hr: Grožđice
 it: Uve secche
 ja: レーズン, 干しぶどう, 干しブドウ, 干し葡萄
 lt: Razinos, Džiovintos vynuogės
+nb: Rosiner
 nl: Gedroogde rozijnen
+nn: Rosiner
 pl: Rodzynki, suszone winogrona
 ru: Изюм, виноград сушёный, виноград сушеный, сушеный виноград, сушёный виноград
 sv: Russin
@@ -72306,16 +72331,20 @@ ciqual_food_name:en: Raisin
 wikidata:en: Q13186
 
 < en:Raisins
-en: Raisins of Corinth
+en: Zante currants, Raisins of Corinth
+da: Korender
 de: Korinthen
 es: Uvas pasas de Corinto, Pasas de Corinto
 fr: Raisins secs de Corinthe
 hr: Grožđice iz korinta
 lt: Corinth razinos
 nl: Krenten
+sv: Korinter
+wikidata:en: Q1382423
 
 < en:Raisins
 en: Sultana raisins
+da: Sultanarosiner
 de: Sultaninen
 es: Uvas pasas sultanas, Pasas sultanas
 fi: Sulttaanirusinat
@@ -72325,6 +72354,12 @@ it: Uvetta, Uvetta sultanina
 lt: Sultana razinos
 nl: Sultanas
 sv: Sultanrussin
+wikidata:en: Q19883728
+
+< en:Raisins
+en: Green raisins
+da: Grønne rosiner
+sv: Gröna russin
 
 < en:Canned plant-based foods
 en: Canned fruits
@@ -119055,6 +119090,7 @@ wikidata:en: Q254979
 
 < en:Viennoiseries
 en: Breads with raisins, Raisin puff pastry, Viennese pastries, Viennese pastry
+da: Brød med rosiner, Rosinbrød
 de: Rosinenbrote, Rosinenbrot
 fi: rusinaleivät
 fr: Pains aux raisins, escargots aux raisins, escargot aux raisins, pain aux raisins
@@ -119063,6 +119099,7 @@ it: Pane con uvetta, Pane all'uvetta
 lt: Duona su razinomis, Razinų sluoksniuota tešla, Vienos pyragaičiai, Vienos tešla
 nl: Rozijnenbroden, Rozijnenbrood
 ro: Pâini cu stafide, Pâine cu stafide
+sv: Bröd med russin, Russinbröd
 agribalyse_food_code:en: 7720
 ciqual_food_code:en: 7720
 ciqual_food_name:en: Raisin puff pastry (Viennese pastries)


### PR DESCRIPTION
- Adds “Green raisins” category
- Adds some `wikidata` properties
- Adds Danish+Swedish and a few Norwegian translations

Needed-for: https://se.openfoodfacts.org/product/7331974101701/gr%C3%B6na-russin-famous