### PR TITLE
taxonomy: Add category for Aristeus antennatus (red prawn)

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -103000,6 +103000,15 @@ ciqual_food_name:fr: Crevette, crue
 wikidata:en: Q1058410
 
 < en:Prawns
+en: Blue and red shrimp, Red prawn, Aristeus antennatus
+ca: Gamba vermella, gamba roja, gamba de Palamós, gamba rosada
+es: Gamba roja, gamba rosada
+fr: Crevette rouge, gambon rouge
+it: Gambero rosso mediterraneo
+la: Aristeus antennatus
+wikidata:en: Q500678
+
+< en:Prawns
 en: Deep water pink shrimps
 fr: Crevettes roses
 agribalyse_food_code:en: 10059


### PR DESCRIPTION
### What

Adds a new category for *Aristeus antennatus* as a child of `en:Prawns`.

This species is commercially significant in the Western Mediterranean (known as "gamba vermella" or "gamba de Palamós" in Catalan, "gamba roja" in Spanish). Currently products of this species can only be tagged under the broader `en:Prawns` (Aristeidae family), with no species-level specificity.

The new category includes translations for `ca`, `es`, `fr`, `it`, `la` and a Wikidata link to Q500678.

References:
- Wikidata: https://www.wikidata.org/wiki/Q500678
- Wikipedia (en): https://en.wikipedia.org/wiki/Aristeus_antennatus

### Large Language Models usage disclosure

Used Claude (Anthropic) to help draft the synonym list and verify the Wikidata mapping.

### Screenshot or video

N/A — text-only taxonomy file changes. Diff visible in the "Files changed" tab.

### Related issue(s) and discussion

- Fixes: #13512