### PR TITLE
taxonomy(food): add missing taxons for HMB product

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -26514,6 +26514,13 @@ sv: metylsulfonylmetan
 wikidata:en: Q423842
 wikipedia:en: https://en.wikipedia.org/wiki/Methylsulfonylmethane
 
+en: hydroxymethylbutyrate, HMB
+xx: hydroxymethylbutyrate, HMB
+wikidata:en: Q223081
+
+< en:hydroxymethylbutyrate
+en: calcium beta-hydroxy beta-methyl butyrate
+
 # Japanese additives can be listed only with their type (e.g. amino acids), without the specific additive name
 
 # Explanation of 「調味料」(flavoring?) https://www.hokeniryo.metro.tokyo.lg.jp/shokuhin/shokuten/chomiryo.html

--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -735,6 +735,10 @@ xx: Mutti
 #web:en: https://mutti-parma.com/
 wikidata:en: Q16580706
 
+xx: MYPROTEIN
+#web:en: https://www.myprotein.com/
+wikidata:en: Q20709719
+
 xx: nākd
 wikidata:en: Q137870223
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -122529,6 +122529,9 @@ fr: Produits thermogéniques
 hr: Termogenika
 wikidata:en: Q7783178
 
+< en:Bodybuilding supplements
+en: HMB supplements, HMB
+
 < en:Dietary supplements
 en: Ayurvedic supplements, Ayurvedic medicines
 wikidata:en: Q112879390

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -93949,7 +93949,10 @@ hr: biljni pigment
 it: pigmento vegetale
 ja: 野菜色素
 
-
+en: capsule shell
+vegan:en: maybe
+vegetarian:en: maybe
+wikidata:en: Q519410
 
 # following ingredients have two meanings in some languages
 


### PR DESCRIPTION
Needed-for: https://world.openfoodfacts.org/product/5059883302638/hmb-beta-hydroxy-beta-methylbutyrate-myprotein
Related-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13372