### PR TITLE
taxonomy(food): peanut 🥜 edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -58761,23 +58761,62 @@ wco_hs_heading:en: 20.08
 #do not put in nut butters, peanut is not a nut
 < en:Legume butters
 en: Peanut butters, peanut paste, peanut creme
+af: Grondboontjiebotter
+ar: زبدة فول سوداني
 bg: Фъстъчено масло
 ca: Mantega de cacauet
+cs: Burákové máslo
+cy: Menyn cnau mwnci
+da: Jordnøddesmør
 de: Erdnussbutter
-es: Mantecas de cacahuete, Cremas de cacahuete, Crema de maní, Crema de cacaheute, Pasta de maní
-fi: maapähkinävoit
-fr: Beurres de cacahuètes, beurres d’arachide, Purées de cacahuète, Purée de cacahuète, Purées d'arachide, Purée d'arachide, Pâtes à tartiner aux cacahuètes, beurre de cacahuète, pâte d'arachide
+el: Φιστικοβούτυρο
+eo: Arakida buteroj
+es: Mantecas de cacahuete, Cremas de cacahuete, Crema de maní, Crema de cacaheute, Pasta de maní, Mantequilla de maní
+et: Maapähklivõi
+eu: Kakahuete-gurin
+fa: کره بادام زمینی
+fi: Maapähkinävoit
+fr: Beurres de cacahuètes, beurres d’arachide, Purées de cacahuète, Purée de cacahuète, Purées d'arachide, Purée d'arachide, Pâtes à tartiner aux cacahuètes, beurre de cacahuète, pâte d'arachide, Beurre d'arachide
+fy: Nútsjesmoar
+ga: Im piseanna talún
+gl: Manteiga de cacahuete
 he: חמאות בוטנים
 hr: Maslaci od kikirikija
-it: Burri di arachidi
-ja: ピーナッツバター
-lt: Žemės riešutų sviestai, žemės riešutų pastos
+hu: Mogyoróvaj
+hy: Գետնանուշի կարագ
+id: Selai kacang
+is: Hnetusmjör
+it: Burri di arachidi, Burro di arachidi
+ja: ピーナッツバター, ピーナッツ・バター, ピーナツ・バター
+jv: Selé kacang
+kn: ಪೀನಟ್ ಬಟರ್
+ko: 땅콩버터
+la: Butyrum arachidum
+ln: Mwǎmba-ngúba
+lt: Žemės riešutų sviestai, Žemės riešutų pastos, Žemės riešutų sviestas
+lv: Zemesriekstu sviests
+mg: Menaka voanjo
+mi: Pīnati pata
+mk: Путер од кикиритки
+ms: Mentega kacang
+nb: Peanøttsmør
 nl: Pindakazen, Pindakaas
-pl: Masło z orzeszków ziemnych, Masło z orzeszków arachidowych
+nn: Peanøttsmør
+pl: Masło z orzeszków ziemnych, Masło z orzeszków arachidowych, Masło orzechowe
 pt: Manteigas de amendoim
+ro: Unt de arahide
 ru: Арахисовая паста, Арахисовые пасты
+sk: Arašidové maslo
+sl: Arašidovo maslo
+sn: Dovi
+sr: Путер од кикирикија
 sv: Jordnötssmör
-tr: Yerfıstığı ezmesi
+sw: Siagi ya karanga
+th: เนยถั่วลิสง
+tr: Yerfıstığı ezmesi, Fıstık ezmesi
+uk: Арахісова паста
+vi: Bơ đậu phộng
+zh: 花生酱
 agribalyse_food_code:en: 15202
 ciqual_food_code:en: 15202
 ciqual_food_name:en: Peanut butter or peanut paste
@@ -58788,19 +58827,40 @@ wco_hs_heading:en: 20.08
 wikidata:en: Q147651
 
 < en:Peanut butters
