### PR TITLE
taxonomy(food): add somun categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -37739,6 +37739,20 @@ wikidata:en: Q115456219
 < en:Lepinja
 en: Frozen lepinja
 
+< en:Breads
+en: Somun (Turkish), Turkish somun
+tr: Somun
+wikidata:en: Q3491553
+
+< en:Flatbreads
+en: Somun (Balkan), Balkan somun
+bs: Somun
+wikidata:en: Q108181168
+
+< en:Frozen breads
+< en:Somun (Balkan)
+en: Frozen Balkan somun
+
 en: Breakfasts
 ca: Esmorzars
 da: Morgenmad


### PR DESCRIPTION
There’s both a Turkish bread and a Balkan (flat)bread going by the name of “somun”, so this adds both with a disambiguation parenthesis.

Needed-for: https://se.openfoodfacts.org/product/3870004009579/somun-br%C3%B6d-plivit
Source: https://www.tasteatlas.com/somun