### PR TITLE
taxonomy: classify gelatin and anchovy variants, add isinglass and carmine entries

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -754,6 +754,18 @@ pt: gelatina kosher
 vegan:en: no
 vegetarian:en: no
 
+< en:gelatin
+# from:en:fish
+en: isinglass
+allergens:en: en:fish
+vegan:en: no
+vegetarian:en: no
+
+< en:E120
+en: carmine, carmines
+vegan:en: no
+vegetarian:en: no
+
 < en:E440
 de: flüssiges pektin
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -694,6 +694,8 @@ fr: gélatine non porcine
 de: schweinefreie Gelatine
 es: gelatina no porcina
 it: gelatina non suina
+vegan:en: no
+vegetarian:en: no
 # ingredient/fr:gélatine-non-porcine has 1 product in french @2019-02-10
 
 < en:gelatin
@@ -714,6 +716,8 @@ pl: żelatyna drobiowa
 pt: gelatina de aves
 sr: želatin od peradi
 zh: 家禽明胶
+vegan:en: no
+vegetarian:en: no
 # ingredient/fr:gélatine-de-volaille has 17 products in french @2019-02-10
 
 < en:gelatin
@@ -747,6 +751,8 @@ it: Gelatina kosher
 nl: koosjere gelatine
 pl: koszerna żelatyna
 pt: gelatina kosher
+vegan:en: no
+vegetarian:en: no
 
 < en:E440
 de: flüssiges pektin

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -75687,6 +75687,8 @@ ifct_food_code:en: P003
 ifct_food_name:en: Anchovy
 wikidata:en: Q192662
 wikipedia:en: https://en.wikipedia.org/wiki/Anchovy
+vegan:en: no
+vegetarian:en: no
 # 2820 in 19 @2021-09-12
 
 < en:anchovy
@@ -75709,6 +75711,8 @@ nl: ansjovispasta
 pl: pasta z anchois
 wikidata:en: Q3897482
 wikipedia:en: https://en.wikipedia.org/wiki/Anchovy_paste
+vegan:en: no
+vegetarian:en: no
 # ingredient/fr:pâte-d’anchois has 101 products @2019-01-06
 
 #process:en: en:extract
@@ -75738,6 +75742,8 @@ fi: anjovisfilee
 fr: filets d'anchois
 hr: filet inćuna, fileti inćuna
 it: Filetti d'acciuga
+vegan:en: no
+vegetarian:en: no
 # ingredient/fr:filets-d'anchois has 36 products in 4 languages @2019-01-06
 
 #process:en: en:salted
@@ -75753,6 +75759,8 @@ it: Filetti d'acciuga
 en: marinated anchovy fillets
 hr: fileti mariniranih incuna
 it: filetti di acciuga marinati
+vegan:en: no
+vegetarian:en: no
 
 < en:anchovy
 en: European anchovy
@@ -75776,6 +75784,8 @@ description:en: The European anchovy (Engraulis encrasicolus) is a forage fish s
 wikidata:en: 188387
 # translations can not be trusted
 wikipedia:en: https://en.wikipedia.org/wiki/European_anchovy
+vegan:en: no
+vegetarian:en: no
 # ingredient/fr:Engraulis-encrasicolus has 32 products @2019-01-12
 # ingredient/fr:Engraulis-encrasicholus has 1 product @2019-01-12
 


### PR DESCRIPTION
### What
Adds `vegan:en` / `vegetarian:en` properties to eight existing ingredient entries currently missing the classification, and introduces two new entries.

Gelatin variants (children of `en:gelatin`, inherit `no` / `no` from parent; classified explicitly to match siblings such as `en:pork gelatin` and `en:fish gelatine`):
- `fr: gélatine non porcine`
- `fr: gélatine de volaille`
- `en: kosher gelatin`

Anchovy variants (descendants of `en:fish`, inherit `no` / `no` from parent; classified explicitly for the same reason):
- `en: anchovy, anchovies`
- `en: anchovy paste`
- `en: anchovy filets`
- `en: marinated anchovy fillets`
- `en: European anchovy`

New entries:
- `en: isinglass` under `en:gelatin` with `# from:en:fish` and `allergens:en: en:fish`, mirroring the existing `en: fish gelatine` pattern. Isinglass is a fish-swim-bladder collagen used as a clarifier.
- `en: carmine, carmines` under `en:E120`. The additive form already exists in `additives.txt`; this is the ingredient-label form referenced on products.

### Large Language Models usage disclosure
Claude (Opus 4.7) via Claude Code, agentic. Used for drafting and locating entries. Classifications derived from existing inline taxonomy context: the `en:gelatin` parent classification (`no` / `no`) propagating to gelatin children, the `en:fish` parent (`no` / `no`) propagating to anchovy children, and the explicit substance naming of isinglass (fish-derived) and carmine (E120 colourant). No external sources cited; no files other than `taxonomies/food/ingredients.txt` touched.

### Screenshot or video
N/A. Taxonomy data change with no UI impact.

### Related issue(s) and discussion
- Addresses #9092 (Add better support for specific diets, Vegan, Vegetarian)