+en: Creamy peanut butters
+da: Cremede jordnøddesmør, Creamy jordnøddesmør
+pt: Manteigas de amendoim cremosas
+sv: Jordnötssmör utan bitar, Creamy jordnötssmör
+wikidata:en: Q134165564
+
+< en:Peanut butters
 en: Crunchy peanut butters
+da: Sprøde jordnøddesmør, Crunchy jordnøddesmør
 fr: Beurres de cacahuetes croustillants
 hr: Hrskavi maslaci od kikirikija
 lt: Traškūs žemės riešutų sviestai
 nl: Pindakzen met stukjes pinda
+pt: Manteigas de amendoim crocantes
+sv: Jordnötssmör med bitar, Crunchy jordnötssmör
 
-#contains only peanut, no added whatever
 < en:Peanut butters
 en: Pure peanut butters
+da: Rene jordnøddesmør
 fr: Pur beurre de cacahuettes
 hr: Čisti maslac od kikirikija
 lt: Žemės riešutų sviestai (100%)
 nl: Pindakazen (100% pinda)
+pt: Manteigas de amendoim puras
+sv: Rena jordnötssmör, 100% jordnötssmör
+comment:en: contains only peanut, no added whatever
+expected_ingredients:en: en:peanut
+
+< en:Crunchy peanut butters
+< en:Pure peanut butters
+en: Crunchy pure peanut butters, Pure crunchy peanut butters
+da: Sprøde rene jordnøddesmør, Rene sprøde jordnøddesmør
+pt: Manteigas de amendoim puras e crocantes, Manteigas de amendoim crocantes puras
+sv: Rena jordnötssmör med bitarm, 100% jordnötssmör med bitar
 
 < en:Legume butters
 en: Flavoured peanut butters

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -116,6 +116,8 @@ synonyms:pt: oliva, oliveira
 
 synonyms:pt: láctico, lático, lácteo
 
+synonyms:da: ristet, ristede
+synonyms:sv: rostat, rostad, rostade
 
 # comment:en:These are words that occur inside the name of one ingredient, but that can be removed for matching the ingredient with entries in the taxonomy
 
@@ -58863,8 +58865,6 @@ sv: blandade bönor
 ##########################
 
 
-# description:en:A LEGUME is a plant in the family Fabaceae (or Leguminosae), or the fruit or seed of such a plant (also called a pulse).
-# Legumes are grown agriculturally, primarily for human consumption. Grain legumes include beans, lentils, lupins, peas, and peanuts.
 < en:vegetable
 en: legume
 af: Peulgewas
@@ -58873,7 +58873,7 @@ ar: بقول
 bg: бобово растение
 ca: llegum
 cs: luštěnina
-da: Bælgfrugt
+da: bælgfrugt
 de: Hülsenfrucht
 el: Όσπρια
 eo: Guŝo
@@ -58918,7 +58918,7 @@ sh: Mahuna
 sk: Strukoviny
 sl: Strok
 sr: махуна
-sv: ärtväxter
+sv: ärtväxt, ärtväxter
 sw: Jamii kunde
 ta: அவரை
 th: ถั่ว
@@ -58928,28 +58928,29 @@ uk: бобові культури
 uz: dukkakli don ekinlari
 vi: Quả đậu
 zh: 荚果
+#ast: Llegume
+#csb: Łušćinowy płod
+#eml: Scurnècia
+#hsb: Łušćinowy płód
+#hsb: Łušćinowy płód
+#nan: Ngeh-kó
+#new: बूबः
+#scn: Vaiana
+#sco: legume
+#sgs: Onkštėnis augals
+#sr-ec: махуна
+#sr-el: Mahuna
+#war: Legume
+#yue: 豆類
+#zh-cn: 荚果
+#zh-hans: 荚果
+#zh-hant: 莢果
+#zh-hk: 莢果
+#zh-sg: 荚果
+#zh-tw: 莢果
+description:en: A LEGUME is a plant in the family Fabaceae (or Leguminosae), or the fruit or seed of such a plant (also called a pulse). Legumes are grown agriculturally, primarily for human consumption. Grain legumes include beans, lentils, lupins, peas, and peanuts.
 vegan:en: yes
 vegetarian:en: yes
