### PR TITLE
taxonomy: follow-up to #13690

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -1373,17 +1373,18 @@ es: bifidobacterias y otros fermentos lácticos
 fr: ferments lactiques dont bifidobacterium
 
 < en:ferment
-en: kefir ferments, kefir cultures, live kefir cultures, active kefir cultures, kefir grains microflora
+en: kefir ferment, kefir ferments, kefir cultures, live kefir cultures, active kefir cultures, kefir grains microflora
 es: fermentos de kéfir, cultivos microbianos de kéfir, levaduras de kéfir, fermentos propios del kéfir
 fr: ferments du kéfir, culture de kéfir, cultures de kéfir
 hr: kefirna kultura
 hu: kefirkultúra
 it: coltura di kefir, fermenti di kefir, fermenti vivi di kefir
 pl: kultury kefirowe, żywe kultury bakterii kefirowych, żywe kultury bakterii i drożdży kefirowych
+comment:en: maybe this needs children categories for bacteria and yeast/fungus ferments/cultures
 
-< en:kefir ferments
+< en:kefir ferment
 < en:lactic ferments
-en: kefir lactic ferments
+en: kefir lactic ferment, kefir lactic ferments
 es: fermentos lácticos de kéfir, fermentos lácticos de gránulos de kéfir
 fr: ferments lactiques du kéfir
 hr: kefir mliječni fermenti
@@ -37481,7 +37482,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Juice
 # 1687 products in 6 languages @2018-10-04
 
 < en:fruit juice
-en: berry-juice
+en: berry juice
 pl: sok z jagód, soku z jagód, sok jagodowy
 
 # don't put under fruit juice, because concentrate fruit juices that are not reconstituted to 100% of their initial volume don't count for the nutriscore
@@ -46486,7 +46487,7 @@ pt: concentrado de polme de framboesa
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-framboise-concentrée
 # 51 products in 4 languages @2018-09-27
 
-< en:fruit juice
+< en:berry juice
 < en:raspberry
 en: raspberry juice
 bg: сок от малина, сок от малини
@@ -46852,7 +46853,7 @@ fr: préparation de fraise
 hr: pripravak od jagoda, pripravak od jagode
 it: preparazione di fragole
 
-< en:fruit juice
+< en:berry juice
 < en:strawberry
 en: strawberry juice
 bg: ягодов сок, сок от ягоди

--- a/tests/integration/expected_test_results/export/export_database/rows/5601009974337.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/5601009974337.json
@@ -87,7 +87,7 @@
    "image_small_url" : "",
    "image_url" : "",
    "ingredients_analysis_tags" : "en:may-contain-palm-oil,en:non-vegan,en:vegetarian-status-unknown",
-   "ingredients_tags" : "en:pasteurized-skimmed-milk,en:dairy,en:milk,en:skimmed-milk,en:sugar,en:added-sugar,en:disaccharide,en:strawberry-juice,en:fruit,en:berries,en:juice,en:fruit-juice,en:strawberry,en:banana,en:skimmed-milk-powder,en:milk-powder,en:dextrose,en:monosaccharide,en:glucose,pt:aroma banana,pt:aroma morango,en:colour,en:e160ai,en:e160a,en:corn-starch,en:starch,en:thickener,en:lactic-ferments,en:ferment,en:microbial-culture,en:acidity-regulator,en:preservative,en:e163,en:e440b,en:e415,en:e331iii,en:e331,en:e202",
+   "ingredients_tags" : "en:pasteurized-skimmed-milk,en:dairy,en:milk,en:skimmed-milk,en:sugar,en:added-sugar,en:disaccharide,en:strawberry-juice,en:fruit,en:berries,en:juice,en:fruit-juice,en:berry-juice,en:strawberry,en:banana,en:skimmed-milk-powder,en:milk-powder,en:dextrose,en:monosaccharide,en:glucose,pt:aroma banana,pt:aroma morango,en:colour,en:e160ai,en:e160a,en:corn-starch,en:starch,en:thickener,en:lactic-ferments,en:ferment,en:microbial-culture,en:acidity-regulator,en:preservative,en:e163,en:e440b,en:e415,en:e331iii,en:e331,en:e202",
    "ingredients_text" : "_Leite_ pasteurizado desnatado, _leite_ pasteurizado, açucar, sumo de morango reconstituído e polpa de morango, polpa de banana, _leite_ em pó magro, dextrose, aroma banana, aroma morango, corantes da fruta (antocianinas, beta-caroteno), amido de milho, espessantes (pectina amidada, goma xantana), fermentos lácticos, regulador de acidez (citrato trissódico), conservante da fruta (sorbato de potássio).",
    "inositol_100g" : "",
    "insoluble-fiber_100g" : "",

--- a/tests/unit/expected_test_results/ingredients/es-procedente-e-agricultura-biologica.json
+++ b/tests/unit/expected_test_results/ingredients/es-procedente-e-agricultura-biologica.json
@@ -15,7 +15,7 @@
          "vegetarian" : "yes"
       },
       {
-         "id" : "en:kefir-lactic-ferments",
+         "id" : "en:kefir-lactic-ferment",
          "is_in_taxonomy" : 1,
          "percent_estimate" : 25,
          "percent_max" : 50,
@@ -43,18 +43,18 @@
    ],
    "ingredients_original_tags" : [
       "en:cow-s-milk",
-      "en:kefir-lactic-ferments"
+      "en:kefir-lactic-ferment"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
       "en:cow-s-milk",
       "en:dairy",
       "en:milk",
-      "en:kefir-lactic-ferments",
+      "en:kefir-lactic-ferment",
       "en:ferment",
       "en:microbial-culture",
       "en:lactic-ferments",
-      "en:kefir-ferments"
+      "en:kefir-ferment"
    ],
    "ingredients_text" : "Leche entera pasteurizada de vaca*, fermentos lácticos de gránulos de kéfir. *Procedente e agricultura ecológica.",
    "ingredients_with_specified_percent_n" : 0,
@@ -62,11 +62,11 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:kefir-lactic-ferments"
+      "en:kefir-lactic-ferment"
    ],
    "ingredients_without_ciqual_codes_n" : 1,
    "ingredients_without_ecobalyse_ids" : [
-      "en:kefir-lactic-ferments"
+      "en:kefir-lactic-ferment"
    ],
    "ingredients_without_ecobalyse_ids_n" : 1,
    "known_ingredients_n" : 2,

--- a/tests/unit/expected_test_results/recipes/nectars.strawberry-nectar.json
+++ b/tests/unit/expected_test_results/recipes/nectars.strawberry-nectar.json
@@ -68,6 +68,7 @@
       "en:berries",
       "en:juice",
       "en:fruit-juice",
+      "en:berry-juice",
       "en:strawberry",
       "en:sugar",
       "en:added-sugar",


### PR DESCRIPTION
- Use “berry juice” instead of “berry-juice”.
- Make some berry juices children of berry juice instead of fruit juice.
- Normalise some ingredient names toward singular forms.
- Add a `comment` about possibly splitting up the kefir ferment ingredient.
  - Not acted upon for now as it seems only Polish so far does any distinguishing between bacterial and fungal cultures, and it might be a lot of added complexity for little or no gain.

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13690
Follow-up-to: 90fbc91f5d7ea84702a11ab870576d224d1b1486