### PR TITLE
docs: update API doc, mark v2 deprecated

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,13 +11,13 @@ Open Food Facts is a food products database made by everyone, for everyone, that
 
 The Open Food Facts API enables developers to get information like ingredients and nutritional values of products, and even add more _facts_ to the products database. You can use the API to build applications that allow users to contribute to the database and make healthier food choices.
 
-**The current version of the API is `2`.**
+| API version | Status | Notes |
+|-------------|--------|-------|
+| **v3** (latest: **v3.6**) | ✅ **Current** — recommended for all new integrations | v3.6 introduces a new tags schema (`tags_sources`); see the [change log](ref-api-and-product-schema-change-log.md) |
+| **v2** | ⚠️ **Deprecated** — still supported for backward compatibility | Migrate to v3 for new integrations |
+| v1 / v0 | Legacy — not recommended | |
 
 > Data in the Open Food Facts database is provided voluntarily by users who want to support the program. As a result, there are no assurances that the data is accurate, complete, or reliable. The user assumes the entire risk of using the data.
-
-**The next version of the API is `3`.**
-
-> This version is in active development and may be subject to frequent changes.
 
 ## Before You Start
 
@@ -71,14 +71,14 @@ If you expect your app to generate a lot of API traffic, we **strongly encourage
 
 - If you submit the product's **nutritional values** and **category**, you'll get the **Nutri-Score**.
 - If you submit the product **ingredients**, you'll get the **NOVA group** (about food ultra-processing), **additives**, **allergens**, **normalized ingredients**, **vegan**, **vegetarian**…