-# ast:Llegume
-# csb:Łušćinowy płod
-# eml:Scurnècia
-# hsb:Łušćinowy płód
-# hsb:Łušćinowy płód
-# nan:Ngeh-kó
-# new:बूबः
-# scn:Vaiana
-# sco:legume
-# sgs:Onkštėnis augals
-# sr-ec:махуна
-# sr-el:Mahuna
-# war:Legume
-# yue:豆類
-# zh-cn:荚果
-# zh-hans:荚果
-# zh-hant:莢果
-# zh-hk:莢果
-# zh-sg:荚果
-# zh-tw:莢果
 wikidata:en: Q145909
 
 < en:legume
@@ -58960,9 +58961,10 @@ it: legumi secchi
 lv: žāvēti pākšaugi
 nl: gedroogde peulvruchten
 pt: pulso
+sv: baljfrukt
+comment:it: "en:pulse" e "en:legumes" in italiano spesso si confondono perché entrambi i termini vengono generalmente tradotti come "legumi", anche se tecnicamente sarebbe più preciso distinguere tra "legumi secchi" (pulses) e "leguminose" (legume plants).
 eurocode_2_group_2:en: 7.10
 wikidata:en: Q2727662
-#comment:it: "en:pulse" e "en:legumes" in italiano spesso si confondono perché entrambi i termini vengono generalmente tradotti come "legumi", anche se tecnicamente sarebbe più preciso distinguere tra "legumi secchi" (pulses) e "leguminose" (legume plants).
 
 # description:en:Phaseolus lunatus, commonly known as the LIMA BEAN, butter bean, sieva bean, Double Bean or Madagascar bean, is a legume grown for its edible seeds or beans
 
@@ -61950,23 +61952,23 @@ wikidata:en: Q11027461
 < en:nut
 en: peanut, peanuts
 ar: فول سوداني
-ay: Chuqupa
-az: Araxis
+ay: chuqupa
+az: araxis
 bg: фъстък, фъстъци
 bs: kikiriki
-ca: Cacauet, cacauets
+ca: cacauet, cacauets
 cs: arašídy
-da: jordnødder, jordnød, peanuts
+da: jordnød, jordnødder, peanuts
 de: Erdnuss, Erdnüsse, Erdnüssen, Erdnusse, Erdnusskerne
 el: αραχίδες, αραχίδα, αραπικα φιστικια
 eo: ternukso
 es: cacahuetes, cacahuete, cacahuates, cacahuate, maní
-et: Maapähkel, maapähklid, maapähkleid
+et: maapähkel, maapähklid, maapähkleid
 fi: maapähkinä, maapähkinät, maapähkinää
 fr: arachides, arachide, cacahuètes, cacahuète, cacahouètes, cacahouète
-ga: Cnó talún, piseanna
+ga: cnó talún, piseanna
 gu: મગફળી
-ha: Gyaɗa
+ha: gyaɗa
 he: בוטן, בוטנים, חמאת בוטנים
 hr: kikiriki, kikirikija
 hu: földimogyoró, amerikaimogyoró
@@ -61975,9 +61977,9 @@ it: arachide, arachidi
 ja: ラッカセイ, 落花生
 ka: არაქისი
 ko: 땅콩
-ku: Fistiqa axê
+ku: fistiqa axê
 la: arachis hypogaea
-ln: Ngúba
+ln: ngúba
 lt: žemės riešutai, žemės riešutų
 lv: zemesrieksti, zemesriekstus, zemesriekstu
 mr: भुईमूग
@@ -61985,50 +61987,43 @@ mt: karawett
 nb: peanøtter
 nl: pinda, pinda's, aardnoot, aardnoten, pindanoten, pindas, vliespinda's
 nn: peanøtter
