### PR TITLE
taxonomy(food): OFF DK+SE brand edits

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -74,6 +74,9 @@ wikidata:en: Q137477221
 xx: Anna & Clara's
 # subbrand of Søstrene Grene
 
+xx: Anthon Berg
+wikidata:en: Q139899538
+
 xx: apoteket
 wikidata:en: Q1785637
 
@@ -332,6 +335,9 @@ xx: Delief
 xx: Deluxe
 # subbrand of xx:Lidl
 
+xx: Den Gamle Fabrik
+wikidata:en: Q139899420
+
 xx: Diamant
 
 xx: dmBio, dm Bio
@@ -514,8 +520,10 @@ xx: Gröna Bladet
 wikidata:en: Q139595342
 
 xx: Grøn Balance
-#web:da: https://www.grønbalance.dk/
 wikidata:en: Q65410727
+
+xx: Gårdschips
+wikidata:en: Q139900224
 
 xx: H-E-B, HEB
 wikidata:en: Q830621
@@ -569,6 +577,9 @@ xx: ICA Asia
 xx: ICA Basic, ICA Bas%c
 
 #< xx:ICA
+xx: ICA Gott Liv
+
+#< xx:ICA
 xx: ICA i❤️eco, ICA I Love Eco, i love eco, I Love Eco ICA, ICA i♥eco, i♥eco, i❤️eco, ICA i <3 eco, i <3 eco, I Heart Eco, ICA eco
 #web:sv: https://www.ica.se/icas-egna-varor/varumarken/ica-i-love-eco/
 
@@ -593,7 +604,7 @@ wikidata:en: Q138566349
 
 xx: Issawi Bageri, Bageri Issawi, Issawi, مخبز العيساوي, العيساوي
 ar: مخبز العيساوي
-#web:sv: https://www.issawi.se/
+wikidata:en: Q139900587
 
 #< xx:Lidl
 xx: Italiamo
@@ -627,6 +638,9 @@ wikidata:en: Q136824610
 
 xx: Kaptein
 wikidata:en: Q136825884
+
+xx: Karen Volf
+wikidata:en: Q139899511
 
 xx: Kavli
 wikidata:en: Q1208110
@@ -992,6 +1006,9 @@ wikidata:en: Q3092323
 
 xx: Rice Krispies
 
+xx: Risberg
+wikidata:en: Q139902513
+
 xx: Risenta
 
 xx: River
@@ -1130,6 +1147,9 @@ xx: Sum & Sam
 xx: Svansø
 wikidata:en: Q139498971
 
+xx: Svenska LantChips, Svenska Lant Chips, LantChips
+wikidata:en: Q10685096
+
 xx: Svenskt Kosttillskott
 #web:sv: https://www.svensktkosttillskott.se/
 
@@ -1179,6 +1199,9 @@ xx: Thise
 xx: Tlant
 
 xx: Tokapi
+
+xx: Toms
+wikidata:en: Q139899437
 
 xx: Tortex
 wikidata:en: Q1747471


### PR DESCRIPTION
- Adds some brands from Danish and Swedish OFF.
- Adds `wikidata` properties.
- Removes some `web` comments since their Wikidata entries have them as “official website” properties.

Needed-for: https://dk.openfoodfacts.org/facets/brands
Needed-for: https://se.openfoodfacts.org/facets/brands