### PR TITLE
chore: make git ignore *.bak files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ Thumbs.db
 .vscode/settings.json
 .idea/
 
+# Backup files
+*.bak
+
 # Logs
 logs/
 !scripts/utils/logs


### PR DESCRIPTION
`*.bak` is a common extension to use for making backup copies of files, also used by many tools. E.g., `perltidy` with the `-b` argument is one example of these.