### PR TITLE
chore(gen_feeds_daily): export MongoDB dump & JSONL first

### DIFF
--- a/scripts/gen_feeds_daily.sh
+++ b/scripts/gen_feeds_daily.sh
@@ -52,6 +52,9 @@ fi
 ./remove_empty_products.pl || report_error $? "remove_empty_products.pl"
 ./gen_top_tags_per_country.pl  || report_error $? "gen_top_tags_per_country.pl"
 
+# Generate the MongoDB dumps and jsonl export
+./mongodb_dump.sh $OFF_PUBLIC_DATA_DIR $PRODUCT_OPENER_FLAVOR $MONGODB_HOST $PRODUCT_OPENER_FLAVOR_SHORT || report_error $? "mongodb_dump.sh"
+
 # Generate the CSV and RDF exports
 ./export_database.pl || report_error $? "export_database.pl"
 
@@ -75,10 +78,7 @@ mc cp \
     s3/$PRODUCT_OPENER_FLAVOR-ds \
     || report_error $? "mc.cp.csv"
 
-# Generate the MongoDB dumps and jsonl export
 cd $OFF_SCRIPTS_DIR
-
-./mongodb_dump.sh $OFF_PUBLIC_DATA_DIR $PRODUCT_OPENER_FLAVOR $MONGODB_HOST $PRODUCT_OPENER_FLAVOR_SHORT || report_error $? "mongodb_dump.sh"
 
 # Small products data and images export for Docker dev environments
 # for about 1/100000th of the products contained in production.

--- a/scripts/remove_empty_products.pl
+++ b/scripts/remove_empty_products.pl
@@ -48,7 +48,10 @@ while (my $product_ref = $cursor->next) {
 
 	if ((defined $product_ref) and ($code ne '')) {
 
-		if (($product_ref->{empty} == 1) and (time() > $product_ref->{last_modified_t} + 86400)) {
+		if (    (defined $product_ref->{empty})
+			and ($product_ref->{empty} == 1)
+			and (time() > $product_ref->{last_modified_t} + 86400))
+		{
 			$product_ref->{deleted} = 'on';
 			my $comment = "[$0] automatic removal of product without information or images";
 			# Apply the deletion. Use specific user "remove-empty-products".


### PR DESCRIPTION
Currently, the CSV and RDF files are exported before the MongoDB and JSONL files.

There seems to be a bug in the `export_database.pl`, when we sort the CSV by code: the following call never ends, and the systemd service gets killed after 20h:

`system("(head -1 $csv_filename.temp && (tail -n +2 $csv_filename.temp | sort)) > $csv_filename.temp2");`

We need to investigate why this fails, but in the meantime, we can still have the JSONL and MongoDB dumps, which are the most important ones. The JSONL dump is notably used for the Parquet export.

In this PR, I change the run order and run MongoDB and JSONL export before the CSV/RDF export.

I also fixed a warning in remove_empty_products.pl script:

```
remove_empty_products.pl: Use of uninitialized value in numeric eq (==) at ./remove_empty_products.pl line 51.
```