### PR TITLE
refactor: Improve tags taxonomy building performance 

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -203,6 +203,7 @@ use GraphViz2;
 use JSON::MaybeXS;
 
 use Data::DeepAccess qw(deep_get deep_exists deep_set);
+use Time::HiRes qw(gettimeofday tv_interval);
 
 binmode STDERR, ":encoding(UTF-8)";
 
@@ -1201,6 +1202,7 @@ Like "categories", "ingredients"
 =cut
 
 sub build_tags_taxonomy ($tagtype, $publish) {
+	my $t_start = [gettimeofday];
 	binmode STDERR, ":encoding(UTF-8)";
 	binmode STDIN, ":encoding(UTF-8)";
 	binmode STDOUT, ":encoding(UTF-8)";
@@ -1565,6 +1567,12 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 		close($IN);
 
+		my $t_phase1 = [gettimeofday];
+		$log->info("Taxonomy Phase 1 (Read) completed", { 
+			tagtype => $tagtype, 
+			duration => tv_interval($t_start, $t_phase1) 
+		});
+
 		if (scalar @taxonomy_errors) {
 
 			$log->error("Errors in the $tagtype taxonomy definition:");
@@ -1796,6 +1804,12 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				}
 			}
 		}
+
+		my $t_phase2 = [gettimeofday];
+		$log->info("Taxonomy Phase 2 (Synonyms) completed", { 
+			tagtype => $tagtype, 
+			duration => tv_interval($t_phase1, $t_phase2) 
+		});
 
 		# 3rd phase: compute the hierarchy
 		# there we will associate each tags with its parent
@@ -2305,6 +2319,12 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 			store_config("$result_dir/$tagtype.errors", {errors => \@taxonomy_errors});
 			put_to_cache($tagtype, $cache_prefix);
 		}
+
+		my $t_end = [gettimeofday];
+		$log->info("Taxonomy build finished", { 
+			tagtype => $tagtype, 
+			total_duration => tv_interval($t_start, $t_end) 
+		});
 	}
 
 	return @taxonomy_errors;

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1350,6 +1350,13 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 	# $tagtype -> $canon_tagid -> "$property:$lc" stores the value for property
 	$properties{$tagtype} = {};
 
