### PR TITLE
taxonomy(food): monk fruit extract edits

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -33255,9 +33255,13 @@ el: Ολιγοσακχαρίτες mannan
 et: Mannano oligosahhariidid
 it: Mannano oligo saccaridi
 
+< en:fruit extract
 < en:sweetener
 en: monk fruit extract
+de: Mönchsfruchtextrakt
 it: estratto di frutto del monaco
+nb: balsampæreekstrakt
+sv: luo han guo-extrakt, munkfruktextrakt
 
 ##################################################################################
 #
@@ -95178,14 +95182,16 @@ fi: hedelmäuute
 fr: extrait de fruit
 # hr:ekstrakt voća # see ingredients_processing.txt
 it: Estratto di frutta, estratti di frutta
+nb: fruktekstrakt
 nl: vruchtenextract
+nn: fruktekstrakt
 pl: ekstrakt z owoców
 pt: extrato de fruto, extrato de fruta, extrato de frutos, extrato de frutas, extracto de fruto, extracto de fruta, extracto de frutos, extracto de frutas
 sv: fruktextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-fruit
-# 54 products in 4 languages @2018-10-04
 vegan:en: maybe
 vegetarian:en: yes
+# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-fruit
+# 54 products in 4 languages @2018-10-04
 
 < en:fruit extract
 en: apple extract, apple essence


### PR DESCRIPTION
- Makes monk fruit extract a child of fruit extract
- Adds some translations

Needed-for: https://world.openfoodfacts.org/product/0860002152493/cocoa-grain-free-cereal-three-wishes