### PR TITLE
fix: flush memcached in remove_all_results in tests

### DIFF
--- a/lib/ProductOpener/Test.pm
+++ b/lib/ProductOpener/Test.pm
@@ -260,6 +260,8 @@ sub remove_all_products () {
 	# Note: we do not remove categories stats from PRIVATE_DATA and TEST_PRIVATE_DATA
 	# In integration tests, PRIVATE_DATA/categories_stats should not exist,
 	# and categories stats should be loaded from TEST_PRIVATE_DATA/categories_stats
+
+	return;
 }
 
 =head2 remove_all_users ()

--- a/lib/ProductOpener/Test.pm
+++ b/lib/ProductOpener/Test.pm
@@ -67,6 +67,7 @@ use IO::Capture::Stdout::Extended;
 use IO::Capture::Stderr::Extended;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Cache qw/$memd/;
 use ProductOpener::Data qw/execute_query get_orgs_collection get_products_collection get_recent_changes_collection/;
 use ProductOpener::Store "store";
 use ProductOpener::Auth qw/get_token_using_client_credentials get_oidc_implementation_level/;
@@ -254,6 +255,8 @@ sub remove_all_products () {
 	if (@$err) {
 		confess("not able to remove some products directories: " . join(":", @$err));
 	}
+	# flush Memcached to avoid stale cache entries (search results) from previous test files
+	$memd->flush_all();
 	# Note: we do not remove categories stats from PRIVATE_DATA and TEST_PRIVATE_DATA
 	# In integration tests, PRIVATE_DATA/categories_stats should not exist,
 	# and categories stats should be loaded from TEST_PRIVATE_DATA/categories_stats


### PR DESCRIPTION
Different test files make search queries (including searches with no filters which return all products in the database). Search results get cached in Memcached and depending on test order during runs, the tests can get stale cached search results.

This hopefully will fix the issues we have seen in the last few days with the cors.t test