### PR TITLE
taxonomy(product): lambi toilet roll edits

### DIFF
--- a/taxonomies/product/brands.txt
+++ b/taxonomies/product/brands.txt
@@ -91,6 +91,9 @@ wikidata:en: Q276507
 
 xx: Kitchen Everyday
 
+xx: Lambi
+wikidata:en: Q18451494
+
 xx: LEGO
 wikidata:en: Q170484
 

--- a/taxonomies/product/labels.txt
+++ b/taxonomies/product/labels.txt
@@ -115,6 +115,29 @@ pl: Bez perfum
 pt: Sem perfume
 sv: Utan parfym
 
+xx: Asthma Allergy Nordic
+en: Asthma Allergy Nordic
+image:en: asthma-allergy-nordic.90x90.png
+web:en: https://www.asthmaallergynordic.com/
+
+xx: Nordic Swan Ecolabel, Nordic Ecolabel
+en: Nordic Swan Ecolabel, Nordic Ecolabel
+da: Svanemærket, Nordisk miljømærkning
+fi: Joutsenmerkki, pohjoismainen ympäristömerkki, ympäristömerkki, ympäristömerkki miljömärkt
+is: Svansmerkið, Svanurinn, Umhverfismerkið Svanurinn
+nb: Svanemerket, miljømerket
+sv: Svanenmärkt, Svanen, Svanenmärkt miljömärkt
+image:en: nordic-swan-ecolabel.90x90.svg
+image:da: svanemaerket.90x90.svg
+image:sv: svanenmarkt.90x90.svg
+web:en: https://www.nordic-swan-ecolabel.org/
+web:da: https://www.svanemaerket.dk/
+web:fi: https://joutsenmerkki.fi/
+web:is: https://svanurinn.is/
+web:nb: https://svanemerket.no/
+web:sv: https://www.svanen.se/
+wikidata:en: Q3054668
+
 xx: IP 2X
 description:fr: protégé contre les corps solides supérieurs à 12,5 mm. Aucune protection contre les intrusions d'eau.
 


### PR DESCRIPTION
- Adds “Lambi” brand.
- Copies over two labels from the beauty taxonomy’s `labels.txt`.

Needed-for: https://se.openproductsfacts.org/product/6414301054060/wc-papier-lambi