### PR TITLE
taxonomy(food): add Dutch ingredient synonyms and translations

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -41416,6 +41416,7 @@ fi: limetinlehti, limenlehti, limen lehti
 fr: feuille de lime, feuille de citron vert
 hr: list lipe
 it: foglia di lime
+nl: limoenblaadjes, limoenblad
 sv: limeblad
 # ingredient/en:lime-leaf has 8 products in 1 language @2020-05-23
 


### PR DESCRIPTION
### What
Adds Dutch translations and synonyms to ingredients. All ingredients were found in a dataset of ingredient labels of food products that are currently being sold in the Netherlands. Each commit message contains the source label that contained this ingredient.

### LLM disclosure
LLM used: Claude Opus 4.6 via Claude Code. All edits were manually reviewed by me (Victor).