### PR TITLE
taxonomy: Add Portuguese translations to food categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -1012,7 +1012,6 @@ ciqual_food_name:fr: Petit pot fruit sans banane pour bébé
 < en:From 4 months
 < en:Main meals for babies
 en: Soups for babies, Soups for baby, Soup for babies, Soup for baby
-pt: Sopas para bebês, Sopas para bebê, Sopa para bebês, Sopa para bebê
 de: Babysuppen
 es: Sopas para bebés, Sopas para bebé, Sopa para bebés, Sopa para bebé
 fi: Keitot vauvoille, Keitto vauvoille
@@ -1020,12 +1019,13 @@ fr: Potages pour bébé
 hr: Juhe za bebe
 it: Zuppe e minestre per neonati
 nl: Babysoepen, Babysoep
+pt: Sopas para bebês, Sopas para bebê, Sopa para bebês, Sopa para bebê
 
 < en:From 4 months
 < en:Main meals for babies
 en: Instant cereal powder to be reconstituted for baby from 4/6 months
-pt: Pó de cereais instantâneo para ser reconstituído para bebês a partir de 4/6 meses
 fr: Céréales instantanées en poudre pour bébé dès 4/6 mois
+pt: Pó de cereais instantâneo para ser reconstituído para bebês a partir de 4/6 meses
 agribalyse_food_code:en: 13167
 ciqual_food_code:en: 13167
 ciqual_food_name:en: Instant cereal (powder to be reconstituted) for baby from 4/6 months
@@ -1034,13 +1034,13 @@ ciqual_food_name:fr: Céréales instantanées, poudre à reconstituer, dès 4/6 
 < en:From 6 months
 < en:Main meals for babies
 en: Instant cereal powder to be reconstituted for baby from 6 months
-pt: Pó de cereais instantâneo para ser reconstituído para bebês a partir de 6 meses
 de: Instantes Getreidepulver zur Zubereitung für Babys ab 6 Monaten
 es: Cereal en polvo instantáneo para bebés a partir de 6 meses
 fr: Céréales instantanées en poudre pour bébé dès 6 mois
 hr: Instant žitarice u prahu za rekonstituciju za bebe od 6 mjeseci
 it: Cereali in polvere istantanei da reidratare per bambini a partire dai 6 mesi
 nl: Instante graanpoeder om te reconstitueren voor baby's vanaf 6 maanden
+pt: Pó de cereais instantâneo para ser reconstituído para bebês a partir de 6 meses
 agribalyse_food_code:en: 13168
 ciqual_food_code:en: 13168
 ciqual_food_name:en: Instant cereal (powder to be reconstituted) for baby from 6 months
@@ -1048,13 +1048,13 @@ ciqual_food_name:fr: Céréales instantanées, poudre à reconstituer, dès 6 mo
 
 < en:Main meals for babies
 en: Soup for baby with vegetables and cereals and milk
-pt: Sopa para bebês com vegetais, cereais e leite
 de: Suppe für Baby mit Gemüse, Getreide und Milch
 es: Sopa para bebé con verduras, cereales y leche
 fr: Soupe pour bébé aux légumes aux céréales et au lait
 hr: Juha za bebu s povrćem i žitaricama i mlijekom
 it: Zuppa per bambini con verdure, cereali e latte
 nl: Soep voor baby met groenten, granen en melk
+pt: Sopa para bebês com vegetais, cereais e leite
 agribalyse_food_code:en: 20253
 ciqual_food_code:en: 20253
 ciqual_food_name:en: Soup for baby, with vegetables, cereals and milk
@@ -1062,13 +1062,13 @@ ciqual_food_name:fr: Soupe pour bébé légumes, céréales et lait
 
 < en:Main meals for babies
 en: Soup for baby with vegetables and potatoes
-pt: Sopa para bebê com vegetais e batatas
 da: Babysuppe med grøntsager og kartofler
 de: Suppe für Baby mit Gemüse und Kartoffeln
 es: Sopa para bebé con verduras y papas
 fr: Soupe pour bébé aux légumes et aux pommes de terre
 hr: Juha za bebu s povrćem i krumpirom
 nl: Soep voor baby met groenten en aardappelen, Babysoepen met groenten en aardappelen
+pt: Sopa para bebê com vegetais e batatas
 agribalyse_food_code:en: 20252
 ciqual_food_code:en: 20252
 ciqual_food_name:en: Soup for baby, with vegetables and potatoes
