### PR TITLE
ci: only generate SBOMs when manifests change

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,9 @@ jobs:
     outputs:
       code_modified: ${{ steps.filter.outputs.code }}
       taxonomy_only: ${{ steps.filter.outputs.any_non_taxonomy == 'false' }}
+      perl_sbom: ${{ steps.filter-some.outputs.perl_sbom }}
+      docker_sbom: ${{ steps.filter-some.outputs.docker_sbom }}
+      frontend_sbom: ${{ steps.filter-some.outputs.frontend_sbom }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -44,6 +47,20 @@ jobs:
             - '**/*'           # Catch everything
             - '!taxonomies/**' # Except taxonomy files
           predicate-quantifier: 'every'
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter-some
+        with:
+          # FIXME: since this uses 'some' it isn’t able to exclude files (e.g., docker/*.md)
+          filters: |
+            perl_sbom:
+            - 'cpanfile'
+            docker_sbom:
+            - 'Dockerfile'
+            - 'docker-compose.yml'
+            frontend_sbom:
+            - 'Dockerfile.frontend'
+            - 'docker-compose.yml'
+          predicate-quantifier: 'some'
 
   lint:
     name: 🕵️‍♀️ NPM lint
@@ -403,7 +420,7 @@ jobs:
       contents: write
     needs: [filter, build_backend]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.code_modified == 'true' && needs.filter.outputs.taxonomy_only == 'false'
+    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.perl_sbom == 'true'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -448,7 +465,7 @@ jobs:
       security-events: write
     needs: [filter, build_backend]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.code_modified == 'true' && needs.filter.outputs.taxonomy_only == 'false'
+    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.docker_sbom == 'true'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -499,7 +516,7 @@ jobs:
       security-events: write
     needs: [build_frontend]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.taxonomy_only == 'false'
+    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request') && needs.filter.outputs.frontend_sbom == 'true'
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
The SBOM generations seem very prone to breaking due to upstream connectivity/availability issues, leaving PRs with nasty red ×’s.

This adds some `*_sbom` filters on manifest files so we only generate SBOMs when any manifests actually change.