### PR TITLE
refactor: Replace Time::Monotonic with Time::HiRes

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -120,7 +120,7 @@ requires 'Crypt::JWT';
 requires 'Module::Load';
 
 # To measure the time taken by requests
-requires 'Time::Monotonic';
+requires 'Time::HiRes';
 
 # To measure similarity between words and find possible typo
 requires 'Text::Levenshtein';

--- a/lib/ProductOpener/RequestStats.pm
+++ b/lib/ProductOpener/RequestStats.pm
@@ -29,7 +29,7 @@ BEGIN {
 use vars @EXPORT_OK;
 
 use Log::Any qw/$log/;
-use Time::Monotonic qw(monotonic_time);
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 # Specific logger to log request stats
 our $requeststats_log = Log::Any->get_logger(category => 'requeststats');
@@ -49,12 +49,12 @@ sub set_request_stats_value($stats_ref, $key, $value) {
 }
 
 sub set_request_stats_time_start($stats_ref, $key) {
-	$stats_ref->{$key . "_start"} = monotonic_time();
+	$stats_ref->{$key . "_start"} = clock_gettime(CLOCK_MONOTONIC);
 	return;
 }
 
 sub set_request_stats_time_end($stats_ref, $key) {
-	$stats_ref->{$key . "_end"} = monotonic_time();
+	$stats_ref->{$key . "_end"} = clock_gettime(CLOCK_MONOTONIC);
 	return;
 }
 


### PR DESCRIPTION
### What

Replace the `Time::Monotonic` dependency with `Time::HiRes` to provide monotonic clock functionality using `clock_gettime(CLOCK_MONOTONIC)`.

Reasoning: While testing OFF with Debian Trixie, I got Perl compiler issues while building `Time::Monotonic`. Turns out the Perl module hasn't been updated in [11 years](https://github.com/caldwell/Time-Monotonic/tree/0.9.8) and the underlying C library hasn't been updated in [7 years](https://github.com/ThomasHabets/monotonic_clock/tree/20b16818951d6a22a8904bf2a8f490b09ec5335b).
The replacement `Time::HiRes` also provides an option to get monotonic time. While it hasn't been updated since [2020](https://metacpan.org/dist/Time-HiRes/changes) either, it is a standard Perl module ([repo](https://github.com/Perl/perl5/tree/blead/dist/Time-HiRes), [list](https://perldoc.perl.org/modules#Standard-Modules)) and stands better chances of being kept up-to-date.

### Large Language Models usage disclosure

None.

### Screenshot or video

Not applicable.

### Related issue(s) and discussion

None.