### PR TITLE
feat: Update donation form integration with Donorbox

### DIFF
--- a/html/donate/aa.html
+++ b/html/donate/aa.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/aa.html
+++ b/html/donate/aa.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ach.html
+++ b/html/donate/ach.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ach.html
+++ b/html/donate/ach.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/af.html
+++ b/html/donate/af.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/af.html
+++ b/html/donate/af.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ak.html
+++ b/html/donate/ak.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ak.html
+++ b/html/donate/ak.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/am.html
+++ b/html/donate/am.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/am.html
+++ b/html/donate/am.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ar.html
+++ b/html/donate/ar.html
@@ -210,24 +210,11 @@ Anca، Éloïse، Florence، Léonore، Marie، Christian، Ludovic، Sébastien
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>يتم تحميل نموذج التبرع.<br>يمكنك أيضا الوصول إليه عن طريق <a href=" https://donorbox. org/your-donation-to-open-food-facts">النقر هنا</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="تبرع عبر Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ar.html
+++ b/html/donate/ar.html
@@ -213,7 +213,7 @@ Anca، Éloïse، Florence، Léonore، Marie، Christian، Ludovic، Sébastien
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
           <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>يتم تحميل نموذج التبرع.<br>يمكنك أيضا الوصول إليه عن طريق <a href=" https://donorbox. org/your-donation-to-open-food-facts">النقر هنا</a>.</p>
