### PR TITLE
taxonomy(food): edits for a glutenfree crispbread

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -57,6 +57,8 @@ synonyms:sv: matvaror, matvara, mat
 
 synonyms:hu: koncentrátumból, sűrítményből, koncentrátum, sűrítmény
 
+synonyms:da: glutenfri, glutenfrie, glutenfrit
+
 stopwords:fr: aux, au, de, le, du, la, a, et, avec, base
 stopwords:ca: als, a les, de, el, del, de la, la, té, i, amb, base
 stopwords:nl: bevat, en
@@ -36745,6 +36747,7 @@ nl: Glutenvrije broden, Glutenvrij brood, Broden zonder gluten
 pl: Pieczywo bezglutenowe
 pt: Pães sem glúten
 ro: Pâini fără gluten, Pâine fără gluten
+sv: Glutenfria bröd
 agribalyse_food_code:en: 7130
 ciqual_food_code:en: 7130
 ciqual_food_name:en: Bread, gluten free
@@ -100504,6 +100507,7 @@ nl: Producten verkocht i de jaren 90
 en: Products without gluten, gluten-free products, gluten free
 bg: Продукти без глутен
 cs: Bezlepkové potraviny
+da: Produkter uden gluten, Glutenfri produkter
 de: Glutenfrei
 es: Productos sin gluten
 fi: gluteeniton
@@ -100516,6 +100520,7 @@ nl: Glutenvrije producten
 pl: Produkty bezglutenowe
 pt: Produtos sem glútem
 ru: Безглютеновые продукты
+sv: Produkter utan gluten, Glutenfria produkter
 
 < en:Products without gluten
 en: Gluten free bread mixes

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -3735,6 +3735,7 @@ tr: yağsız süt tozu, kaymağı alınmış süt tozu
 ciqual_food_code:en: 19054
 ciqual_food_name:en: Milk, powder, skimmed
 ciqual_food_name:fr: Lait en poudre, écrémé
+wikidata:en: Q120598270
 
 < en:milk powder
 en: whole milk powder, dried whole milk, powdered whole milk, whole powdered milk, whole dry milk, dry whole milk
@@ -30376,7 +30377,7 @@ kn: ಸಕ್ಕರೆ
 ko: 설탕
 ku: Şekir
 ky: Кант
-la: Saccharum
+la: saccharum
 li: Sókker
 ln: Sukáli
 lt: Cukrus
@@ -30866,14 +30867,111 @@ vegetarian:en: yes
 wikidata:en: Q402587
 
 en: sugarcane, sugar cane
+am: ሸንኮራ ኣገዳ
+ar: قصب السكر
+as: কুঁহিয়াৰ
+az: dərman şəkərqamışı
+be: цукровы трыснёг
 bg: захарна тръстика
+bi: sugarcane
+bn: আখ
+bo: བུར་ཤིང་།
+bs: šećerna trska
+ca: saccharum
+ch: tupu
+cs: cukrová třtina
+cy: cansen siwgr
 da: sukkerrør
 de: Zuckerrohr
+dv: އުއްދަނޑި
+el: ζαχαροκάλαμο
+eo: sukerkano
+es: caña de azúcar
+et: suhkruroog
+eu: azukre-kanabera
+fa: نیشکر
+fi: sokeriruoko
+fj: dovu
 fr: canne à sucre, cannes à sucre
-hr: šećerne repice
+ga: cána siúcra
+gl: cana de azucre
+gn: takuare'ẽ
+gu: શેરડી
+gv: cane millish
+ha: rake
+hi: गन्ना
+hr: šećerna trska
+ht: kann
+hu: cukornád
+id: tebu
+ig: okpete
+io: sukrokano
+is: sykurreyr
 it: canna da zucchero
+ja: サトウキビ
+jv: tebu
+ka: შაქრის ლერწამი
+kg: nkuku
+kn: ಕಬ್ಬು
+ko: 사탕수수
+ky: бал камыш
+#la: saccharum  # “saccharum” is also the latin word for en:sugar
+lg: kikajjo
+lt: cukranendrė
+lv: cukurniedres
+mg: fary
+mi: tō
+mk: шеќерна трска
+ml: കരിമ്പ്
+mn: чихрийн нишингэ
+mr: ऊस
+ms: tebu
+my: ကြံပင်
+nb: sukkerrør
+ne: उखु
+nl: suikerriet
+nn: sukkerrøyr
+nv: dáʼákaz łikaní
+oc: cana de sucre
+or: ଆଖୁ
+pa: ਗੰਨਾ
+pl: trzcina cukrowa
+ps: گني
+pt: cana-de-açúcar
+qu: misk'i wiru
+rn: isuka
+ro: trestie de zahăr
+ru: сахарный тростник
+sh: šećerna trska
+sk: cukrová trstina
+sl: sladkorni trst
+sn: nzimbe
+so: qassab
+sq: kallam Sheqeri
+sr: шећерна трска
+su: tiwu
+sv: sockerrör
+sw: muwa
+ta: கரும்பு
+te: చెరకు
+th: อ้อย
+tl: tubo
+to: tō
+tr: şeker kamışı
+ts: xikhovha xa chukele
+tw: ahwedeɛ
+uk: цукрова тростина
+ur: گنا
+uz: shakarqamish
+vi: mía
+yi: צוקערראר
+yo: ìrèké
+za: oij
+zh: 甘蔗
+zu: umoba
 vegan:en: yes
 vegetarian:en: yes
