### PR TITLE
taxonomy: easter eggs

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -41331,12 +41331,12 @@ lt: Velykų maistas, valykiniai šokoladai
 nl: Paasproducten
 pt: Alimentos da páscoa
 
-< en:Chocolate eggs
+# don't put in chocolate eggs, not all easter eggs are made of chocolate
 < en:Easter food
 en: Easter eggs, Easter chocolate eggs
 bg: Великденски яйца
 de: Osterschokoladeneier
-es: Huevos de Pascua de chocolate
+es: Huevos de Pascua, Huevos de Pascua de chocolate
 fi: pääsiäissuklaamunat
 fr: Œufs de Pâques, oeuf de pâques, Oeufs de pâques en chocolat, oeuf de pâques en chocolat
 hr: Uskrsna jaja


### PR DESCRIPTION
Removed "Easter eggs" from "Chocolate eggs" because some easter eggs are not made of chocolate. E.g. https://world.openfoodfacts.org/product/4069365158661/salted-caramel-eier-oster-phantasie