### PR TITLE
chore(taxonomies): fix in-line comments

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1638,7 +1638,8 @@ description:en: Caramel color or caramel coloring is a water-soluble food colori
 e_number:en: 150a
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/2004.pdf
 efsa_evaluation:en: Refined exposure assessment for caramel colours (E 150a, c, d)
-efsa_evaluation_adi:en: 300 #not the ADI of E150a alone but an ADI shared by the four E150(a,b,c,d)
+# 300 is not the ADI of E150a alone but an ADI shared by the four E150(a,b,c,d)
+efsa_evaluation_adi:en: 300
 efsa_evaluation_date:en: 2012-12-03
 efsa_evaluation_exposure_95th_greater_than_adi:en: en:no-group
 efsa_evaluation_exposure_mean_greater_than_adi:en: en:no-group
@@ -9926,9 +9927,8 @@ efsa_evaluation_overexposure_risk:en: en:high
 efsa_evaluation_url:en: https://efsa.onlinelibrary.wiley.com/doi/10.2903/j.efsa.2019.5674
 vegan:en: yes
 vegetarian:en: yes
-wikidata:en: Q2634889 # Q723683
+wikidata:en: Q6731399
 wikipedia:en: https://en.wikipedia.org/wiki/Magnesium_phosphate
-
 
 # description:en:Monomagnesium phosphate is one of the forms of magnesium phosphate. chemical formula Mg(H2PO4)2.
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -3804,7 +3804,7 @@ hr: Destilirana pića
 hu: Italpárlatok
 it: Distillati, Bevande spiritose
 nl: Gedestilleerde dranken
-wikidata:en: Q56139 #Q17562878
+wikidata:en: Q56139
 
 < en:Distilled beverages
 en: distilled anis

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -25556,7 +25556,8 @@ sl: amarente flour
 sv: amarantmel
 ciqual_proxy_food_code:en: 9345
 ciqual_proxy_food_name:en: Amaranth, raw
-ciqual_proxy_food_name:fr: Amarante, crue# 249 in 10 @2021-10-05
+ciqual_proxy_food_name:fr: Amarante, crue
+# 249 in 10 @2021-10-05
 
 < en:amaranth flour
 < en:wholemeal flour
@@ -70061,7 +70062,7 @@ ku: Sûs
 la: Glycyrrhiza glabra
 lb: Séissholz
 lt: Paprastasis saldymedis
-lv: lakrica# mai:मुलेठी
+lv: lakrica
 ml: ഇരട്ടിമധുരം
 mr: ज्येष्ठमध
 ms: Akar manis
@@ -70096,6 +70097,7 @@ description:en: LIQUORICE or licorice is the root of Glycyrrhiza glabra from whi
 # frr:Swetholt
 # gsw:Lakritze
 # hsb:Słódnik
+# mai:मुलेठी
 # sco:alicreesh
 # tcy:ಜೇಷ್ಠಮಧು
 # vec:Sugorisia

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -20375,7 +20375,7 @@ hu: Lakto-vegetáriánus
 it: Latto-vegetariano
 pt: Latto-vegetariano
 sv: Lakto-vegetarisk
-incompatible_with:en: ingredients:en:eggs # labels:en:contains-eggs
+incompatible_with:en: ingredients:en:eggs
 wikidata:en: Q3496076
 
 # non English needs the English synonyms too so that "European V-Label Végétarien" can be recognized too


### PR DESCRIPTION
There are a handful of entries in the taxonomy files with "inline" comments, but also several places with `#` inline that are _not_ denoting the start of a comment.

Some of these are clearly mistakes (e.g., missing a newline) but others of them seem to either capture a previously used value, or add context to the current line.

I’ve tried to generally fix the comments, but I took the liberty of dropping some comments that don’t seem all that relevant anymore:
- some `wikidata` alternates, possibly formerly used WD items
- an `incompatible_with` entry for taxon that doesn’t exist
  - this is also one I added a while back when I did a small overhaul/clean-up of the lacto/ovo vegetarian labels.

This does not deal with the taxonomy files under `unused/`.

See-also: https://openfoodfacts.slack.com/archives/C02VDSWHT/p1780944396672989