### PR TITLE
fix: prevent float overflow in number_of_units

### DIFF
--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -413,8 +413,13 @@ sub get_checked_and_taxonomized_packaging_component_data ($tags_lc, $input_packa
 			}
 		);
 	}
-	# Require a positive and non zero number of units
-	elsif (($input_packaging_ref->{number_of_units} =~ /^\d+$/) and ($input_packaging_ref->{number_of_units} > 0)) {
+	# Require a positive integer no greater than 10000.
+	# Larger values overflow to a float on serialization (e.g. 9.22e+18 in JSON),
+	# which breaks integer fields in exports.
+	elsif ( ($input_packaging_ref->{number_of_units} =~ /^\d+$/)
+		and ($input_packaging_ref->{number_of_units} > 0)
+		and ($input_packaging_ref->{number_of_units} <= 10000))
+	{
 		$packaging_ref->{number_of_units} = $input_packaging_ref->{number_of_units} + 0;
 		$has_data = 1;
 	}

--- a/tests/unit/packaging.t
+++ b/tests/unit/packaging.t
@@ -53,6 +53,18 @@ my @tests = (
 		expected_output => undef,
 	},
 	{
+		desc => "number_of_units above maximum should be rejected",
+		lc => "en",
+		input => {"number_of_units" => 9223372036854775807, "shape" => "en:bottle"},
+		expected_output => {'shape' => 'en:bottle'},
+	},
+	{
+		desc => "number_of_units at maximum (10000) should be accepted",
+		lc => "en",
+		input => {"number_of_units" => 10000, "shape" => "en:bottle"},
+		expected_output => {'number_of_units' => 10000, 'shape' => 'en:bottle'},
+	},
+	{
 		desc => "Value 0 should be considered empty, 1 value is not 0",
 		lc => "en",
 		input => {


### PR DESCRIPTION
### What

- Fixed an issue where very large values for `number_of_units` (e.g. `9223372036854775807`) were accepted and stored as a float, causing JSON serialization to produce scientific notation like `9.22e+18` instead of an integer
- Added an upper bound of `10000` so values beyond that are rejected with the existing validation warning, same as other invalid inputs

### Large Language Models 

Used GitHub Copilot (Claude Sonnet 4.6) to understand the issue and help generate the Perl fix. Code was self-reviewed and tested locally with `make unit_test`

### Screenshot or video
N/A

### Related issue(s) and discussion
- Fixes: #12675