### PR TITLE
taxonomy(product): more brands

### DIFF
--- a/taxonomies/product/brands.txt
+++ b/taxonomies/product/brands.txt
@@ -11,26 +11,134 @@
 # Note: an old draft owners/brands taxonomy lives in taxonomies/unused/brands.txt, but it is hierarchic, which is something we do not want in this taxonomy.
 # You can usefully read: https://wiki.openfoodfacts.org/Brands to get up and running on the subtleties of the topic.
 
+xx: Adidas
+wikidata:en: Q12358242
+
+xx: Ajax
+wikidata:en: Q2828856
+
+xx: Always
+wikidata:en: Q3500302
+
 xx: apoteket
 wikidata:en: Q1785637
 
+xx: Apple
+wikidata:en: Q312
+
+xx: Ariel
+wikidata:en: Q658915
+
+xx: ASUS
+wikidata:en: Q152864
+
+xx: Auchan
+wikidata:en: Q758603
+
+#< xx:Auchan
+xx: Auchan Baby
+
+xx: BiC
+wikidata:en: Q795981
+
 xx: Bluewear
+
+xx: Bosch
+wikidata:en: Q234021
+
+xx: Bosque Verde
+
+xx: Brandt
+wikidata:en: Q2923799
+
+xx: Colgate
+wikidata:en: Q2523492
+
+xx: Cosmia
 
 xx: DELTACO
 wikidata:en: Q112801046
+
+xx: Dettol
+wikidata:en: Q15061688
+
+xx: Downy
+comment:en: Going by “Lenor” in Europe, Taiwan, and Japan.
+wikidata:en: Q903922
+
+xx: Duracell
+wikidata:en: Q858702
+
+xx: Energizer, ENERGIZER TRADING EUROPE B.V.
+wikidata:en: Q1200840
+
+xx: Fairy
+wikidata:en: Q1393460
+
+xx: febreze
+wikidata:en: Q910264
+
+xx: finish
+wikidata:en: Q21169666
 
 xx: Future Sport
 
 xx: HAALE, HAALE Ring
 #web:en: https://haalering.com/
 
+xx: Henkel
+wikidata:en: Q276507
+
+xx: LEGO
+wikidata:en: Q170484
+
+xx: Lenor
+comment:en: Going by “Downy” in the USA.
+wikidata:en: Q903922
+
 xx: MEEC Tools
+
+xx: Miele, Miele & Cie. KG
+wikidata:en: Q695230
+
+xx: Nike
+wikidata:en: Q483915
 
 xx: Nintendo
 wikidata:en: Q8093
 
+xx: Omo
+wikidata:en: Q64831229
+
+xx: Oral-B
+wikidata:en: Q1987067
+
+xx: Panasonic
+wikidata:en: Q833266
+
+xx: Persil
+wikidata:en: Q2071993
+
+xx: Philips
+wikidata:en: Q170416
+
+xx: Post-it
+wikidata:en: Q181331
+
 xx: Renée Voltaire, Renee Voltaire
 wikidata:en: Q136622857
+
+xx: Samsung
+wikidata:en: Q124989916
+
+xx: Sega
+wikidata:en: Q122741
+
+xx: Siemens
+wikidata:en: Q81230
+
+xx: Skip
+wikidata:en: Q105906650
 
 xx: Sony
 wikidata:en: Q41187


### PR DESCRIPTION
Adds a selection of the most used brands on OPF that are currently unknown.