### PR TITLE
fix: Add last_updated_t index as this is needed by off_query

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -253,6 +253,7 @@ jobs:
         script: |
           cd ${{ matrix.env }} && \
           make init_backend
+          make create_mongodb_indexes
 
     # NOTE: the mongodb and redis containers are deployed by openfoodfacts-shared-services 
     - name: Start services

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ reset_owner:
 
 init_backend: build_taxonomies build_lang build_pro_platform
 
-create_mongodb_indexes: run_deps
+create_mongodb_indexes:
 	@echo "🥫 Creating MongoDB indexes …"
 	${DOCKER_COMPOSE} run --rm backend perl /opt/product-opener/scripts/create_mongodb_indexes.pl
 

--- a/docs/dev/how-to-release.md
+++ b/docs/dev/how-to-release.md
@@ -54,6 +54,10 @@ To deploy you need to execute the following steps:
    ```bash
    sudo -u off /srv/$SERVICE/scripts/deploy/install-dist-files.sh $VERSION $SERVICE
    ```
+1. updated MongoDB indexes (if necessary)
+   ```bash
+   sudo -u off bash -c "cd /srv/$SERVICE; source env/setenv.sh $SERVICE; perl ./scripts/create_mongodb_indexes.pl"
+   ```
 1. update openfoodfacts-web content (using version you just released):
    ```bash
    cd /srv/openfoodfacts-web/

--- a/scripts/create_mongodb_indexes.pl
+++ b/scripts/create_mongodb_indexes.pl
@@ -70,6 +70,7 @@ add_index('labels_tags', 1, 'last_modified_t', -1);
 add_index('languages_tags', 1, 'last_modified_t', -1);
 add_index('last_edit_dates_tags', 1, 'last_modified_t', -1);
 add_index('last_modified_t', -1);
+add_index('last_updated_t', -1);
 add_index('lc', 1);
 add_index('manufacturing_places_tags', 1, 'last_modified_t', -1);
 add_index('minerals_tags', 1, 'last_modified_t', -1);
@@ -88,7 +89,6 @@ add_index('popularity_tags', 1, 'last_modified_t', -1);
 add_index('purchase_places_tags', 1, 'last_modified_t', -1);
 add_index('states_tags', 1, 'last_modified_t', -1);
 add_index('stores_tags', 1, 'last_modified_t', -1);
-add_index('teams_tags', 1, 'last_modified_t', -1);
 add_index('traces_tags', 1, 'last_modified_t', -1);
 add_index('unique_scans_n', -1);
 add_index('users_tags', 1, 'last_modified_t', -1);
@@ -106,6 +106,7 @@ add_index('vitamins_tags', 1, 'last_modified_t', -1);
 #add_index('pnns_groups_2_tags', 1, 'last_modified_t', -1);
 #add_index('unknown_nutrients_tags', 1, 'last_modified_t', -1);
 #add_index('owner', 1, 'countries_tags', 1, 'last_modified_t', -1);
+#add_index('teams_tags', 1, 'last_modified_t', -1);
 
 die "Cannot have more than 63 indexes" if (@index_list > 63);
 


### PR DESCRIPTION
### What
During off_query's incremental import the data is searched using the last_updated_t field which is not currently indexed, resulting in a slow query and excessive load on the MongoDB server.

The teams index was dropped to make space for this

### Large Language Models usage disclosure
None
