### PR TITLE
fix(web): remove unused jquery.form.js script

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -834,7 +834,6 @@ HTML
 <script type="text/javascript" src="$static_subdomain/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/cropper.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/jquery-cropper.js"></script>
-<script type="text/javascript" src="$static_subdomain/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/tagify.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="$static_subdomain/js/dist/jquery.fileupload.js"></script>

--- a/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
+++ b/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
@@ -33641,7 +33641,6 @@ $(document).on("focus", ".select2", function (e) {
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"></script>

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -33927,7 +33927,6 @@ $(document).on("focus", ".select2", function (e) {
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"></script>

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -33925,7 +33925,6 @@ $(document).on("focus", ".select2", function (e) {
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/cropper.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery-cropper.js"></script>
-<script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.form.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/tagify.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="//static.openfoodfacts.localhost/js/dist/jquery.fileupload.js"></script>


### PR DESCRIPTION
### What

Remove the inclusion of jquery.form.js script from product edit pages and update corresponding test expectations.

The script was originally removed in #12751, but I seem to have missed some remnants.

### Large Language Models usage disclosure

None

### Screenshot or video

None

### Related issue(s) and discussion

#12751
