### PR TITLE
ci: allow merge-conflict-autolabel to fail

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0  # v3.0.3 (2025-01-06)
+        continue-on-error: true  # Don’t mark PRs as failing because this errs
         with:
           dirtyLabel: "💥 Merge Conflicts"
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action will sometimes gets cancelled on PRs, presumably because something else triggers it and it cancels itself to not run multiple times/to avoid race conditions.

However, this job cancellation counts as a failure and the PR will subsequently get a red “×” even if everything else passes.

This makes it so that the `triage` job’s step failing (e.g., getting cancelled) won’t mark the whole job as a failure.