### PR TITLE
taxonomy(food): ciabatta edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -35648,11 +35648,41 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Bread (Perishable)
 
 < en:Breads
-en: Ciabatta
-xx: Ciabatta
+en: Ciabattas, Ciabatta
+xx: Ciabatta, Ciabattas
+ar: شباتة
+be: Чыябата
 bg: Чабата
+ca: Xapata
+da: Ciabattabrød
+el: Τσιαμπάτα
+eu: Txapata
+hi: चबाटा
+hy: Չիաբատտա
+it: Ciabatte
+ja: チャバッタ
+ka: Ჩიაბატა
+ko: 치아바타
+lt: Čiabata
+lv: Čabata
+nb: Ciabattaer
+nn: Ciabattaer, Ciabattaar
+ru: Чиабатта
+sr: Ћабата
+sv: Ciabattor
+uk: Чіабата
+zh: 拖鞋麵包
 sales_format:en: package, item
 wikidata:en: Q246703
+
+< en:Ciabattas
+en: Plain ciabattas
+sv: Naturella ciabattor
+
+< en:Ciabattas
+en: Ciabattas with olives
+da: Ciabattabrød med oliven
+sv: Ciabattor med oliv
 
 < en:Breads
 en: Pinsa breads


### PR DESCRIPTION
- Normalises category name to plural form
- Adds a number of translations
- Adds two new subcategories
  - Plain ciabattas, and
  - Ciabattas with olives

Needed-for: https://se.openfoodfacts.org/product/7311043024940/ciabatta-garant
Needed-for: https://se.openfoodfacts.org/product/7311043024957/ciabatta-oliv-garant