### PR TITLE
fix: add U+25CF (●) to ingredient separators for Japanese labels

### DIFF
--- a/lib/ProductOpener/IngredientsStrings.pm
+++ b/lib/ProductOpener/IngredientsStrings.pm
@@ -94,8 +94,9 @@ use vars @EXPORT_OK;
 # U+2219 "∙" (Bullet Operator )
 # U+22C5 "⋅" (Dot Operator)
 # U+30FB "・" (Katakana Middle Dot)
+# U+25CF "●" (Black Circle). Commonly used as an ingredient separator on Japanese product labels.
 $middle_dot
-	= qr/(?: \N{U+00B7} |\N{U+2022}|\N{U+2023}|\N{U+25E6}|\N{U+2043}|\N{U+204C}|\N{U+204D}|\N{U+2219}|\N{U+22C5}|\N{U+30FB})/i;
+	= qr/(?: \N{U+00B7} |\N{U+2022}|\N{U+2023}|\N{U+25E6}|\N{U+2043}|\N{U+204C}|\N{U+204D}|\N{U+2219}|\N{U+22C5}|\N{U+30FB}|\N{U+25CF})/i;
 
 # Unicode category 'Punctuation, Dash', SWUNG DASH and MINUS SIGN
 $dashes = qr/(?:\p{Pd}|\N{U+2053}|\N{U+2212})/i;


### PR DESCRIPTION
## What
Adds `\N{U+25CF}` (`●`, BLACK CIRCLE) to the `$middle_dot` separator set in `lib/ProductOpener/IngredientsStrings.pm`.

Fixes #13688.

## Why
Japanese ingredient lists very commonly use `●` (U+25CF) as a bullet/separator between ingredients, e.g.:

```
小麦粉●砂糖●植物油脂●食塩／香料●乳化剤●膨張剤
```

`$middle_dot` already handles related bullets (U+25E6 `◦`, U+30FB `・`, U+2022 `•`, …) but not `●`, so adjacent tokens were glued together (e.g. `香料●乳化剤` parsed as one token) and ingredients that **already have `ja:` synonyms** (`香料` = flavouring, `乳化剤` = emulsifier, …) failed to match.

In a sample of ~400 `en:japan` products with an ingredient list, ~22% of parsed tokens were out of taxonomy, and a large share were `●`-glued tokens rather than genuinely missing synonyms.

## Validation
Verified at the regex level that the updated `$middle_dot` splits `香料●乳化剤` → `香料 | 乳化剤` and `小麦粉●砂糖` → `小麦粉 | 砂糖`, while existing separators (`◦`, `・`, …) still match.

## Test (note)
I couldn't run the full Perl test suite locally (it needs the OFF Docker backend to regenerate the data-driven expected results via `make update_unit_tests_results`), so I haven't committed an expected-results file. I'd suggest adding a `ja` case to `tests/unit/ingredients.t`, e.g.:

```perl
{
    id => 'ja-bullet-separator',
    lc => 'ja',
    ingredients_text => '小麦粉●砂糖●植物油脂●食塩●香料●乳化剤',
},
```

then regenerating with `make update_unit_tests_results`. Happy to add this in a follow-up, or to update this PR if a maintainer can regenerate the expected JSON — whichever you prefer.