-nv: Neeshchʼííłbáhí
+nv: neeshchʼííłbáhí
 pl: orzeszki, orzeszki arachidowe, orzeszki ziemne, arachidowe, orzechy arachidowe, orzeszków ziemnych, orzeszków arachidowych, orzechów ziemnych, orzechów arachidowych, orzechy ziemne
-pt: amendois, amendoins, amendoim
+pt: amendoim, amendois, amendoins
 ro: alune, arahide
 ru: арахис
 sk: arašidy
 sl: arašidi, araśidi, kikiriki
-sn: Nzungu
+sn: nzungu
 sr: кикирики
-sv: jordnötter
+sv: jordnöt, jordnötter, jordnöts
 th: ถั่วลิสง
-tr: Yer fıstığı, yerfıstığı
+tr: yer fıstığı, yerfıstığı
 tt: җир чикләвеге
-uz: Yeryongʻoq
+uz: yeryongʻoq
 yi: סטאשקע
-za: Duhdoem
+za: duhdoem
 zh: 花生仁, 花生
-# ceb:Mani
-# hak:Thì-thèu
-# mrj:Кӹдӓлӓн пӱкш
-# scn:Calacavisi
-# tt-cyrl:җир чикләвеге
+#ceb: Mani
+#hak: Thì-thèu
+#mrj: Кӹдӓлӓн пӱкш
+#scn: Calacavisi
+#tt-cyrl: җир чикләвеге
 allergens:en: en:peanuts
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:arachide
-# 1147 products in 9 languages @2018-10-05
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuète
-# 806 products in 19 languages @2018-10-06
 ciqual_food_code:en: 15001
 ciqual_food_name:en: Peanut
 ecobalyse:en: peanut-non-eu
 ecobalyse_labels_en_organic:en: peanut-organic
+wikidata:en: Q37383
+# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:arachide
+# 1147 products in 9 languages @2018-10-05
+# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuète
+# 806 products in 19 languages @2018-10-06
 
 < en:peanut
-en: peanut paste
-de: Erdnusspaste
-es: pasta de cacahuete, pasta de maní
-hr: pasta od kikirikija, kikiriki pasta
-it: crema di arachidi
-pl: pasta z orzechów arachidowych, pasta z orzeszków arachidowych
-
-< en:peanut
-en: roasted peanuts
+en: roasted peanut, roasted peanuts
 bg: печени фъстъци
-da: ristede peanuts
+da: ristet jordnød, ristede peanuts
 de: geröstete Erdnüsse
 es: cacahuetes tostados, maní tostado
 fi: paahdettu maapähkinä, paahdetut maapähkinät
@@ -62038,16 +62033,20 @@ it: arachidi tostate
 ja: ローストピーナッツ
 lt: skrudinti žemės riešutai
 nl: geroosterde pinda's, geroosterde pindanoten
+pt: amendoim torrado
 ru: арахис обжаренный
+sv: rostad jordnöt, rostade jordnötter
 tr: kavrulmuş yer fıstığı, kavrulmuş yerfıstığı
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuètes-grillées
-# 66 products in 6 languages @2018-10-06
 ciqual_food_code:en: 15037
 ciqual_food_name:en: Peanut, grilled
 ciqual_food_name:fr: Cacahuète, grillée
+wikidata:en: Q110495337
+# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuètes-grillées
+# 66 products in 6 languages @2018-10-06
 
-< en:roasted peanuts
-en: organic roasted peanuts
+< en:roasted peanut
+en: organic roasted peanut, organic roasted peanuts
+da: økologisk ristet jordnød
 de: geröstete biologisch Erdnüsse
 el: φυστίκια ψημένος βιολογική
 es: cacahuetes tostados ecológicos
@@ -62056,33 +62055,40 @@ fr: arachides grillées biologique
 hr: organski prženi kikiriki
 it: arachidi tostate biologiche
 nl: biologische geroosterde pinda's
