### PR TITLE
taxonomy(food): pommes duchesses category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -45186,10 +45186,12 @@ ciqual_food_code:en: 4021
 ciqual_food_name:en: Dauphine potato, frozen, cooked
 ciqual_food_name:fr: Pomme de terre dauphine, surgelée, cuite
 
+< en:Duchesse potatoes
 < en:Frozen fried potatoes
 en: Frozen duchesse potatoes, Frozen cooked duchesse potato
 da: Frosne duchesse-kartofler
 fr: Pommes duchesses surgelées, Pomme de terre duchesse surgelée, Pomme de terre duchesse cuite surgelée
+sv: Frysta duchessepotatisar
 agribalyse_food_code:en: 4034
 ciqual_food_code:en: 4034
 ciqual_food_name:en: Duchesse potato, frozen, cooked
@@ -121923,6 +121925,35 @@ wikidata:en: Q627331
 < en:Potato preparations
 en: Bubble and squeak
 description:en: Bubble and squeak is a British dish made from cooked potatoes and cabbage, mixed together and fried.
+wikidata:en: Q573516
+
+< en:Potato preparations
+en: Duchesse potatoes
+ca: Patates duquessa
+cz: Bramborové pusinky
+da: Duchesse-kartofler, Pommes duchesse
+de: Herzoginkartoffeln
+es: Patatas duquesa
+fi: Duchesseperunat
+fr: Pommes duchesses, Pomme de terre duchesse
+hu: Hercegnőburgonya
+it: Patate duchesse
+ja: ポメ・デュセス
+jv: Duchess kenthang
+ko: 폼 뒤셰스
+lv: Kartupelu rozites
+nl: Hertoginnenaardappelen
+pl: Rozetki ziemniaczne
+ru: Картофельные розочки, Картофель дюшес
+sv: Duchessepotatisar, Pommes duchesse
+uk: Картопля Дюшес
+uz: Dyushes kartoshka
+vi: Khoai tây nữ Công tước
+agribalyse_proxy_food_code:en: 4034
+ciqual_proxy_food_code:en: 4034
+ciqual_proxy_food_name:en: Duchesse potato, frozen, cooked
+ciqual_proxy_food_name:fr: Pomme de terre duchesse, surgelée, cuite
+wikidata:en: Q1148776
 
 < en:Potato preparations
 en: Hash Browns, hashed browns


### PR DESCRIPTION
- Adds a category for not-necessarily-frozen duchesse potatoes.
- Adds Swedish translation for frozen duchesse potatoes.
- Also `wikidata` for “bubble and squeak” just because.

Needed-for: https://world.openfoodfacts.org/facets/categories/en:frozen-duchesse-potatoes