### PR TITLE
taxonomy: Add Portuguese translations for some ingredients

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -192,6 +192,7 @@ en: frying
 fr: friture
 hr: prženje
 it: fritto, frittura
+pt: fritura
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -647,6 +648,7 @@ it: gelatina
 ja: ゼラチン
 lt: želatina, želatinos
 pl: żelatyna, żelatyna spożywcza
+pt: gelatina
 # ingredient/fr:gélatine has 1575 products in 12 languages @2019-02-10
 description:en: GELATIN or GELATINE is a translucent, colorless, brittle (when dry), flavorless food ingredient that is derived from collagen obtained from various animal body parts.
 vegan:en: no
@@ -667,6 +669,7 @@ it: gelatina di manzo
 lt: jautienos želatina
 nl: rundergelatine
 pl: żelatyna wołowa
+pt: gelatina bovina, gelatina de vaca, gelatina de carne
 # ingredient/fr:gélatine-de-bœuf has 216 products in 4 languages @2019-02-10
 vegan:en: no
 vegetarian:en: no
@@ -684,6 +687,7 @@ hr: riblja želatina
 it: gelatina di pesce
 lt: žuvies želatina
 nl: visgelatine
+pt: gelatina de peixe
 allergens:en: en:fish
 vegan:en: no
 vegetarian:en: no
@@ -698,13 +702,13 @@ it: gelatina non suina
 
 < en:gelatin
 < en:poultry
-fr: gélatine de volaille
 bg: птичи желатин
 ca: gelatina d'aviram
 da: fjerkrægelatine
 de: Geflügelgelatine
 es: gelatina de pollo
 fi: siipikarjaliivate
+fr: gélatine de volaille
 hr: želatina od peradi
 hu: baromfihús-zselatin
 it: gelatina di pollame
@@ -966,6 +970,7 @@ fi: tapiokadekstriini
 fr: dextrine de tapioca, dextrine de manioc
 hr: tapioka dekstrin
 it: destrina di tapioca
+pt: dextrina de tapioca
 pl: dekstryny z tapioki, dekstryna z tapioki
 # ingredient/fr:dextrine-de-tapioca has 49 products in 4 languages @2019-01-26
 
@@ -979,6 +984,7 @@ fr: dextrine de pomme de terre
 hr: krumpirov dekstrin
 it: destrina di patate
 nl: aardappeldextrine
+pt: dextrina de batata
 
 < en:E1400
 bg: пшеничен декстрин
@@ -996,6 +1002,7 @@ de: Maisdextrin
 es: dextrina de maiz
 fi: maissidekstriini
 fr: dextrine de maïs
+pt: dextrina de milho
 hr: kukuruzni dekstrin
 hu: kukoricadextrin, dextrin kukoricából
 it: Destrina di mais
@@ -28085,6 +28092,7 @@ hu: quinoa liszt, quinoaliszt
 it: Farina di quinoa
 nl: quinoameel
 pl: mąka z komosy ryżowej
+pt: farinha de quinoa
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/quinoa-flour
 # 173 products in 5 languages @2018-09-22
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -970,8 +970,8 @@ fi: tapiokadekstriini
 fr: dextrine de tapioca, dextrine de manioc
 hr: tapioka dekstrin
 it: destrina di tapioca
-pt: dextrina de tapioca
 pl: dekstryny z tapioki, dekstryna z tapioki
+pt: dextrina de tapioca
 # ingredient/fr:dextrine-de-tapioca has 49 products in 4 languages @2019-01-26
 
 < en:E1400
@@ -1002,11 +1002,11 @@ de: Maisdextrin
 es: dextrina de maiz
 fi: maissidekstriini
 fr: dextrine de maïs
-pt: dextrina de milho
 hr: kukuruzni dekstrin
 hu: kukoricadextrin, dextrin kukoricából
 it: Destrina di mais
 nl: maïsdextrine
+pt: dextrina de milho
 # ingredient/fr:dextrine-de-maïs has 39 products in 3 languages @2019-01-26
 
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -669,7 +669,7 @@ it: gelatina di manzo
 lt: jautienos želatina
 nl: rundergelatine
 pl: żelatyna wołowa
-pt: gelatina bovina, gelatina de vaca, gelatina de carne
+pt: gelatina bovina, gelatina de vaca
 # ingredient/fr:gélatine-de-bœuf has 216 products in 4 languages @2019-02-10
 vegan:en: no
 vegetarian:en: no
@@ -94189,4 +94189,3 @@ description:en: “Paprika” can be either the dried powder or the fruit of a p
 en: vitamin and mineral blend, vitamin and mineral mix
 it: vitamine e minerali misti
 ru: витаминно минеральный премикс, витаминный премикс
-


### PR DESCRIPTION
Added Portuguese translations for gelatin, beef gelatin, fish gelatine, tapioca dextrin, potato dextrin, corn dextrin, frying, and quinoa flour to `taxonomies/food/ingredients.txt`. The translations are properly formatted and alphabetically sorted by language tags within their respective blocks. Checked for exact matches to use `xx:` prefix but all translated terms differ from the English ones, so `pt:` was used.

---
*PR created automatically by Jules for task [6437299340663266304](https://jules.google.com/task/6437299340663266304) started by @teolemon*