### PR TITLE
ci: Update Auto-Label Merge Conflicts action

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -1,20 +1,20 @@
 name: '💥 Auto-Label Merge Conflicts on PRs'
 on:
   push:
-    branches:
-      - main
+  pull_request_target:
+    types: [synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@5981f8933e92b78098af86b9e33fe0871cc7a3be  # v2.0 (2020-01-27)
+      - uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0  # v3.0.3 (2025-01-06)
         with:
-          CONFLICT_LABEL_NAME: "💥 Merge Conflicts"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_RETRIES: 5
-          WAIT_MS: 5000
+          dirtyLabel: "💥 Merge Conflicts"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          retryMax: 5
+          retryAfter: 5000


### PR DESCRIPTION
https://github.com/mschilde/auto-label-merge-conflicts has a number of issues and hasn’t had any commits since 2023. One of these issues is not removing the label again once the conflict has been resolved.

https://github.com/eps1lon/actions-label-merge-conflict is a more modern and actively maintained action that seeks to provide the same functionality.