### PR TITLE
taxonomy(brands): add crisps brands

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -162,7 +162,7 @@ wikidata:en: Q4947502
 xx: Bostan
 wikidata:en: Q137459231
 
-xx: Brets
+xx: Brets, Bret's
 wikidata:en: Q137863645
 
 xx: Brouwmeester
@@ -192,6 +192,10 @@ comment:en: subbrand of Lidl
 
 xx: Chef Select
 # only sold in Lidl, also subbrand of Lidl
+
+#< xx:Intersnack
+xx: Chio
+wikidata:en: Q108201931
 
 xx: Chokay
 wikidata:en: Q136951951
@@ -301,6 +305,10 @@ xx: Diamant
 
 xx: dmBio, dm Bio
 
+#< xx:PepsiCo
+xx: Doritos
+wikidata:en: Q776795
+
 xx: Driscoll's
 wikidata:en: Q136955368
 
@@ -394,6 +402,9 @@ wikidata:en: Q137568908
 xx: Frutesse
 comment:en: work trademark in Benelux
 wikidata:en: Q137177165
+
+#< xx:Intersnack
+xx: funny-frisch
 
 xx: GAAM
 
@@ -566,6 +577,8 @@ wikidata:en: Q1208110
 
 xx: Kellogg's, Kelloggs, Kellogg
 
+xx: Kettle
+
 xx: Kit Kat
 wikidata:en: Q367251
 
@@ -620,7 +633,7 @@ wikidata:en: Q1625477
 xx: La vie est belle
 wikidata:en: Q137440477
 
-xx: Lay's
+xx: Lay's, Lays
 wikidata:en: Q136914164
 
 xx: Lay's Max
@@ -653,6 +666,9 @@ wikidata:en: Q152822
 
 xx: Loka
 wikidata:en: Q10568903
+
+xx: Lorenz
+wikidata:en: Q876429
 
 xx: Lotus, Lotus Bakeries, Lotus Since 1932
 wikidata:en: Q590113
@@ -823,6 +839,9 @@ xx: Premieur
 xx: Priméal
 wikidata:en: Q137393142
 
+xx: Pringles
+wikidata:en: Q528187
+
 xx: ProActiv
 wikidata:en: Q136880765
 
@@ -877,6 +896,9 @@ wikidata:en: Q137799710
 xx: Roosterz & Co
 
 xx: Roze Bunker
+
+xx: Ruffles
+wikidata:en: Q2947936
 
 xx: Rydbergs
 
@@ -1106,6 +1128,10 @@ xx: Verpaco
 
 xx: Verstegen
 
+#< xx:Intersnack
+xx: Vico
+wikidata:en: Q3556968
+
 xx: Vitasia
 wikidata:en: Q137300729
 
@@ -1116,6 +1142,9 @@ xx: Vivera
 wikidata:en: Q2492388
 
 xx: Vivo
+
+xx: Walkers
+wikidata:en: Q1296097
 
 xx: wasa
 wikidata:en: Q2298302


### PR DESCRIPTION
Needed-for: https://world.openfoodfacts.org/facets/brands/pringles
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/bret-s
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/chio
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/doritos
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/funny-frisch
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/kettle
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/lays
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/lorenz
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/ruffles
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/vico
Needed-for: https://world.openfoodfacts.org/facets/categories/crisps/brands/walkers