### PR TITLE
fix: keep original unnormalized input values when upgrading non taxonomized fields

### DIFF
--- a/lib/ProductOpener/ProductSchemaChanges.pm
+++ b/lib/ProductOpener/ProductSchemaChanges.pm
@@ -63,7 +63,7 @@ use vars @EXPORT_OK;
 use Log::Any qw($log);
 
 use ProductOpener::Tags
-	qw/get_minimal_tags_subset get_property @writable_tags_fields_list list_taxonomy_tags_in_language display_taxonomy_tag/;
+	qw/get_minimal_tags_subset get_property %taxonomy_fields @writable_tags_fields_list list_taxonomy_tags_in_language display_taxonomy_tag/;
 use ProductOpener::ProductsTags qw/generate_field_tags_from_all_sources compute_field_tags/;
 use ProductOpener::Products qw/normalize_code/;
 use ProductOpener::Config qw/:all/;
@@ -875,8 +875,8 @@ sub _compute_nutrition_data_per_100g_and_per_serving_for_old_nutrition_schema ($
 				$product_ref->{nutriments}{$nid . $product_type . "_100g"} += 0.0;
 				delete $product_ref->{nutriments}{$nid . $product_type . "_serving"};
 
-				my $unit = get_property("nutrients", "zz:$nid", "unit:en")
-					;    # $unit will be undef if the nutrient is not in the taxonomy
+				my $unit = get_property("nutrients", "zz:$nid", "unit:en");
+				# $unit will be undef if the nutrient is not in the taxonomy
 
 				# petfood, Value for 100g is 10x smaller than in the nutrition table (kg)
 				if (    (defined $product_ref->{product_type})
@@ -929,22 +929,34 @@ sub convert_schema_1003_to_1004_refactor_tags ($product_ref) {
 
 	foreach my $tagtype (@writable_tags_fields_list) {
 
-		# we put the content of fields like categories_hierarchy inside categories_tags
-		# for some very old revisions we may not have the _hierarchy field, but only the _tags field, so we use it as a fallback
-		my $tags_hierarchy_or_tags_field = $product_ref->{$tagtype . "_hierarchy"}
-			// $product_ref->{$tagtype . "_tags"};
+		# Reconstruct the input tags list for this tagtype
+		my $input_tags_ref;
 
-		if (defined $tags_hierarchy_or_tags_field) {
+		# If the tagtype has no taxonomy (e.g. stores, purchase_places), then the input tags are in the "stores" and "purchase_places"
+		# and they don't have a language
+		if (not exists $taxonomy_fields{$tagtype}) {
+			$input_tags_ref = [split(/,\s*/, $product_ref->{$tagtype})];
+		}
+		else {
 
-			if (scalar @{$tags_hierarchy_or_tags_field} > 0) {
+			# For taxonomy fields like categories, the input tags were in the [tagtype]_hierarchy field
 
-				$product_ref->{$tagtype . "_tags"} = $tags_hierarchy_or_tags_field;
+			# we put the content of fields like categories_hierarchy inside categories_tags
+			# for some very old revisions we may not have the _hierarchy field, but only the _tags field, so we use it as a fallback
+			$input_tags_ref = $product_ref->{$tagtype . "_hierarchy"} // $product_ref->{$tagtype . "_tags"};
+		}
+
+		if (defined $input_tags_ref) {
+
+			if (scalar @{$input_tags_ref} > 0) {
+
+				$product_ref->{$tagtype . "_tags"} = $input_tags_ref;
 
 				# we create a tags_source.categories with the minimal tags subset to generate categories_tags
 
 				my $source_ref = {
 					last_updated_t => $product_ref->{last_updated_t} // $product_ref->{last_modified_t},
-					tags => [get_minimal_tags_subset($tagtype, $tags_hierarchy_or_tags_field)],
+					tags => [get_minimal_tags_subset($tagtype, $input_tags_ref)],
 				};
 
 				$product_ref->{tags_sources}->{$tagtype} = {$source => $source_ref};

--- a/tests/unit/expected_test_results/product_schema_changes/1003-to-1004-new-tags-schema.json
+++ b/tests/unit/expected_test_results/product_schema_changes/1003-to-1004-new-tags-schema.json
@@ -22,9 +22,9 @@
       "en:sweet-spreads",
       "en:oilseed-purees",
       "en:legume-butters",
-      "en:peanut-butters",
       "fr:pates-a-tartiner",
       "en:nut-butters",
+      "en:peanut-butters",
       "fr:Catégorie inconnue en français"
    ],
    "ingredients_analysis_tags" : [
@@ -42,7 +42,17 @@
       "en:salt"
    ],
    "lc" : "fr",
+   "purchase_places_tags" : [
+      "france",
+      "paris",
+      "saint-maur-des-fosses"
+   ],
    "schema_version" : 1004,
+   "stores_tags" : [
+      "biocoop",
+      "intermarche",
+      "trader-joe-s"
+   ],
    "tags_sources" : {
       "allergens" : {
          "packaging" : {
@@ -68,6 +78,26 @@
                "en:nut-butters",
                "en:peanut-butters",
                "fr:Catégorie inconnue en français"
+            ]
+         }
+      },
+      "purchase_places" : {
+         "packaging" : {
+            "last_updated_t" : null,
+            "tags" : [
+               "saint-maur-des-fosses",
+               "paris",
+               "france"
+            ]
+         }
+      },
+      "stores" : {
+         "packaging" : {
+            "last_updated_t" : null,
+            "tags" : [
+               "intermarche",
+               "biocoop",
+               "trader-joe-s"
             ]
          }
       }

--- a/tests/unit/expected_test_results/product_schema_changes/1003-to-1004-new-tags-schema.json
+++ b/tests/unit/expected_test_results/product_schema_changes/1003-to-1004-new-tags-schema.json
@@ -22,9 +22,9 @@
       "en:sweet-spreads",
       "en:oilseed-purees",
       "en:legume-butters",
+      "en:peanut-butters",
       "fr:pates-a-tartiner",
       "en:nut-butters",
-      "en:peanut-butters",
       "fr:Catégorie inconnue en français"
    ],
    "ingredients_analysis_tags" : [

--- a/tests/unit/expected_test_results/product_schema_changes/1003-to-1004-new-tags-schema.json
+++ b/tests/unit/expected_test_results/product_schema_changes/1003-to-1004-new-tags-schema.json
@@ -43,15 +43,15 @@
    ],
    "lc" : "fr",
    "purchase_places_tags" : [
-      "france",
-      "paris",
-      "saint-maur-des-fosses"
+      "France",
+      "Paris",
+      "Saint-Maur des Fossés"
    ],
    "schema_version" : 1004,
    "stores_tags" : [
-      "biocoop",
-      "intermarche",
-      "trader-joe-s"
+      "Biocoop",
+      "Intermarché",
+      "Trader Joe's"
    ],
    "tags_sources" : {
       "allergens" : {
@@ -85,9 +85,9 @@
          "packaging" : {
             "last_updated_t" : null,
             "tags" : [
-               "saint-maur-des-fosses",
-               "paris",
-               "france"
+               "Saint-Maur des Fossés",
+               "Paris",
+               "France"
             ]
          }
       },
@@ -95,9 +95,9 @@
          "packaging" : {
             "last_updated_t" : null,
             "tags" : [
-               "intermarche",
-               "biocoop",
-               "trader-joe-s"
+               "Intermarché",
+               "Biocoop",
+               "Trader Joe's"
             ]
          }
       }

--- a/tests/unit/product_schema_changes.t
+++ b/tests/unit/product_schema_changes.t
@@ -1527,6 +1527,12 @@ my @tests = (
 				"en:lactic-ferments", "en:ferment", "en:microbial-culture", "en:rennet",
 				"en:enzyme", "en:coagulating-enzyme", "en:salt"
 			],
+			# stores and purchase places have normalized values (without en: prefix) for stores_tags and purchase_places_tags
+			# and the source value is in "stores" and "purchase_places" fields
+			stores => "Intermarché, Biocoop, Trader Joe's",
+			stores_tags => ["intermarche", "biocoop", "trader-joe-s"],
+			purchase_places => "Saint-Maur des Fossés, Paris, France",
+			purchase_places_tags => ["saint-maur-des-fosses", "paris", "france"]
 		},
 	],
 


### PR DESCRIPTION
This is a fix for the tags refactor, to upgrade existing tags field that are not taxonomies, such as "stores" and "purchase_places".
Previously, "stores" contained a comma separated list of the input values, and "stores_tags" contained an array of normalized values.
In the new tags refactor, we don't normalize (unaccent, lowercase) fields that are not taxonomized. This PR changes the product schema upgrade to take "stores" as input, instead of "stores_tags" which is normalized in the old schema (and not normalized in the new one).