### PR TITLE
fix: upgrade for undefined untaxonomized tags

### DIFF
--- a/lib/ProductOpener/ProductSchemaChanges.pm
+++ b/lib/ProductOpener/ProductSchemaChanges.pm
@@ -934,7 +934,7 @@ sub convert_schema_1003_to_1004_refactor_tags ($product_ref) {
 
 		# If the tagtype has no taxonomy (e.g. stores, purchase_places), then the input tags are in the "stores" and "purchase_places"
 		# and they don't have a language
-		if (not exists $taxonomy_fields{$tagtype}) {
+		if ((defined $product_ref->{$tagtype}) and (not exists $taxonomy_fields{$tagtype})) {
 			$input_tags_ref = [split(/,\s*/, $product_ref->{$tagtype})];
 		}
 		else {


### PR DESCRIPTION
Issue reported by @john-gom :

`modperl_error_log : Use of uninitialized value in split at /opt/product-opener/lib/ProductOpener/ProductSchemaChanges.pm line 938.`