### PR TITLE
taxonomy(food): add chili pepper flavours

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -20668,6 +20668,19 @@ it: aroma di brandy
 pl: aromat brandy
 
 < en:flavouring
+en: chili pepper flavouring
+da: chilipeppersmag
+fi: chilipippuriaromi
+nl: chilipepersmaak
+sv: chilipepparsmak
+
+< en:flavouring
+en: sweet chili pepper flavouring
+da: sød chilipeppersmag, sød chili-smag, sød chili smag
+fr: base aromatisante piment doux
+sv: söt chilipepparsmak, söt chili-smak
+
+< en:flavouring
 en: maple flavouring
 fr: arôme d'érable
 hr: aroma javora


### PR DESCRIPTION
“Chili pepper flavouring” with and without “sweet”.

Both of these are used for the same thing on `8710398603319` depending on the language: `fr` and `dk/se/no` use “sweet”, `nl` and `fi` don’t. (`de` just uses unspecified “flavouring”.)

Needed-for: https://world.openfoodfacts.org/product/8710398603319/sweet-chilli-pepper-flavour-doritos