### PR TITLE
docs: fix doubled preposition in api-v3.yaml

### DIFF
--- a/docs/api/ref/api-v3.yaml
+++ b/docs/api/ref/api-v3.yaml
@@ -119,7 +119,7 @@ paths:
         - name: code
           in: path
           description: |
-            The barcode of the product to to create or update, or "test" to analyze the product data sent without creating or updating a product.
+            The barcode of the product to create or update, or "test" to analyze the product data sent without creating or updating a product.
           required: true
           style: simple
           explode: false


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `product to to create` → `product to create` in `docs/api/ref/api-v3.yaml`.
