### PR TITLE
chore: update the S3 bucket used for non-food OxF

### DIFF
--- a/scripts/gen_feeds_daily.sh
+++ b/scripts/gen_feeds_daily.sh
@@ -75,7 +75,7 @@ mc cp \
     fr.$PRODUCT_OPENER_DOMAIN.products.csv \
     fr.$PRODUCT_OPENER_DOMAIN.products.csv.gz \
     fr.$PRODUCT_OPENER_DOMAIN.products.rdf \
-    s3/$PRODUCT_OPENER_FLAVOR-ds \
+    s3/openfoodfacts-ds \
     || report_error $? "mc.cp.csv"
 
 cd $OFF_SCRIPTS_DIR


### PR DESCRIPTION
We created a "openfoodfacts-ds" bucket that was meant to contain datasets for all projects. However, in the current configuration, we use a new bucket for each flavor:

<img width="1050" height="418" alt="Capture d’écran du 2026-06-05 10-31-27" src="https://github.com/user-attachments/assets/83a66b51-1453-4a51-af7c-58d3b4fd6857" />

All `us-east-1` buckets were created automatically during the first push from Product Opener.