### PR TITLE
feat(taxonomies): add missing Portuguese translations to ingredients

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -39726,11 +39726,10 @@ fr: pomme séchée, pommes séchées, pommes déshydratées
 he: תפוח מיובש, תפוחים מיובשים
 hr: sušene jabuke
 hu: szárított almadarabkák
-pt: maçã seca, maçãs secas
 it: mele secche
 nl: gedroogde appel
 pl: liofilizowane jabłka, suszony owoc jabłka
-pt: maçãs desidratadas
+pt: maçã seca, maçãs secas, maçãs desidratadas
 ru: Сушеное яблоко
 sk: sušené jablká
 sv: torkat äpple
@@ -39814,7 +39813,6 @@ es: Puré de manzana
 fi: omenapyree
 fr: purée de pomme
 hr: pire od jabuka
-pt: puré de maçã
 hu: almapüré
 it: purea di mele
 lv: ābolu pīrāgs
@@ -39896,7 +39894,6 @@ da: æblemost, æblesaft
 de: Apfelsaft, Apfelsaft von Streuobstwiesen-Äpfeln
 el: χυμός μήλου, μηλοχυμός
 eo: poma suko
-pt: sumo de maçã
 es: jugo de manzana, zumo de manzana
 et: õunamahl
 fa: آب سیب
@@ -39918,7 +39915,7 @@ nb: eplemost
 nl: appelsap
 nn: eplemost
 pl: sok jabłkowy, soku jabłkowego
-pt: suco de maçã, sumo de maçã
+pt: sumo de maçã, suco de maçã
 ru: яблочный сок
 sa: सेवफलरसः
 sl: jabolčni sok

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -39669,6 +39669,7 @@ es: manzana verde, manzanas verdes
 fr: pomme verte, pommes vertes
 hr: zelena jabuka
 it: mela verde
+pt: maçã verde
 
 < en:apple
 en: red apple
@@ -39703,6 +39704,7 @@ fr: pomme bio, Pommes bio
 hr: organska jabuka
 it: mele bio
 nl: biologische appel, Biologische appels
+pt: maçã biológica
 # ingredient/fr:pommes-bio has 18 products in 4 languages @2019-05-23
 
 < en:apple
@@ -39724,6 +39726,7 @@ fr: pomme séchée, pommes séchées, pommes déshydratées
 he: תפוח מיובש, תפוחים מיובשים
 hr: sušene jabuke
 hu: szárított almadarabkák
+pt: maçã seca, maçãs secas
 it: mele secche
 nl: gedroogde appel
 pl: liofilizowane jabłka, suszony owoc jabłka
@@ -39751,6 +39754,7 @@ fr: morceaux de pomme, morceaux de pommes
 hr: komadići jabuke
 it: pezzi di mela
 nl: stukjes appel
+pt: pedaços de maçã
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:morceaux-de-pomme
 # 45 products in 4 languages @2018-10-04
 
@@ -39790,6 +39794,7 @@ hr: pulpa jabuke
 it: polpa di mele
 ja: りんごパルプ
 nl: appelpuree
+pt: polpa de maçã
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pulpe-de-pomme
 # 46 products @2018-10-04
 ciqual_food_code:en: 13050
@@ -39809,6 +39814,7 @@ es: Puré de manzana
 fi: omenapyree
 fr: purée de pomme
 hr: pire od jabuka
+pt: puré de maçã
 hu: almapüré
 it: purea di mele
 lv: ābolu pīrāgs
@@ -39890,6 +39896,7 @@ da: æblemost, æblesaft
 de: Apfelsaft, Apfelsaft von Streuobstwiesen-Äpfeln
 el: χυμός μήλου, μηλοχυμός
 eo: poma suko
+pt: sumo de maçã
 es: jugo de manzana, zumo de manzana
 et: õunamahl
 fa: آب سیب
@@ -40050,7 +40057,7 @@ fr: confiture de pommes
 hr: džem od jabuka
 it: confettura di mele, marmellata di mele, confettura alle mele
 nl: appeljam
-pt: geleia de maçã
+pt: geleia de maçã, doce de maçã, compota de maçã
 ru: повидло яблочное, яблочное повидло
 
 < en:apple
@@ -40065,6 +40072,7 @@ it: succo di arance e mele, succo d'arance e mele, succo di mele e arance, succo
 en: apple wine
 hr: vino od jabuke
 it: vino di mele, vino di mela
+pt: vinho de maçã
 
 < en:preparation
 en: apple preparation


### PR DESCRIPTION
This PR adds several missing Portuguese translations to the `ingredients` taxonomy, specifically targeting apple-related terms. This addresses the request to add a human-reviewable amount of missing Portuguese translations to one of the taxonomies.

Key additions:
- `en: green apple` -> `pt: maçã verde`
- `en: Organic apple` -> `pt: maçã biológica`
- `en: dried apple` -> `pt: maçã seca, maçãs secas`
- `en: apple pieces` -> `pt: pedaços de maçã`
- `en: apple pulp` -> `pt: polpa de maçã`
- `en: apple puree` -> `pt: puré de maçã`
- `en: apple juice` -> `pt: sumo de maçã`
- `en: apple jam` -> merged into existing `pt: geleia de maçã, doce de maçã, compota de maçã`
- `en: apple wine` -> `pt: vinho de maçã`

Scratchpad files used for analysis were removed.

---
*PR created automatically by Jules for task [13113013323224666552](https://jules.google.com/task/13113013323224666552) started by @teolemon*