### PR TITLE
taxonomy(food): fix da:paprika ingredient

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -57048,6 +57048,7 @@ br: paprika
 bs: paprika
 ca: pebre vermell, piment vermell, pebre vermell picant
 cy: Paprica
+da: paprika
 # de: Paprika # also "en: bell pepper", see "en: paprika or bell pepper"
 el: πάπρικα
 eo: papriko
@@ -93990,7 +93991,6 @@ de: Gurke, Gurken
 en: paprika or bell pepper
 bg: червен пипер, паприка
 cs: paprika
-da: paprika
 de: Paprika
 fi: paprika
 hu: paprika


### PR DESCRIPTION
The fruit is a “peberfrugt” in Danish and “paprika” is only used for the spice. (Note that “paprika” _is_ used for both in both Swedish and Norwegian!)