### PR TITLE
docs: add Matomo analytics tracking to RapiDoc and MkDoc

### DIFF
--- a/docs/assets/api-rapidoc.html
+++ b/docs/assets/api-rapidoc.html
@@ -2,6 +2,21 @@
 <html>
 <head>
   <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://analytics.openfoodfacts.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '16']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
   <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
   <style>
     /* style for our menus */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ site_dir: gh_pages
 # for available extensions
 theme:
   name: material
+  custom_dir: overrides
   features:
     - content.action.edit
   logo: https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://analytics.openfoodfacts.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '16']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+{% endblock %}


### PR DESCRIPTION
Added Matomo analytics tracking to the API documentation pages:

- Added Matomo script to MkDocs via `custom_dir/overrides/main.html` (injected into `<head>`)
- Added Matomo script directly into `docs/assets/api-rapidoc.html` 

### Related issue
Fixes #10182 