### PR TITLE
refactor: modernize taxonomy building with parallelization and Log::Any

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,24 +494,32 @@ build_packager_codes: create_folders
 	@echo "🥫 build packager codes"
 	${DOCKER_COMPOSE_BUILD} run --no-deps --rm backend /opt/product-opener/scripts/update_packager_codes.pl
 
+build_taxonomies: name ?= *
+build_taxonomies: jobs ?= $(CPU_COUNT)
 build_taxonomies: create_folders
 	$(MAKE) MOUNT_FOLDER=build-cache MOUNT_VOLUME=build_cache _bind_local
 	@echo "🥫 build taxonomies"
 # GITHUB_TOKEN might be empty, but if it's a valid token it enables pushing taxonomies to build cache repository
-	${DOCKER_COMPOSE_BUILD} run --no-deps --rm -e GITHUB_TOKEN=${GITHUB_TOKEN} backend /opt/product-opener/scripts/taxonomies/build_tags_taxonomy.pl ${name}
+	${DOCKER_COMPOSE_BUILD} run --no-deps --rm -e GITHUB_TOKEN=${GITHUB_TOKEN} backend \
+	  scripts/taxonomies/build_tags_taxonomy.pl "${name}" -j "${jobs}"
 
 # a version where we force building without using cache
 # use it when you are developing in Tags.pm and want to iterate
 # at the end, change the $BUILD_TAGS_VERSION in Tags.pm
+rebuild_taxonomies: name ?= *
+rebuild_taxonomies: jobs ?= $(CPU_COUNT)
 rebuild_taxonomies:
 	$(MAKE) MOUNT_FOLDER=build-cache MOUNT_VOLUME=build_cache _bind_local
-	${DOCKER_COMPOSE_BUILD} run --no-deps --rm -e TAXONOMY_NO_GET_FROM_CACHE=1 backend /opt/product-opener/scripts/taxonomies/build_tags_taxonomy.pl ${name}
+	${DOCKER_COMPOSE_BUILD} run --no-deps --rm -e TAXONOMY_NO_GET_FROM_CACHE=1 backend \
+	  scripts/taxonomies/build_tags_taxonomy.pl "${name}" -j "${jobs}" -v
 
+build_taxonomies_test: name ?= *
+build_taxonomies_test: jobs ?= $(CPU_COUNT)
 build_taxonomies_test: create_folders
 	$(MAKE) MOUNT_FOLDER=build-cache MOUNT_VOLUME=build_cache PROJECT_SUFFIX=_test _bind_local
 	@echo "🥫 build taxonomies"
 # GITHUB_TOKEN might be empty, but if it's a valid token it enables pushing taxonomies to build cache repository
