### PR TITLE
fix: upload release please assets

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -146,6 +146,7 @@ jobs:
         uses: svenstaro/upload-release-action@2.11.4
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file_glob: /tmp/release-assets/*.tgz
+          file: /tmp/release-assets/*.tgz
+          file_glob: true
           tag: ${{ steps.release.outputs.tag_name }}
           overwrite: true


### PR DESCRIPTION
There's a typo in the release please action to upload release assets, file_glob is a boolean.

https://github.com/svenstaro/upload-release-action