### PR TITLE
taxonomy(food): more peanut edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -58089,6 +58089,7 @@ wco_hs_heading:en: 08.02
 en: Peanuts, ground nuts, groundnuts
 bg: Фъстъци
 ca: Cacauets
+da: Jordnødder, Peanuts
 de: Erdnüsse
 es: Cacahuetes, Cacahuates, Manís
 fi: maapähkinät
@@ -58841,14 +58842,15 @@ wco_hs_heading:en: 20.08
 wikidata:en: Q147651
 
 < en:Peanut butters
-en: Creamy peanut butters
+en: Creamy peanut butters, Smooth peanut butters
 da: Cremede jordnøddesmør, Creamy jordnøddesmør
 pt: Manteigas de amendoim cremosas
 sv: Jordnötssmör utan bitar, Creamy jordnötssmör
+incompatible_with:en: categories:en:crunchy-peanut-butters
 wikidata:en: Q134165564
 
 < en:Peanut butters
-en: Crunchy peanut butters
+en: Crunchy peanut butters, Chunky peanut butters
 da: Sprøde jordnøddesmør, Crunchy jordnøddesmør
 fr: Beurres de cacahuetes croustillants
 hr: Hrskavi maslaci od kikirikija
@@ -58856,6 +58858,7 @@ lt: Traškūs žemės riešutų sviestai
 nl: Pindakzen met stukjes pinda
 pt: Manteigas de amendoim crocantes
 sv: Jordnötssmör med bitar, Crunchy jordnötssmör
+incompatible_with:en: categories:en:creamy-peanut-butters
 
 < en:Peanut butters
 en: Pure peanut butters
@@ -58869,12 +58872,19 @@ sv: Rena jordnötssmör, 100% jordnötssmör
 comment:en: contains only peanut, no added whatever
 expected_ingredients:en: en:peanut
 
+< en:Creamy peanut butters
+< en:Pure peanut butters
+en: Creamy pure peanut butters, Pure creamy peanut butters
+da: Cremede rene jordnøddesmør, Rene cremede jordnøddesmør
+pt: Manteigas de amendoim puras e cremosas, Manteigas de amendoim cremosas puras
+sv: Rena jordnötssmör utan bitar, 100% jordnötssmör utan bitar
+
 < en:Crunchy peanut butters
 < en:Pure peanut butters
 en: Crunchy pure peanut butters, Pure crunchy peanut butters
 da: Sprøde rene jordnøddesmør, Rene sprøde jordnøddesmør
 pt: Manteigas de amendoim puras e crocantes, Manteigas de amendoim crocantes puras
-sv: Rena jordnötssmör med bitarm, 100% jordnötssmör med bitar
+sv: Rena jordnötssmör med bitar, 100% jordnötssmör med bitar
 
 < en:Legume butters
 en: Flavoured peanut butters


### PR DESCRIPTION
- Adds the two other common English terms for peanut butters with or without chunks/crunch.
- Adds Danish translation for “Peanuts”.
- Adds category for pure+creamy peanut butters.
- Adds `incompatible_with` for crunchy/creamy peanut butters.
- Fixes typo in Swedish.

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13554
Follow-up-to: 311aacd6f10937b6063f491f3daddc15dcac8f8e