-sv: ekologisk rostade jordnötter
+pt: amendoim torrado biológico
+sv: ekologisk rostad jordnöt, ekologiska rostade jordnötter, ekologisk rostade jordnötter
 # ingredient/nl:biologische-geroosterde-pinda-s has 1 product @2019-05-24
 
-< en:roasted peanuts
-en: milled roasted peanuts
+< en:roasted peanut
+en: milled roasted peanut, milled roasted peanuts
+da: malet ristet jordnød
 de: Erdnüsse geröstet und gemahlen, geröstete und gemahlene Erdnüsse, gemahlene geröstete Erdnüsse, geröstete gemahlene Erdnüsse
 es: cacahuetes tostados molidos
 fr: cacahuètes grillées moulues, arachides grillées moulues
 hr: mljeveni prženi kikiriki
 it: arachidi tostate macinate
 nl: geroosterde germalen pinda's
-pt: amendoins torrados moídos
+pt: amendoim torrado moído, amendoins torrados moídos
+sv: mald rostad jordnöt
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuètes-grillées-moulues
 # 53 products in 6 languages @2018-10-06
 
 < en:peanut
-en: shelled peanuts
+en: shelled peanut, shelled peanuts
+da: afskallet jordnød, jordnød uden skal
 de: geschälte Erdnüsse
 fi: kuoreton maapähkinä, kuorettomat maapähkinät
 fr: cacahuètes décortiquées
 hr: kikiriki bez opne
 it: arachidi sgusciate
 nl: Pinda's in de dop
+pt: amendoim sem casca
+sv: jordnöt utan skal, jordnötter utan skal
 # ingredient/nl:pinda-s-in-de-dop has 1 product @2019-05-24
 
 < en:peanut
 en: peanut with shell
+da: jordnød med skal
 de: Erdnüsse mit Schale
 es: cacahuete con cáscara
 fi: kuorellinen maapähkinä
@@ -62091,64 +62097,113 @@ hr: kikiriki s ljuskom
 it: arachidi con guscio
 nl: pinda met schil
 pt: amendoim com casca
+sv: jordnöt med skal, jordnötter med skal
 
 < en:peanut
 en: peanut flour
+ar: دقيق الفول السوداني
 bg: фъстъчено брашно, брашно от фъстъци
+ca: flor del cacauet
+da: jordnøddemel
 de: Erdnussmehl
-es: Harina de cacahuete, harina de maní
+es: harina de cacahuete, harina de maní
 fr: farine d'arachide
 hr: brašno od kikirikija
-it: Farina di arachidi
-nl: Pinda bloem
+it: farina di arachidi
+jv: glepung kacang
+ko: 땅콩가루
+nl: pinda bloem, pindameel
 pl: mąka arachidowa, mąka z orzeszków ziemnych, mąki arachidowej
+pt: farinha de amendoim
+sl: arašidova moka
+sv: jordnötsmjöl
+zh: 花生粉
+wikidata:en: Q7157936
 # ingredient/en:peanut-flour has 786 products in 3 languages @2020-06-11
 
-# <en:compound
-# <en:roasted peanuts
-en: honey roasted peanuts
+#< en:compound
+#< en:roasted peanut
+en: honey roasted peanut, honey roasted peanuts
 de: honiggeröstete Erdnüsse
 es: cacahuetes tostados con miel, maní tostado con miel, maníes tostados con miel, cacahuate tostado con miel, cacahuete tostado con miel, cacahuetes tostados con miel
 fi: hunajapaahdettu maapähkinä
 hr: u medu pečeni kikiriki
 it: arachidi tostate al miele
-sv: honungsrostade jordnötter
+pt: amendoim torrado com mel
+sv: honungsrostad jordnöt, honungsrostade jordnötter
 allergens:en: en:peanuts
+vegan:en: no
+vegetarian:en: yes
+wikidata:en: Q18349953
 # usage:en:honey roasted peanuts (peanuts, honey, sugar, corn starch, cottonseed oil and salt)
 # mainIngredient:en:peanuts
 
 #en:compound
 #en:category:en:Peanut butters
 < en:peanut