-	${DOCKER_COMPOSE_TEST} run --no-deps --rm -e GITHUB_TOKEN=${GITHUB_TOKEN} backend /opt/product-opener/scripts/taxonomies/build_tags_taxonomy.pl ${name}
+	${DOCKER_COMPOSE_TEST} run --no-deps --rm -e GITHUB_TOKEN=${GITHUB_TOKEN} backend /opt/product-opener/scripts/taxonomies/build_tags_taxonomy.pl "${name}" -j "${jobs}"
 
 build_pro_platform: create_folders
 	$(MAKE) MOUNT_FOLDER=build-cache MOUNT_VOLUME=build_cache _bind_local

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -942,8 +942,15 @@ sub get_lc_tagid ($synonyms_ref, $lc, $tagtype, $tag, $warning) {
 		# and try again to see if it is associated to a canonical tag id
 		$lc_tagid = $synonyms_ref->{$lc}{$stopped_tagid};
 		if ($warning) {
-			print STDERR "$warning tagid $tagid, trying stopped_tagid $stopped_tagid - result canon_tagid: "
-				. ($lc_tagid // "") . "\n";
+			$log->info(
+				'tagid not found, trying with stopped_tagid',
+				{
+					warning => $warning,
+					tagid => $tagid,
+					stopped_tagid => $stopped_tagid,
+					canon_tagid => $lc_tagid // ""
+				}
+			);
 		}
 
 	}
@@ -971,7 +978,7 @@ sub get_file_from_cache ($source, $target) {
 		copy($local_cache_source, $target);
 		if ($source =~ /\.result\.json$/) {
 			# Only give one message rather than one for each individual file
-			print "Fetched $source from GitHub cache\n";
+			$log->info('Fetched source from GitHub cache', {source => $source});
 		}
 
 		return 2;
@@ -1029,7 +1036,8 @@ sub get_from_cache ($tagtype, @files) {
 		$got_from_cache = get_file_from_cache("$cache_prefix.extended.json", "$tag_www_root.extended.json");
 	}
 	if ($got_from_cache) {
-		print "obtained taxonomy for $tagtype from " . ('', 'local', 'GitHub')[$got_from_cache] . " cache.\n";
+		$log->info('obtained taxonomy from cache',
+			{tagtype => $tagtype, origin => ('', 'local', 'GitHub')[$got_from_cache]});
 		$cache_prefix = '';
 		# Clean up old cache files when fetching from cache
 		my $cache_root = "$BASE_DIRS{CACHE_BUILD}/taxonomies";
@@ -1064,11 +1072,11 @@ sub put_file_to_cache ($source, $target) {
 		);
 
 		if (!$response->is_success()) {
-			print "Error uploading to GitHub cache for $target: ${\$response->message()}\n";
+			$log->error('Error uploading to GitHub cache', {target => $target, message => $response->message()});
 		}
 		elsif ($target =~ /\.result\.json$/) {
 			# Only give one message rather than one for each individual file
-			print "Uploaded $target to GitHub cache\n";
+			$log->info('Uploaded target to GitHub cache', {target => $target});
 		}
 	}
 
@@ -1130,7 +1138,8 @@ sub cleanup_old_cache_files ($tagtype, $cache_root) {
 			}
 		}
 		my $deleted_count = scalar(@hashes_to_delete);
-		print "Cleaned up $deleted_count old cache set(s) ($deleted_files files) for $tagtype taxonomy\n";
+		$log->info('Cleaned up old cache set(s) for taxonomy',
+			{count => $deleted_count, files => $deleted_files, tagtype => $tagtype});
 	}
 
 	return;
@@ -1246,7 +1255,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		return;
 	}
 
-	print("building taxonomy for $tagtype - publish: $publish\n");
+	$log->info('building taxonomy', {tagtype => $tagtype, publish => $publish});
 
 	# Concatenate taxonomy files if needed
 	my $file_path;
@@ -1349,9 +1358,9 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		my $lc_tagid;
 		# Canonical id of the tag (main language prefix + normalized form in the main language)
 		# e.g. "en:coffee-with-milk"
-		my $canon_tagid;
+		my $canon_tagid = undef;
 
-		# print STDERR "Tags.pm - load_tags_taxonomy - tagtype: $tagtype \n";
+		$log->debug('load_tags_taxonomy', {tagtype => $tagtype}) if $log->is_debug();
 
 		# 1st phase: read translations and synonyms
 
@@ -1549,7 +1558,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				}
 			}
 			else {
-				$log->info("unrecognized line in taxonomy", {tagtype => $tagtype, line => $line}) if $log->is_info();
+				$log->debug("unrecognized line in taxonomy", {tagtype => $tagtype, line => $line}) if $log->is_warn();
 			}
 
 		}
@@ -1558,8 +1567,8 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 		if (scalar @taxonomy_errors) {
 
-			print STDERR "Errors in the $tagtype taxonomy definition:\n";
-			print STDERR join("", map {_taxonomy_error_display($_)} @taxonomy_errors);
+			$log->error("Errors in the $tagtype taxonomy definition:");
+			$log->error(join('', map {_taxonomy_error_display($_)} @taxonomy_errors));
 			# do we only have duplicate synonyms errors ?
 			my $only_duplicate_errors = !(first {$_->{type} ne "duplicate_synonym"} @taxonomy_errors);
 			# Disable die for the ingredients taxonomy that is merged with additives, minerals etc.
@@ -1618,7 +1627,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 		for (my $pass = 1; $pass <= $max_pass; $pass++) {
 
-			print STDERR "computing synonyms - $tagtype - pass $pass\n";
+			$log->info('computing synonyms', {tagtype => $tagtype, pass => $pass});
 
 			foreach my $lc (sort keys %{$synonyms{$tagtype}}) {
 
@@ -1870,8 +1879,14 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 							if ((not defined $canon_tagid) and (defined $possible_canon_tagid)) {
 								# this is the first line of a block
 								$canon_tagid = "$lc:" . $possible_canon_tagid;
-								print STDERR
-									"taxonomy : $tagtype : we already have a canon_tagid $canon_tagid for the tag $tag\n";
+								$log->warn(
+									'already have a canon_tagid for the tag',
+									{
+										tagtype => $tagtype,
+										canon_tagid => $canon_tagid,
+										tag => $tag
+									}
+								);
 								last;
 							}
 						}
@@ -1912,8 +1927,14 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					$properties{$tagtype}{$canon_tagid}{"$property:$lc"} = $line;
 				}
 				else {
-					print STDERR "taxonomy : $tagtype : discarding orphan line : $property : "
-						. substr($line, 0, 50) . "...\n";
+					$log->warn(
+						'discarding orphan line in taxonomy',
+						{
+							tagtype => $tagtype,
+							property => $property,
+							line => substr($line, 0, 50) . "..."
+						}
+					);
 				}
 			}
 		}
