### PR TITLE
fix: nginx priority map

### DIFF
--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -26,13 +26,13 @@ map "$uri:$priority_user_agent" $apache_port {
 
 	# Everything is priority but:
 	# facets
-	"~*^/facets/:0$" 8001;
+	"~*^/facets/.*:0$" 8001;
 	# pages > 1 on home page
-	"~*^/[0-9]+:0$" 8001;
+	"~*^/[0-9]+.*:0$" 8001;
 	# search (api or cgi)
-	"~*^/cgi/search\.pl:0$" 8001;
-	"~*^/api/v[^/]*/search:0$" 8001;
-	"~*^/cgi/opensearch\.pl:0$" 8001;
+	"~*^/cgi/search\.pl.*:0$" 8001;
+	"~*^/api/v[^/]*/search.*:0$" 8001;
+	"~*^/cgi/opensearch\.pl.*:0$" 8001;
 }
 
 # variables definitions for expiry headers are loaded from /etc/nginx/conf.d/expires-no-json-xml.conf


### PR DESCRIPTION
A lot of search and facets queries mistakenly went to the priority Apache.