+wikidata:en: Q36940
 
 < en:sugarcane
 en: sugarcane juice, cane juice
@@ -36706,7 +36804,7 @@ nb: surdeig
 nl: zuurdesem, zuurdeeg, desem
 nn: surdeig
 pl: Zakwas chlebowy, zakwas, zakwasu, zakwas piekarski
-pt: Massa lêveda
+pt: massa lêveda, massa fermentada
 ru: Хлебная закваска
 sh: Кисело тесто
 sk: Kvások
@@ -36918,6 +37016,13 @@ fr: levain naturel de riz
 hr: prirodno kiselo tijesto od riže
 it: lievito madre naturale di riso
 pl: naturalny zakwas ryżowy
+
+< en:rice sourdough
+< en:sourdough powder
+en: rice sourdough powder
+da: rissurdejspulver
+nl: rijstzuurdesempoeder
+sv: rissurdegspulver, surdegspulver av ris
 
 < en:sourdough
 en: inactive sourdough starter
@@ -68750,7 +68855,7 @@ fr: betterave sucrière
 gl: remolacha azucreira
 gv: beetys shugyr
 he: סלק סוכר
-hr: šećerna repa
+hr: šećerna repa, šećerne repice
 hu: cukorrépa
 hy: շաքարի ճակնդեղ
 io: betravo
@@ -87438,8 +87543,8 @@ ja: 水溶性食物繊維
 nl: oplosbare vezels
 pl: błonnik rozpuszczalny, rozpuszczalny błonnik
 
-< en:fiber
 < en:flax seed
+< en:vegetable fiber
 en: flax seed fiber, flaxseed fiber, flax fiber, flax fibers
 da: hørfrøfiber
 fi: pellavansiemenkuitu
@@ -87449,13 +87554,16 @@ it: fibra di semi di lino
 no: linfrøfiber
 sv: linfröfiber
 
-< en:fiber
 < en:sugarcane
+< en:vegetable fiber
 en: sugarcane fiber, sugarcane fibers
+da: sukkerrørsfiber
 fr: fibre de canne à sucre, fibres de canne à sucre
 hr: vlakna šećerne trske
 it: fibra di canna da zucchero
 pl: błonnik z trzciny cukrowej
+pt: fibra de cana-de-açúcar
+sv: sockerrörsfiber, sockerrörfiber
 
 < en:fiber
 en: betaglucan, β-glucane
@@ -87594,7 +87702,7 @@ it: fibra di ceci
 
 < en:vegetable fiber
 en: sugar beet fibre, sugar beet fiber
-da: sukkerrørsfiber, sukkerroefiber
+da: sukkerroefiber
 de: zuckerrübenfaser
 fi: sokerijuurikaskuitu
 fr: fibre de betterave sucrière

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -2804,23 +2804,41 @@ uk: гомогенізований, гомогенізована, гомоген
 wikidata:en: Q1165158
 wikipedia:en: https://en.wikipedia.org/wiki/Homogenization_(chemistry)
 
-# for ingredients, lactose-free is not a processing but involves a chemical process,
-# use of enzyme lactase to break down lactose into simpler sugars (glucose and galactose),
-# which are easier to digest for those with lactose intolerance.
-en: lactose-free
+en: lactose-free, lactose free
 bg: без лактоза, безлактозно
+bn: ল্যাকটোজ মুক্ত
+br: hep laktoz
 ca: sense lactosa
-de: laktosefreie
+de: laktosefrei, laktosefreie
 es: sin lactosa
+et: laktoosivaba
+fi: laktoositon
 fr: sans lactose
+gl: sen lactosa
+hi: लैक्टोज मुक्त
 hr: bez laktoze
+hu: laktózmentes
+hy: առանց լակտոզի
+id: bebas laktosa
 it: delattosato, senza lattosio
-nl: lactosevrije
+ka: ულაქტოზო
+mk: без лактоза
+ml: ലാക്ടോസ് രഹിതം
+ms: bebas laktosa
+nb: laktosefri
+ne: ल्याक्टोज निःशुल्क
+nl: lactose vrij, lactosevrije
 pl: bez laktozy
 pt: sem lactose
 ro: fără lactoză
-sv: laktosfri
+ru: без лактозы
+se: laktosakeahtes
+sq: pa laktozë
+sv: laktosfri, laktosfritt, laktosfria
+tr: laktozsuz
 uk: без лактози, безлактозний, безлактозна, безлактозне, безлактозні
+description:en: for ingredients, “lactose-free” is not a processing per se, but involves a chemical process, use of enzyme lactase to break down lactose into simpler sugars (glucose and galactose), which are easier to digest for those with lactose intolerance.
+wikidata:en: Q11874508
 
 # result of a filtration
 en: filtrate


### PR DESCRIPTION
- Adds Danish and Swedish translations and synonyms.
- Adds Wikidata properties.
- Adds translations/synonyms from Wikidata.
- Adds new ingredient `rice sourdough powder`.
- Moves `hr:šećerne repice` to sugar beets.
- Makes flax and sugar cane fibers be children of vegetable fiber instead of generic fiber.
- Moves a commented out block into a `description` property.
  - Also did some minor editing of it.

Needed-for: https://se.openfoodfacts.org/product/7300400481861/laktosfri-glutenfri-naturella-kn%C3%A4ckebr%C3%B6d-wasa