### PR TITLE
fix(taxonomy): merge `paprika or bell pepper` ingredients

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -56278,27 +56278,6 @@ it: insalata composta
 # wikipedia says "In many languages, but not English, the word paprika also refers to the plant and the fruit from which the spice is made, as well as to peppers in the Grossum group (e.g. bell peppers)."
 # do not make pepper a synonym of bell pepper
 
-
-< en: bell pepper
-< en: paprika
-en: paprika or bell pepper
-bg: червен пипер, паприка
-cs: paprika
-da: paprika
-de: Paprika
-fi: paprika
-hu: paprika
-lv: paprika
-nb: paprika
-nl: paprika, paprika's, zoete peper, snack paprika
-nn: paprika
-no: paprika
-pl: papryka, papryki, paprykowy, paprykowe, paprykowa
-sl: paprika
-sv: paprika
-description:en: paprika can be either the dried powder or the fruit of a plant in some language. Put it only here if that is the case, otherwise put the ingredient under en:bell pepper or en:paprika
-
-
 < en:fruit vegetable
 en: capsicum annuum
 xx: capsicum annuum, capsicum
@@ -94009,18 +93988,22 @@ de: Gurke, Gurken
 < en: bell pepper
 < en: paprika
 en: paprika or bell pepper
+bg: червен пипер, паприка
 cs: paprika
 da: paprika
 de: Paprika
 fi: paprika
 hu: paprika
+lv: paprika
 nb: paprika
-nl: paprika
+nl: paprika, paprika's, zoete peper, snack paprika
 nn: paprika
 no: paprika
+pl: papryka, papryki, paprykowy, paprykowe, paprykowa
 sl: paprika
 sv: paprika
 comment:en: Put here the name if it can have multiple meanings. The context should dtermine whether it is the spice or the vegetable.
+description:en: “Paprika” can be either the dried powder or the fruit of a plant in some languages. Put it only here if that is the case, otherwise put the ingredient under en:bell pepper or en:paprika.
 
 < en:Minerals
 < en:Vitamins


### PR DESCRIPTION
`en:paprika or bell pepper` exists twice as a result of 54a058c16875fa127a31130e4a2c67fe71de5c0 and somehow didn’t get caught by the CI.

This merges the two ingredients back together.

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/11923
Follow-up-to: d54a058c16875fa127a31130e4a2c67fe71de5c0