### PR TITLE
fix: user and org creation on pro platform with OIDC >= 2

### DIFF
--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -442,9 +442,13 @@ elsif ($action eq 'process') {
 
 		$template_data_ref->{user_requested_org} = $user_ref->{requested_org};
 
-		my $requested_org_ref = retrieve_org($user_ref->{requested_org});
-		$template_data_ref->{add_user_existing_org}
-			= sprintf(lang("add_user_existing_org"), org_name($requested_org_ref) // '');
+		# At OIDC level 2 and above, requested org processing happens later via Redis/Minion,
+		# so the org may not exist yet when we render the signup result page.
+		if (get_oidc_implementation_level() < 2) {
+			my $requested_org_ref = retrieve_org($user_ref->{requested_org});
+			$template_data_ref->{add_user_existing_org}
+				= sprintf(lang("add_user_existing_org"), org_name($requested_org_ref) // '');
+		}
 
 		$template_data_ref->{user_org} = $user_ref->{org};
 

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -679,6 +679,8 @@ the request object
 
 sub notify_user_requested_org ($user_ref, $org_created, $request_ref) {
 
+	$log->debug("notify_user_requested_org", {user_ref => $user_ref, org_created => $org_created}) if $log->is_debug();
+
 	# the template for the email, we will build it gradually
 	my $template_data_ref = {
 		userid => $user_ref->{userid},

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -273,6 +273,10 @@ msgctxt "add_user_existing_org_pending"
 msgid "Your request to join the organization is pending approval of the organization administrator."
 msgstr "Your request to join the organization is pending approval of the organization administrator."
 
+msgctxt "add_user_requested_org_processing"
+msgid "Your organization request has been received and is being processed."
+msgstr ""
+
 msgctxt "admin_status_updated"
 msgid "Admin Status Updated"
 msgstr "Admin Status Updated"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -270,6 +270,10 @@ msgctxt "add_user_existing_org_pending"
 msgid "Your request to join the organization is pending approval of the organization administrator."
 msgstr "Your request to join the organization is pending approval of the organization administrator."
 
+msgctxt "add_user_requested_org_processing"
+msgid "Your organization request has been received and is being processed."
+msgstr "Your organization request has been received and is being processed."
+
 msgctxt "admin_status_updated"
 msgid "Admin Status Updated"
 msgstr "Admin Status Updated"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -179,6 +179,10 @@ msgctxt "add_user_existing_org_pending"
 msgid "Your request to join the organization is pending approval of the organization administrator."
 msgstr "Votre demande pour rejoindre l'organisation est en attente d'approbation de l'administrateur de l'organisation."
 
+msgctxt "add_user_requested_org_processing"
+msgid "Your organization request has been received and is being processed."
+msgstr "Votre demande d'organisation a bien été reçue et est en cours de traitement."
+
 msgctxt "admin_status_updated"
 msgid "Admin Status Updated"
 msgstr "Statut d'administrateur mis à jour"

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -218,13 +218,25 @@
 
         [% IF user_requested_org.defined %]
 
-            <!-- Pro account, but the requested org already exists -->
+            [% IF oidc_implementation_level < 2 %]
 
-            <div id="existing_org_warning">
-                <p>[% add_user_existing_org %]</p>
-                <p>[% lang("add_user_existing_org_pending") %]</p>
-                <p>[% lang("please_email_producers") %]</p>
-            </div>
+                <!-- Pro account, but the requested org already exists -->
+
+                <div id="existing_org_warning">
+                    <p>[% add_user_existing_org %]</p>
+                    <p>[% lang("add_user_existing_org_pending") %]</p>
+                    <p>[% lang("please_email_producers") %]</p>
+                </div>
+
+            [% ELSE %]
+
+                <!-- Pro account org request is processed asynchronously -->
+
+                <div id="existing_org_warning">
+                    <p>[% lang("add_user_requested_org_processing") %]</p>
+                </div>
+
+            [% END %]
 
         [% ELSIF user_org.defined %]
 


### PR DESCRIPTION
At OIDC >= 2, the org creation / request when a user creates an account on the pro platform is not done synchronously anymore, instead Keycloak generates a REDIS event which is then processed by Minion.

As a result, we cannot tell the user right away after user creation if the org has been created or not.

Related to: https://github.com/openfoodfacts/openfoodfacts-server/issues/13489