### PR TITLE
fix: handle missing Nutri-Score data

### DIFF
--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -254,10 +254,19 @@ sub display_data_quality_description ($product_ref, $tagid) {
 	my $template_data_ref_quality = {};
 
 	$template_data_ref_quality->{tagid} = $tagid;
-	$template_data_ref_quality->{product_ref_nutriscore_score} = $product_ref->{nutriscore_score};
-	$template_data_ref_quality->{product_ref_nutriscore_score_producer} = $product_ref->{nutriscore_score_producer};
-	$template_data_ref_quality->{product_ref_nutriscore_grade_producer} = uc($product_ref->{nutriscore_grade_producer});
-	$template_data_ref_quality->{product_ref_nutriscore_grade} = uc($product_ref->{nutriscore_grade});
+    # Ensure safe display when NutriScore data is missing
+
+    $template_data_ref_quality->{product_ref_nutriscore_score} =
+    defined $product_ref->{nutriscore_score} ? $product_ref->{nutriscore_score} : 'N/A';
+
+    $template_data_ref_quality->{product_ref_nutriscore_score_producer} =
+    defined $product_ref->{nutriscore_score_producer} ? $product_ref->{nutriscore_score_producer} : 'N/A';
+
+    $template_data_ref_quality->{product_ref_nutriscore_grade_producer} =
+    defined $product_ref->{nutriscore_grade_producer} ? uc($product_ref->{nutriscore_grade_producer}) : 'N/A';
+
+    $template_data_ref_quality->{product_ref_nutriscore_grade} =
+    defined $product_ref->{nutriscore_grade} ? uc($product_ref->{nutriscore_grade}) : 'N/A';
 
 	process_template('web/common/includes/display_data_quality_description.tt.html', $template_data_ref_quality, \$html)
 		|| return "template error: " . $tt->error();


### PR DESCRIPTION
Summary
This PR improves the robustness of data quality descriptions by adding safe handling for missing NutriScore-related fields.

Problem
Currently, fields such as `nutriscore_score`, `nutriscore_grade`, and their producer variants are accessed directly from the product object.  
If these fields are undefined or missing, it can lead to inconsistent display or potential runtime issues in templates.

Solution
This PR introduces safe checks before accessing these fields and provides fallback values when data is missing.

Changes Made
- Added conditional checks for NutriScore fields
- Introduced default fallback values (e.g., "N/A")
- Added inline comments for better readability

Impact
- Prevents undefined values from affecting UI rendering
- Improves reliability of data quality display
- Enhances robustness of the validation system

Relevance
This aligns with improving data quality handling and ensuring consistent validation output.