### PR TITLE
taxonomy(food): dietary supplements edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -123415,7 +123415,7 @@ cs: Doplněk stravy
 da: Kosttilskud
 de: Nahrungsergänzungsmittel
 el: Συμπλήρωμα διατροφής
-eo: Dieta suplemento
+eo: Dieta suplementoj
 es: Suplementos dietéticos, Complementos alimenticios
 eu: Elikadura-osagarri
 fa: مکمل‌های غذایی طبیعی
@@ -123466,12 +123466,12 @@ en: Flavoured dietary supplements
 sv: Kosttillskott med smak
 
 < en:Dietary supplements
-en: Collagen
+en: Collagen supplements, Collagen
 nl: Collageen
 sv: Kollagen
 
 < en:Dietary supplements
-en: Spirulina
+en: Spirulina supplements, Spirulina
 xx: Spirulina
 bg: Спирулина
 es: Espirulina, Spirulina
@@ -123486,24 +123486,19 @@ wikidata:en: Q285335
 
 < en:Dietary supplements
 < en:Seaweeds and their products
-en: Chlorella
+en: Chlorella supplements, Chlorella
 xx: Chlorella
 wikidata:en: Q285335
 
 < en:Dietary supplements
-en: Vitamin mineral combinations
-gpc_category_code:en: 10000467
-gpc_category_description:en: Definition: Includes any products that can be described/observed as a preparation, composed of one or more minerals such as calcium, silica, zinc, or of one or more vitamins, such as A, C, B-complex, or a combination of vitamins and minerals, which is taken as a dietary supplement to help prevent and/or mitigate vitamin or mineral deficiency conditions of the human body. Definition Excludes: Excludes products such as Vitamins and Minerals obtained only by prescription or from a healthcare professional, Nutritional Supplements, Appetite Suppressants and Fat Blockers.
-gpc_category_name:en: Vitamins/Minerals
-
-< en:Dietary supplements
-en: Vitamins, vitamines
+en: Vitamin supplements, Vitamins
 bg: Витамини
-da: Vitaminer
+ca: Suplement vitamínic
+da: Vitamintilskud, Vitaminer
 de: Vitamine
-es: Vitaminas, Suplementos vitamínicos
+es: Suplementos vitamínicos, Vitaminas
 fi: vitamiinit
-fr: Vitamines
+fr: Compléments alimentaires vitamines, Complément alimentaire vitamine, Vitamines
 hr: Vitamini
 hu: Vitaminok
 it: Vitamine
@@ -123511,22 +123506,129 @@ ja: ビタミン剤
 nl: Vitamines
 ro: Vitamine
 ru: Витамины
-sv: Vitaminer
+sv: Vitamintillskott, Vitaminer
 tr: Vitaminler
 zh: 维生素
-wikidata:en: Q34956
+wikidata:en: Q130148368
 
-< en:Vitamins
-en: D vitamins, Vitamin D supplements
-da: D-vitaminer
-sv: D-vitaminer
+< en:Vitamin supplements
+en: Vitamin B12 supplements, Vitamin B₁₂ supplements, B₁₂ vitamins, B12 vitamins
+da: B₁₂-vitamintilskud, B12-vitamintilskud, B₁₂-vitaminer, B12-vitaminer
+sv: B₁₂-vitamintillskott, B12-vitamintillskott, B₁₂-vitaminer, B12-vitaminer
+wikidata:en: Q140051628
+
+< en:Vitamin supplements
+en: Vitamin C supplements, C vitamins
+da: C-vitamintilskud, C-vitaminer
+sv: C-vitamintillskott, C-vitaminer
+
+< en:Vitamin supplements
+en: Vitamin D supplements, D vitamins
+da: D-vitamintilskud, D-vitaminer
+sv: D-vitamintillskott, D-vitaminer
+
+< en:Vitamin D supplements
+en: Vitamin D3 supplements, Vitamin D₃ supplements, D₃ vitamins, D3 vitamins
+da: D₃-vitamintilskud, D3-vitamintilskud, D₃-vitaminer, D3-vitaminer
+sv: D₃-vitamintillskott, D3-vitamintillskott, D₃-vitaminer, D3-vitaminer
 
 < en:Dietary supplements
