### PR TITLE
taxonomy: pumpkin in catalan

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -57998,7 +57998,7 @@ bg: тиква
 bn: মিষ্টিকুমড়া
 bo: ལྷོ་ཀུབ།
 br: Sitrouilhez
-ca: Carbassera de rabequet
+ca: carabassa, carbassa
 cs: dýně
 cy: pwmpen
 da: Græskar
@@ -58224,7 +58224,7 @@ ar: قرع كبير
 az: i̇ri balqabaq
 be: гарбуз вялікі
 bg: гигантска тиква
-ca: carabassa
+ca: Carbassera de rabequet
 chy: mo'ôhtáemâhoo'o
 cs: tykev velkoplodá, dýně obrovská
 # cy:pwmpen is already under pumpkin


### PR DESCRIPTION
The translation of pumpkin and giant pumpkin was reversed in catalan compared to other language. In Wikipedia, "Carbassera de rabequet" corresponds to _Cucurbita maxima_ https://ca.wikipedia.org/wiki/Carbassera_de_rabequet