+            <p>يتم تحميل نموذج التبرع.<br>يمكنك أيضا الوصول إليه عن طريق <a href="https://donorbox.org/your-donation-to-open-food-facts">النقر هنا</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ar.html
+++ b/html/donate/ar.html
@@ -211,9 +211,9 @@ Anca، Éloïse، Florence، Léonore، Marie، Christian، Ludovic، Sébastien
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>يتم تحميل نموذج التبرع.<br>يمكنك أيضا الوصول إليه عن طريق <a href="https://donorbox.org/your-donation-to-open-food-facts">النقر هنا</a>.</p>
+            <p>يتم تحميل نموذج التبرع.<br>يمكنك أيضا الوصول إليه عن طريق <a href="https://donorbox.org/help-open-food-facts-stay-afloat">النقر هنا</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/as.html
+++ b/html/donate/as.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/as.html
+++ b/html/donate/as.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ast.html
+++ b/html/donate/ast.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ast.html
+++ b/html/donate/ast.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/az.html
+++ b/html/donate/az.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/az.html
+++ b/html/donate/az.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/be.html
+++ b/html/donate/be.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/be.html
+++ b/html/donate/be.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ber.html
+++ b/html/donate/ber.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ber.html
+++ b/html/donate/ber.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/bg.html
+++ b/html/donate/bg.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Формулярът за дарение се зарежда.<br>Можеш също да получиш достъп до него, като <a href="https://donorbox.org/your-donation-to-open-food-facts">щракнеш тук</a>.</p>
+            <p>Формулярът за дарение се зарежда.<br>Можеш също да получиш достъп до него, като <a href="https://donorbox.org/help-open-food-facts-stay-afloat">щракнеш тук</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/bg.html
+++ b/html/donate/bg.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Формулярът за дарение се зарежда.<br>Можеш също да получиш достъп до него, като <a href="https://donorbox.org/your-donation-to-open-food-facts">щракнеш тук</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Дари чрез Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/bm.html
+++ b/html/donate/bm.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/bm.html
+++ b/html/donate/bm.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/bn.html
+++ b/html/donate/bn.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/bn.html
+++ b/html/donate/bn.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/bo.html
+++ b/html/donate/bo.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/bo.html
+++ b/html/donate/bo.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/br.html
+++ b/html/donate/br.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/br.html
+++ b/html/donate/br.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/bs.html
+++ b/html/donate/bs.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/bs.html
+++ b/html/donate/bs.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ca.html
+++ b/html/donate/ca.html
@@ -216,24 +216,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>S'està carregant el formulari de donació.<br>També podeu accedir-hi <a href="https://donorbox.org/your-donation-to-open-food-facts">fent clic aquí</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Feu una donació mitjançant Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ca.html
+++ b/html/donate/ca.html
@@ -217,9 +217,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>S'està carregant el formulari de donació.<br>També podeu accedir-hi <a href="https://donorbox.org/your-donation-to-open-food-facts">fent clic aquí</a>.</p>
+            <p>S'està carregant el formulari de donació.<br>També podeu accedir-hi <a href="https://donorbox.org/help-open-food-facts-stay-afloat">fent clic aquí</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ce.html
+++ b/html/donate/ce.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ce.html
+++ b/html/donate/ce.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/chr.html
+++ b/html/donate/chr.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/chr.html
+++ b/html/donate/chr.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/co.html
+++ b/html/donate/co.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/co.html
+++ b/html/donate/co.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/crs.html
+++ b/html/donate/crs.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/crs.html
+++ b/html/donate/crs.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/cs.html
+++ b/html/donate/cs.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Darovací formulář se načítá.<br>Můžete k němu také přistupovat <a href="https://donorbox.org/your-donation-to-open-food-facts">kliknutím sem</a>.</p>
+            <p>Darovací formulář se načítá.<br>Můžete k němu také přistupovat <a href="https://donorbox.org/help-open-food-facts-stay-afloat">kliknutím sem</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/cs.html
+++ b/html/donate/cs.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Darovací formulář se načítá.<br>Můžete k němu také přistupovat <a href="https://donorbox.org/your-donation-to-open-food-facts">kliknutím sem</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Darujte přes Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/cv.html
+++ b/html/donate/cv.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/cv.html
+++ b/html/donate/cv.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/cy.html
+++ b/html/donate/cy.html
@@ -215,9 +215,9 @@ datblygu ac ychwanegu at nodweddion hynod  newydd ar gyfer yr app i declynnau mu
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/cy.html
+++ b/html/donate/cy.html
@@ -214,24 +214,11 @@ datblygu ac ychwanegu at nodweddion hynod  newydd ar gyfer yr app i declynnau mu
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/da.html
+++ b/html/donate/da.html
@@ -220,9 +220,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Donationsformularen indlæses. <br>Du kan tilgå den ved at <a href="https://donorbox.org/your-donation-to-open-food-facts">klikke hér</a>.</p>
+            <p>Donationsformularen indlæses. <br>Du kan tilgå den ved at <a href="https://donorbox.org/help-open-food-facts-stay-afloat">klikke hér</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/da.html
+++ b/html/donate/da.html
@@ -219,24 +219,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Donationsformularen indlæses. <br>Du kan tilgå den ved at <a href="https://donorbox.org/your-donation-to-open-food-facts">klikke hér</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Doner via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/de.html
+++ b/html/donate/de.html
@@ -207,9 +207,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Das Spendenformular wird geladen.<br>Sie können es auch aufrufen, indem Sie <a href="https://donorbox.org/your-donation-to-open-food-facts">hier klicken</a>.</p>
+            <p>Das Spendenformular wird geladen.<br>Sie können es auch aufrufen, indem Sie <a href="https://donorbox.org/help-open-food-facts-stay-afloat">hier klicken</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/de.html
+++ b/html/donate/de.html
@@ -206,24 +206,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Das Spendenformular wird geladen.<br>Sie können es auch aufrufen, indem Sie <a href="https://donorbox.org/your-donation-to-open-food-facts">hier klicken</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Spenden Sie über Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/el.html
+++ b/html/donate/el.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Γίνεται φόρτωση της φόρμας δωρεάς.<br>Μπορείτε επίσης να αποκτήσετε πρόσβαση σε αυτή <a href="https://donorbox.org/your-donation-to-open-food-facts">κάνοντας κλικ εδώ</a>.</p>
+            <p>Γίνεται φόρτωση της φόρμας δωρεάς.<br>Μπορείτε επίσης να αποκτήσετε πρόσβαση σε αυτή <a href="https://donorbox.org/help-open-food-facts-stay-afloat">κάνοντας κλικ εδώ</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/el.html
+++ b/html/donate/el.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Γίνεται φόρτωση της φόρμας δωρεάς.<br>Μπορείτε επίσης να αποκτήσετε πρόσβαση σε αυτή <a href="https://donorbox.org/your-donation-to-open-food-facts">κάνοντας κλικ εδώ</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Δωρεά μέσω Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -218,8 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          
-          <script type="module" src="https://donorbox.org/widgets.js" async></script><dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -218,30 +218,15 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          
+          <script type="module" src="https://donorbox.org/widgets.js" async></script><dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
                  alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
             >
-            <!-- h3>Where your donation goes</h3>
+            <!-- 
+            <h3>Where your donation goes</h3>
 
             <p>
               <strong>Technology:</strong> Development, maintenance, servers to keep the

