### PR TITLE
taxonomy(food): ungarnised sauerkraut ciqual code

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -84964,7 +84964,6 @@ ciqual_food_code:en: 20240
 ciqual_food_name:en: Piperade, Basque-style (fondue of sweet peppers and tomatoes flavoured with onions and garlics)
 ciqual_food_name:fr: Piperade basquaise
 
-
 en: Sauerkrauts
 af: Suurkool
 ar: ساوركراوت
@@ -85035,6 +85034,9 @@ fr: Choucroutes sans garniture
 hr: Kiseli kupus bez ukrasa
 lt: Rauginti kopūstai be garnyro
 nl: Zuurkolen zonder garnering
+ciqual_food_code:en: 25004
+ciqual_food_name:en: Sauerkraut, without garnish, drained
+ciqual_food_name:fr: Choucroute, sans garniture, égouttée
 
 < en:Sauerkrauts without garnish
 en: Cooked sauerkrauts without garnish, Cooked sauerkraut without garnish
@@ -85050,9 +85052,6 @@ ciqual_food_name:fr: Choucroute, sans garniture, égouttée, cuite
 < en:Sauerkrauts without garnish
 en: Raw sauerkrauts without garnish
 fr: Choucroutes crues sans garnitures
-ciqual_food_code:en: 25004
-ciqual_food_name:en: Sauerkraut, without garnish, drained
-ciqual_food_name:fr: Choucroute, sans garniture, égouttée
 
 < en:Meals
 < en:Sauerkrauts


### PR DESCRIPTION
Moves the Ciqual code for “Sauerkraut, without garnish, drained” to “Sauerkrauts without garnish” rather than “Raw sauerkrauts without garnish”. Ciqual entries usually have separate entries for “…, raw”, and the cooked variant/child already has its own `ciqual_food_code` entry.

- Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/12905
- Follow-up-to: 7493df0d5c77b1872bf7144e3e3c51fb2861ecd2