### PR TITLE
taxonomy: Pizzas

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -85873,6 +85873,10 @@ gpc_category_name:en: Pies/Pastries/Pizzas/Quiches - Savoury (Perishable)
 en: Mini appetizer pizzas
 fr: Mini pizzas apéritives
 
+< en:Pizzas pies and quiches
+en: Pizza pockets
+fr: Pizzas pocket
+
 < en:Meals
 < en:Pizzas pies and quiches
 en: Pizzas
@@ -85946,7 +85950,6 @@ ciqual_food_name:fr: Pizza jambon fromage champignons ou pizza royale, reine ou 
 < en:Pizzas
 fr: Pizzas savoyardes, Pizza savoyarde
 
-< en:Pizzas
 < en:Vegetarian pizzas
 en: Cheese and mushrooms pizza
 fr: Pizza champignons fromage
@@ -85957,7 +85960,6 @@ ciqual_food_code:en: 25477
 ciqual_food_name:en: Pizza, cheese and mushrooms
 ciqual_food_name:fr: Pizza champignons fromage
 
-< en:Pizzas
 < en:Vegetarian pizzas
 en: Margherita Pizza, Cheese and tomato pizza
 bg: Пица Маргарита
@@ -85976,6 +85978,10 @@ ciqual_food_code:en: 25404
 ciqual_food_name:en: Pizza, cheese and tomato or Margherita pizza
 ciqual_food_name:fr: Pizza au fromage ou Pizza margherita
 
+< en:Vegetarian pizzas
+en: Cheese and tomato pizzas
+fr: Pizzas tomates fromage
+
 < en:Pizzas
 en: Vegetarian pizzas
 fr: Pizzas végétariennes, pizza végétarienne
@@ -85985,8 +85991,8 @@ ciqual_proxy_food_name:en: Pizza, vegetables or pizza 4 seasons
 ciqual_proxy_food_name:fr: Pizza aux légumes ou Pizza 4 saisons
 
 < en:Pizzas
-en: Plant-based pizzas, Vegetal pizzas, vegan pizzas
-fr: Pizzas végétales, pizzas végétaliennes, pizzas véganes, pizza végétale, pizza végétalienne, pizza végane
+en: Vegan pizzas, Plant-based pizzas, Vegetal pizzas
+fr: Pizzas véganes, Pizzas végétales, pizzas végétaliennes, pizza végétale, pizza végétalienne, pizza végane
 agribalyse_proxy_food_code:en: 25472
 ciqual_proxy_food_code:en: 25472
 ciqual_proxy_food_name:en: Pizza, vegetables or pizza 4 seasons
@@ -86129,7 +86135,7 @@ bg: Пица с шунка
 de: Schinkenpizzas
 es: Pizzas de jamón york
 fi: kinkkupizzat
-fr: Pizzas au jambon
+fr: Pizzas au jambon, Pizza au jambon
 hr: Pizze sa šunkom
 it: Pizze al prosciutto
 lt: Picos su kumpiu
@@ -86139,8 +86145,8 @@ agribalyse_proxy_food_name:en: Pizza, cured ham
 agribalyse_proxy_food_name:fr: Pizza au speck ou jambon cru
 
 < en:Ham pizzas
-en: Cured Ham Pizza
-fr: Pizza au jambon, Pizza au jambon cru
+en: Cured ham pizza
+fr: Pizza au jambon cru
 hr: Pizza sa suhom šunkom
 lt: Picos su vytintu kumpiu
 agribalyse_food_code:en: 26274
@@ -86168,7 +86174,6 @@ ciqual_food_code:en: 26271
 ciqual_food_name:en: Pizza, kebab
 ciqual_food_name:fr: Pizza kebab
 
-< en:Pizzas
 < en:Vegetarian pizzas
 en: Vegetable pizza, Four seasons pizza, Pizza quattro stagioni
 es: Pizzas de verduras
@@ -86182,7 +86187,6 @@ ciqual_food_code:en: 25472
 ciqual_food_name:en: Pizza, vegetables or pizza 4 seasons
 ciqual_food_name:fr: Pizza aux légumes ou Pizza 4 saisons
 
-< en:Pizzas
 < en:Vegetarian pizzas
 en: Cheese pizzas
 bg: Пица със сирена
@@ -86258,7 +86262,7 @@ agribalyse_proxy_food_code:en: 25478
 agribalyse_proxy_food_name:en: Pizza, four cheeses
 agribalyse_proxy_food_name:fr: Pizza 4 fromages
 
-< en:Cheese pizzas
+< en:Pizzas
 en: Cheese and onion pizza with lardoons
 fr: Pizza aux lardons oignons et fromage
 hr: Pizza od sira i luka s pečenjem
@@ -86268,7 +86272,7 @@ ciqual_food_code:en: 25570
 ciqual_food_name:en: Pizza, lardoons onions and cheese
 ciqual_food_name:fr: Pizza aux lardons, oignons et fromage
 
-< en:Cheese pizzas
+< en:Pizzas
 en: Pizza with raclette cheese and lardoons, Pizza with tartiflette cheese and lardoons
 fr: Pizza type raclette, Pizza type tartiflette, Pizza à la montagnarde, Pizzas raclette
 hr: Pizza s raclette sirom i pečenicama

--- a/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
@@ -529,8 +529,6 @@
 <td style="text-align:right"><a href="/facets/categories/pizzas" class="tag known">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/pizzas-pies-and-quiches" class="tag known">Pizzas pies and quiches</a></td>
 <td style="text-align:right"><a href="/facets/categories/pizzas-pies-and-quiches" class="tag known">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td><a href="/facets/categories/plant-based-pizzas" class="tag known">Plant-based pizzas</a></td>
-<td style="text-align:right"><a href="/facets/categories/plant-based-pizzas" class="tag known">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/raspberry-juices" class="tag user_defined">Raspberry-juices</a></td>
 <td style="text-align:right"><a href="/facets/categories/raspberry-juices" class="tag user_defined">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/salads" class="tag user_defined">Salads</a></td>
@@ -541,6 +539,8 @@
 <td style="text-align:right"><a href="/facets/categories/sodas" class="tag known">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/sweet-snacks" class="tag known">Sweet snacks</a></td>
 <td style="text-align:right"><a href="/facets/categories/sweet-snacks" class="tag known">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td><a href="/facets/categories/vegan-pizzas" class="tag known">Vegan pizzas</a></td>
+<td style="text-align:right"><a href="/facets/categories/vegan-pizzas" class="tag known">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/it:creme-di-nocciole" class="tag user_defined">it:creme-di-nocciole</a></td>
 <td style="text-align:right"><a href="/facets/categories/it:creme-di-nocciole" class="tag user_defined">1</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/it:creme-spalmabili" class="tag user_defined">it:creme-spalmabili</a></td>


### PR DESCRIPTION
* Created a "Tomato and cheese pizzas" category
* Removed "Cheese and onion pizza with lardoons" and "Pizza with raclette cheese and lardoons" from "Cheese pizzas". The category "Cheese pizzas" is in vegetarian pizzas and is designed to contain pizzas in which cheese is the main, if not only, ingredient on top. Except for vegan pizzas, all pizzas have cheese, a category for pizzas that contain cheese wouldn't make sense.
* Removed the category "Pizzas" for the categories which were already in a sub-category of pizzas
* Created a category pizza pockets for those weird products https://fr.openfoodfacts.org/produit/3250393477065/pizza-pocket-jamon-y-queso-netto