### PR TITLE
taxonomy(food): add common Dutch ingredient synonyms and translations

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -32092,7 +32092,7 @@ ja: 果糖ぶどう糖液糖
 lt: gliukozės-fruktozės sirupas
 lv: glikozes-fruktozes sīrups
 nb: glukose-fruktosesirup
-nl: glucose-fructosestroop, glucose-fructose-stroop
+nl: glucose-fructosestroop, glucose-fructose-stroop, glucosefructosestroop
 nn: glukos-fruktossirap
 no: glukose-fruktosesirup, glukose-fruktose-sirup, glukose-fruktose sirup
 pl: syrop glukozowo-fruktozowy, syrop fruktozowo-glukozowy


### PR DESCRIPTION
### What

Adds Dutch translations and synonyms to ingredients. All ingredients were found in a dataset of ingredient labels of food products that are currently being sold in the Netherlands. Each commit message contains the source label that contained this ingredient.

### LLM disclosure
LLM used: Claude Opus 4.6 via Claude Code. All edits were manually reviewed by me (Victor).