### PR TITLE
feat: allow searching by product name or generic name only

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -355,6 +355,7 @@ foreach my $series (@search_series, "nutrition_grades") {
 if ($action eq 'display') {
 
 	$template_data_ref->{search_terms} = $search_terms;
+	$template_data_ref->{search_type} = $search_type;
 
 	my $active_list = 'active';
 	my $active_map = '';
@@ -640,6 +641,12 @@ elsif ($action eq 'process') {
 		$page = 1;
 	}
 
+	# Search type (name, generic_name, or all)
+	my $search_type = remove_tags_and_quote(decode utf8 => single_param('search_type')) || 'all';
+	if (($search_type ne 'name') and ($search_type ne 'generic_name') and ($search_type ne 'all')) {
+		$search_type = 'all';
+	}
+
 	# Search terms
 
 	if ((defined $search_terms) and ($search_terms ne '')) {
@@ -664,8 +671,18 @@ elsif ($action eq 'process') {
 				}
 			}
 			if (scalar keys %terms > 0) {
-				$query_ref->{_keywords} = {'$all' => [keys %terms]};
+				my $keywords_field = '_keywords';
+				if ($search_type eq 'name') {
+					$keywords_field = '_keywords_product_name';
+				}
+				elsif ($search_type eq 'generic_name') {
+					$keywords_field = '_keywords_generic_name';
+				}
+				$query_ref->{$keywords_field} = {'$all' => [keys %terms]};
 				$current_link .= "\&search_terms=" . URI::Escape::XS::encodeURIComponent($search_terms);
+				if ($search_type ne 'all') {
+					$current_link .= "\&search_type=$search_type";
+				}
 			}
 		}
 	}

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -352,6 +352,12 @@ foreach my $series (@search_series, "nutrition_grades") {
 	}
 }
 
