### PR TITLE
taxonomy: triangle sandwiches

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -100857,11 +100857,11 @@ gpc_category_name:en: Sandwiches/Filled Rolls/Wraps (Frozen)
 
 < en:Sandwiches
 en: Triangle sandwiches, Sandwich made with loaf bread, Club sandwich
-es: sándwich de pan de molde, sándwich club
+es: Sándwich de pan de molde, sándwich club
 fr: Sandwichs triangles, sandwich club, sandwich triangle, sandwich pain de mie
 hr: Sendvič od pogače
-it: tramezzino, sandwich club
-nl: club sandwich, sandwich met witbrood
+it: Tramezzino, sandwich club
+nl: Club sandwich, sandwich met witbrood
 wikidata:en: Q1093380
 
 < en:Sandwiches

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -100856,9 +100856,9 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Sandwiches/Filled Rolls/Wraps (Frozen)
 
 < en:Sandwiches
-en: Sandwich made with loaf bread, Club sandwich
+en: Triangle sandwiches, Sandwich made with loaf bread, Club sandwich
 es: sándwich de pan de molde, sándwich club
-fr: sandwich club, sandwich triangle, sandwich pain de mie
+fr: Sandwichs triangles, sandwich club, sandwich triangle, sandwich pain de mie
 hr: Sendvič od pogače
 it: tramezzino, sandwich club
 nl: club sandwich, sandwich met witbrood


### PR DESCRIPTION
I renamed "Sandwich made with loaf bread" to "Triangle sandwiches". This is not an ideal name, because it's an expression that doesn't exist in English, but there is no expression for this kind of sandwiches anyway. "Sandwich made with loaf bread" is long and not really understandable. "Triangle sandwiches" is at least really explicite, even if the expression doesn't exist, people will understand what it refers to.
Club sandwich is also a close synonym, but from what I understand on wikipedia, in English it refers to a sandwich with three slices of breads, which is not the case of all "triangle sandwiches". https://en.wikipedia.org/wiki/Club_sandwich

