### PR TITLE
fix: reset to-be-exported on pro platform

### DIFF
--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -163,7 +163,8 @@ my $force_new_version = 0;
 my $fix_to_be_exported = 0
 	; # Reset the en:to-be-exported status for product that have en:exported with the last_exported_t data within a specific time frame
 
-my %fix_to_be_exported_orgs = (); # Used to record which orgs had products with en:exported status that were updated with the --fix-to-be-exported option.
+my %fix_to_be_exported_orgs = ()
+	; # Used to record which orgs had products with en:exported status that were updated with the --fix-to-be-exported option.
 
 my $query_params_ref = {};    # filters for mongodb query
 
@@ -1376,7 +1377,8 @@ while (my $product_ref = $cursor->next) {
 			add_tag($product_ref, "states", "en:to-be-exported");
 			$product_values_changed = 1;
 			# Record the org from the owner field
-			defined $fix_to_be_exported_orgs{$product_ref->{owner}} or $fix_to_be_exported_orgs{$product_ref->{owner}} = 0;
+			defined $fix_to_be_exported_orgs{$product_ref->{owner}}
+				or $fix_to_be_exported_orgs{$product_ref->{owner}} = 0;
 			$fix_to_be_exported_orgs{$product_ref->{owner}}++;
 		}
 

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -94,6 +94,7 @@ use Encode;
 use JSON::MaybeXS;
 use Data::DeepAccess qw(deep_get deep_exists deep_set);
 use Data::Compare;
+use Time::Local;
 
 use Log::Any::Adapter 'TAP';
 
@@ -339,14 +340,14 @@ my $query_ref = {};
 add_params_to_query($query_params_ref, $query_ref);
 
 # --fix-to-be-exported: filter on states_tags en:exported
-# and last_updated_t between April 1st 2026 and June 2nd 2026
+# and last_exported_t between April 1st 2026 and June 2nd 2026
 # as we had an issue with exports to the public platform silently failing and products marked as exported  without actually being exported
 # we want to reset the en:to-be-exported status for those products so that they can be exported correctly.
 if ($fix_to_be_exported) {
 	$query_ref->{'states_tags'} = 'en:exported';
-	my $start_t = timegm(0, 0, 0, 1, 3 - 1, 2026 - 1900);    # April 1st 2026
-	my $end_t = timegm(0, 0, 0, 2, 5 - 1, 2026 - 1900);    # June 2nd 2026
-	$query_ref->{'last_updated_t'} = {'$gte' => $start_t, '$lte' => $end_t};
+	my $start_t = timegm(0, 0, 0, 1, 4 - 1, 2026 - 1900);    # April 1st 2026
+	my $end_t = timegm(0, 0, 0, 2, 6 - 1, 2026 - 1900);    # June 2nd 2026
+	$query_ref->{'last_exported_t'} = {'$gte' => $start_t, '$lte' => $end_t};
 }
 
 # Query products on the pro platform where _id is missing the owner prefix

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -160,6 +160,10 @@ my $fix_obsolete;
 my $fix_last_modified_t;    # Will set the update key and ensure last_updated_t is initialised
 my $add_product_type = '';    # Add product type to products that don't have it, based on off/opf/obf/opff flavor
 my $force_new_version = 0;
+my $fix_to_be_exported = 0
+	; # Reset the en:to-be-exported status for product that have en:exported with the last_exported_t data within a specific time frame
+
+my %fix_to_be_exported_orgs = (); # Used to record which orgs had products with en:exported status that were updated with the --fix-to-be-exported option.
 
 my $query_params_ref = {};    # filters for mongodb query
 
@@ -227,6 +231,7 @@ GetOptions(
 	"fix-obsolete" => \$fix_obsolete,
 	"fix-last-modified-t" => \$fix_last_modified_t,
 	"add-product-type" => \$add_product_type,
+	"fix-to-be-exported" => \$fix_to_be_exported,
 ) or die("Error in command line arguments:\n\n$usage");
 
 use Data::Dumper;
@@ -309,6 +314,7 @@ if (    (not $process_ingredients)
 	and (not $fix_obsolete)
 	and (not $fix_last_modified_t)
 	and (not $add_product_type)
+	and (not $fix_to_be_exported)
 	and (not $analyze_and_enrich_product_data))
 {
 	die("Missing fields to update or --count option:\n$usage");
@@ -330,6 +336,17 @@ load_data();
 my $query_ref = {};
 
 add_params_to_query($query_params_ref, $query_ref);
+
+# --fix-to-be-exported: filter on states_tags en:exported
+# and last_updated_t between April 1st 2026 and June 2nd 2026
+# as we had an issue with exports to the public platform silently failing and products marked as exported  without actually being exported
+# we want to reset the en:to-be-exported status for those products so that they can be exported correctly.
+if ($fix_to_be_exported) {
+	$query_ref->{'states_tags'} = 'en:exported';
+	my $start_t = timegm(0, 0, 0, 1, 3 - 1, 2026 - 1900);    # April 1st 2026
+	my $end_t = timegm(0, 0, 0, 2, 5 - 1, 2026 - 1900);    # June 2nd 2026
+	$query_ref->{'last_updated_t'} = {'$gte' => $start_t, '$lte' => $end_t};
+}
 
 # Query products on the pro platform where _id is missing the owner prefix
 # (e.g. _id = "5060323905388" instead of "org-xxx/5060323905388")
@@ -1348,6 +1365,21 @@ while (my $product_ref = $cursor->next) {
 			}
 		}
 
+		# Fix products to_be_exported status if last_exported_t is within a specific time frame, as we had an issue with exports to the public platform silently failing and products marked as exported  without actually being exported
+		# The en:exported states_tag and the last_exported_t have been added to the query,
+		# so we can apply the fix to all selected products in this loop
+		if ($fix_to_be_exported) {
+			# Remove en:exported from states_tags and add en:to-be-exported
+
+			print STDERR "fixing to_be_exported status for product $code\n";
+			remove_tag($product_ref, "states", "en:exported");
+			add_tag($product_ref, "states", "en:to-be-exported");
+			$product_values_changed = 1;
+			# Record the org from the owner field
+			defined $fix_to_be_exported_orgs{$product_ref->{owner}} or $fix_to_be_exported_orgs{$product_ref->{owner}} = 0;
+			$fix_to_be_exported_orgs{$product_ref->{owner}}++;
+		}
+
 		if ($process_packagings) {
 			analyze_and_combine_packaging_data($product_ref, $response_ref);
 		}
@@ -1654,5 +1686,13 @@ print STDERR "products_changed: $products_changed\n";
 print STDERR "products_new_version_created: $products_new_version_created\n";
 print STDERR "products_silently_updated: $products_silently_updated\n";
 print STDERR "products_pushed_to_redis: $products_pushed_to_redis\n";
+
+# List orgs with products that had their to-be-exported status fixed
+if ($fix_to_be_exported) {
+	print "\nOrgs with products that had their to-be-exported status fixed:\n";
+	foreach my $org (sort keys %fix_to_be_exported_orgs) {
+		print "$org\t" . $fix_to_be_exported_orgs{$org} . "\n";
+	}
+}
 
 exit(0);


### PR DESCRIPTION
There was an issue with the mount mp8: /zfs-hdd/podata/pro_export_files,mp=/mnt/off-pro/cache/export_files on the off contained that resulted in products being marked as exported on the pro platform, while they were not actually imported on the public platform.

This fix is to reset the en:exported -> en:to-be-exported state when last_updated_t is within a specific range.

Discussion: https://openfoodfacts.slack.com/archives/CN25JTE6N/p1780392784039839