-en: Melatonin, Melatonin supplements
+en: Mineral supplements, Minerals
+da: Mineraltilskud
+sv: Mineraltillskott
+wikidata:en: Q140051529
+
+< en:Mineral supplements
+en: Calcium supplements, Calcium
+ar: مكملات الكالسيوم
+da: Kalciumtilskud, Calciumtilskud, Kalcium, Calcium
+el: Συμπλήρωμα ασβεστίου
+eo: Kalcia suplementoj
+es: Suplemento de calcio
+hy: Կալցիումի հավելումներ
+ja: カルシウムサプリメント
+or: କ୍ୟାଲସିଅମ ପରିପୂରକ
+pt: Suplementos de cálcio
+sl: Kalcijevo dopolnilo
+sv: Kalciumtillskott, Calciumtillskott, Kalcium, Calcium
+vi: Thuốc bổ sung calci
+zh: 鈣補充劑
+wikidata:en: Q28403082
+
+< en:Mineral supplements
+en: Iron supplements, Iron
+ar: مكملات الحديد
+da: Jerntilskud, Jern
+de: Eisen-Präparate, Eisen
+el: Συμπλήρωμα σιδήρου
+es: Suplemento de hierro
+fa: مکمل‌های آهن
+fr: Fer
+ht: Fè
+id: Suplemen besi
+it: Terapia marziale
+kk: Құрамында темірі бар дәрілермен емдеу
+ko: 철 보충제
+lv: Dzelzs preparāti
+ne: आइरन चक्की
+nl: Staalpillen
+nn: Jerntilskot
+or: ଲୌହ ପରିପୂରକ
+pl: Suplement diety z żelazem
+pt: Suplementos de ferro
+ru: Препараты железа
+sv: Järntilskott, Järn
+ta: இரும்புச் சத்து
+tl: Uwit
+tr: Demir takviyesi
+vi: Bổ sung sắt
+zh: 鐵劑
+wikidata:en: Q769796
+
+< en:Mineral supplements
+en: Magnesium supplements, Magnesium
+da: Magnesiumtilskud, Magnesium
+sv: Magnesiumtillskott, Magnesium
+wikidata:en: Q660
+
+< en:Mineral supplements
+en: Zinc supplements, Zinc
+da: Zinktilskud, Zink
+sv: Zinktillskott, Zink
+wikidata:en: Q758
+
+< en:Mineral supplements
+< en:Vitamin supplements
+en: Multivitamin and mineral supplements, Multivitamins, Combined vitamin and mineral supplements, Vitamin mineral combinations
+ar: متعدد الفيتامينات
+bn: মাল্টিভিটামিন
+eo: Multvitamina suplementoj
+eu: Multibitamina
+fa: مولتی ویتامین
+fr: Compléments alimentaires multivitaminés, Complément alimentaire multivitaminé
+ko: 종합비타민
+mk: Мултивитамин
+nl: Multivitamine
+pt: Multivitamínico
+ru: Поливитаминные препараты
+sh: Multivitamin
+sr: Multivitamin
+th: มัลติวิตามิน
+ur: کثیر الحیاتین
+vi: Vitamin tổng hợp
+zh: 复合维生素, 綜合維他命
+description:en: Dietary supplements providing multiple different vitamins, minerals, and/or other nutritional supplements.
+gpc_category_code:en: 10000467
+gpc_category_description:en: Definition: Includes any products that can be described/observed as a preparation, composed of one or more minerals such as calcium, silica, zinc, or of one or more vitamins, such as A, C, B-complex, or a combination of vitamins and minerals, which is taken as a dietary supplement to help prevent and/or mitigate vitamin or mineral deficiency conditions of the human body. Definition Excludes: Excludes products such as Vitamins and Minerals obtained only by prescription or from a healthcare professional, Nutritional Supplements, Appetite Suppressants and Fat Blockers.
+gpc_category_name:en: Vitamins/Minerals
+wikidata:en: Q172395
+
+< en:Dietary supplements
+en: Melatonin supplements, Melatonin
 xx: Melatonin
 
 < en:Flavoured dietary supplements
-< en:Melatonin
+< en:Melatonin supplements
 en: Flavoured melatonin supplements
 
 < en:Dietary supplements

--- a/tests/integration/expected_test_results/facets/category-vitamins.html
+++ b/tests/integration/expected_test_results/facets/category-vitamins.html
@@ -1,0 +1,9 @@
+<!DOCTYPE --ignore-->
+<html><head>
+<title>302 Found</title>
+</head><body>
+<h1>Found</h1>
+<p>The document has moved <a href="//world.openfoodfacts.localhost/facets/categories/Vitamin supplements.json?fields=product_name,labels_tags">here</a>.</p>
+<hr>
+<address>Apache/--ignore-- (Debian) Server at world.openfoodfacts.localhost Port 80</address>
+</body></html>

--- a/tests/integration/expected_test_results/facets/category-vitamins.html.metadata
+++ b/tests/integration/expected_test_results/facets/category-vitamins.html.metadata
@@ -1,0 +1,11 @@
+{
+   "api_call" : {
+      "body" : null,
+      "content-type" : null,
+      "method" : "GET",
+      "parameters" : {
+         "fields" : "product_name,labels_tags"
+      },
+      "path" : "/categories/Vitamins.json"
+   }
+}

--- a/tests/integration/facets.t
+++ b/tests/integration/facets.t
@@ -339,14 +339,18 @@ my $tests_ref = [
 		expected_status_code => 200,
 		sort_products_by => 'product_name',
 	},
-	# facet name that is the same as a facet type
+	# facet alias that is the same as a facet type
 	# https://github.com/openfoodfacts/openfoodfacts-server/issues/9708
 	{
 		test_case => 'category-vitamins',
 		method => 'GET',
 		path => 'facets/categories/Vitamins.json?fields=product_name,labels_tags',
-		expected_status_code => 200,
-		sort_products_by => 'product_name',
+		expected_status_code => 302,
+		headers => {
+			Location =>
+				'http://world.openfoodfacts.localhost/facets/categories/Vitamin supplements.json?fields=product_name,labels_tags',
+		},
+		expected_type => 'html',
 	},
 	# test some redirects
 	{


### PR DESCRIPTION
I was browsing the [“Vitamins” category facet](https://world.openfoodfacts.org/facets/categories/Vitamins) and noticed several mineral supplements being listed there, and realising they didn’t have a good other “home” (best would be the very generic “Dietary supplements”). Additionally, a number of single-vitamin supplements seemed fairly common and probably common enough to have their own categories.

As such, this PR:
- Makes category names explicitly specify that they’re supplements.
- Adds a number of new categories:
  - Vitamin B₁₂, C, and D₃ supplements
  - Mineral supplements, incl. calcium, iron, magnesium, and zinc ones.
  - Translations mostly from Wikidata.
- Renames “Vitamin mineral combinations” to “Multivitamin and mineral supplements”
  - “Multivitamins” is colloquially used for supplements containing both vitamins and minerals and possibly other dietary supplements too.
- Adds/updates some `wikidata` properties.