-en: peanut butter, peanut paste, Peanut butter or peanut paste
-bg: фъстъчено масло, фъстъчена паста
-cs: arašídové máslo, arašídová pasta
+en: peanut butter
+bg: фъстъчено масло
+cs: arašídové máslo
+da: jordnøddesmør
 de: Erdnussbutter
 es: crema de cacahuete, crema de maní
-fr: beurre d'arachide, beurre de cacahuète, beurre de cacahouète, pâte d'arachide
+fr: beurre d'arachide, beurre de cacahuète, beurre de cacahouète
 hr: kikiriki maslac
-it: Burro di arachidi
+it: burro di arachidi
 ja: ピーナッツバーター
 nb: peanøttssmör
 nl: pindakaas
-pl: Masło z orzeszków ziemnych
-pt: Manteiga de amendoim
-sv: jordnöttssmör
-ciqual_food_code:en: 15202
-ciqual_food_name:en: Peanut butter or peanut paste
-ciqual_food_name:fr: Beurre de cacahuète ou Pâte d'arachide
+pl: masło z orzeszków ziemnych
+pt: manteiga de amendoim
+sv: jordnötssmör
+ciqual_proxy_food_code:en: 15202
+ciqual_proxy_food_name:en: Peanut butter or peanut paste
+ciqual_proxy_food_name:fr: Beurre de cacahuète ou Pâte d'arachide
 from_palm_oil:en: no
 vegan:en: yes
 vegetarian:en: yes
+wikidata:en: Q147651
 # ingredient/en:peanut-butter has 2899 products in 13 languages @2021-07-12
 
 < en:peanut butter
 en: crunchy peanut butter
+da: sprødt jordnøddesmør
 de: knusprige Erdnussbutter
 es: crema de cacahuete crujiente, crema de cacahuete con trozos
 hr: hrskavi maslac od kikirikija
 it: burro di arachidi croccante
+pt: manteiga de amendoim crocante
+sv: jordnötssmör med bitar
 
+< en:peanut
+en: peanut paste
+bg: фъстъчена паста
+cs: arašídová pasta
+da: jordnøddepasta
+de: Erdnusspaste
+eo: pasto de ternukso
+es: pasta de cacahuete, pasta de maní
+fr: pâte d'arachide
+hr: pasta od kikirikija, kikiriki pasta
+it: crema di arachidi
+pl: pasta z orzechów arachidowych, pasta z orzeszków arachidowych
+pt: pasta de amendoim
+sl: arašidova krema
+sv: jordnötspasta
+zh: 花生糊
+ciqual_proxy_food_code:en: 15202
+ciqual_proxy_food_name:en: Peanut butter or peanut paste
+ciqual_proxy_food_name:fr: Beurre de cacahuète ou Pâte d'arachide
+wikidata:en: Q15734719
+
+< en:peanut butter
+< en:peanut paste
+en: peanut butter or peanut paste
+da: jordnøddesmør eller -pasta
+sv: jordnötssmör eller -pasta
+ciqual_food_code:en: 15202
+ciqual_food_name:en: Peanut butter or peanut paste
+ciqual_food_name:fr: Beurre de cacahuète ou Pâte d'arachide
 
 ###################################################################################################
 #

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -849,11 +849,6 @@ es: partido, partida, partidos, partidas
 pl: łamane, łamana, łamany
 pt: partido, partida, partidos, partidas
 
-#de:comment:geschält is a generic term and can mean en:peeled or en:shelled
-de: geschält, geschälte, geschälter, geschälten, geschältes
-
-de: ungeschält, ungeschälte, ungeschälter, ungeschältes
-
 #es:comment:deshuesadas is a generic term and can mean en:pitted or en:boned
 #process of removing the bone from meat
 en: boned