@@ -1077,12 +1077,12 @@ ciqual_food_name:fr: Soupe pour bébé légumes et pomme de terre
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 6 months with starch and fish
-pt: Prato de vegetais para bebês a partir de 6 meses com amido e peixe
 es: Plato de verduras para bebés a partir de los 6 meses con almidón y pescado
 fr: Plat avec légumes pour bébés dès 6 mois avec féculents et poisson
 hr: Jelo od povrća za bebe od 6 mjeseci sa škrobom i ribom
 it: Piatto di verdure per bambini dai 6 mesi con amido e pesce
 nl: Groentegerecht voor baby's vanaf 6 maanden met zetmeel en vis
+pt: Prato de vegetais para bebês a partir de 6 meses com amido e peixe
 agribalyse_food_code:en: 42603
 ciqual_food_code:en: 42603
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 6-8 months
@@ -1091,8 +1091,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 6-8 m
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 6 months with starch and meat
-pt: Prato de vegetais para bebês a partir de 6 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 6 mois avec féculents et viande
+pt: Prato de vegetais para bebês a partir de 6 meses com amido e carne
 agribalyse_food_code:en: 42603
 ciqual_food_code:en: 42603
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 6-8 months
@@ -1101,8 +1101,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 6-8 m
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 6 months, Vegetable dish for baby with cream and starch from 6-8 months
-pt: Prato de vegetais para bebê com leite e amido a partir de 6 meses, Prato de vegetais para bebê com creme e amido a partir de 6-8 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 6 mois, Plat de légumes et féculents avec crème pour bébé dès 6-8 mois
+pt: Prato de vegetais para bebê com leite e amido a partir de 6 meses, Prato de vegetais para bebê com creme e amido a partir de 6-8 meses
 agribalyse_food_code:en: 20249
 ciqual_food_code:en: 20249
 ciqual_food_name:en: Vegetable dish for baby, with milk/cream and starch, from 6-8 months
@@ -1111,8 +1111,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et lait/crème, dès 6-8 mois
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for baby from 6 months with starch
-pt: Prato de vegetais para bebê a partir de 6 meses com amido
 fr: Plat de légumes et féculents pour bébés dès 6 mois
+pt: Prato de vegetais para bebê a partir de 6 meses com amido
 agribalyse_food_code:en: 20248
 ciqual_food_code:en: 20248
 ciqual_food_name:en: Vegetable dish for baby, with starch, from 6-8 months
@@ -1121,12 +1121,12 @@ ciqual_food_name:fr: Plat légumes, avec féculent, dès 6-8 mois
 < en:From 8 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 8 months with starch and fish
-pt: Prato de vegetais para bebês a partir de 8 meses com amido e peixe
 es: Plato de verduras para bebés a partir de los 8 meses con almidón y pescado
 fr: Plat avec légumes pour bébés dès 8 mois avec féculents et poisson
 hr: Jelo od povrća za bebe od 8 mjeseci sa škrobom i ribom
 it: Piatto di verdure per bambini dai 8 mesi con amido e pesce
 nl: Groentegerecht voor baby's vanaf 8 maanden met zetmeel en vis
+pt: Prato de vegetais para bebês a partir de 8 meses com amido e peixe
 agribalyse_food_code:en: 42604
 ciqual_food_code:en: 42604
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 8-12 months
@@ -1135,8 +1135,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 8-12 
 < en:From 8 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 8 months with starch and meat
-pt: Prato de vegetais para bebês a partir de 8 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 8 mois avec féculents et viande
+pt: Prato de vegetais para bebês a partir de 8 meses com amido e carne
 agribalyse_food_code:en: 42604
 ciqual_food_code:en: 42604
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 8-12 months
@@ -1145,8 +1145,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 8-12 
 < en:From 8 months
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 8 months, Vegetable dish for baby with cream and starch from 8 months
-pt: Prato de vegetais para bebê com leite e amido a partir de 8 meses, Prato de vegetais para bebê com creme e amido a partir de 8 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 8 mois, Plat de légumes et féculents avec crème pour bébé dès 8 mois
+pt: Prato de vegetais para bebê com leite e amido a partir de 8 meses, Prato de vegetais para bebê com creme e amido a partir de 8 meses
 agribalyse_food_code:en: 20250
 ciqual_food_code:en: 20250
 ciqual_food_name:en: Vegetable dish for baby, with milk/cream and starch, from 8-12 months
@@ -1155,12 +1155,12 @@ ciqual_food_name:fr: Plat légumes, avec féculent et lait/crème, dès 8-12 moi
 < en:From 12 months old
 < en:Main meals for babies
 en: Vegetable dish for babies from 12 months with starch and fish
