### PR TITLE
taxonomy(food): `xx` entry for all TR-BIO-* labels

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -8012,6 +8012,7 @@ exceptions:en: en:except products covered by Annex III,en:in-conversion products
 
 < en:EU organic
 en: TR-BIO-171
+xx: TR-BIO-171
 auth_address:en: 2 Tilou street, 54638, Thessaloniki, Greece
 auth_name:en: A CERT European Organization for Certification S.A.
 auth_url:en: http://www.a-cert.org
@@ -8743,6 +8744,7 @@ exceptions:en: en: in conversion products,en:wine
 
 < en:EU organic
 en: TR-BIO-139
+xx: TR-BIO-139
 auth_address:en: Rr. Kavajes”, Nd.132, Hy.9, Kati 8, Ap.43, perball pallatit me shigjeta, Tirana, Albania
 auth_name:en: Albinspekt
 auth_url:en: http://www.albinspekt.com
@@ -8923,6 +8925,7 @@ exceptions:en: en: in-conversion products,en:wine
 
 < en:EU organic
 en: TR-BIO-175
+xx: TR-BIO-175
 auth_address:en: Çinarli Mahallesi Şehit Polis Fethi Sekin Cad. No:3, 1006, Konak/IZMIR, Turkey
 auth_name:en: BAȘAK Ekolojik Ürünler Kontrol ve Sertifikasyon Hizmetleri Tic.
 auth_url:en: http://basakekolojik.com.tr
@@ -9364,7 +9367,7 @@ exceptions:en: en:wine,en:until 30 June 2021
 
 < en:EU organic
 en: TR-BIO-161
-de: TR-BIO-161
+xx: TR-BIO-161
 auth_address:en: Ackerstrasse, 5070, Frick, Switzerland
 auth_name:en: Bio.inspecta AG
 auth_url:en: http://www.bio-inspecta.ch
@@ -9691,6 +9694,7 @@ exceptions:en: en: in-conversion products,en:wine
 
 < en:EU organic
 en: TR-BIO-132
+xx: TR-BIO-132
 auth_address:en: Via dei Macabraccia 8, Casalecchio di Reno, 40033, Bologna, Italy
 auth_name:en: Bioagricert S.r.l.
 auth_url:en: http://bioagricert.org
@@ -10475,6 +10479,7 @@ exceptions:en: en: except products covered by Annex III,en:in-conversion product
 
 < en:EU organic
 en: TR-BIO-102
+xx: TR-BIO-102
 auth_address:en: Viale Masini, 36, 40126, Bologna, Italy
 auth_name:en: CCPB Srl
 auth_url:en: http://www.ccpb.it
@@ -11162,6 +11167,7 @@ exceptions:en: en: except products covered by Annex III,en:in-conversion product
 
 < en:EU organic
 en: TR-BIO-140
+xx: TR-BIO-140
 auth_address:en: Vorderhaslach 1, 91230, Happurg, Germany
 auth_name:en: CERES Certification of Environmental Standards GmbH
 auth_url:en: http://www.ceres-cert.com
@@ -13638,7 +13644,7 @@ exceptions:en: en:except products covered by Annex III,en:in conversion products
 
 < en:EU organic
 en: TR-BIO-154
-de: TR-BIO-154
+xx: TR-BIO-154
 auth_address:en: BP 47, 32600, L'Isle-Jourdain, France
 auth_name:en: Ecocert SA
 auth_url:en: http://www.ecocert.com
@@ -14126,6 +14132,7 @@ exceptions:en: en:except products covered by Annex III,en:in conversion products
 
 < en:EU organic
 en: TR-BIO-144
+xx: TR-BIO-144
 auth_address:en: 5700 SW 34th st, suite 349, 326048, Gainesville FL, United States of America
 auth_name:en: Florida Certified Organic Growers and Consumers, Inc. (FOG),
 auth_url:en: http:// www.qcsinfo.org
@@ -15432,6 +15439,7 @@ exceptions:en: en:except products covered by Annex III,en:in conversion products
 
 < en:EU organic
 en: TR-BIO-115
+xx: TR-BIO-115
 auth_address:en: Via Giovanni Brugnoli, 15, 40122, Bologna, Italy
 auth_name:en: Istituto Certificazione Etica e Ambientale
 auth_url:en: http://www.icea.info
@@ -16239,7 +16247,7 @@ exceptions:en: en:except products covered by Annex III,en:in-conversion products
 
 < en:EU organic
 en: TR-BIO-141
-de: TR-BIO-141
+xx: TR-BIO-141
 auth_address:en: Marientorgraben 3-5, 90402, Nürnberg, Germany
 auth_name:en: Kiwa BCS Öko-Garantie GmbH
 auth_url:en: http://www.kiwabcs-oeko.com
@@ -16628,6 +16636,7 @@ exceptions:en: en:except products covered by Annex III,en:in-conversion products
 
 < en:EU organic
 en: TR-BIO-134
+xx: TR-BIO-134
 auth_address:en: Moltkestrasse 4, 77654, Offenburg, Germany
 auth_name:en: LACON GmbH
 auth_url:en: http://www.lacon-institut.com
@@ -16952,6 +16961,7 @@ exceptions:en: en:except products covered by Annex III,en:in-conversion products
 
 < en:EU organic
 en: TR-BIO-135
+xx: TR-BIO-135
 auth_address:en: Urquiza 1285 planta alta, S2000KPA, Rosario, Santa Fe, Argentina
 auth_name:en: Letis S.A.
 auth_url:en: http://www.letis.org
@@ -17971,6 +17981,7 @@ exceptions:en: en:in-conversion products,en:
 
 < en:EU organic
 en: TR-BIO-166
+xx: TR-BIO-166
 auth_address:en: Prof. Dr Ahmet Taner Kislali Mah.2842 Sok.No: 4, 06810, Cayyolu, Cankaya-Ankara, Turkey
 auth_name:en: ORSER
 auth_url:en: http://orser.com.tr
@@ -18061,6 +18072,7 @@ exceptions:en: en:in-conversion products,en:
 
 < en:EU organic
 en: TR-BIO-179
+xx: TR-BIO-179
 auth_address:en: 9-17 Erithrou Stavrou str., 41221, Larissa, Greece
 auth_name:en: Q-check
 auth_url:en: http://www.qcheck-cert.gr
@@ -18196,6 +18208,7 @@ exceptions:en: en:www.caae.es,en:until 30 June 2021
 
 < en:EU organic
 en: TR-BIO-178
+xx: TR-BIO-178
 auth_address:en: Avenida Emilio Lemos, 2 mod. 603, 41020, Seville, Spain
 auth_name:en: Servicio de Certificación CAAE S.L.U.
 auth_url:en: https://www.caae.es/


### PR DESCRIPTION
Some TR-BIO-* labels had a `de` label but otherwise, they would all show as "en:TR-BIO-…" on the site when not using English.

This adds `xx` entries (or replaces `de` ones with `xx` ones) so they should work better for all languages/locales.

Needed-for: https://se.openfoodfacts.org/product/7317731501205/soltorkade-russin-salt%C3%A5-kvarn