### PR TITLE
fix: use JSON allow_nonref

### DIFF
--- a/lib/ProductOpener/APIProductServices.pm
+++ b/lib/ProductOpener/APIProductServices.pm
@@ -98,6 +98,7 @@ use ProductOpener::EnvironmentalImpact;
 use ProductOpener::HTTP qw/create_user_agent/;
 use ProductOpener::Store qw/$json_for_objects/;
 
+use Cpanel::JSON::XS;
 use Storable qw/dclone/;
 use Encode;
 use Types::Serialiser;

--- a/lib/ProductOpener/APIProductServices.pm
+++ b/lib/ProductOpener/APIProductServices.pm
@@ -98,7 +98,6 @@ use ProductOpener::EnvironmentalImpact;
 use ProductOpener::HTTP qw/create_user_agent/;
 use ProductOpener::Store qw/$json_for_objects/;
 
-use Cpanel::JSON::XS;
 use Storable qw/dclone/;
 use Encode;
 use Types::Serialiser;

--- a/lib/ProductOpener/APIProductServices.pm
+++ b/lib/ProductOpener/APIProductServices.pm
@@ -97,10 +97,12 @@ use ProductOpener::API qw/add_error customize_response_for_product init_api_resp
 use ProductOpener::EnvironmentalImpact;
 use ProductOpener::HTTP qw/create_user_agent/;
 
-use JSON qw(decode_json encode_json);
+use JSON::MaybeXS;
 use Storable qw/dclone/;
 use Encode;
 use Types::Serialiser;
+
+my $json_utf8 = JSON::MaybeXS->new->convert_blessed->utf8(1)->allow_nonref->canonical;
 
 =head2 add_product_data_from_external_service ($request_ref, $product_ref, $url, $services_ref)
 
@@ -160,7 +162,7 @@ sub add_product_data_from_external_service ($request_ref, $product_ref, $url, $s
 
 	my $response = $ua->post(
 		$url,
-		Content => encode_json($body_ref),
+		Content => $json_utf8->encode($body_ref),
 		"Content-Type" => "application/json; charset=utf-8",
 	);
 
@@ -199,7 +201,7 @@ sub add_product_data_from_external_service ($request_ref, $product_ref, $url, $s
 		my $decoded_json;
 		my $json_decode_error;
 		eval {
-			$decoded_json = decode_json($response_content);
+			$decoded_json = $json_utf8->decode($response_content);
 			1;
 		} or do {
 			$json_decode_error = $@;

--- a/lib/ProductOpener/APIProductServices.pm
+++ b/lib/ProductOpener/APIProductServices.pm
@@ -96,13 +96,12 @@ use ProductOpener::Products qw/:all/;
 use ProductOpener::API qw/add_error customize_response_for_product init_api_response/;
 use ProductOpener::EnvironmentalImpact;
 use ProductOpener::HTTP qw/create_user_agent/;
+use ProductOpener::Store qw/$json_for_objects/;
 
-use JSON::MaybeXS;
+use Cpanel::JSON::XS;
 use Storable qw/dclone/;
 use Encode;
 use Types::Serialiser;
-
-my $json_utf8 = JSON::MaybeXS->new->convert_blessed->utf8(1)->allow_nonref->canonical;
 
 =head2 add_product_data_from_external_service ($request_ref, $product_ref, $url, $services_ref)
 
@@ -162,7 +161,7 @@ sub add_product_data_from_external_service ($request_ref, $product_ref, $url, $s
 
 	my $response = $ua->post(
 		$url,
-		Content => $json_utf8->encode($body_ref),
+		Content => $json_for_objects->encode($body_ref),
 		"Content-Type" => "application/json; charset=utf-8",
 	);
 
@@ -201,7 +200,7 @@ sub add_product_data_from_external_service ($request_ref, $product_ref, $url, $s
 		my $decoded_json;
 		my $json_decode_error;
 		eval {
-			$decoded_json = $json_utf8->decode($response_content);
+			$decoded_json = $json_for_objects->decode($response_content);
 			1;
 		} or do {
 			$json_decode_error = $@;

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -48,6 +48,9 @@ BEGIN {
 		&write_json
 		&write_canonical_json
 		&read_json
+
+		$json_for_config
+		$json_for_objects
 	);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -72,8 +75,8 @@ use Carp qw/carp/;
 # Use Cpanel::JSON::XS directly rather than JSON::MaybeXS as otherwise check_perl gives error:
 # Can't locate object method "indent_length" via package "JSON::XS"
 # Make sure we include convert_blessed to cater for blessed objects, like booleans
-my $json_for_config = Cpanel::JSON::XS->new->allow_nonref->convert_blessed->canonical->indent->indent_length(1)->utf8;
-my $json_for_objects = Cpanel::JSON::XS->new->allow_nonref->convert_blessed->utf8;
+$json_for_config = Cpanel::JSON::XS->new->allow_nonref->convert_blessed->canonical->indent->indent_length(1)->utf8;
+$json_for_objects = Cpanel::JSON::XS->new->allow_nonref->convert_blessed->utf8;
 
 # Text::Unaccent unac_string causes Apache core dumps with Apache 2.4 and mod_perl 2.0.9 on jessie
 


### PR DESCRIPTION
Should fix this error reported on Slack: https://openfoodfacts.slack.com/archives/C02KVRT2C/p1781092853221419

```
I'm having trouble editing some products on the website, for instance 0744096655408, 3660992012756 and 0731509930092. When I click Save I get the following error:

-----
Software error:

encountered object '1', but neither allow_blessed, convert_blessed nor allow_tags settings are enabled (or TO_JSON/FREEZE method missing) at /srv/off/lib/ProductOpener/APIProductServices.pm line 161.

For help, please send mail to the webmaster ([contact@openfoodfacts.org](mailto:contact@openfoodfacts.org)), giving this error message and the time and date of the error.
```