### PR TITLE
taxonomy: add German translations

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -1160,7 +1160,7 @@ bg: Млечни ферментации, млечна закваска, млеч
 ca: Ferments làctics
 cs: bakterie mléčného kvašení, mléčné ferminty
 da: yoghurtkultur, starterkultur, mælkesyrekultur, ostekulturer
-de: Milchfermenten, Milchsäurekulturen, Milchsäurebakterienkultur, Milchsäurebakterien, Käsekultur, Milchsäurebakterienkulturen, Joghurtkulturen, Säuerungskulturen, milchsauer vergoren, Milchsäuerungskulturen, Milchsäurekultur, Käsereikulturen, Starterkulturen, Biogarde-Markenkulturen, Milchfermente
+de: Milchfermenten, Milchsäurekulturen, Milchsäurebakterienkultur, Milchsäurebakterien, Käsekultur, Milchsäurebakterienkulturen, Joghurtkulturen, lebende Joghurtkulturen, Säuerungskulturen, milchsauer vergoren, Milchsäuerungskulturen, Milchsäurekultur, Käsereikulturen, Starterkulturen, Biogarde-Markenkulturen, Milchfermente
 el: γαλακτικά ένζυμα
 es: fermentos lácticos, fermentos lácteos, cultivos lácticos, ferments del yogur, cultivos de bacterias lácticas especificas, cultivos lácticos específicos
 et: juuretis
@@ -4577,7 +4577,7 @@ nova:en: 4
 en: whey permeate, milk permeate
 bg: суроватъчен пермеат
 ca: permeat de sèrum de la llet, permeat làctic
-de: Molkepermeat, Milchpermeat
+de: Molkenpermeat, Milchpermeat, Molkepermeat
 es: permeado de suerodérivé de la
 fi: herapermeaatti, maitopermeaatti
 fr: perméat de petit lait
@@ -4596,11 +4596,11 @@ it: permeato di siero di latte ricostituito
 
 < en:whey permeate
 en: whey permeate powder
+de: Molkenpermeatpulver, Molkepermeatpulver
 hr: prašak permeata sirutke
 it: permeato di siero di latte in polvere
 #en:process:en:powder
 #ca:permeta de sèrum de llet en pols
-#de:Molkepermeat Pulver
 #es:permeado de suero en polvo
 #fi:herapermeaattijauhe
 #fr:perméat de petit lait en poudre


### PR DESCRIPTION
Fixes: Translations added to "ingredients.txt" file in taxonomy folder

taxonomy: Added lebende Joghurtkulturen, Molkenpermeat (mainly used spelling), Molkenpermeatpulver (mainly used), Molkepermeatpulver (minor used); deleted: Comment section de:Molkepermeat Pulver

What: You asked for HELP with EAN 4056489117537, https://de.openfoodfacts.org/product/4316734209609/mochi-red-bean-ita-san and 5202258200200: https://uk.openfoodfacts.org/product/5202258200200/griechischedr-joghurt-greco

Large Language Models usage disclosure: I don't know. 

Screenshot or video: No, I have none

Related issue(s) and discussion: Section "Details of the analysis of the ingredients" in EAN 4056489117537, https://de.openfoodfacts.org/product/4316734209609/mochi-red-bean-ita-san and 5202258200200: https://uk.openfoodfacts.org/product/5202258200200/griechischedr-joghurt-greco
