### PR TITLE
fix: Updating preferences on staging is wiping the user name in keycloak

### DIFF
--- a/.test_info.41.json
+++ b/.test_info.41.json
@@ -1,0 +1,1 @@
+{"workdir":"/tmp/yath-41-VDWdo9","job_count":1}

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -483,12 +483,18 @@ sub check_user_form ($request_ref, $type, $user_ref, $errors_ref) {
 	# Assigning 'userid' to 0 -- if userid is not defined
 	$user_ref->{userid} = remove_tags_and_quote(single_param('userid'));
 
-	# Check for spam
 	my $is_spam = undef;
-	# e.g. name with "Lydia want to meet you! Click here:" + an url or + a .com / .ru
-	if (is_suspicious_name($user_ref->{name})) {
-		$is_spam = 1;
+	# Allow for sending the 'name' & 'email' as a form parameter instead of a HTTP header, as web based apps may not be able to change the header sent by the browser
+	if (defined single_param('name')) {
+		$user_ref->{name} = remove_tags_and_quote(decode utf8 => single_param('name'));
+
+		# Check for spam
+		# e.g. name with "Lydia want to meet you! Click here:" + an url or + a .com / .ru
+		if (is_suspicious_name($user_ref->{name})) {
+			$is_spam = 1;
+		}
 	}
+
 	# check for spam, that may have filled the honeypot faxnumber field
 	my $faxnumber = single_param('faxnumber');
 	if ((defined $faxnumber) and ($faxnumber ne "")) {
@@ -501,11 +507,6 @@ sub check_user_form ($request_ref, $type, $user_ref, $errors_ref) {
 		close($log);
 		# bail out, return 200 status code
 		display_error_and_exit($request_ref, "", 200);
-	}
-
-	# Allow for sending the 'name' & 'email' as a form parameter instead of a HTTP header, as web based apps may not be able to change the header sent by the browser
-	if (defined single_param('name')) {
-		$user_ref->{name} = remove_tags_and_quote(decode utf8 => single_param('name'));
 	}
 
 	my $email = remove_tags_and_quote(decode utf8 => single_param('email'));

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -483,9 +483,6 @@ sub check_user_form ($request_ref, $type, $user_ref, $errors_ref) {
 	# Assigning 'userid' to 0 -- if userid is not defined
 	$user_ref->{userid} = remove_tags_and_quote(single_param('userid'));
 
-	# Allow for sending the 'name' & 'email' as a form parameter instead of a HTTP header, as web based apps may not be able to change the header sent by the browser
-	$user_ref->{name} = remove_tags_and_quote(decode utf8 => single_param('name'));
-
 	# Check for spam
 	my $is_spam = undef;
 	# e.g. name with "Lydia want to meet you! Click here:" + an url or + a .com / .ru
@@ -504,6 +501,11 @@ sub check_user_form ($request_ref, $type, $user_ref, $errors_ref) {
 		close($log);
 		# bail out, return 200 status code
 		display_error_and_exit($request_ref, "", 200);
+	}
+
+	# Allow for sending the 'name' & 'email' as a form parameter instead of a HTTP header, as web based apps may not be able to change the header sent by the browser
+	if (defined single_param('name')) {
+		$user_ref->{name} = remove_tags_and_quote(decode utf8 => single_param('name'));
 	}
 
 	my $email = remove_tags_and_quote(decode utf8 => single_param('email'));
@@ -532,10 +534,13 @@ sub check_user_form ($request_ref, $type, $user_ref, $errors_ref) {
 	}
 
 	# Country and preferred language
-	# Still allow these to be sent for legacy API support
-	$user_ref->{preferred_language} = remove_tags_and_quote(single_param('preferred_language')) || $request_ref->{lc};
-	$user_ref->{country} = remove_tags_and_quote(single_param('country')) || $request_ref->{country};
-
+	# Still allow these to be sent for legacy API support, but don't update if supplied by the preferences form
+	# Which we deduce by the absence of a name field
+	if (defined single_param('name')) {
+		$user_ref->{preferred_language}
+			= remove_tags_and_quote(single_param('preferred_language')) || $request_ref->{lc};
+		$user_ref->{country} = remove_tags_and_quote(single_param('country')) || $request_ref->{country};
+	}
 	# Is there a checkbox to make a professional account
 	if (defined single_param("pro_checkbox")) {
 

--- a/tests/integration/modify_user.t
+++ b/tests/integration/modify_user.t
@@ -6,6 +6,7 @@ use Test2::V0;
 use ProductOpener::APITest qw/construct_test_url create_user new_client wait_application_ready/;
 use ProductOpener::Test qw/remove_all_users/;
 use ProductOpener::TestDefaults qw/%default_user_form/;
+use ProductOpener::Users qw/retrieve_user/;
 
 wait_application_ready(__FILE__);
 remove_all_users();
@@ -14,7 +15,7 @@ my $ua = new_client();
 my %create_user_args = (%default_user_form, (email => 'bob@example.com'));
 create_user($ua, \%create_user_args);
 
-#editing the user preferences
+#editing the user preferences as if via the API
 my %edit_form = (
 	email => 'notbob@example.com',
 	name => 'NotTest',
@@ -37,5 +38,27 @@ is($user_ref->{email}, 'notbob@example.com', "the new email has been well saved"
 is($user_ref->{name}, 'NotTest', "the new name has been well saved");
 is($user_ref->{preferred_language}, 'fr', "new language saved");
 is($user_ref->{country}, 'en:france', "new country saved");
+
+#editing the user preferences as if via the User Form (most fields no longer supplied)
+%edit_form = (
+	userid => 'tests',
+	pro_checkbox => 1,
+	pro => 1,
+	display_barcode => 1,
+	action => "process",
+	type => "edit"
+);
+$response_edit = $ua->post($url_edit, \%edit_form);
+
+#checking if the changes were saved
+$user_ref = retrieve_user('tests');
+
+is($user_ref->{pro}, 1, "pro flag changed");
+is($user_ref->{display_barcode}, 1, "display barcode flag changed");
+is($user_ref->{email}, 'notbob@example.com', "the new email has not been changed");
+is($user_ref->{name}, 'NotTest', "the name has not been changed");
+is($user_ref->{preferred_language}, 'fr', "language not changed");
+is($user_ref->{country}, 'en:france', "country not changed");
+
 
 done_testing();

--- a/tests/integration/modify_user.t
+++ b/tests/integration/modify_user.t
@@ -60,5 +60,4 @@ is($user_ref->{name}, 'NotTest', "the name has not been changed");
 is($user_ref->{preferred_language}, 'fr', "language not changed");
 is($user_ref->{country}, 'en:france', "country not changed");
 
-
 done_testing();


### PR DESCRIPTION
### What
Only update the user name, language and country in Keycloak Level 5 if the form has been submitted via an API (e.g. the DART SDK). This is detected by the presence of the name field in the payload.

### Large Language Models usage disclosure
None

### Related issue(s) and discussion
- Fixes: https://github.com/openfoodfacts/openfoodfacts-server/issues/13743