-pt: Prato de vegetais para bebês a partir de 12 meses com amido e peixe
 es: Plato de verduras para bebés a partir de los 12 meses con almidón y pescado
 fr: Plat avec légumes pour bébés dès 12 mois avec féculents et poisson
 hr: Jelo od povrća za bebe od 12 mjeseci sa škrobom i ribom
 it: Piatto di verdure per bambini dai 12 mesi con amido e pesce
 nl: Groentegerecht voor baby's vanaf 12 maanden met zetmeel en vis
+pt: Prato de vegetais para bebês a partir de 12 meses com amido e peixe
 agribalyse_food_code:en: 42605
 ciqual_food_code:en: 42605
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 12 months
@@ -1169,8 +1169,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 12 mo
 < en:From 12 months old
 < en:Main meals for babies
 en: Vegetable dish for babies from 12 months with starch and meat
-pt: Prato de vegetais para bebês a partir de 12 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 12 mois avec féculents et viande
+pt: Prato de vegetais para bebês a partir de 12 meses com amido e carne
 agribalyse_food_code:en: 42605
 ciqual_food_code:en: 42605
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 12 months
@@ -1179,8 +1179,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 12 mo
 < en:From 12 months old
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 12 months, Vegetable dish for baby with cream and starch from 12 months
-pt: Prato de vegetais para bebê com leite e amido a partir de 12 meses, Prato de vegetais para bebê com creme e amido a partir de 12 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 12 mois, Plat de légumes et féculents avec crème pour bébé dès 12 mois
+pt: Prato de vegetais para bebê com leite e amido a partir de 12 meses, Prato de vegetais para bebê com creme e amido a partir de 12 meses
 agribalyse_food_code:en: 20251
 ciqual_food_code:en: 20251
 ciqual_food_name:en: Vegetable dish for baby, with milk/cream and starch, from 12 months
@@ -1189,8 +1189,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et lait/crème, dès 12 mois
 < en:From 18 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 18 months with starch and fish
-pt: Prato de vegetais para bebês a partir de 18 meses com amido e peixe
 fr: Plat avec légumes pour bébés dès 18 mois avec féculents et poisson
+pt: Prato de vegetais para bebês a partir de 18 meses com amido e peixe
 agribalyse_food_code:en: 42606
 ciqual_food_code:en: 42606
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 18 months
@@ -1199,8 +1199,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 18 mo
 < en:From 18 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 18 months with starch and meat
-pt: Prato de vegetais para bebês a partir de 18 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 18 mois avec féculents et viande
+pt: Prato de vegetais para bebês a partir de 18 meses com amido e carne
 agribalyse_food_code:en: 42606
 ciqual_food_code:en: 42606
 ciqual_food_name:en: Vegetable dish for baby, w meat/fish and starch, from 18 months
@@ -1209,8 +1209,8 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 18 mo
 < en:From 18 months
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 18 months, Vegetable dish for baby with cream and starch from 18 months
-pt: Prato de vegetais para bebê com leite e amido a partir de 18 meses, Prato de vegetais para bebê com creme e amido a partir de 18 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 18 mois, Plat de légumes et féculents avec bébé pour enfant dès 18 mois
+pt: Prato de vegetais para bebê com leite e amido a partir de 18 meses, Prato de vegetais para bebê com creme e amido a partir de 18 meses
 agribalyse_food_code:en: 20254
 ciqual_food_code:en: 20254
 ciqual_food_name:en: Vegetable dish for baby, with milk/cream and starch, from 18 months
@@ -1325,7 +1325,6 @@ wikidata:en: Q79932
 
 < en:Pollens
 en: Partially dried pollen
-pt: Pólen parcialmente seco
 da: Delvist tørret pollen
 de: Teilweise getrockneter Pollen
 es: Polen parcialmente seco
@@ -1334,13 +1333,13 @@ hr: Djelomično osušeni pelud
 hu: Részlegesen szárított virágpor
 it: Pollen parzialmente essiccato
 nl: Gedeeltelijk gedroogd stuifmeel
+pt: Pólen parcialmente seco
 ciqual_food_code:en: 31109
 ciqual_food_name:en: Pollen, partially dried
 ciqual_food_name:fr: Pollen, partiellement séché
 
 < en:Pollens
 en: Fresh pollen
-pt: Pólen fresco
 da: Frisk pollen
 de: Frischer Pollen
 es: Polen fresco
@@ -1349,6 +1348,7 @@ hr: Svježi pelud
 hu: Friss virágpor
 it: Pollen fresco
 nl: Verse pollen
+pt: Pólen fresco
 ciqual_food_code:en: 31111
 ciqual_food_name:en: Pollen, fresh
 ciqual_food_name:fr: Pollen,frais

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -1012,6 +1012,7 @@ ciqual_food_name:fr: Petit pot fruit sans banane pour bébé
 < en:From 4 months
 < en:Main meals for babies
 en: Soups for babies, Soups for baby, Soup for babies, Soup for baby