@@ -2214,10 +2235,10 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 		if (scalar @taxonomy_errors) {
 
-			print STDERR "Errors in the $tagtype taxonomy definition:\n";
-			print STDERR join("", map {_taxonomy_error_display($_)} @taxonomy_errors);
+			$log->error("Errors in the $tagtype taxonomy definition:");
+			$log->error(join('', map {_taxonomy_error_display($_)} @taxonomy_errors));
 			# do we only have duplicate synonyms errors ?
-			my $only_duplicate_errors = !(first {%{$_}{type} ne "duplicate_synonym"} @taxonomy_errors);
+			my $only_duplicate_errors = !(first {$_->{type} ne "duplicate_synonym"} @taxonomy_errors);
 			# Disable die for the ingredients taxonomy that is merged with additives, minerals etc.
 			# Disable die for the packaging taxonomy as some legit material and shape might have same name
 
@@ -2262,8 +2283,6 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				}
 			}
 		}
-
-		$log->error("taxonomy errors", {errors => \@taxonomy_errors}) if $log->is_error();
 
 		my $taxonomy_ref = {
 			stopwords => $stopwords{$tagtype},
@@ -4706,9 +4725,15 @@ sub add_users_translations_to_taxonomy ($tagtype) {
 						$translations{$l} = $users_translations_ref->{$l}{$tagid}{to};
 					}
 					else {
-						print STDERR "ignoring translation for already existing translation:\n";
-						print STDERR "existing: " . $translations{$l} . "\n";
-						print STDERR "new: " . $users_translations_ref->{$l}{$tagid}{to} . "\n";
+						$log->warn(
+							'ignoring translation for already existing translation',
+							{
+								lc => $l,
+								tagid => $tagid,
+								existing => $translations{$l},
+								new => $users_translations_ref->{$l}{$tagid}{to}
+							}
+						);
 					}
 				}
 			}
@@ -4947,7 +4972,7 @@ The user country as a 2-letters code (fr, it, ch) or `world`
 =head3 Return value
 
 If a content exists for the tag type, tag value, language code and country code, return the HTML text,
-return undef otherwise. 
+return undef otherwise.
 
 =cut
 

--- a/scripts/taxonomies/build_tags_taxonomy.pl
+++ b/scripts/taxonomies/build_tags_taxonomy.pl
@@ -20,38 +20,225 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use Modern::Perl '2017';
-use utf8;
+use ProductOpener::PerlStandards;
 
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Tags qw/:all/;
 
-my $tagtype = $ARGV[0] // '*';
-my $publish = $ARGV[1] // 1;
+use Log::Any qw($log);
+use Log::Log4perl qw(:levels);
+use Log::Log4perl::Layout::PatternLayout;
+use Log::Any::Adapter;
+use JSON::MaybeXS;
+use Term::ANSIColor;
+use Getopt::Long;
 