@@ -905,27 +900,20 @@ en: machine boned
 hr: strojno otkošteno
 it: disossato meccanicamente
 
-#en:description:To remove the outer covering or shell of something
-< en:peeled
-en: shelled
-ca: sense closca, pelat, pelats, pelada, pelades
-cs: loupaná
-es: sin cascara, pelada, pelado, peladas, pelados
-fi: kuoreton, kuorettomat
-fr: décortiqué, décortiquée, décortiqués, décortiquées, décoquillé, décoquillée, décoquillés, décoquillées, émondé, émondée, émondés, émondées
-hr: oljuštene, oljušteni, golice, bez opne
-it: decorticato, decorticati, decorticata, decorticate, sbucciati, sgusciato, sgusciati, sgusciata, sgusciate
-pl: łuskany, łuskana, łuskane, obłuskany, obłuskana, obłuskane
-pt: descascado, descascada, descascados, descascadas, sem casca, sem cascas
-uk: лущений, лущена, лущене, лущені
+en: peeled or shelled
+de: geschält, geschälte, geschälter, geschälten, geschältes
+sv: skalad, skalat, skalade, utan skal
+comment:en: de:geschält is a generic term and can mean en:peeled or en:shelled
 
-en: unshelled, in shell
+en: unpeeled or unshelled
+de: ungeschält, ungeschälte, ungeschälter, ungeschältes
+sv: med skal
 
-# en:description:With the outermost layer or skin removed
+< en:peeled or shelled
 en: peeled, hulled
 bg: обелен, обелено, обелена, обелени, белен, белена, белено, белени, грухана
 ca: sense pell
-da: afskallede
+da: skrællet, skrællede, uden skræl
 # de:geschälte is a separate entry
 es: sin piel, repelada, repelado, repeladas, repelados, descascarrillado, descascarrillada, descascarrillados, descascarrilladas, descascarilladas
 fi: kuoritut
@@ -936,9 +924,30 @@ it: pelato, pelati, pelata, pelate
 nl: gepeld, gepelde
 pl: obrany, obrana, obrane
 pt: pelado, pelada, pelados, peladas, sem pele, sem peles
-sv: skalade
 uk: чищений, чищена, чищене, чищені
+description:en: With the outermost layer or skin removed
+wikidata:en: Q23022934
 # en:wiktionary:peeled
+
+< en:peeled
+en: shelled
+ca: sense closca, pelat, pelats, pelada, pelades
+cs: loupaná
+da: afskallet, afskallede, uden skal
+es: sin cascara, pelada, pelado, peladas, pelados
+fi: kuoreton, kuorettomat
+fr: décortiqué, décortiquée, décortiqués, décortiquées, décoquillé, décoquillée, décoquillés, décoquillées, émondé, émondée, émondés, émondées
+hr: oljuštene, oljušteni, golice, bez opne
+it: decorticato, decorticati, decorticata, decorticate, sbucciati, sgusciato, sgusciati, sgusciata, sgusciate
+pl: łuskany, łuskana, łuskane, obłuskany, obłuskana, obłuskane
+pt: descascado, descascada, descascados, descascadas, sem casca, sem cascas
+uk: лущений, лущена, лущене, лущені
+description:en: To remove the outer covering or shell of something
+
+< en:unpeeled or unshelled
+en: unshelled, in shell
+da: med skal
+pt: com casca, com cascas
 
 en: scalding
 da: skoldning, skoldet, skoldede
@@ -2203,6 +2212,7 @@ pl: smażony, smażona, smażone
 pt: frito, frita, fritos, fritas
 sv: friterad, friterade, stekt
 uk: смажений, смажена, смажене, смажені, обсмажений, обсмажена, обсмажене, обсмажені, засмажений, засмажена, засмажене, засмажені
+wikidata:en: Q300472
 # en:wikitionary:To cook food by heating in an oven or over a fire without covering, resulting in a crisp, possibly even slightly charred appearance.
 
 en: roasted, baked
