### PR TITLE
taxonomy: classify E441 and lecithin variants vegan/vegetarian

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -8115,6 +8115,8 @@ additives_classes:en: en:antioxidant, en:emulsifier
 # issue with ingredient @2018-10-11 mixed with sunflower
 e_number:en: 322
 organic_eu:en: authorized
+vegan:en: maybe
+vegetarian:en: maybe
 wikidata:en: Q241595
 wikipedia:en: https://en.wikipedia.org/wiki/Lecithin
 
@@ -8145,6 +8147,8 @@ sv: E322(ii), Delvis hydrolyserad lecitin
 additives_classes:en: en:antioxidant, en:emulsifier
 e_number:en: 322
 organic_eu:en: authorized
+vegan:en: maybe
+vegetarian:en: maybe
 wikidata:en: Q241595
 
 < en:E322
@@ -8186,6 +8190,8 @@ tr: E322a, Yulaf lesitini
 uk: E322a, Вівсяний лецитин
 zh: E322a, 燕麦卵磷脂
 e_number:en: 322a
+vegan:en: yes
+vegetarian:en: yes
 
 en: E323, Anoxomer
 xx: E323
@@ -12988,6 +12994,8 @@ fr: E441, Huile de colza superglycérinée hydrogénée
 it: E441
 nl: E441
 e_number:en: 441
+vegan:en: yes
+vegetarian:en: yes
 
 # description:en:The mix of ammonium salts of phosphorylated glycerides can be either made synthetically or from mixture of glycerol and partially hardened plant (most often used:rapeseed oil) oils
 


### PR DESCRIPTION
### What
Adds `vegan:en` / `vegetarian:en` properties to four additive entries currently missing the classification:

- **E441** (Superglycerinated hydrogenated rapeseed oil) — `vegan:en: yes` / `vegetarian:en: yes`. The entry is rapeseed oil; the inline comment immediately above the entry already records that "E441 is not officially listed as 'animal gelatin'".
- **E322(i)** (Lecithin) — `vegan:en: maybe` / `vegetarian:en: maybe`. Inherits the parent `E322` classification (lecithin can be soy/sunflower-derived or egg-yolk-derived).
- **E322(ii)** (Partially hydrolyzed lecithin) — `vegan:en: maybe` / `vegetarian:en: maybe`. Same rationale as E322(i).
- **E322a** (Oat lecithin) — `vegan:en: yes` / `vegetarian:en: yes`. Oat is plant-derived; the entry name is unambiguous.

Property ordering follows the convention shown on the parent `E322` entry (between `organic_eu:en:` and `wikidata:en:` where those properties exist; appended after `e_number:en:` where they don't).

### Large Language Models usage disclosure
Claude (Opus 4.7) via Claude Code, agentic — used for drafting and locating entries. Classifications derived from existing inline taxonomy context: the E441 disambiguation comment already in the file, the parent `E322` classification (children inherit), and the explicit "Oat lecithin" name for E322a. No external sources cited; no files other than `taxonomies/additives.txt` touched.

### Screenshot or video
N/A — taxonomy-only data change with no UI impact.

### Related issue(s) and discussion
- Addresses #9092 (Add better support for specific diets — Vegan, Vegetarian)
