### PR TITLE
taxonomy: add Japanese (ja) ingredient synonym variants (sugar, malt, sweet bean paste)

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -24789,7 +24789,7 @@ id: Malt
 io: Malto
 is: Malt
 it: malto
-ja: 麦芽
+ja: 麦芽, モルト
 ko: 엿기름
 lb: Malz
 lt: Salyklas
@@ -30401,7 +30401,7 @@ id: gula
 is: sykur, matarsykur
 it: zucchero, zuccheri, lo zucchero, diversi zuccheri
 iu: ᓱᑲᒃ
-ja: 砂糖, 糖類
+ja: 砂糖, 糖類, 砂糖類
 jv: Gula
 ka: შაქარი
 kk: Қант
@@ -60002,7 +60002,7 @@ es: Pasta de judía dulce
 fr: Pâte de haricots
 hr: pasta od slatkog graha
 it: Pasta di fagioli
-ja: 餡, こしあん
+ja: 餡, こしあん, あん, あんこ, つぶあん
 jv: Pasta kacang legi
 ko: 콩소
 pa: ਮਿੱਠੀ ਬੀਨ ਦਾ ਪੇਸਟ


### PR DESCRIPTION
## What
Adds Japanese spelling/variant synonyms to three existing ingredient entries:

| entry (en) | existing ja: | added |
|---|---|---|
| sugar | 砂糖, 糖類 | 砂糖類 |
| malt | 麦芽 | モルト |
| sweet bean paste | 餡, こしあん | あん, あんこ, つぶあん |

## Why
Follow-up to #13687. These are standard terms / spelling variants that appear on Japanese labels (e.g. `モルト` is the common katakana form of malt; `あん`/`あんこ`/`つぶあん` are everyday forms of 餡). They are variant forms of synonyms that already exist, so they only improve matching of Japanese ingredient text — low risk.

## Source
Standard Japanese ingredient terms / spelling variants per Japan's food-labeling standards (Consumer Affairs Agency, 食品表示基準) and common usage.