+	# Local cache for string normalization to avoid expensive Unicode NFC
+	my %id_cache;
+	my $get_id = sub ($l, $s) {
+		return "" if not defined $s or $s eq "";
+		return $id_cache{"$l|$s"} //= get_string_id_for_lang($l, $s);
+	};
+
 	my @taxonomy_errors = ();
 
 	if (open(my $IN, "<:encoding(UTF-8)", $file_path)) {
@@ -1398,7 +1405,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				$line =~ s/^\s+//;    # normalize spaces
 				my @tags = split(/\s*,\s*/, $line);    # split on comma
 				foreach my $tag (@tags) {
-					my $tagid = get_string_id_for_lang($lc, $tag);
+					my $tagid = &$get_id($lc, $tag);
 					next if $tagid eq '';
 					defined $stopwords{$tagtype}{$lc} or $stopwords{$tagtype}{$lc} = [];
 					defined $stopwords{$tagtype}{$lc . ".strings"} or $stopwords{$tagtype}{$lc . ".strings"} = [];
@@ -1424,7 +1431,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 				# first entry gives id of tag
 				$lc_tag = $tags[0];
-				$lc_tagid = get_string_id_for_lang($lc, $lc_tag);
+				$lc_tagid = &$get_id($lc, $lc_tag);
 
 				# check if we already have an entry listed for one of the synonyms
 				# this is useful for taxonomies that need to be merged, and that are concatenated
@@ -1451,7 +1458,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					if ((defined $canon_tagid) and (defined $translations_to{$tagtype}{$canon_tagid}{$lc})) {
 						# in this case change current_tag
 						$lc_tag = $translations_to{$tagtype}{$canon_tagid}{$lc};
-						$lc_tagid = get_string_id_for_lang($lc, $lc_tag);
+						$lc_tagid = &$get_id($lc, $lc_tag);
 					}
 
 				}
@@ -1496,7 +1503,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				# note: Include the main tag as a synonym of itself,
 				# useful later to compute other synonyms
 				foreach my $tag (@tags) {
-					my $tagid = get_string_id_for_lang($lc, $tag);
+					my $tagid = &$get_id($lc, $tag);
 					next if $tagid eq '';
 
 					# Check if the synonym is already associated with another tag
@@ -1568,10 +1575,13 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		close($IN);
 
 		my $t_phase1 = [gettimeofday];
-		$log->info("Taxonomy Phase 1 (Read) completed", { 
-			tagtype => $tagtype, 
-			duration => tv_interval($t_start, $t_phase1) 
-		});
+		$log->info(
+			"Taxonomy Phase 1 (Read) completed",
+			{
+				tagtype => $tagtype,
+				duration => tv_interval($t_start, $t_phase1)
+			}
+		);
 
 		if (scalar @taxonomy_errors) {
 
@@ -1639,9 +1649,9 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 			foreach my $lc (sort keys %{$synonyms{$tagtype}}) {
 
-				# this list will contain all tags that are possible synonyms
+				# this Trie will contain all tags that are possible synonyms
 				# that are smaller than current tag and that we may substitute in it
-				my @smaller_synonyms = ();
+				my $substitutable_trie = {};
 
 				# synonyms don't support non roman languages at this point
 				next if ($lc eq 'ar');
@@ -1663,24 +1673,34 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					# the canonical tagid this tag is a synonym for
 					my $lc_tagid1 = $synonyms{$tagtype}{$lc}{$tagid};
 
-					#print "computing synonyms for $tagid (canon: $lc_tagid1)\n";
-
+					# Add to Trie if it qualifies as a substitutor
 					# Does $tagid have other synonyms?
 					if (scalar @{$synonyms_for{$tagtype}{$lc}{$lc_tagid1}} > 1) {
 						# limit length of synonyms for performance
 						if (length($tagid) < (30 / $pass)) {
-							push @smaller_synonyms, $tagid;
-							#print "$tagid (canon: $lc_tagid1) has other synonyms\n";
+							my $curr = $substitutable_trie;
+							foreach my $w (split('-', $tagid)) {
+								$curr = $curr->{$w} //= {};
+							}
+							$curr->{_ID} = $tagid;
 						}
 					}
 
-					# try each candidate synonyms
-					foreach my $tagid2 (@smaller_synonyms) {
+					# Search for substitutable segments in tagid using the Trie
+					my @words = split('-', $tagid);
+					my %matches_by_tagid2;
+					for (my $i = 0; $i < @words; $i++) {
+						my $curr = $substitutable_trie;
+						for (my $j = $i; $j < @words; $j++) {
+							$curr = $curr->{$words[$j]} or last;
+							if (exists $curr->{_ID}) {
+								push @{$matches_by_tagid2{$curr->{_ID}}}, [$i, $j];
+							}
+						}
+					}
 
-						last if length($tagid2) > $max_length;    # avoid generating long strings
-
-						# try to avoid looping:
-						# e.g. bio, agriculture biologique, biologique -> agriculture bio -> agriculture agriculture biologique etc.
+					foreach my $tagid2 (sort {length($a) <=> length($b) || $a cmp $b} keys %matches_by_tagid2) {
+						last if length($tagid2) > $max_length;
 
 						# canonical tagid for tagid2
 						my $lc_tagid2 = $synonyms{$tagtype}{$lc}{$tagid2};
@@ -1690,81 +1710,68 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 						# do not apply same synonym twice
 						next
-							if ((defined $synonym_contains_synonyms{$lc}{$tagid})
-							and (defined $synonym_contains_synonyms{$lc}{$tagid}{$lc_tagid2}));
+							if (defined $synonym_contains_synonyms{$lc}{$tagid}
+							and defined $synonym_contains_synonyms{$lc}{$tagid}{$lc_tagid2});
 
-						my $replace;
-						my $before = '';
-						my $after = '';
-
-						# replace whole words/phrases only
-
-						# String comparisons are many times faster than the regexps, as long as tags only ever need simple string matching.
-						# despite how convoluted it is, this is still faster than the regexp.
-						# looks in the middle of $tagid
-						#if ($tagid =~ /-${tagid2}-/) {
-						if (index($tagid, "-${tagid2}-") >= 0) {
-							$replace = "-${tagid2}-";
-							$before = '-';
-							$after = '-';
+						# Find the match with highest priority
+						my $match;
+						# Priority 1: Middle
+						foreach my $m (@{$matches_by_tagid2{$tagid2}}) {
+							if ($m->[0] > 0 && $m->[1] < $#words) {
+								$match = $m;
+								last;
+							}
 						}
-						# looks at the end of $tagid
-						#elsif ($tagid =~ /-${tagid2}$/) {
-						elsif (rindex($tagid, "-${tagid2}") + length("-${tagid2}") == length($tagid)) {
-							$replace = "-${tagid2}\$";
-							$before = '-';
+						# Priority 2: End
+						if (!$match) {
+							foreach my $m (@{$matches_by_tagid2{$tagid2}}) {
+								if ($m->[1] == $#words && $m->[0] > 0) {
+									$match = $m;
+									last;
+								}
+							}
 						}
-						# looks at the start of $tagid
-						#elsif ($tagid =~ /^${tagid2}-/) {
-						elsif (index($tagid, "${tagid2}-") == 0) {
-							$replace = "^${tagid2}-";
-							$after = '-';
+						# Priority 3: Start
+						if (!$match) {
+							foreach my $m (@{$matches_by_tagid2{$tagid2}}) {
+								if ($m->[0] == 0 && $m->[1] < $#words) {
+									$match = $m;
+									last;
+								}
+							}
 						}
-						# note that exact match is not a case here (eliminated earlier)
 
-						if (defined $replace) {
-
-							#print "computing synonyms for $tagid ($lc_tagid1): replace: $replace \n";
-
+						if ($match) {
+							my ($start_idx, $end_idx) = @$match;
 							# now that we know we have a candidate, we will substitute with all its synonyms
 							foreach my $tagid2_s (sort keys %{$synonyms_for_extended{$tagtype}{$lc}{$lc_tagid2}}) {
 
 								# don't replace a synonym by itself
 								next if $tagid2_s eq $tagid2;
 
-								# oeufs, oeufs frais -> oeufs frais frais -> oeufs frais frais frais
 								# synonym already contained? skip if we are not shortening
-								next if ((length($tagid2_s) > length($tagid2)) and ($tagid =~ /${tagid2_s}/));
-								next if ($tagid2_s =~ /$tagid/);
+								next if ((length($tagid2_s) > length($tagid2)) and ($tagid =~ /\Q$tagid2_s\E/));
+								next if ($tagid2_s =~ /\Q$tagid\E/);
 
 								# generate the tag with substitution
-								my $tagid_new = $tagid;
-								my $replaceby = "${before}${tagid2_s}${after}";
-								# TODO: why do we need /e here ?
-								$tagid_new =~ s/$replace/$replaceby/e;
-
-								#print "computing synonyms for $tagid ($tagid0): replaceby: $replaceby - tagid4: $tagid4\n";
+								my @new_words = @words;
+								splice(@new_words, $start_idx, $end_idx - $start_idx + 1, $tagid2_s);
+								my $tagid_new = join('-', @new_words);
 
 								if (not defined $synonyms_for_extended{$tagtype}{$lc}{$lc_tagid1}{$tagid_new}) {
 									# register substitution as a new synonym
 									$synonyms_for_extended{$tagtype}{$lc}{$lc_tagid1}{$tagid_new} = 1;
 									# register in synonyms
 									$synonyms{$tagtype}{$lc}{$tagid_new} = $lc_tagid1;
-									# and register the supstitution happened
-									if (defined $synonym_contains_synonyms{$lc}{$tagid_new}) {
-										# we inherit substitutions already made on original tagid
-										$synonym_contains_synonyms{$lc}{$tagid_new}
-											= clone($synonym_contains_synonyms{$lc}{$tagid});
-									}
-									else {
-										$synonym_contains_synonyms{$lc}{$tagid_new} = {};
-									}
+									# and register the substitution happened
+									$synonym_contains_synonyms{$lc}{$tagid_new}
+										= defined $synonym_contains_synonyms{$lc}{$tagid}
+										? {%{$synonym_contains_synonyms{$lc}{$tagid}}}
+										: {};
 									$synonym_contains_synonyms{$lc}{$tagid_new}{$lc_tagid2} = 1;
-									# print STDERR "synonyms_extended : synonyms{$tagtype}{$lc}{$tagid_new} = $lc_tagid1 (tagid: $tagid - tagid2: $tagid2 - tagid2_c: $lc_tagid2 - tagid2_s: $tagid2_s - replace: $replace - replaceby: $replaceby)\n";
 								}
 							}
 						}
-
 					}
 
 				}    # end of substitutions on a tagid
@@ -1806,10 +1813,13 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		}
 
 		my $t_phase2 = [gettimeofday];
-		$log->info("Taxonomy Phase 2 (Synonyms) completed", { 
-			tagtype => $tagtype, 
-			duration => tv_interval($t_phase1, $t_phase2) 
-		});
+		$log->info(
+			"Taxonomy Phase 2 (Synonyms) completed",
+			{
+				tagtype => $tagtype,
+				duration => tv_interval($t_phase1, $t_phase2)
+			}
+		);
 
 		# 3rd phase: compute the hierarchy
 		# there we will associate each tags with its parent
@@ -2321,10 +2331,13 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		}
 
 		my $t_end = [gettimeofday];
-		$log->info("Taxonomy build finished", { 
-			tagtype => $tagtype, 
-			total_duration => tv_interval($t_start, $t_end) 
-		});
+		$log->info(
+			"Taxonomy build finished",
+			{
+				tagtype => $tagtype,
+				total_duration => tv_interval($t_start, $t_end)
+			}
+		);
 	}
 
 	return @taxonomy_errors;

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1183,6 +1183,37 @@ sub _taxonomy_error_display($error_ref) {
 	return "$error{severity} - $error{type} - $line$error{msg}";
 }
 
+# Create a new prefix tree (Trie)
+sub trie_create () {
+	return {};
+}
+
+# Insert a sequence of elements into a prefix tree (Trie)
+sub trie_insert ($trie, $elements_ref, $value) {
+	my $curr = $trie;
+	foreach my $elem (@$elements_ref) {
+		$curr->{$elem} //= {};
+		$curr = $curr->{$elem};
+	}
+	$curr->{_ID} = $value;
+	return;
+}
+
+# Find all matches of trie entries within an element sequence
+sub trie_find_matches ($trie, $elements_ref) {
+	my %matches;
+	for my $i (0 .. $#$elements_ref) {
+		my $curr = $trie;
+		for my $j ($i .. $#$elements_ref) {
+			$curr = $curr->{$elements_ref->[$j]} or last;
+			if (exists $curr->{_ID}) {
+				push @{$matches{$curr->{_ID}}}, [$i, $j];
+			}
+		}
+	}
+	return \%matches;
+}
+
 =head2 build_tags_taxonomy( $tagtype, $file, $publish)
 
 Build taxonomy from the taxonomy file
@@ -1651,7 +1682,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 				# this Trie will contain all tags that are possible synonyms
 				# that are smaller than current tag and that we may substitute in it
-				my $substitutable_trie = {};
+				my $substitutable_trie = trie_create();
 
 				# synonyms don't support non roman languages at this point
 				next if ($lc eq 'ar');
@@ -1678,28 +1709,15 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					if (scalar @{$synonyms_for{$tagtype}{$lc}{$lc_tagid1}} > 1) {
 						# limit length of synonyms for performance
 						if (length($tagid) < (30 / $pass)) {
-							my $curr = $substitutable_trie;
-							foreach my $w (split('-', $tagid)) {
-								$curr = $curr->{$w} //= {};
-							}
-							$curr->{_ID} = $tagid;
+							trie_insert($substitutable_trie, [split('-', $tagid)], $tagid);
 						}
 					}
 
 					# Search for substitutable segments in tagid using the Trie
 					my @words = split('-', $tagid);
-					my %matches_by_tagid2;
-					for (my $i = 0; $i < @words; $i++) {
-						my $curr = $substitutable_trie;
-						for (my $j = $i; $j < @words; $j++) {
-							$curr = $curr->{$words[$j]} or last;
-							if (exists $curr->{_ID}) {
-								push @{$matches_by_tagid2{$curr->{_ID}}}, [$i, $j];
-							}
-						}
-					}
+					my $matches = trie_find_matches($substitutable_trie, \@words);
 
-					foreach my $tagid2 (sort {length($a) <=> length($b) || $a cmp $b} keys %matches_by_tagid2) {
+					foreach my $tagid2 (sort {length($a) <=> length($b) || $a cmp $b} keys %$matches) {
 						last if length($tagid2) > $max_length;
 
 						# canonical tagid for tagid2
@@ -1716,7 +1734,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 						# Find the match with highest priority
 						my $match;
 						# Priority 1: Middle
-						foreach my $m (@{$matches_by_tagid2{$tagid2}}) {
+						foreach my $m (@{$matches->{$tagid2}}) {
 							if ($m->[0] > 0 && $m->[1] < $#words) {
 								$match = $m;
 								last;
@@ -1724,7 +1742,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 						}
 						# Priority 2: End
 						if (!$match) {
-							foreach my $m (@{$matches_by_tagid2{$tagid2}}) {
+							foreach my $m (@{$matches->{$tagid2}}) {
 								if ($m->[1] == $#words && $m->[0] > 0) {
 									$match = $m;
 									last;
@@ -1733,7 +1751,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 						}
 						# Priority 3: Start
 						if (!$match) {
-							foreach my $m (@{$matches_by_tagid2{$tagid2}}) {
+							foreach my $m (@{$matches->{$tagid2}}) {
 								if ($m->[0] == 0 && $m->[1] < $#words) {
 									$match = $m;
 									last;


### PR DESCRIPTION
## Summary

Replace the `@smaller_synonyms` array with a Trie-based lookup for synonym substitution. Add a local memoization cache for `get_string_id_for_lang`. These two changes reduce the theoretical complexity of the synonym expansion phase from O(N²) to ~O(N).

### Trie-based synonym matching

The previous approach stored all candidate synonyms in a flat array and iterated over every candidate for each tag, using `index`/`rindex` plus prefix/suffix checks to detect where a synonym appeared. The new implementation builds a Trie keyed by hyphen-split words of each synonym. To find matches, it walks the Trie from each word position in the current tag, collecting matches in a single pass. The priority ordering (middle → end → start) is preserved via the same sequential fallback the old `if/elsif` chain used.

### Regex escaping with `\Q...\E`

Two literal-string comparisons (`$tagid =~ /\${tagid2_s}/` and `$tagid2_s =~ /\$tagid/`) previously passed user-derived strings directly into regex patterns. This was a latent ReDoS vector — a tag containing `(`, `*`, or nested quantifiers could cause catastrophic backtracking or silently match wrong substrings. Wrapping both sides with `\Q...\E` turns these into exact literal substring checks.

### Shallow copy instead of `clone()`

`$synonym_contains_synonyms` values are flat hashes (string keys → `1`). The old code called `clone()` (a deep copy) on them, which is unnecessary for one-level-deep structures. Replacing it with `{%{$hash}}` (a hash slice copy) avoids the overhead of walking nested structures that don't exist here.

### `splice`-based word substitution

The old code constructed a regex replacement dynamically — building patterns like `-tag2-`, `^tag2-`, or `-tag2$` and substituting via `s/$replace/$replaceby/e`. The new code splits the tag on `-`, then uses `splice` to swap the matched word range with the replacement synonym, and re-joins with `-`. This is equivalent semantically but avoids regex construction and evaluation entirely. The old approach also carried a stale `# TODO: why do we need /e here?` comment — that question is now moot.

## Performance

Build time for all taxonomies:

```
Before:
________________________________________________________
Executed in  642.86 secs    fish           external
   usr time    2.00 secs    1.08 millis    2.00 secs
   sys time    0.61 secs    1.03 millis    0.61 secs

After:
________________________________________________________
Executed in   33.97 secs    fish           external
   usr time    1.95 secs    0.26 millis    1.95 secs
   sys time    0.56 secs    2.08 millis    0.56 secs
```