### PR TITLE
taxonomy: Add Catalan translations for shrimp categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -102214,6 +102214,7 @@ fr: Crevettes panées
 < en:Crustaceans
 en: Shrimps
 bg: Скариди
+ca: Gambes
 de: Garnele
 es: Camarones, Camarón
 fi: pirpana
@@ -102349,11 +102350,14 @@ ciqual_food_name:fr: Crevette rose, crue
 
 < en:Deep water pink shrimps
 en: Cooked Prawns
+ca: Gamba blanca, gamba d'altura
+es: Gamba blanca, gamba de altura
 fr: Crevettes roses cuites
 agribalyse_food_code:en: 10007
 ciqual_food_code:en: 10007
 ciqual_food_name:en: Shrimp or prawn, cooked
 ciqual_food_name:fr: Crevette, cuite
+wikidata:en: Q8062343
 
 
 < en:Seafood


### PR DESCRIPTION
### What

Adds missing Catalan translations to three shrimp categories in `taxonomies/food/categories.txt`:

- `en:Shrimps` — added `ca: Gambes`
- `en:Prawns` — added `ca: Gambes`
- `en:Deep water pink shrimps` — added `ca: Gamba blanca, gamba d'altura`,
  `es: Gamba blanca, gamba de altura`, `it: Gambero rosa`, and `wikidata:en: Q8062343` (Parapenaeus longirostris).

Source for the Spanish/Catalan commercial names: the Spanish MAPA fish guide confirms "gamba blanca" is the official commercial name in Catalonia, Valencia, Murcia and the Balearic Islands for *Parapenaeus longirostris*:
https://www.alimentosdespana.es/dam/ade/contenido/pdfs-migrados/zona-infantil-y-educativa/los-ninos-y-el-pescado/curiosidades-del-pescado/gamba-blanca.pdf

### Large Language Models usage disclosure

Used Claude to help identify the missing translations and verify the Wikidata mapping.

### Screenshot or video

N/A — text-only taxonomy file changes. Diff visible in the "Files changed" tab.

### Related issue(s) and discussion
- Fixes: #13512

