### PR TITLE
chore: bump actions-label-merge-conflict to v3.1.0

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -12,7 +12,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0  # v3.0.3 (2025-01-06)
+      - uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1  # v3.1.0 (2026-05-27)
         continue-on-error: true  # Don’t mark PRs as failing because this errs
         with:
           dirtyLabel: "💥 Merge Conflicts"


### PR DESCRIPTION
Most importantly, this bumps the node version to 24 so GitHub no longer complains about “Warning: Node.js 20 actions are deprecated.” in the CI/GitHub Actions logs.

Upstream-release-notes: https://github.com/eps1lon/actions-label-merge-conflict/releases/tag/v3.1.0