### PR TITLE
chore: add git .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+Alex Garel <alex@openfoodfacts.org> <Alex Garel>
+Alex Garel <alex@openfoodfacts.org> <alex@garel.org>
+Arnaud Leene <aleene@gmail.com> <aleene@ns3135968.ip-51-77-65.eu>
+Charles Nepote <charles@openfoodfacts.org> <charles@nepote.org>
+Freso <freso.dk@gmail.com>
+Freso <freso.dk@gmail.com> <177659+Freso@users.noreply.github.com>
+hangy <hangy@hangy.de>
+hangy <hangy@hangy.de> <87124+hangy@users.noreply.github.com>
+hangy <hangy@hangy.de> <johannes@athmer.name>
+Jagjeevan Kashid <jagjeevankashid97@gmail.com>
+Jagjeevan Kashid <jagjeevankashid97@gmail.com> <83103469+JagjeevanAK@users.noreply.github.com>
+Jagjeevan Kashid <jagjeevankashid97@gmail.com> <jagjeevandev97@gmail.com>
+James Addison <55152140+jayaddison@users.noreply.github.com> <james@reciperadar.com>
+moon-rabbitOFF <34795011+moon-rabbitOFF@users.noreply.github.com> <hermione.lowell@gmail.com>
+Pierre Slamich <pierre@openfoodfacts.org> <pierre.slamich@gmail.com>
+Pierre Slamich <pierre@openfoodfacts.org> <pierre@dashjob.fr>
+Pierre Slamich <pierre@openfoodfacts.org> <pierre@jobmindapp.com>
+Pierre Slamich <pierre@openfoodfacts.org> <pierreslam@Slambook.local>
+Pierre Slamich <pierre@openfoodfacts.org> <root@SlamBook-2.local>
+Pierre Slamich <pierre@openfoodfacts.org> <root@slambook.local>
+Pierre Slamich <pierre@openfoodfacts.org> <teolemon@users.noreply.github.com>
+Raphaël Bournhonesque <raphael@bournhonesque.eu> <raphael0202@users.noreply.github.com>
+Raphaël Bournhonesque <raphael@bournhonesque.eu> <raphael@mppteam.com>
+Stéphane Gigandet <stephane@openfoodfacts.org>
+Stéphane Gigandet <stephane@openfoodfacts.org> Stéphane Gigandet <biz@joueb.com>
+Stéphane Gigandet <stephane@openfoodfacts.org> Stéphane Gigandet <root@openfoodfacts.org>
+VaiTon <eyadlorenzo@gmail.com>
+VaiTon <eyadlorenzo@gmail.com> <12072630+VaiTon@users.noreply.github.com>


### PR DESCRIPTION
The project has been around for a long time, and several contributors have changed how they identify themselves over the years (or might have commits using different aliases for other reasons). This means that stats and logs may be misleading as git doesn’t know that certain committers/authors are actually the same people. Git _does_ have a mechanism to help assist with this: the `.mailmap` file.

This adds a .mailmap file mapping some of the more frequent committers where I could identify additional aliases of theirs. I’ve generally steered towards making the most frequently used one the canonical alias, but for committers with @openfoodfacts.org e-mails, I gave those priority.

The entries have been sorted using `env LC_ALL=C sort -f`.

Documentation: https://git-scm.com/docs/gitmailmap
Inspiration: https://openfoodfacts.slack.com/archives/C02LDQDDD/p1775670861158229