+pt: Sopas para bebês, Sopas para bebê, Sopa para bebês, Sopa para bebê
 de: Babysuppen
 es: Sopas para bebés, Sopas para bebé, Sopa para bebés, Sopa para bebé
 fi: Keitot vauvoille, Keitto vauvoille
@@ -1023,6 +1024,7 @@ nl: Babysoepen, Babysoep
 < en:From 4 months
 < en:Main meals for babies
 en: Instant cereal powder to be reconstituted for baby from 4/6 months
+pt: Pó de cereais instantâneo para ser reconstituído para bebês a partir de 4/6 meses
 fr: Céréales instantanées en poudre pour bébé dès 4/6 mois
 agribalyse_food_code:en: 13167
 ciqual_food_code:en: 13167
@@ -1032,6 +1034,7 @@ ciqual_food_name:fr: Céréales instantanées, poudre à reconstituer, dès 4/6 
 < en:From 6 months
 < en:Main meals for babies
 en: Instant cereal powder to be reconstituted for baby from 6 months
+pt: Pó de cereais instantâneo para ser reconstituído para bebês a partir de 6 meses
 de: Instantes Getreidepulver zur Zubereitung für Babys ab 6 Monaten
 es: Cereal en polvo instantáneo para bebés a partir de 6 meses
 fr: Céréales instantanées en poudre pour bébé dès 6 mois
@@ -1045,6 +1048,7 @@ ciqual_food_name:fr: Céréales instantanées, poudre à reconstituer, dès 6 mo
 
 < en:Main meals for babies
 en: Soup for baby with vegetables and cereals and milk
+pt: Sopa para bebês com vegetais, cereais e leite
 de: Suppe für Baby mit Gemüse, Getreide und Milch
 es: Sopa para bebé con verduras, cereales y leche
 fr: Soupe pour bébé aux légumes aux céréales et au lait
@@ -1058,6 +1062,7 @@ ciqual_food_name:fr: Soupe pour bébé légumes, céréales et lait
 
 < en:Main meals for babies
 en: Soup for baby with vegetables and potatoes
+pt: Sopa para bebê com vegetais e batatas
 da: Babysuppe med grøntsager og kartofler
 de: Suppe für Baby mit Gemüse und Kartoffeln
 es: Sopa para bebé con verduras y papas
@@ -1072,6 +1077,7 @@ ciqual_food_name:fr: Soupe pour bébé légumes et pomme de terre
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 6 months with starch and fish
+pt: Prato de vegetais para bebês a partir de 6 meses com amido e peixe
 es: Plato de verduras para bebés a partir de los 6 meses con almidón y pescado
 fr: Plat avec légumes pour bébés dès 6 mois avec féculents et poisson
 hr: Jelo od povrća za bebe od 6 mjeseci sa škrobom i ribom
@@ -1085,6 +1091,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 6-8 m
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 6 months with starch and meat
+pt: Prato de vegetais para bebês a partir de 6 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 6 mois avec féculents et viande
 agribalyse_food_code:en: 42603
 ciqual_food_code:en: 42603
@@ -1094,6 +1101,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 6-8 m
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 6 months, Vegetable dish for baby with cream and starch from 6-8 months
+pt: Prato de vegetais para bebê com leite e amido a partir de 6 meses, Prato de vegetais para bebê com creme e amido a partir de 6-8 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 6 mois, Plat de légumes et féculents avec crème pour bébé dès 6-8 mois
 agribalyse_food_code:en: 20249
 ciqual_food_code:en: 20249
@@ -1103,6 +1111,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et lait/crème, dès 6-8 mois
 < en:From 6 months
 < en:Main meals for babies
 en: Vegetable dish for baby from 6 months with starch
+pt: Prato de vegetais para bebê a partir de 6 meses com amido
 fr: Plat de légumes et féculents pour bébés dès 6 mois
 agribalyse_food_code:en: 20248
 ciqual_food_code:en: 20248
@@ -1112,6 +1121,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent, dès 6-8 mois
 < en:From 8 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 8 months with starch and fish
+pt: Prato de vegetais para bebês a partir de 8 meses com amido e peixe
 es: Plato de verduras para bebés a partir de los 8 meses con almidón y pescado
 fr: Plat avec légumes pour bébés dès 8 mois avec féculents et poisson
 hr: Jelo od povrća za bebe od 8 mjeseci sa škrobom i ribom
@@ -1125,6 +1135,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 8-12 
 < en:From 8 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 8 months with starch and meat
