### PR TITLE
taxonomy: add Japanese (ja) synonyms for additive functional classes

### DIFF
--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -114,6 +114,7 @@ wikidata:en: Q898753
 
 # nova:en:anti-caking-agent
 en: Anti-caking agent, anticaking agent, anti-stick agent, anti-sticking, drying agent, dusting agent, prevent caking, prevents caking, anti-clumping, anticaking blend, anticake
+ja: 固結防止剤, ケーキング防止剤
 bg: Антислепващ агент
 ca: Antiaglomerant
 cs: Protispékavá látka, protispékavé látky
@@ -163,6 +164,7 @@ wikidata:en: Q726460
 
 
 en: Anti-foaming agent, de-foaming agent, antifoaming agent, defoaming agent, anti-foaming
+ja: 消泡剤
 bg: Антипенител
 ca: Antiespumant
 cs: Odpěňovač, odpěňovače
@@ -665,6 +667,7 @@ zh: 外壳着色剂
 
 # http://www.fao.org/gsfaonline/additives/results.html?techFunction=10&searchBy=tf
 en: colour retention agent, colour adjunct, colour fixative, colour stabilizer, maintain color, color retention
+ja: 発色剤
 de: Farbstabilisator
 es: Agente de retención de color, complementos del color, estabilizador del color, estabilizadores del color, fijadores del color, fijador del color
 fr: agent de rétention de la couleur, fixateur de la couleur, fixateur de couleur, adjuvant de la couleur, stabilisant de la couleur, agent de rétention de couleur, fixateur de couleur, adjuvant de couleur, stabilisant de couleur
@@ -1168,6 +1171,7 @@ wikidata:en: Q334582
 
 
 en: Humectant, moisture retention agent, water retention agent, wetting agent, moisture retention
+ja: 保湿剤
 bg: Влагозадържащ агент
 ca: Humectant
 cs: Zvlhčující látka, zvlhčující látky

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -114,7 +114,6 @@ wikidata:en: Q898753
 
 # nova:en:anti-caking-agent
 en: Anti-caking agent, anticaking agent, anti-stick agent, anti-sticking, drying agent, dusting agent, prevent caking, prevents caking, anti-clumping, anticaking blend, anticake
-ja: 固結防止剤, ケーキング防止剤
 bg: Антислепващ агент
 ca: Antiaglomerant
 cs: Protispékavá látka, protispékavé látky
@@ -129,6 +128,7 @@ ga: Oibreán frithstolptha
 hr: sredstvo protiv zgrudnjavanja, sredstvo protiv zgrušavanja, sredstvo protiv zgrudvavanja, tvar protiv zgrudnjavanja, tvar protiv zgrušavanja, tvar za sprečavanje zgrudnjava, tvar za sprečavanje zgrudnjavanja, tvar za sprječavanje zgrudnjavanja, suha tvar, tvar za sprečavanju zgrudnjavanja
 hu: Csomósodást és lesülést gátló anyag, Csomósodást gátló anyag
 it: Agente antiagglomerante, agenti antiagglomeranti, antiagglomerante, antiagglomeranti
+ja: 固結防止剤, ケーキング防止剤
 lt: Lipnumą reguliuojanti medžiaga
 lv: Pretsalipes viela
 mt: Aġent kontra t-tagħqid
@@ -164,7 +164,6 @@ wikidata:en: Q726460
 
 
 en: Anti-foaming agent, de-foaming agent, antifoaming agent, defoaming agent, anti-foaming
-ja: 消泡剤
 bg: Антипенител
 ca: Antiespumant
 cs: Odpěňovač, odpěňovače
@@ -179,6 +178,7 @@ ga: Oibreán frithchúrtha
 hr: tvar protiv pjenjenja
 hu: Habzásgátló
 it: Agente antischiumogeno, agenti antischiumogeni, antischiumogeno, antischiumogeni
+ja: 消泡剤
 lt: Medžiaga nuo putojimo
 lv: Putu dzēsējs
 mt: Aġent kontra r-ragħwa
@@ -667,10 +667,10 @@ zh: 外壳着色剂
 
 # http://www.fao.org/gsfaonline/additives/results.html?techFunction=10&searchBy=tf
 en: colour retention agent, colour adjunct, colour fixative, colour stabilizer, maintain color, color retention
-ja: 発色剤
 de: Farbstabilisator
 es: Agente de retención de color, complementos del color, estabilizador del color, estabilizadores del color, fijadores del color, fijador del color
 fr: agent de rétention de la couleur, fixateur de la couleur, fixateur de couleur, adjuvant de la couleur, stabilisant de la couleur, agent de rétention de couleur, fixateur de couleur, adjuvant de couleur, stabilisant de couleur
+ja: 発色剤
 pl: do korekcji barwy, substancja wzmacniająca kolor
 pt: estabilizador de cor
 description:es: Aditivos alimentarios que estabilizan, retienen o intensifican el color de un alimento.
@@ -1171,7 +1171,6 @@ wikidata:en: Q334582
 
 
 en: Humectant, moisture retention agent, water retention agent, wetting agent, moisture retention
-ja: 保湿剤
 bg: Влагозадържащ агент
 ca: Humectant
 cs: Zvlhčující látka, zvlhčující látky
@@ -1186,6 +1185,7 @@ ga: Taisleán
 hr: tvar za zadržavanje vlage, humektant, sredstvo za zadržavanje vlage, tvari za zadržavanje vlage
 hu: Nedvesítőszer
 it: Umidificante, umidificanti, agente umidificante, agenti umidificanti, umettante, umettanti
+ja: 保湿剤
 lt: Drėgmę išlaikanti medžiaga
 lv: Mitrumuzturētājs
 nb: Fuktighetsbevarer


### PR DESCRIPTION
## What
Adds Japanese (`ja:`) functional-class names to `taxonomies/additives_classes.txt` for classes that are extremely common on Japanese food labels but had no `ja:` synonym:

| additive class (en) | added ja: |
|---|---|
| colour retention agent | 発色剤 |
| flavour enhancer | 調味料, 調味料（アミノ酸等）, うま味調味料, 旨味調味料 |
| anti-foaming agent | 消泡剤 |
| anti-caking agent | 固結防止剤, ケーキング防止剤 |
| humectant | 保湿剤 |

## Why
Japanese ingredient labels declare additives by functional class, e.g. `調味料（アミノ酸等）`, `発色剤（亜硝酸Na）`. These class words appear on a large share of products, so adding them improves additive-class detection for Japanese products.

## Sources
- `発色剤` and `調味料` are official display class names (用途名) defined in Japan's Food Labeling Standards — Consumer Affairs Agency, 食品表示基準 別表第七.
- `消泡剤` / `固結防止剤` / `保湿剤` are standard functional-class names from the Japanese Specifications and Standards for Food Additives (MHLW, 食品添加物公定書).

## Notes
Follow-up to #13687 / #13691. These are additive-class synonyms (taxonomy data), validated by the taxonomy build; no parser test needed. Happy to add more (e.g. 起泡剤 = foaming agent, 増量剤 = bulking agent) in a separate PR if useful.
