### PR TITLE
fix: other is a valid image type for upload

### DIFF
--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -186,7 +186,8 @@ e.g. food, pet food and beauty products have an "ingredients" image type.
 
 %valid_image_types = (
 	front => 1,
-	packaging => 1
+	packaging => 1,
+	other => 1,
 );
 
 if (feature_enabled("ingredients")) {


### PR DESCRIPTION
currently some images sent by our mobile app are blocked because having type like 'other_fr'

<img width="1080" height="2400" alt="Screenshot_20260520-181219 OpenFoodFacts" src="https://github.com/user-attachments/assets/8422c330-2e41-4c3c-ba58-aab3170286fc" />