--- a/html/donate/en_AU.html
+++ b/html/donate/en_AU.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/en_AU.html
+++ b/html/donate/en_AU.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/en_GB.html
+++ b/html/donate/en_GB.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/en_GB.html
+++ b/html/donate/en_GB.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/eo.html
+++ b/html/donate/eo.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/eo.html
+++ b/html/donate/eo.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/es.html
+++ b/html/donate/es.html
@@ -218,9 +218,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>El formulario de donación se está cargando.<br>También puedes acceder al mismo haciendo <a href="https://donorbox.org/your-donation-to-open-food-facts">clic aquí</a>.</p>
+            <p>El formulario de donación se está cargando.<br>También puedes acceder al mismo haciendo <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clic aquí</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/es.html
+++ b/html/donate/es.html
@@ -217,24 +217,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>El formulario de donación se está cargando.<br>También puedes acceder al mismo haciendo <a href="https://donorbox.org/your-donation-to-open-food-facts">clic aquí</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donar vía Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/et.html
+++ b/html/donate/et.html
@@ -214,9 +214,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/et.html
+++ b/html/donate/et.html
@@ -213,24 +213,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/eu.html
+++ b/html/donate/eu.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/eu.html
+++ b/html/donate/eu.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/fa.html
+++ b/html/donate/fa.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/fa.html
+++ b/html/donate/fa.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/fi.html
+++ b/html/donate/fi.html
@@ -216,24 +216,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Lahjoituslomaketta ladataan.<br>Pääset siihen myös <a href="https://donorbox.org/your-donation-to-open-food-facts">napsauttamalla tästä</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Lahjoita Donorboxin kautta"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/fi.html
+++ b/html/donate/fi.html
@@ -217,9 +217,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Lahjoituslomaketta ladataan.<br>Pääset siihen myös <a href="https://donorbox.org/your-donation-to-open-food-facts">napsauttamalla tästä</a>.</p>
+            <p>Lahjoituslomaketta ladataan.<br>Pääset siihen myös <a href="https://donorbox.org/help-open-food-facts-stay-afloat">napsauttamalla tästä</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/fil.html
+++ b/html/donate/fil.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/fil.html
+++ b/html/donate/fil.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Mag-donate sa pamamagitan ng Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/fo.html
+++ b/html/donate/fo.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/fo.html
+++ b/html/donate/fo.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/fr.html
+++ b/html/donate/fr.html
@@ -213,7 +213,7 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <div class="loading">
-            <p>Le formulaire de don est en cours de chargement.<br>Vous pouvez aussi y accéder en <a href="https://donorbox.org/your-donation-to-open-food-facts">cliquant ici</a>.</p>
+            <p>Le formulaire de don est en cours de chargement.<br>Vous pouvez aussi y accéder en <a href="https://donorbox.org/help-open-food-facts-stay-afloat">cliquant ici</a>.</p>
           </div>
 
           <script