-- If you submit the product's **category** and **labels**, you'll get the **Eco-Score** (a rating of the product's environmental impact)
+- If you submit the product's **category** and **labels**, you'll get the **Green-Score** (a rating of the product's environmental impact)
 
 ## API Deployments
 
 The OpenFoodFacts API has two deployments.
 
 - Production: https://world.openfoodfacts.org
-- Staging: https://world.openfoodfacts.net
+- Staging: https://world.openfoodfacts.net (need extra http basic auth with username `off` and password `off`, see below)
 
 Consider using the [staging environment](https://world.openfoodfacts.net) if you are not in a production scenario.
 
@@ -87,7 +87,7 @@ While testing your applications, **make all API requests to the staging environm
 Staging require an http basic auth to avoid search engine indexing. The username is `off`, and the password `off`. Here is a small javascript code that you can test in your browser console:
 
 ```js 
-fetch("https://world.openfoodfacts.net/api/v2/product/3274080005003.json", {
+fetch("https://world.openfoodfacts.net/api/v3.6/product/3274080005003.json", {
   method: "GET",
   headers: { Authorization: "Basic " + btoa("off:off") },
 })
@@ -119,7 +119,8 @@ We however ask that you send the [`app_name`, `app_version` and `app_uuid` param
 
 > Production and staging have different account databases, so **the account you create in the production environment will only work for production requests**. If you want to query (WRITE requests) the staging environment, you'll need to create another account there too.
 
-> Note: we're currently moving to a modern Auth system (Keycloak), so we will have new Auth options, hopefully this year.
+> Note: Open Food Facts is migrating to Keycloak as its authentication system. OIDC-based authentication (OAuth 2.0 bearer tokens) 
+will be supported in the future. The legacy username/password approach will remain available for backward compatibility.
 
 ^[user_id_not_email]: user_id is the username of your account. You must not use your email address.
 
@@ -127,10 +128,31 @@ We however ask that you send the [`app_name`, `app_version` and `app_uuid` param
 
 We are building a complete OpenAPI reference. Here is a list of the current API documentation available:
 
-- [OpenAPI documentation (v2)](../api/ref-v2.md)
-- [OpenAPI documentation for v3](../api/ref-v3.md) (under active development, may change frequently)
+- [OpenAPI documentation for v3](../api/ref-v3.md) *(current — latest sub-version v3.6)*
+- [OpenAPI documentation (v2)](../api/ref-v2.md) *(deprecated)*
 - A [cheatsheet](../api/ref-cheatsheet.md) listing some common patterns.
 - A [change log for the API and product schema](../api/ref-api-and-product-schema-change-log.md)
+
+### Search
+
+Structured (filter-based) search by categories, brands, nutrients, and other fields is available in API v2 via the `/api/v2/search` endpoints.
+
+> **Note:** Full-text / plain-text search is **not** available in the v2 server-side API.
+> Full-text search will be available in [Search-a-licious](https://search.openfoodfacts.org/), which will provide a dedicated search API at [search.openfoodfacts.org](https://search.openfoodfacts.org/docs).
+
+### API v2 vs v3 — Feature availability
+
+| Feature | API v2 | API v3 | Notes |
+|---------|--------|--------|-------|
+| Read product | ✅ | ✅ | |
+| Write product | ✅ | ✅ | |
+| Structured search | ✅ `/api/v2/search` | ❌ Not available | |
+| Full-text search | ⚠️ Legacy `/cgi/search.pl` only | ❌ Not available | Use [Search-a-licious](https://search.openfoodfacts.org/) |
+| Image upload | ✅ | ✅ `/api/v3.3/product/*/images` | New structured endpoint since v3.3 |
+| Image selection | ✅ | ✅ (v3.3+) | |
+| Attribute groups | ✅ | ✅ `/api/v3/attribute_groups` | Attributes with parameters excluded from v2 response (since v3.4) |
+| Taxonomy suggestions | ✅ | ✅ `/api/v3/taxonomy_suggestions` | |
+| Tags sources | ❌ | ✅ `tags_sources` field | New in v3.6; see change log |
 
 ## Tutorials
 

--- a/docs/api/ref-api-and-product-schema-change-log.md
+++ b/docs/api/ref-api-and-product-schema-change-log.md
@@ -32,6 +32,15 @@ Note: API v3 is under active development, and the API and corresponding product 
 
 ## Schema version and API version change log
 
+### 2026-05-27 — Product version 1004 — API version 3.6 — New tags schema with tags_sources
+
+Breaking changes for product read API responses:
+- The `*_hierarchy` and `*_lc` fields for writable taxonomy fields (categories, labels, brands, etc.) have been removed. Their content is now stored in the new `tags_sources` structure, keyed by source.
+- The `*_tags` fields now contain the canonical form of input tags (or unnormalized input tags for non taxonomized fields or entries that do not exist in the taxonomy) + their parents if they exist ().
+- A new `tags_sources` top-level field holds the minimal input tags per source and per tag type, enabling provenance tracking.
+
+See `convert_schema_1003_to_1004_refactor_tags` and the downgrade function `convert_schema_1004_to_1003_refactor_tags` in `ProductSchemaChanges.pm` for the full transformation logic.
+
 ### 2025-126-01 - Product version 1003 - API version 3.5 - New product nutrition facts structure
 
 Breaking changes:

--- a/docs/api/ref-cheatsheet.md
+++ b/docs/api/ref-cheatsheet.md
@@ -70,13 +70,21 @@ https://world.openfoodfacts.org/api/v2/product/3017620422003.json?fields=product
 
 ## Search for Products
 
-**Important:** full text search currently works only for v1 API (or search-a-licious, which is in beta)
+### Structured (filter-based) search — API v2
 
-* [Documentation for v1 Search API](https://wiki.openfoodfacts.org/API/Read/Search)
+Structured search by tags, nutrients, categories, brands, and other fields is available via the `/api/v2/search` endpoint:
 
-* [Reference documentation for v2 search API](https://openfoodfacts.github.io/openfoodfacts-server/api/ref-v2/#get-/api/v2/search)
+- [Reference documentation for v2 search API](https://openfoodfacts.github.io/openfoodfacts-server/api/ref-v2/#get-/api/v2/search)
 
-* The future of search in Open Food Facts is the [search-a-licious project](https://github.com/openfoodfacts/search-a-licious), deployed, in beta, at [search.openfoodfacts.org](https://search.openfoodfacts.org/). It has an API: [Search-a-licious API](https://search.openfoodfacts.org/docs)
+> **Note:** `/api/v3/search` is not yet implemented.
+
+### Full-text / plain-text search
+
+**Full-text search is not available in the v2 or v3 server-side API.**
+
+For full-text search, we are building [Search-a-licious](https://search.openfoodfacts.org/), which will be deployed at [search.openfoodfacts.org](https://search.openfoodfacts.org/). Search-a-licious will have a dedicated API: [Search-a-licious API documentation](https://search.openfoodfacts.org/docs).
+
+The legacy v1 search endpoint (`/cgi/search.pl`) supports keyword search but is not recommended for new integrations.
 
 ## Get suggestions for fields
 ### New solution: Search-a-licious (has all actually used values)


### PR DESCRIPTION
I think it's time to tell reusers to use API v3 (the latest sub-version of it, currently v3.6) as it's stable and we provide backward compatibility when the schema changes.