### PR TITLE
taxonomy(food): merge gherkins→pickled gherkins

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -109809,17 +109809,8 @@ sv: Gurkor i lag, Inlagda gurkor
 tr: Salatalık turşusu, Hıyar turşusu
 wikidata:en: Q1365891
 
-< en:Cucumbers
-en: Small cucumbers, Gherkins (non-pickled)
-sv: Smågurkor
-
-< en:Vegetables based foods
-en: Gherkins
-comment:en: “Gherkins” can refer to both non-pickled and pickled small cucumbers
-
-< en:Gherkins
 < en:Pickled cucumbers
-en: Pickled gherkins, Gherkins (pickled), Pickled small cucumbers
+en: Pickled gherkins, Gherkins (pickled), Pickled small cucumbers, Gherkins
 bg: Кисели краставички
 de: Essiggurken
 es: Pepinillos, Pepinillos encurtidos
@@ -109830,7 +109821,8 @@ hu: Csemegeuborka
 it: Cetriolini
 nl: Ingemaakte Augurken
 sv: Smågurkor i lag, Inlagda smågurkor
-comment:en: Pickled small cucumbers (gherkins) regardless of the method used to pickle them.
+comment:en: “Gherkins” can refer to both non-pickled and pickled small cucumbers, but in actual use on products it seems like it far more often refers to pickled small cucumbers than small cucumbers in general.
+description:en: Pickled small cucumbers (gherkins) regardless of the method used to pickle them.
 intake24_category_code:en: GHRK
 intake24_category_code:fr: GHRK
 
@@ -111685,6 +111677,10 @@ hr: Svježi krastavci
 pl: Ogórki świeże
 sales_format:en: weight, package
 season_in_country_fr:en: 5,6,7,8,9,10
+
+< en:Cucumbers
+en: Small cucumbers, Gherkins (non-pickled)
+sv: Smågurkor
 
 < en:Vegetables
 en: Endives, Endive, Escaroles


### PR DESCRIPTION
It seems like most products in practice called “gherkins” are actually pickled gherkins, so it probably makes sense to merge these two instead of having a weird pseudo-parent category for pickled and unpickled small cucumbers.

(Also moves “Small cucumbers” (aka “Gherkins (non-pickled)”) to be physically next/closer to “Cucumbers”.)

- Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/11806
- Follow-up-to: 2775e91cb0bf1c3fa5880d31709a49ba754d6f8b
- Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13459
- Follow-up-to: e8c0b5d949a82b6848679a006f0ffde85ef739f5