### PR TITLE
chore(docker): Use cpm for CPAN installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG USER_UID=1000
 ARG USER_GID=1000
 # options for cpan installs
-ARG CPANMOPTS=
+ARG CPANMOPTS=""
 
 ######################
 # Base modperl image stage
@@ -208,19 +208,23 @@ COPY ./cpanfile* /tmp/
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt \
     --mount=type=cache,id=cpanm-cache,target=/root/.cpanm \
+    --mount=type=cache,id=cpm-cache,target=/root/.perl-cpm \
     set -x && \
     # also run apt update if needed because some package might need to apt install
     ( ( [ ! -e /var/cache/apt/pkgcache.bin ] || [ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ] ) && \
       apt-get update || true \
     ) && \
+    # install cpm for parallel installation
+    cpanm --notest --quiet --skip-satisfied "App::cpm" && \
+    export PERL_MM_OPT="INSTALL_BASE=/tmp/local/" && \
+    export PERL_MB_OPT="--install_base /tmp/local/" && \
+    export PERL5LIB="/tmp/local/lib/perl5/" && \
     # first install some dependencies that are not well handled
-    cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ "Apache::Bootstrap" && \
-    cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . && \
+    cpm install --show-build-log-on-failure -w $(nproc) -g "Apache::Bootstrap" && \
+    cpm install $CPANMOPTS --show-build-log-on-failure -w $(nproc) -g && \
     # Install the JUnit renderer separately so tests can keep using --renderer=JUnit
     # without adding an unresolved dependency back into cpanfile.
-    cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ "Test2::Harness::Renderer::JUnit" \
-    # in case of errors show build.log, but still, fail
-    || ( for f in /root/.cpanm/work/*/build.log;do echo $f"= start =============";cat $f; echo $f"= end ============="; done; false )
+    cpm install --show-build-log-on-failure -w $(nproc) -g "Test2::Harness::Renderer::JUnit"
 
 ######################
 # backend production image stage


### PR DESCRIPTION
### What

Replace cpanm calls with parallel cpm install. This should significantly reduce the backend image build time.

### Tests

With patch:

```
________________________________________________________
Executed in  251.91 secs    fish           external
   usr time    3.40 secs    0.00 millis    3.40 secs
   sys time    2.69 secs    9.17 millis    2.69 secs
```

Without patch
```
________________________________________________________
Executed in   15.93 mins    fish           external
   usr time    5.66 secs    0.40 millis    5.66 secs
   sys time    4.76 secs    8.47 millis    4.75 secs
```
