### PR TITLE
taxonomy(food): add “UHT” label

### DIFF
--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -2007,6 +2007,7 @@ hu: UHT, pasztőrözött UHT
 it: UHT, pastorizzato UHT, UHT sterilizzato, uht verhit
 nl: UHT, UHT-gesteriliseerde
 sv: UHT, UHT-behandlad
+wikidata:en: Q1562464
 
 en: thermised, thermized, thermalised, thermalized
 ca: termitzada

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -23246,6 +23246,10 @@ en: Rinsed and ready to eat
 sv: Sköljd & färdig att äta, Sköljd och färdig att äta
 #processing:en: en:rinsed
 
+xx: UHT
+#processing:en: en:uht
+wikidata:en: Q1562464
+
 fr: Haute Valeur Environnementale, HVE
 xx: Haute Valeur Environnementale, HVE
 auth_url:fr: https://hve-asso.com


### PR DESCRIPTION
While UHT is a processing method, it is frequently found as a label for a processing applied to the product as a whole, rather than any specific of its ingredients.

Also adds `wikidata` property for the processing method entry.

Needed-for: https://world.openfoodfacts.org/facets/labels/uht