-print STDERR "tagtype: $tagtype\n";
-
-if ($tagtype eq '*') {
-	print "::group::Building all taxonomies\n";
-	my $errors_ref = ProductOpener::Tags::build_all_taxonomies($publish);
-	foreach my $taxonomy (keys %{$errors_ref}) {
-		if (@{$errors_ref->{$taxonomy}}) {
-			print STDERR "::error::"
-				. (scalar @{$errors_ref->{$taxonomy}})
-				. " errors while building $taxonomy taxonomy\n";
-		}
+# Define custom conversion specifiers
+# %S: Serialized MDC context as JSON
+Log::Log4perl::Layout::PatternLayout::add_global_cspec(
+	'S',
+	sub {
+		my $context = Log::Log4perl::MDC->get_context;
+		return JSON::MaybeXS->new->allow_nonref->convert_blessed->canonical->encode($context);
 	}
-	print "::endgroup::\n";
+);
+
+# %K: Colored priority (log level)
+Log::Log4perl::Layout::PatternLayout::add_global_cspec(
+	'K',
+	sub {
+		my ($layout, $message, $category, $priority) = @_;
+		my $color = 'reset';
+		if ($priority eq 'ERROR' or $priority eq 'FATAL') {$color = 'red';}
+		elsif ($priority eq 'WARN') {$color = 'yellow';}
+		elsif ($priority eq 'DEBUG') {$color = 'cyan';}
+		return ($color eq 'reset') ? $priority : color($color) . $priority . color('reset');
+	}
+);
+
+# Init log4perl to log to screen
+my $log_level = $ENV{LOG_LEVEL} // 'INFO';
+Log::Log4perl->init(
+	{
+		'log4perl.rootLogger' => "$log_level, Screen",
+		'log4perl.appender.Screen' => 'Log::Log4perl::Appender::Screen',
+		'log4perl.appender.Screen.stderr' => 1,
+		'log4perl.appender.Screen.layout' => 'PatternLayout',
+		'log4perl.appender.Screen.layout.ConversionPattern' => '[%d] [%K] %m %S%n',
+	}
+);
+
+Log::Any::Adapter->set('Log4perl');    # Send all logs to Log::Log4perl
+
+my $publish = 1;
+my $max_workers = 1;
+my $verbose = 0;
+
+GetOptions(
+	"publish=i" => \$publish,
+	"jobs|j=i" => \$max_workers,
+	"verbose|v" => \$verbose,
+) or die("Error in command line arguments\n");
+
+if ($max_workers < 1) {
+	print_error("Invalid number of workers: $max_workers. Must be at least 1.");
+	exit(1);
+}
+
+my $tagtype = $ARGV[0];
+$tagtype = '*' if !defined $tagtype || $tagtype eq '';
+
+my $IS_GITHUB_CI = $ENV{GITHUB_ACTIONS} // 0;
+
+sub print_error ($msg) {
+	print STDERR colored("error: ", 'red'), "$msg\n";
+	return;
+}
+
+sub print_success ($msg) {
+	print colored("$msg", 'green bold'), "\n";
+	return;
+}
+
+sub print_info ($msg) {
+	print colored("$msg", 'bold'), "\n";
+	return;
+}
+
+my $is_terminal = -t STDOUT;    ## no critic (InputOutput::ProhibitInteractiveTest) - we don't want to add IO::Interactive as a dependency
+my $built_count = 0;
+my $total_count = 0;
+
+sub print_status ($children) {
+	return unless $is_terminal && !$IS_GITHUB_CI;
+	my @active = sort map {$_->{taxonomy}} values %$children;
+	if (@active) {
+		my $label = colored("Building ($built_count/$total_count): ", 'bold green');
+		my $names = join(", ", @active);
+		# \r returns to start of line, \e[K clears to end of line
+		print "\r" . $label . $names . "\e[K";
+		$| = 1;    # Flush STDOUT
+	}
+	return;
+}
+
+sub clear_status () {
+	return unless $is_terminal && !$IS_GITHUB_CI;
+	print "\r\e[K";
+	$| = 1;
+	return;
+}
+
+sub build_taxonomy ($taxonomy) {
+	# We don't print "Building $taxonomy..." here as it's handled by print_status in the parent.
+	# But we print it in the child's log in case of error.
+	print "Building $taxonomy taxonomy...\n";
+	my @errors = ProductOpener::Tags::build_tags_taxonomy($taxonomy, $publish);
+	if (@errors) {
+		print_error("Failed to build $taxonomy taxonomy with " . scalar(@errors) . " error(s):");
+		foreach my $error (@errors) {
+			print_error(ProductOpener::Tags::_taxonomy_error_display($error));
+		}
+		return 0;
+	}
+	else {
+		print "$taxonomy taxonomy built successfully\n";
+		return 1;
+	}
+}
+
+sub wait_for_child ($children, $has_any_errors_ref) {
+	my $pid = wait();
+	if ($pid > 0 && exists $children->{$pid}) {
+		my $child = delete $children->{$pid};
+		my $fh = $child->{reader};
+		my $log = do {local $/; <$fh>};
+		close $fh;
+
+		$built_count++;
+
+		if ($? != 0) {
+			$$has_any_errors_ref = 1;
+			clear_status();
+			print map {colored("[$child->{taxonomy}] ", 'red') . $_ . "\n"} split("\n", $log);
+		}
+		elsif ($verbose) {
+			clear_status();
+			print map {colored("[$child->{taxonomy}] ", 'green') . $_ . "\n"} split("\n", $log);
+		}
+		print_status($children);
+	}
+	return;
+}
+
+print_info("Building tags taxonomy (tagtype: $tagtype, max_workers: $max_workers)");
+
+my @taxonomy_list;
+if ($tagtype eq '*') {
+	@taxonomy_list = (@ProductOpener::Tags::taxonomy_fields, 'test');
+	# Exclude "traces" and any taxonomy starting with "data_quality_"
+	@taxonomy_list = grep {$_ ne "traces" && rindex($_, 'data_quality_', 0) != 0}
+		sort @taxonomy_list;
+	print_info("Found " . scalar(@taxonomy_list) . " taxonomies to build: " . join(", ", @taxonomy_list));
 }
 else {
-	print "::group::Building $tagtype taxonomy\n";
-	my @errors = ProductOpener::Tags::build_tags_taxonomy($tagtype, $publish);
-	if (@errors) {
-		print STDERR "::error::" . (scalar @errors) . " errors while building $tagtype taxonomy\n";
-	}
-	print "::endgroup::\n";
+	@taxonomy_list = ($tagtype);
 }
 
-print STDERR "done building tags taxonomy\n";
+$total_count = scalar @taxonomy_list;
 
-exit(0);
+my $has_any_errors = 0;
+my %children;    ## { pid => { taxonomy => ..., reader => ... } }
+
+foreach my $taxonomy (@taxonomy_list) {
+	# If we reached the max number of workers, wait for one to finish
+	while (keys %children >= $max_workers) {
+		wait_for_child(\%children, \$has_any_errors);
+	}
+
+	my ($reader, $writer);
+	pipe($reader, $writer) or die "Could not open pipe: $!";
+
+	my $pid = fork();
+	if (!defined $pid) {
+		die "Could not fork: $!";
+	}
+	if ($pid == 0) {
+		# Child process
+		close $reader;
+		# Redirect STDOUT and STDERR to the pipe
+		open(STDOUT, ">&", $writer) or die "Could not redirect STDOUT: $!";
+		open(STDERR, ">&", $writer) or die "Could not redirect STDERR: $!";
+		close $writer;
+
+		my $success = build_taxonomy($taxonomy);
+		exit($success ? 0 : 1);
+	}
+	else {
+		# Parent process
+		close $writer;
+		$children{$pid} = {
+			taxonomy => $taxonomy,
+			reader => $reader,
+		};
+		print_status(\%children);
+	}
+}
+
+# Wait for all remaining children
+while (keys %children > 0) {
+	wait_for_child(\%children, \$has_any_errors);
+}
+
+clear_status();
+
+if (!$has_any_errors) {
+	if ($tagtype eq '*') {
+		print_success("All taxonomies built successfully");
+	}
+	else {
+		print_success("$tagtype taxonomy built successfully");
+	}
+}
+
+exit($has_any_errors ? 1 : 0);


### PR DESCRIPTION
### What
This PR modernizes the taxonomy building process by:
- Replacing manual `print` and `warn` calls with `Log::Any` in `ProductOpener::Tags` to provide structured logging.
- Enabling parallelization in `build_tags_taxonomy.pl` using `fork`, which significantly speeds up the building of all taxonomies.
- Adding support for parallel jobs in the `Makefile` via the `jobs` parameter (defaulting to the number of CPUs).
- Improving script output with colored logs and a real-time progress indicator for interactive terminal sessions.
- Ensuring the build script exits with a non-zero status code on failure for better CI integration.

### Large Language Models usage disclosure
I used Gemini CLI (agentic) to review the commits and generate this PR description.

### Related issue(s) and discussion
- Fixes: #