### PR TITLE
docs: fix duplicate-word typo in APITest.pm POD comment

### DIFF
--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -537,7 +537,7 @@ Constructs the URL to send the HTTP request to for the API.
 
 =head3 Arguments
 
-Takes in two string arguments, One being the the target and other a prefix. 
+Takes in two string arguments, One being the target and other a prefix. 
 The prefix could be simply the country code (eg: US for America or "World") OR something like ( {country-code}-{language-code} )
 
 An example below


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate-word typo (`the the target` → `the target`) in the POD documentation header of `lib/ProductOpener/APITest.pm` (Arguments section, line 540).

## Why

Trivial doc copy-edit; consistent with previously merged duplicate-word typo PRs in this repo (e.g. [#13561](https://github.com/openfoodfacts/openfoodfacts-server/pull/13561), [#13433](https://github.com/openfoodfacts/openfoodfacts-server/pull/13433), [#13434](https://github.com/openfoodfacts/openfoodfacts-server/pull/13434)).

## How verified

Pure POD comment change; no Perl semantics affected.

## Maintainer note

Happy to close if you prefer not to land agent-authored typo fixes.