@@ -2223,6 +2233,8 @@ pt: assado, assada, assados, assadas
 sk: pražené
 sv: rostad, rostat, rostade, bakad
 uk: печений, печена, печене, печені, запечений, запечена, запечене, запечені
+comment:en: In the actual translations on products, there is not always a difference between toasted and roasted
+wikidata:en: Q4865573
 
 #< en:roasted
 en: dry roasted
@@ -2237,12 +2249,10 @@ nl: droog geroosterd, droog geroosterde, droog geroosterde, droog geroosterde
 pl: prażony na sucho, prażone na sucho, prażona na sucho, prażone na sucho
 pt: torrado a seco, torrada a seco, torrados a seco, torradas a seco
 sv: torrostad, torrostade
-
-#comment:en:In the actual translations on products, there is not always a difference between toasted and roasted
+wikidata:en: Q10860338
 
 en: chargrilled, char grilled
 
-# en:description:To lightly cook by browning via direct exposure to a fire or other heat source.
 en: toasted
 ca: torrat, torrats, torrada, torrades
 de: geröstet, geröstete, geröstetes, gerösteter, getoastet, getoastete, getoasteter, getoastetes
@@ -2256,6 +2266,8 @@ nl: geroosterd, geroosterde, getoaste
 pl: prażony, prażone, prażona, prażonego, prażonej, prażonych
 pt: tostado, tostada, tostados, tostadas, torrado, torrada, torrados, torradas
 sl: praženi
+comment:en: In the actual translations on products, there is not always a difference between toasted and roasted
+description:en: To lightly cook by browning via direct exposure to a fire or other heat source.
 
 en: untoasted
 de: ungeröstet, ungeröstete, ungerösteter, ungeröstetes

--- a/tests/unit/ingredients_processing.t
+++ b/tests/unit/ingredients_processing.t
@@ -898,31 +898,31 @@ my @tests = (
 			{
 				'id' => 'en:shallot',
 				'is_in_taxonomy' => 1,
-				'processing' => 'de:geschält',
+				'processing' => 'en:peeled-or-shelled',
 				'text' => 'Schalotte'
 			},
 			{
 				'id' => 'en:hazelnut',
 				'is_in_taxonomy' => 1,
-				'processing' => 'de:geschält',
+				'processing' => 'en:peeled-or-shelled',
 				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:almond',
 				'is_in_taxonomy' => 1,
-				'processing' => "de:geschält",
+				'processing' => "en:peeled-or-shelled",
 				'text' => 'mandeln'
 			},
 			{
 				'id' => 'en:passionfruit',
 				'is_in_taxonomy' => 1,
-				'processing' => 'de:ungeschält',
+				'processing' => 'en:unpeeled-or-unshelled',
 				'text' => 'passionsfrucht'
 			},
 			{
 				'id' => 'en:celery',
 				'is_in_taxonomy' => 1,
-				'processing' => 'de:ungeschält',
+				'processing' => 'en:unpeeled-or-unshelled',
 				'text' => 'sellerie'
 			}
 		]


### PR DESCRIPTION
Various edits for more better peanutting on OFF. 🥜

In general:
- Adds translations/synonyms and `wikidata` properties.
- Moves comments/descriptions into `comment`/`description` properties.

For categories:
- Normalises to plural and capitalised.
- Adds new categories:
  - Creamy peanut butters
  - Crunchy pure peanut butters

For ingredients:
- Normalises to singular and lowercase.
- ‘Splits out’ “peanut paste” from “peanut butter”.
  - “peanut paste” already existed as its own ingredient, so not sure why it hasn’t raised any errors that this was also a synonym for “peanut butter”.
  - This also includes new combined ingredient “peanut butter or peanut paste” to house the Ciqual code, with the code being changed to a proxy code for the specific butter and paste entries.

For processing:
- Improves shelling family tree(s).

Needed-for: https://se.openfoodfacts.org/product/4056489642398/100-peanut-butter-crunchy-maribel