### PR TITLE
taxonomy(food): new bread loaf category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -36360,7 +36360,7 @@ fr: Fougasses au chorizo
 < en:Filled fougasse
 fr: Fougasses aux olives
 
-< en:Breads
+< en:Bread loaves
 en: Baguettes, French bread
 xx: Baguettes, Baguette
 ar: خبز فرنسي
@@ -36570,6 +36570,15 @@ hr: Panko
 nl: Panko
 wikidata:en: Q1820454
 # How should I translate this in ja? パン粉 would probably be closer to en:Panko, but what about en:Bread crumbs?
+
+< en:Breads
+en: Bread loaves, Bread loaf, Loaf of bread
+is: Hleifur
+ru: Буха́нка
+sv: Brödlimpor, Limpor, Limpa
+yi: לאַבן
+description:en: western style style of bread prepared in oblong shape (wikidata)
+wikidata:en: Q137778889
 
 < en:Breads
 en: Bread rolls, Buns, rolls


### PR DESCRIPTION
We have a number of different bread shape categories (rolls, flats, etc.), but the loaf is maybe the most ubiquitous shape associated with “bread” in Europe, and we didn’t have a category for it… Until now!

Needed-for: https://prices.openfoodfacts.org/proofs/112725