+pt: Prato de vegetais para bebês a partir de 8 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 8 mois avec féculents et viande
 agribalyse_food_code:en: 42604
 ciqual_food_code:en: 42604
@@ -1134,6 +1145,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 8-12 
 < en:From 8 months
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 8 months, Vegetable dish for baby with cream and starch from 8 months
+pt: Prato de vegetais para bebê com leite e amido a partir de 8 meses, Prato de vegetais para bebê com creme e amido a partir de 8 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 8 mois, Plat de légumes et féculents avec crème pour bébé dès 8 mois
 agribalyse_food_code:en: 20250
 ciqual_food_code:en: 20250
@@ -1143,6 +1155,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et lait/crème, dès 8-12 moi
 < en:From 12 months old
 < en:Main meals for babies
 en: Vegetable dish for babies from 12 months with starch and fish
+pt: Prato de vegetais para bebês a partir de 12 meses com amido e peixe
 es: Plato de verduras para bebés a partir de los 12 meses con almidón y pescado
 fr: Plat avec légumes pour bébés dès 12 mois avec féculents et poisson
 hr: Jelo od povrća za bebe od 12 mjeseci sa škrobom i ribom
@@ -1156,6 +1169,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 12 mo
 < en:From 12 months old
 < en:Main meals for babies
 en: Vegetable dish for babies from 12 months with starch and meat
+pt: Prato de vegetais para bebês a partir de 12 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 12 mois avec féculents et viande
 agribalyse_food_code:en: 42605
 ciqual_food_code:en: 42605
@@ -1165,6 +1179,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 12 mo
 < en:From 12 months old
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 12 months, Vegetable dish for baby with cream and starch from 12 months
+pt: Prato de vegetais para bebê com leite e amido a partir de 12 meses, Prato de vegetais para bebê com creme e amido a partir de 12 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 12 mois, Plat de légumes et féculents avec crème pour bébé dès 12 mois
 agribalyse_food_code:en: 20251
 ciqual_food_code:en: 20251
@@ -1174,6 +1189,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et lait/crème, dès 12 mois
 < en:From 18 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 18 months with starch and fish
+pt: Prato de vegetais para bebês a partir de 18 meses com amido e peixe
 fr: Plat avec légumes pour bébés dès 18 mois avec féculents et poisson
 agribalyse_food_code:en: 42606
 ciqual_food_code:en: 42606
@@ -1183,6 +1199,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 18 mo
 < en:From 18 months
 < en:Main meals for babies
 en: Vegetable dish for babies from 18 months with starch and meat
+pt: Prato de vegetais para bebês a partir de 18 meses com amido e carne
 fr: Plat aux légumes pour bébés dès 18 mois avec féculents et viande
 agribalyse_food_code:en: 42606
 ciqual_food_code:en: 42606
@@ -1192,6 +1209,7 @@ ciqual_food_name:fr: Plat légumes, avec féculent et viande/poisson, dès 18 mo
 < en:From 18 months
 < en:Main meals for babies
 en: Vegetable dish for baby with milk and starch from 18 months, Vegetable dish for baby with cream and starch from 18 months
+pt: Prato de vegetais para bebê com leite e amido a partir de 18 meses, Prato de vegetais para bebê com creme e amido a partir de 18 meses
 fr: Plat de légumes et féculents avec lait pour bébé dès 18 mois, Plat de légumes et féculents avec bébé pour enfant dès 18 mois
 agribalyse_food_code:en: 20254
 ciqual_food_code:en: 20254
@@ -1287,6 +1305,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Royal_jelly
 
 < en:Bee products
 en: Pollens
+xx: Pollens
 da: Pollen
 de: Pollen
 es: Polen
@@ -1306,6 +1325,7 @@ wikidata:en: Q79932
 
 < en:Pollens
 en: Partially dried pollen
+pt: Pólen parcialmente seco
 da: Delvist tørret pollen
 de: Teilweise getrockneter Pollen
 es: Polen parcialmente seco
@@ -1320,6 +1340,7 @@ ciqual_food_name:fr: Pollen, partiellement séché
 
 < en:Pollens
 en: Fresh pollen
+pt: Pólen fresco
 da: Frisk pollen
 de: Frischer Pollen
 es: Polen fresco


### PR DESCRIPTION
Added Portuguese (`pt:`) translations for 20 missing baby food and vegetable dish categories in `taxonomies/food/categories.txt`. Also used the multilingual catchall (`xx:`) for `Pollens` where the translation matches the English original.

---
*PR created automatically by Jules for task [5605951683545681989](https://jules.google.com/task/5605951683545681989) started by @teolemon*