--- a/html/donate/ga.html
+++ b/html/donate/ga.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ga.html
+++ b/html/donate/ga.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/gd.html
+++ b/html/donate/gd.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/gd.html
+++ b/html/donate/gd.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/gl.html
+++ b/html/donate/gl.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/gl.html
+++ b/html/donate/gl.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/gu.html
+++ b/html/donate/gu.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/gu.html
+++ b/html/donate/gu.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ha.html
+++ b/html/donate/ha.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ha.html
+++ b/html/donate/ha.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/he.html
+++ b/html/donate/he.html
@@ -215,24 +215,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>טופס התרומה נטען.<br>ניתן גם לגשת אליו ב<a href="https://donorbox.org/your-donation-to-open-food-facts">לחיצה כאן</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="תרומה דרך Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/he.html
+++ b/html/donate/he.html
@@ -216,9 +216,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>טופס התרומה נטען.<br>ניתן גם לגשת אליו ב<a href="https://donorbox.org/your-donation-to-open-food-facts">לחיצה כאן</a>.</p>
+            <p>טופס התרומה נטען.<br>ניתן גם לגשת אליו ב<a href="https://donorbox.org/help-open-food-facts-stay-afloat">לחיצה כאן</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/hi.html
+++ b/html/donate/hi.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/hi.html
+++ b/html/donate/hi.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/hr.html
+++ b/html/donate/hr.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/hr.html
+++ b/html/donate/hr.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ht.html
+++ b/html/donate/ht.html
@@ -218,9 +218,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ht.html
+++ b/html/donate/ht.html
@@ -217,24 +217,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/hu.html
+++ b/html/donate/hu.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/hu.html
+++ b/html/donate/hu.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Adományozz a Donorboxon keresztül"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/hy.html
+++ b/html/donate/hy.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/hy.html
+++ b/html/donate/hy.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/id.html
+++ b/html/donate/id.html
@@ -217,24 +217,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Formulir donasi sedang dimuat.<br>Anda juga dapat mengaksesnya dengan <a href="https://donorbox.org/your-donation-to-open-food-facts">mengklik di sini</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donasi melalui Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/id.html
+++ b/html/donate/id.html
@@ -218,9 +218,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Formulir donasi sedang dimuat.<br>Anda juga dapat mengaksesnya dengan <a href="https://donorbox.org/your-donation-to-open-food-facts">mengklik di sini</a>.</p>
+            <p>Formulir donasi sedang dimuat.<br>Anda juga dapat mengaksesnya dengan <a href="https://donorbox.org/help-open-food-facts-stay-afloat">mengklik di sini</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ii.html
+++ b/html/donate/ii.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ii.html
+++ b/html/donate/ii.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/is.html
+++ b/html/donate/is.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/is.html
+++ b/html/donate/is.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/it.html
+++ b/html/donate/it.html
@@ -219,24 +219,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Il modulo di donazione sta venendo caricato.<br>Puoi anche accedere ad esso <a href="https://donorbox.org/your-donation-to-open-food-facts">cliccando qui</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Dona tramite Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/it.html
+++ b/html/donate/it.html
@@ -220,9 +220,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Il modulo di donazione sta venendo caricato.<br>Puoi anche accedere ad esso <a href="https://donorbox.org/your-donation-to-open-food-facts">cliccando qui</a>.</p>
+            <p>Il modulo di donazione sta venendo caricato.<br>Puoi anche accedere ad esso <a href="https://donorbox.org/help-open-food-facts-stay-afloat">cliccando qui</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/iu.html
+++ b/html/donate/iu.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/iu.html
+++ b/html/donate/iu.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ja.html
+++ b/html/donate/ja.html
@@ -210,24 +210,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>寄付フォームを読み込んでいます。<br> <a href="https://donorbox.org/your-donation-to-open-food-facts">ここをクリック</a>してもアクセスできます。</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donorbox経由で寄付する"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ja.html
+++ b/html/donate/ja.html
@@ -211,9 +211,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>寄付フォームを読み込んでいます。<br> <a href="https://donorbox.org/your-donation-to-open-food-facts">ここをクリック</a>してもアクセスできます。</p>
+            <p>寄付フォームを読み込んでいます。<br> <a href="https://donorbox.org/help-open-food-facts-stay-afloat">ここをクリック</a>してもアクセスできます。</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/jv.html
+++ b/html/donate/jv.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/jv.html
+++ b/html/donate/jv.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ka.html
+++ b/html/donate/ka.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ka.html
+++ b/html/donate/ka.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/kab.html
+++ b/html/donate/kab.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/kab.html
+++ b/html/donate/kab.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/kk.html
+++ b/html/donate/kk.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/kk.html
+++ b/html/donate/kk.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/km.html
+++ b/html/donate/km.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/km.html
+++ b/html/donate/km.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/kmr.html
+++ b/html/donate/kmr.html
@@ -193,9 +193,9 @@ $('iframe').load(function(){
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/kmr.html
+++ b/html/donate/kmr.html
@@ -195,7 +195,7 @@ $('iframe').load(function(){
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
           <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/kmr.html
+++ b/html/donate/kmr.html
@@ -192,24 +192,11 @@ $('iframe').load(function(){
 
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-left">
             <h3>Where your donation goes</h3>

--- a/html/donate/kmr_TR.html
+++ b/html/donate/kmr_TR.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/kmr_TR.html
+++ b/html/donate/kmr_TR.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/kn.html
+++ b/html/donate/kn.html
@@ -220,9 +220,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/kn.html
+++ b/html/donate/kn.html
@@ -219,24 +219,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ko.html
+++ b/html/donate/ko.html
@@ -218,9 +218,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>기부 양식이 로드 되어있습니다.<br><a href="https://donorbox.org/your-donation-to-open-food-facts">여기을 클릭하여</a> 액세스할 수도 있습니다.</p>
+            <p>기부 양식이 로드 되어있습니다.<br><a href="https://donorbox.org/help-open-food-facts-stay-afloat">여기을 클릭하여</a> 액세스할 수도 있습니다.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ko.html
+++ b/html/donate/ko.html
@@ -217,24 +217,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>기부 양식이 로드 되어있습니다.<br><a href="https://donorbox.org/your-donation-to-open-food-facts">여기을 클릭하여</a> 액세스할 수도 있습니다.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donorbox로 기부하기"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/kw.html
+++ b/html/donate/kw.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/kw.html
+++ b/html/donate/kw.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ky.html
+++ b/html/donate/ky.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ky.html
+++ b/html/donate/ky.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/la.html
+++ b/html/donate/la.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/la.html
+++ b/html/donate/la.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/lb.html
+++ b/html/donate/lb.html
@@ -210,24 +210,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/lb.html
+++ b/html/donate/lb.html
@@ -211,9 +211,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/lo.html
+++ b/html/donate/lo.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/lo.html
+++ b/html/donate/lo.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/lt.html
+++ b/html/donate/lt.html
@@ -219,24 +219,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Aukojimo forma įkeliama.<br>Taip pat galite ją pasiekti <a href="https://donorbox.org/your-donation-to-open-food-facts">spustelėję čia</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Aukoti per Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/lt.html
+++ b/html/donate/lt.html
@@ -220,9 +220,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Aukojimo forma įkeliama.<br>Taip pat galite ją pasiekti <a href="https://donorbox.org/your-donation-to-open-food-facts">spustelėję čia</a>.</p>
+            <p>Aukojimo forma įkeliama.<br>Taip pat galite ją pasiekti <a href="https://donorbox.org/help-open-food-facts-stay-afloat">spustelėję čia</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/lv.html
+++ b/html/donate/lv.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/lv.html
+++ b/html/donate/lv.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/me.html
+++ b/html/donate/me.html
@@ -193,9 +193,9 @@ $('iframe').load(function(){
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/me.html
+++ b/html/donate/me.html
@@ -195,7 +195,7 @@ $('iframe').load(function(){
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
           <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/me.html
+++ b/html/donate/me.html
@@ -192,24 +192,11 @@ $('iframe').load(function(){
 
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-left">
             <h3>Where your donation goes</h3>

--- a/html/donate/mg.html
+++ b/html/donate/mg.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/mg.html
+++ b/html/donate/mg.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/mi.html
+++ b/html/donate/mi.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/mi.html
+++ b/html/donate/mi.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ml.html
+++ b/html/donate/ml.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ml.html
+++ b/html/donate/ml.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/mn.html
+++ b/html/donate/mn.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/mn.html
+++ b/html/donate/mn.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/mr.html
+++ b/html/donate/mr.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/mr.html
+++ b/html/donate/mr.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ms.html
+++ b/html/donate/ms.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ms.html
+++ b/html/donate/ms.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Derma melalui Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/mt.html
+++ b/html/donate/mt.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/mt.html
+++ b/html/donate/mt.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/my.html
+++ b/html/donate/my.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/my.html
+++ b/html/donate/my.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/nb.html
+++ b/html/donate/nb.html
@@ -214,9 +214,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/nb.html
+++ b/html/donate/nb.html
@@ -213,24 +213,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ne.html
+++ b/html/donate/ne.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ne.html
+++ b/html/donate/ne.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/nl_BE.html
+++ b/html/donate/nl_BE.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Het donatieformulier wordt geladen.<br>Je kunt het ook openen door <a href="https://donorbox.org/your-donation-to-open-food-facts">hier te klikken</a>.</p>
+            <p>Het donatieformulier wordt geladen.<br>Je kunt het ook openen door <a href="https://donorbox.org/help-open-food-facts-stay-afloat">hier te klikken</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/nl_BE.html
+++ b/html/donate/nl_BE.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Het donatieformulier wordt geladen.<br>Je kunt het ook openen door <a href="https://donorbox.org/your-donation-to-open-food-facts">hier te klikken</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Doneer via Donobox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/nl_NL.html
+++ b/html/donate/nl_NL.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Het donatieformulier wordt geladen.<br>Je kunt het ook openen door <a href="https://donorbox.org/your-donation-to-open-food-facts">hier te klikken</a>.</p>
+            <p>Het donatieformulier wordt geladen.<br>Je kunt het ook openen door <a href="https://donorbox.org/help-open-food-facts-stay-afloat">hier te klikken</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/nl_NL.html
+++ b/html/donate/nl_NL.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Het donatieformulier wordt geladen.<br>Je kunt het ook openen door <a href="https://donorbox.org/your-donation-to-open-food-facts">hier te klikken</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Doneer via Donobox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/nn.html
+++ b/html/donate/nn.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/nn.html
+++ b/html/donate/nn.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/no.html
+++ b/html/donate/no.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/no.html
+++ b/html/donate/no.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/nr.html
+++ b/html/donate/nr.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/nr.html
+++ b/html/donate/nr.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/oc.html
+++ b/html/donate/oc.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/oc.html
+++ b/html/donate/oc.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/or.html
+++ b/html/donate/or.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/or.html
+++ b/html/donate/or.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/pa.html
+++ b/html/donate/pa.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/pa.html
+++ b/html/donate/pa.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/pl.html
+++ b/html/donate/pl.html
@@ -207,24 +207,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Formularz do wspierania się ładuje. <br>Możesz go również otworzyć <a href="https://donorbox.org/your-donation-to-open-food-facts">klikając tu</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Wesprzyj za pośrednictwem Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/pl.html
+++ b/html/donate/pl.html
@@ -208,9 +208,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Formularz do wspierania się ładuje. <br>Możesz go również otworzyć <a href="https://donorbox.org/your-donation-to-open-food-facts">klikając tu</a>.</p>
+            <p>Formularz do wspierania się ładuje. <br>Możesz go również otworzyć <a href="https://donorbox.org/help-open-food-facts-stay-afloat">klikając tu</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/pt_BR.html
+++ b/html/donate/pt_BR.html
@@ -217,24 +217,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>O formulário de doação está sendo carregado.<br>Você também pode acessá-lo <a href="https://donorbox.org/your-donation-to-open-food-facts">clicando aqui</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Doar via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/pt_BR.html
+++ b/html/donate/pt_BR.html
@@ -218,9 +218,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>O formulário de doação está sendo carregado.<br>Você também pode acessá-lo <a href="https://donorbox.org/your-donation-to-open-food-facts">clicando aqui</a>.</p>
+            <p>O formulário de doação está sendo carregado.<br>Você também pode acessá-lo <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicando aqui</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/pt_PT.html
+++ b/html/donate/pt_PT.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>O formulário de doação está a carregar.<br>Também pode aceder <a href="https://donorbox.org/your-donation-to-open-food-facts">clicando aqui</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donativo via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/pt_PT.html
+++ b/html/donate/pt_PT.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>O formulário de doação está a carregar.<br>Também pode aceder <a href="https://donorbox.org/your-donation-to-open-food-facts">clicando aqui</a>.</p>
+            <p>O formulário de doação está a carregar.<br>Também pode aceder <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicando aqui</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/qu.html
+++ b/html/donate/qu.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/qu.html
+++ b/html/donate/qu.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/rm.html
+++ b/html/donate/rm.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/rm.html
+++ b/html/donate/rm.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ro.html
+++ b/html/donate/ro.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Formularul de donație este în curs de încărcare.<br>Îl poți accesa și <a href="https://donorbox.org/your-donation-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-ro">făcând clic aici</a>.</p>
+            <p>Formularul de donație este în curs de încărcare.<br>Îl poți accesa și <a href="https://donorbox.org/help-open-food-facts-stay-afloat?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-ro">făcând clic aici</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ro.html
+++ b/html/donate/ro.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Formularul de donație este în curs de încărcare.<br>Îl poți accesa și <a href="https://donorbox.org/your-donation-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-ro">făcând clic aici</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donează prin Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ru.html
+++ b/html/donate/ru.html
@@ -217,24 +217,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Форма пожертвования загружается.<br>Вы также можете получить к ней доступ <a href="https://donorbox.org/your-donation-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-ru">щёлкнув здесь</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Пожертвовать через Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ru.html
+++ b/html/donate/ru.html
@@ -218,9 +218,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Форма пожертвования загружается.<br>Вы также можете получить к ней доступ <a href="https://donorbox.org/your-donation-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-ru">щёлкнув здесь</a>.</p>
+            <p>Форма пожертвования загружается.<br>Вы также можете получить к ней доступ <a href="https://donorbox.org/help-open-food-facts-stay-afloat?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-ru">щёлкнув здесь</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ry.html
+++ b/html/donate/ry.html
@@ -193,9 +193,9 @@ $('iframe').load(function(){
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/ry.html
+++ b/html/donate/ry.html
@@ -195,7 +195,7 @@ $('iframe').load(function(){
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
           <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/ry.html
+++ b/html/donate/ry.html
@@ -192,24 +192,11 @@ $('iframe').load(function(){
 
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-left">
             <h3>Where your donation goes</h3>

--- a/html/donate/sa.html
+++ b/html/donate/sa.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sa.html
+++ b/html/donate/sa.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sat.html
+++ b/html/donate/sat.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sat.html
+++ b/html/donate/sat.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sc.html
+++ b/html/donate/sc.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sc.html
+++ b/html/donate/sc.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sco.html
+++ b/html/donate/sco.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sco.html
+++ b/html/donate/sco.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sd.html
+++ b/html/donate/sd.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sd.html
+++ b/html/donate/sd.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sg.html
+++ b/html/donate/sg.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sg.html
+++ b/html/donate/sg.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sh.html
+++ b/html/donate/sh.html
@@ -193,9 +193,9 @@ $('iframe').load(function(){
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/sh.html
+++ b/html/donate/sh.html
@@ -195,7 +195,7 @@ $('iframe').load(function(){
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
           <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
           </noscript>
 
           <div class="text-left">

--- a/html/donate/sh.html
+++ b/html/donate/sh.html
@@ -192,24 +192,11 @@ $('iframe').load(function(){
 
       <div class="columns large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href=" https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-left">
             <h3>Where your donation goes</h3>

--- a/html/donate/si.html
+++ b/html/donate/si.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/si.html
+++ b/html/donate/si.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sk.html
+++ b/html/donate/sk.html
@@ -219,24 +219,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Darovací formulár sa načítava.<br>Môžete sa k nemu dostať aj kliknutím <a href="https://donorbox.org/your-donation-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-sk">kliknutím sem</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Darujte cez Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sk.html
+++ b/html/donate/sk.html
@@ -220,9 +220,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Darovací formulár sa načítava.<br>Môžete sa k nemu dostať aj kliknutím <a href="https://donorbox.org/your-donation-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-sk">kliknutím sem</a>.</p>
+            <p>Darovací formulár sa načítava.<br>Môžete sa k nemu dostať aj kliknutím <a href="https://donorbox.org/help-open-food-facts-stay-afloat?utm_source=donate-page-share&utm_campaign=donation-2025&utm_content=donate-page-share-sk">kliknutím sem</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sl.html
+++ b/html/donate/sl.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sl.html
+++ b/html/donate/sl.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sma.html
+++ b/html/donate/sma.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sma.html
+++ b/html/donate/sma.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sn.html
+++ b/html/donate/sn.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sn.html
+++ b/html/donate/sn.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/so.html
+++ b/html/donate/so.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/so.html
+++ b/html/donate/so.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/son.html
+++ b/html/donate/son.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/son.html
+++ b/html/donate/son.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sq.html
+++ b/html/donate/sq.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sq.html
+++ b/html/donate/sq.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sr.html
+++ b/html/donate/sr.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sr.html
+++ b/html/donate/sr.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sr_CS.html
+++ b/html/donate/sr_CS.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sr_CS.html
+++ b/html/donate/sr_CS.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sr_RS.html
+++ b/html/donate/sr_RS.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sr_RS.html
+++ b/html/donate/sr_RS.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ss.html
+++ b/html/donate/ss.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ss.html
+++ b/html/donate/ss.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/st.html
+++ b/html/donate/st.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/st.html
+++ b/html/donate/st.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sv.html
+++ b/html/donate/sv.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sv.html
+++ b/html/donate/sv.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donera via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/sw.html
+++ b/html/donate/sw.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/sw.html
+++ b/html/donate/sw.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ta.html
+++ b/html/donate/ta.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ta.html
+++ b/html/donate/ta.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/te.html
+++ b/html/donate/te.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/te.html
+++ b/html/donate/te.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tg.html
+++ b/html/donate/tg.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tg.html
+++ b/html/donate/tg.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/th.html
+++ b/html/donate/th.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/th.html
+++ b/html/donate/th.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ti.html
+++ b/html/donate/ti.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ti.html
+++ b/html/donate/ti.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tl.html
+++ b/html/donate/tl.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tl.html
+++ b/html/donate/tl.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tn.html
+++ b/html/donate/tn.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tn.html
+++ b/html/donate/tn.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tr.html
+++ b/html/donate/tr.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Bağış formu yükleniyor.<br> <a href="https://donorbox.org/your-donation-to-open-food-facts">buraya tıklayarak da erişebilirsiniz</a>.</p>
+            <p>Bağış formu yükleniyor.<br> <a href="https://donorbox.org/help-open-food-facts-stay-afloat">buraya tıklayarak da erişebilirsiniz</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tr.html
+++ b/html/donate/tr.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Bağış formu yükleniyor.<br> <a href="https://donorbox.org/your-donation-to-open-food-facts">buraya tıklayarak da erişebilirsiniz</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donorbox aracılığıyla bağış yapın"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ts.html
+++ b/html/donate/ts.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ts.html
+++ b/html/donate/ts.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tt.html
+++ b/html/donate/tt.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tt.html
+++ b/html/donate/tt.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tw.html
+++ b/html/donate/tw.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tw.html
+++ b/html/donate/tw.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ty.html
+++ b/html/donate/ty.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ty.html
+++ b/html/donate/ty.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/tzl.html
+++ b/html/donate/tzl.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/tzl.html
+++ b/html/donate/tzl.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ug.html
+++ b/html/donate/ug.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ug.html
+++ b/html/donate/ug.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/uk.html
+++ b/html/donate/uk.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Форма для пожертви завантажується.<br>Доступ до неї також можна отримати <a href="https://donorbox.org/your-donation-to-open-food-facts">натиснувши тут</a>.</p>
+            <p>Форма для пожертви завантажується.<br>Доступ до неї також можна отримати <a href="https://donorbox.org/help-open-food-facts-stay-afloat">натиснувши тут</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/uk.html
+++ b/html/donate/uk.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Форма для пожертви завантажується.<br>Доступ до неї також можна отримати <a href="https://donorbox.org/your-donation-to-open-food-facts">натиснувши тут</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Пожертвувати на сайті"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ur.html
+++ b/html/donate/ur.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ur.html
+++ b/html/donate/ur.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/uz.html
+++ b/html/donate/uz.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/uz.html
+++ b/html/donate/uz.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/val.html
+++ b/html/donate/val.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/val.html
+++ b/html/donate/val.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/ve.html
+++ b/html/donate/ve.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/ve.html
+++ b/html/donate/ve.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/vec.html
+++ b/html/donate/vec.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/vec.html
+++ b/html/donate/vec.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/vi.html
+++ b/html/donate/vi.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>Mẫu quyên góp đang được tải xuống. <br>Bạn cũng có thể truy cập nó bằng cách <a href="https://donorbox.org/your-donation-to-open-food-facts">nhấn vào đây</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Đóng góp qua Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/vi.html
+++ b/html/donate/vi.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>Mẫu quyên góp đang được tải xuống. <br>Bạn cũng có thể truy cập nó bằng cách <a href="https://donorbox.org/your-donation-to-open-food-facts">nhấn vào đây</a>.</p>
+            <p>Mẫu quyên góp đang được tải xuống. <br>Bạn cũng có thể truy cập nó bằng cách <a href="https://donorbox.org/help-open-food-facts-stay-afloat">nhấn vào đây</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/vls.html
+++ b/html/donate/vls.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/vls.html
+++ b/html/donate/vls.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/wa.html
+++ b/html/donate/wa.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/wa.html
+++ b/html/donate/wa.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/wo.html
+++ b/html/donate/wo.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/wo.html
+++ b/html/donate/wo.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/xh.html
+++ b/html/donate/xh.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/xh.html
+++ b/html/donate/xh.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/yi.html
+++ b/html/donate/yi.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/yi.html
+++ b/html/donate/yi.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/yo.html
+++ b/html/donate/yo.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/yo.html
+++ b/html/donate/yo.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/zea.html
+++ b/html/donate/zea.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/zea.html
+++ b/html/donate/zea.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/zh_CN.html
+++ b/html/donate/zh_CN.html
@@ -219,24 +219,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>捐赠表格正在加载。<br>您也可以通过 <a href="https://donorbox.org/your-donation-to-open-food-facts">单击此处</a>来访问它。</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="通过 Donorbox 捐赠"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/zh_CN.html
+++ b/html/donate/zh_CN.html
@@ -220,9 +220,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>捐赠表格正在加载。<br>您也可以通过 <a href="https://donorbox.org/your-donation-to-open-food-facts">单击此处</a>来访问它。</p>
+            <p>捐赠表格正在加载。<br>您也可以通过 <a href="https://donorbox.org/help-open-food-facts-stay-afloat">单击此处</a>来访问它。</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/zh_HK.html
+++ b/html/donate/zh_HK.html
@@ -224,9 +224,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/zh_HK.html
+++ b/html/donate/zh_HK.html
@@ -223,24 +223,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/zh_TW.html
+++ b/html/donate/zh_TW.html
@@ -229,9 +229,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/zh_TW.html
+++ b/html/donate/zh_TW.html
@@ -228,24 +228,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"

--- a/html/donate/zu.html
+++ b/html/donate/zu.html
@@ -219,9 +219,9 @@
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
           <script type="module" src="https://donorbox.org/widgets.js" async></script>
-          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <dbox-widget campaign="help-open-food-facts-stay-afloat" type="donation_form" enable-auto-scroll="true"></dbox-widget>
           <noscript>
-            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
+            <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/help-open-food-facts-stay-afloat">clicking here</a>.</p>
           </noscript>
 
           <div class="text-center">

--- a/html/donate/zu.html
+++ b/html/donate/zu.html
@@ -218,24 +218,11 @@
 
       <div class="columns small-12 medium-6 large-5 xlarge-4 xxlarge-3 text-center">
         <div style="max-width:425px">
-          <div class="loading">
+          <script type="module" src="https://donorbox.org/widgets.js" async></script>
+          <dbox-widget campaign="your-donation-to-open-food-facts" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+          <noscript>
             <p>The donation form is being loaded.<br>You can also access it by <a href="https://donorbox.org/your-donation-to-open-food-facts">clicking here</a>.</p>
-          </div>
-
-          <script
-            src="https://donorbox.org/widget.js"
-            paypalExpress="true"
-          ></script>
-          <iframe
-            title="Donate via Donorbox"
-            allowpaymentrequest=""
-            height="900px"
-            name="donorbox"
-            seamless="seamless"
-            src="https://donorbox.org/embed/your-donation-to-open-food-facts"
-            style="max-width: 500px; min-width: 310px; max-height:none!important;border:0;overflow:hidden;"
-            width="100%"
-          ></iframe>
+          </noscript>
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"


### PR DESCRIPTION
Removed the loading message and old Donorbox widget code, added a new script for the Donorbox widget. migrate to OmniGive Form, as recommanded by Donorbox

"OmniGive offers faster loading speeds, over 20 localized payment methods for global donors, and an optimized checkout to boost conversion rates."
feat: Update donation form integration with Donorbox

https://donorbox.org/nonprofit-blog/donorbox-omnigive-donation-form

it says here that we should enable more payment methods using Stripe, including Revolut, Coins… (20 methods in total)