### PR TITLE
taxonomy(food): baguette category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -36315,18 +36315,56 @@ fr: Fougasses aux olives
 
 < en:Breads
 en: Baguettes, French bread
-de: Baguettes, Baguette
+xx: Baguettes, Baguette
+ar: خبز فرنسي
+az: Baget çörəyi
+be: Французскі багет
+bg: Франзела
+bn: বাগেট
+ca: Baguet
+cs: Bageta
+cv: Багет
+da: Baguetter
+el: Μπαγκέτα
+eo: Bastonpanoj
 es: Baguetes
-fi: patongit
-fr: Baguettes, baguette, Baguettes de pain
+fa: باگت
+fi: Patongit, Patonki
+fr: Baguettes, Baguettes de pain
+gl: Bagueta
 hr: Bageti
+ht: Bagèt
+hy: Ֆրանսիական բագետ
 it: Baguette
 ja: バゲット
-lt: Baguettes, Prancūziška duona
-nl: Stokbroden, Baguettes, Baguette
+ka: Ბაგეტი
+kk: Багета
+ko: 바게트
+lt: Prancūziškas batonas, Prancūziška duona
+lv: Bagete
+mk: Багет
+ml: ബാഗെറ്റ്
+mt: Bagett
+nb: Bagetter
+nl: Stokbroden, Stokbrood
+nn: Bagettar
+pa: ਬਾਗੇਤ
+pl: Bagietka
 pt: Baguetes
 ro: Baghete
-zh: 法式面包, 法式长棍面包
+ru: Французский багет
+sk: Bageta
+sl: Bageta
+sr: Багет
+sv: Baguetter
+ta: பகெத்
+th: บาแก็ต
+tr: Francala
+tt: Француз багет икмәге
+uk: Французький багет
+ur: باگیت
+vi: Bánh mì Pháp
+zh: 法式面包, 法式长棍面包, 法式長棍麵包
 agribalyse_food_code:en: 7001
 ciqual_food_code:en: 7001
 ciqual_food_name:en: Bread, French bread, baguette
@@ -36337,12 +36375,16 @@ wikidata:en: Q208172
 < en:Baguettes
 < en:Frozen breads
 en: Frozen baguettes
+da: Frosne baguetter
 fr: Baguettes surgelées
+sv: Frysta baguetter
 
 < en:Baguettes
 < fr:Pains de tradition française
-en: Traditional French baguette, French traditional baguette
+en: Traditional French baguettes, Traditional French baguette, French traditional baguette
+da: Traditionelle franske baguetter
 fr: Baguettes de tradition française, Baguette de tradition française, baguettes traditionnelles françaises, baguette traditionnelle française, baguettes traditionnelles de France, baguette traditionnelle de France, baguettes tradition, baguette tradition, Baguettes de pain de tradition française
+sv: Traditionella franska baguetter
 agribalyse_food_code:en: 7007
 ciqual_food_code:en: 7007
 ciqual_food_name:en: Bread, French bread, baguette, unsalted
@@ -36350,7 +36392,7 @@ ciqual_food_name:fr: Pain, baguette, de tradition française
 sales_format:en: weight, package
 
 < en:Baguettes
-en: Country-style French baguette bread, Country-style French bread bread
+en: Country-style French baguette breads, Country-style French baguette bread, Country-style French bread bread
 fr: Baguette de campagne, Boule de pain de campagne
 agribalyse_food_code:en: 7100
 ciqual_food_code:en: 7100
@@ -36359,7 +36401,9 @@ ciqual_food_name:fr: Pain, baguette ou boule, de campagne
 
 < en:Baguettes
 en: Unsalted baguettes, Unsalted French bread, French bread without salt
+da: Usaltede baguetter, Baguetter uden salt
 fr: Baguettes de pain sans sel
+sv: Osaltade baguetter, Baguetter utan salt
 agribalyse_food_code:en: 7160
 ciqual_food_code:en: 7160
 ciqual_food_name:en: Bread, French bread, without salt
@@ -36368,7 +36412,9 @@ ciqual_food_name:fr: Pain, baguette, sans sel
 < en:Baguettes
 < en:Sourdough breads
 en: Sourdough baguettes, French baguette with yeast
+da: Surdejsbaguetter
 fr: Baguettes au levain, Baguette de pain au levain, Baguette au levain
+sv: Surdegsbaguetter
 agribalyse_food_code:en: 7002
 ciqual_food_code:en: 7002
 ciqual_food_name:en: Bread, French bread (baguette or ball), with yeast


### PR DESCRIPTION
- Normalises category names to plural forms.
- Adds `xx` entry for `en:Baguettes`.
- Adds several translations.