### PR TITLE
ci: rotate log on staging deployment

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -269,8 +269,10 @@ jobs:
         script: |
           cd ${{ matrix.env }} && \
           make hdown && \
-          # verify dist volumes were removed
+          # verify dist volumes were removed \
           ! (docker volume list |grep po_.*_dist) && \
+          # rotate log, as it's a good occasion \
+          make rotate_logs && \
           make build_lang && \
           make prod_up
 

--- a/Makefile
+++ b/Makefile
@@ -608,6 +608,9 @@ clean_logs:
 	( rm -f logs/* logs/apache2/* logs/nginx/* || true )
 	echo "" > logs/apache2/log4perl.log
 
+rotate_logs:
+	${DOCKER_COMPOSE_BUILD} run --rm --user root backend bash -c "savelog -p logs/{nginx,apache2}/*{.,_}log"
+
 clean: goodbye hdown prune prune_deps prune_cache clean_folders
 
 # Run dependent projects


### PR DESCRIPTION
This is to avoid logs accumulation (which leads to high disk usage)