+# Search type (name, generic_name, or all)
+my $search_type = remove_tags_and_quote(decode utf8 => single_param('search_type')) || 'all';
+if (($search_type ne 'name') and ($search_type ne 'generic_name') and ($search_type ne 'all')) {
+	$search_type = 'all';
+}
+
 if ($action eq 'display') {
 
 	$template_data_ref->{search_terms} = $search_terms;
@@ -639,12 +645,6 @@ elsif ($action eq 'process') {
 	my $page = 0 + (single_param('page') || 1);
 	if (($page < 1) or ($page > 1000)) {
 		$page = 1;
-	}
-
-	# Search type (name, generic_name, or all)
-	my $search_type = remove_tags_and_quote(decode utf8 => single_param('search_type')) || 'all';
-	if (($search_type ne 'name') and ($search_type ne 'generic_name') and ($search_type ne 'all')) {
-		$search_type = 'all';
 	}
 
 	# Search terms

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -2991,6 +2991,7 @@ sub compute_keywords ($product_ref) {
 		my $wordid = get_string_id_for_lang($product_lc, $word);
 		if (length($wordid) >= 2) {
 			$keywords_product_name{normalize_search_terms($wordid)} = 1;
+			$keywords{normalize_search_terms($wordid)} = 1;  # ADD THIS LINE
 		}
 	}
 
@@ -2998,6 +2999,7 @@ sub compute_keywords ($product_ref) {
 		my $wordid = get_string_id_for_lang($product_lc, $word);
 		if (length($wordid) >= 2) {
 			$keywords_generic_name{normalize_search_terms($wordid)} = 1;
+			$keywords{normalize_search_terms($wordid)} = 1;  # ADD THIS LINE
 		}
 	}
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -2967,6 +2967,8 @@ sub compute_keywords ($product_ref) {
 	my @tag_fields = qw(brands categories origins labels);
 
 	my %keywords;
+	my %keywords_product_name;
+	my %keywords_generic_name;
 
 	my $product_lc = $product_ref->{lc} || $lc;
 
@@ -2984,9 +2986,24 @@ sub compute_keywords ($product_ref) {
 		}
 	}
 
+	# Extract keywords from product_name and generic_name separately
+	foreach my $word (split(/,|'|'|\s/, $product_ref->{product_name} // '')) {
+		my $wordid = get_string_id_for_lang($product_lc, $word);
+		if (length($wordid) >= 2) {
+			$keywords_product_name{normalize_search_terms($wordid)} = 1;
+		}
+	}
+
+	foreach my $word (split(/,|'|'|\s/, $product_ref->{generic_name} // '')) {
+		my $wordid = get_string_id_for_lang($product_lc, $word);
+		if (length($wordid) >= 2) {
+			$keywords_generic_name{normalize_search_terms($wordid)} = 1;
+		}
+	}
+
 	foreach my $value (@text_values) {
 
-		foreach my $word (split(/,|'|’|\s/, $value)) {
+		foreach my $word (split(/,|'|'|\s/, $value)) {
 			my $wordid = get_string_id_for_lang($product_lc, $word);
 			if (length($wordid) >= 2) {
 				$keywords{normalize_search_terms($wordid)} = 1;
@@ -2995,6 +3012,8 @@ sub compute_keywords ($product_ref) {
 	}
 
 	$product_ref->{_keywords} = [sort keys %keywords];
+	$product_ref->{_keywords_product_name} = [sort keys %keywords_product_name];
+	$product_ref->{_keywords_generic_name} = [sort keys %keywords_generic_name];
 
 	return;
 }

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -2474,6 +2474,22 @@ msgctxt "search_terms_note"
 msgid "Search for words present in the product name, generic name, brands, categories, origins and labels"
 msgstr "Search for words present in the product name, generic name, brands, categories, origins and labels"
 
+msgctxt "search_type"
+msgid "Search in"
+msgstr "Search in"
+
+msgctxt "search_type_all"
+msgid "All fields"
+msgstr "All fields"
+
+msgctxt "search_type_name"
+msgid "Product name only"
+msgstr "Product name only"
+
+msgctxt "search_type_generic_name"
+msgid "Generic name only"
+msgstr "Generic name only"
+
 msgctxt "search_title"
 msgid "Search a product, brand, ingredient, nutriment etc."
 msgstr "Search a product, brand, ingredient, nutriment etc."

--- a/templates/web/pages/search_form/search_form.tt.html
+++ b/templates/web/pages/search_form/search_form.tt.html
@@ -17,9 +17,9 @@
             <div class="large-12 columns">
                 <label for="search_type">[% lang ('search_type') %]</label>
                 <select name="search_type" id="search_type">
-                    <option value="all" [% IF search_type == 'all' %]selected="selected"[% END %]>[% lang('search_type_all') %]</option>
-                    <option value="name" [% IF search_type == 'name' %]selected="selected"[% END %]>[% lang('search_type_name') %]</option>
-                    <option value="generic_name" [% IF search_type == 'generic_name' %]selected="selected"[% END %]>[% lang('search_type_generic_name') %]</option>
+                    <option value="all" [% IF search_type eq 'all' %]selected="selected"[% END %]>[% lang('search_type_all') %]</option>
+                    <option value="name" [% IF search_type eq 'name' %]selected="selected"[% END %]>[% lang('search_type_name') %]</option>
+                    <option value="generic_name" [% IF search_type eq 'generic_name' %]selected="selected"[% END %]>[% lang('search_type_generic_name') %]</option>
                 </select>
             </div>
         </div>

--- a/templates/web/pages/search_form/search_form.tt.html
+++ b/templates/web/pages/search_form/search_form.tt.html
@@ -12,6 +12,18 @@
             </div>
         </div>
 
+        <!-- Search Type Filter -->
+        <div class="row">
+            <div class="large-12 columns">
+                <label for="search_type">[% lang ('search_type') %]</label>
+                <select name="search_type" id="search_type">
+                    <option value="all" [% IF search_type == 'all' %]selected="selected"[% END %]>[% lang('search_type_all') %]</option>
+                    <option value="name" [% IF search_type == 'name' %]selected="selected"[% END %]>[% lang('search_type_name') %]</option>
+                    <option value="generic_name" [% IF search_type == 'generic_name' %]selected="selected"[% END %]>[% lang('search_type_generic_name') %]</option>
+                </select>
+            </div>
+        </div>
+
         <!-- Criteria -->
 
         <h3>[% lang('search_tags') %]</h3>


### PR DESCRIPTION
## What
Allow users to filter product searches by specific fields instead of searching across all fields. Added a dropdown selector in the search form to choose between:
- All fields (default) - searches product name, generic name, brands, categories, origins, and labels
- Product name only - searches only product name keywords
- Generic name only - searches only generic name keywords

## Changes Made
- Add separate keyword fields `_keywords_product_name` and `_keywords_generic_name` in `compute_keywords()`
- Support `search_type` parameter (values: all, name, generic_name) in search.pl
- Add dropdown filter in search form template to select search scope
- Add English language strings for new search type options
- Default to searching all fields when search_type is not specified

## Related issue(s)
- Fixes #485

## Screenshots
<!-- Add a screenshot or video showing the new dropdown selector if possible -->

## Testing
This feature has been tested to:
- ✅ Search across all fields (default behavior)
- ✅ Search by product name only
- ✅ Search by generic name only
- ✅ Preserve filter selection during pagination
- ✅ Maintain backward compatibility