### PR TITLE
fix: Iterating over `keys %$stats_ref` while deleting keys from the same hash inside the loop (lines 78-79) is unsafe in Perl

### DIFF
--- a/lib/ProductOpener/RequestStats.pm
+++ b/lib/ProductOpener/RequestStats.pm
@@ -63,7 +63,8 @@ sub log_request_stats($stats_ref) {
 	set_request_stats_time_end($stats_ref, "request");
 
 	# Turn all keys ending with _start and _end to a key with the suffix _duration
-	foreach my $key (keys %$stats_ref) {
+	my @start_keys = grep { /_start$/ } keys %$stats_ref;
+	foreach my $key (@start_keys) {
 		if ($key =~ /_start$/) {
 			my $duration_key = $key;
 			$duration_key =~ s/_start$/_duration/;


### PR DESCRIPTION
From Copilot:
```Iterating over `keys %$stats_ref` while deleting keys from the same hash inside the loop (lines 78-79) is unsafe in Perl and can lead to unpredictable behavior or missed iterations. You should collect all matching keys first (e.g., using `grep`) and then iterate over the collected list to safely delete from the hash.```
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/openfoodfacts/openfoodfacts-server/security/quality/ai-findings)._