### PR TITLE
taxonomy: edits for rubber band product

### DIFF
--- a/taxonomies/packaging_shapes.txt
+++ b/taxonomies/packaging_shapes.txt
@@ -492,6 +492,48 @@ en: clipband, clip band
 description:en: A typically short (~5 cm/2″) band of some material (plastic or paper are common), reinforced with metal wires along the edges.
 wikidata:en: Q134396173
 
+< en:fastener
+en: staple, staples
+ar: دبوس مزدوج السن
+ca: grapa
+ce: атлан
+cs: spony do sešívaček
+cv: такар
+cy: stwffwl
+da: hæfteklamme
+de: Heftklammer
+eo: krampo
+es: grapa
+et: aas
+eu: grapa
+fa: سوزن منگنه
+fi: niitti
+fr: agrafe
+gl: grampa
+hu: tűzőkapocs
+id: Kokot
+it: agrafes, graffette
+ja: ホッチキス針, ステープル
+ko: 스테이플
+la: Uncinulus
+ms: dawai kokot
+nb: heftestift
+nl: nietje
+pl: zszywka, zszywki
+pt: agrafos, grampo
+pt_br: grampo
+ro: scoabă
+ru: скобы для степлеров, скоба
+sl: sponka
+su: eusi hékter
+sv: häftklammer, häftklamrar
+tr: zımba telleri, zımba
+uk: скоба
+vi: đinh kẹp
+yi: דרעטל
+zh: 订书钉, 鋦釘, 訂書釘
+wikidata:en: Q377164
+
 # fr:Liens ( collier , ficelle , ruban , ruban adhésif , bolduc , feuillard , bande , cordon , fil , elastique , bracelet…) in data from Les Mousquetaires
 en: Tie, knot
 fr: Lien, noeud, Liens, noeuds, Liens ( collier - ficelle - ruban - ruban adhésif - bolduc - feuillard - bande - cordon - fil - elastique - bracelet…)
@@ -1378,8 +1420,6 @@ fr: enveloppage
 pt: invólucro
 # suggest:packaging_materials:en: en:metal, en:paper, en:other
 # image:xx:enveloppage.svg
-
-fr: agrafe
 
 en: Sleeve, sleeves
 fr: Gaine, gaines, manchon, manchons, sleever, sleevers

--- a/taxonomies/product/brands.txt
+++ b/taxonomies/product/brands.txt
@@ -89,6 +89,8 @@ xx: HAALE, HAALE Ring
 xx: Henkel
 wikidata:en: Q276507
 
+xx: Kitchen Everyday
+
 xx: LEGO
 wikidata:en: Q170484
 

--- a/taxonomies/product/categories.txt
+++ b/taxonomies/product/categories.txt
@@ -82437,8 +82437,8 @@ google_product_taxonomy_id:en: 2689
 wikidata:en: Q181331
 
 < en:General Office Supplies
-en: Rubber Bands
-xx: Rubber Bands
+en: Rubber bands
+xx: Rubber bands
 cs: Gumičky
 da: Elastikker
 de: Gummibänder
@@ -82451,7 +82451,7 @@ no: Strikk
 pl: Gumki recepturki
 pt: Elásticos
 ru: Канцелярские резинки
-sv: Gummiband
+sv: Gummisnoddar, Gummiband
 tr: Paket Lastikleri
 google_product_taxonomy_id:en: 6146
 wikidata:en: Q256817
@@ -82459,20 +82459,44 @@ wikidata:en: Q256817
 < en:General Office Supplies
 en: Staples
 xx: Staples
+ar: دبوس مزدوج السن
+ca: Grapa
+ce: Атлан
 cs: Spony do sešívaček
+cv: Такар
+cy: Stwffwl
 da: Hæfteklammer
 de: Heftklammern
+eo: Krampoj
 es: Grapas
+et: Aas
+eu: Grapa
+fa: سوزن منگنه
+fi: Niitti
 fr: Agrafes
-it: Graffette
-ja: ホッチキス針
+gl: Grampa
+hu: Tűzőkapocs
+id: Kokot
+it: Graffette, Agrafes
+ja: ホッチキス針, ステープル
+ko: 스테이플
+la: Uncinulus
+ms: Dawai kokot
+nb: Heftestifter, Stifter
 nl: Nietjes
-no: Stifter
-pl: Zszywki
-pt: Grampos
-ru: Скобы для степлеров
-sv: Häftklamrar
-tr: Zımba Telleri
+pl: Zszywki, Zszywka
+pt: Agrafos, Grampos
+pt_br: Grampos
+ro: Scoabă
+ru: Скобы для степлеров, Скоба
+sl: Sponka
+su: Eusi hékter
+sv: Häftklamrar, Häftklammer
+tr: Zımba Telleri, Zımba
+uk: Скоба
+vi: Đinh kẹp
+yi: דרעטל
+zh: 订书钉, 鋦釘, 訂書釘
 google_product_taxonomy_id:en: 948
 wikidata:en: Q377164
 


### PR DESCRIPTION
- New (products) brand.
- New packaging shape: staple
- Fixed Swedish translation of rubber bands category.
- Added a bunch of translations to staples category, making it coherent with the packaging shape.

Needed-for: https://se.openproductsfacts.org/product/7330878439293/gummisnoddar-natur-kitchen-everyday