### PR TITLE
taxonomy(food): mini and gluten-free baguettes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -36374,6 +36374,24 @@ ciqual_food_code:en: 7002
 ciqual_food_name:en: Bread, French bread (baguette or ball), with yeast
 ciqual_food_name:fr: Pain, baguette ou boule, au levain
 
+< en:Baguettes
+< en:Gluten-free breads
+en: Gluten-free baguettes
+da: Glutenfrie baguetter
+sv: Glutenfria baguetter
+
+< en:Baguettes
+en: Mini baguettes
+da: Minibaguetter
+fi: Minipatongit
+sv: Minibaguetter
+
+< en:Gluten-free baguettes
+< en:Mini baguettes
+en: Gluten-free mini baguettes
+da: Glutenfrie minibaguetter
+sv: Glutenfria minibaguetter
+
 < en:Breads
 fr: Pains de tradition française, pain de tradition française, pains traditionnels français, pain traditionnel français, pains traditionnels de France, pain traditionnel de France, pains tradition, pain tradition
 #Synonyms are the terms defined in the decret : https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000727617


### PR DESCRIPTION
Adds new categories:
- Gluten-free baguettes
- Mini baguettes
- Gluten-free mini baguettes

Needed-for: https://se.openfoodfacts.org/product/8008698048849/minibaguetter-sch%C3%A4r