### PR TITLE
fix: UTF-8 issue in processing of requested_org in Redis listener

### DIFF
--- a/lib/ProductOpener/Redis.pm
+++ b/lib/ProductOpener/Redis.pm
@@ -335,7 +335,7 @@ sub _process_registered_users_stream($stream_values_ref) {
 			my $user_ref = retrieve_user($user_id);
 			if ($user_ref) {
 				if (defined $requested_org) {
-					$user_ref->{requested_org} = remove_tags_and_quote(decode utf8 => $requested_org);
+					$user_ref->{requested_org} = remove_tags_and_quote($requested_org);
 
 					my $requested_org_id = get_string_id_for_lang("no_language", $user_ref->{requested_org});
 


### PR DESCRIPTION
fix double decoding issue:

`May 05 14:04:05 off listen_to_redis_stream.pl[117]: [Tue May  5 14:04:05 2026] listen_to_redis_stream.pl: EV: error in callback (ignoring): Wide character at /srv/off/lib/ProductOpener/Redis.pm line 338.`

note that this error actually blocks the redis_listener completely: it is still running, but it will not process other redis events