### PR TITLE
taxonomy(food): avocado edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -72078,20 +72078,66 @@ lt: Tropiniai vaisiai, Egzotiniai vaisiai
 nl: Tropisch fruit
 pt: Frutas tropicais
 ru: Тропические фрукты
+sv: Tropiska frukter
 
 < en:Tropical fruits
 en: Avocados
+an: Aguacate
+ar: افوكادو
+az: Avokado
 bg: Авокадо
+bn: আভোকাদো
+br: Avoukez
+ca: Alvocat
+cs: Avokádo
+da: Avokadoer, Avocadoer
 de: Avocados
+el: Αβοκάντο
+eo: Avokadoj
 es: Aguacates
-fi: avokaadot
+et: Avokaado
+eu: Ahuakate
+fi: Avokaadot
 fr: Avocats
+ga: Abhacád
+gl: Aguacate
+hi: एवोकाडो
 hr: Avokado
+ht: Zaboka
+hu: Avokádó
+hy: Ավոկադո
+ia: Avocato
+id: Alpukat
+ig: Ube oyibo
 it: Avocado
 ja: アボカド
-lt: Avokadai
+ka: Ავოკადო
+kw: Avokado
+lb: Avocado
+ln: Sabúká
+lt: Avokadai, Avokadas
+mi: Rahopūru
+mk: Авокадо
+ml: അവോക്കാഡോ
+ms: Avokado
+nb: Avokadoer
+ne: घ्यूँफल
 nl: Avocados
+nn: Avokadoar
 pl: Awokado
+pt: Abacate
+qu: Palta
+ro: Avocado
+ru: Авокадо
+sk: Avokádo
+sl: Avokado
+sq: Avokado
+sv: Avokador, Avokados, Avocador, Avocados
+te: అవోకాడో
+tr: Avokado
+uk: Авокадо
+yi: אַװאָקאַדאָ
+zh: 鳄梨
 agribalyse_proxy_food_code:en: 13004
 agribalyse_proxy_food_name:en: Avocado, pulp, raw
 agribalyse_proxy_food_name:fr: Avocat, pulpe, cru
@@ -72110,10 +72156,38 @@ ciqual_food_name:fr: Avocat, pulpe, cru
 < en:Avocados
 en: Hass avocados
 xx: Hass avocados
+da: Hass-avokadoer
+de: Hass-Avocados
+es: Aguacates Hass
+fa: آووکادوی هاس
+fr: Avocats Hass
+hr: Hass avokado
+it: Avocado hass
+ja: ハスアボカド
+ko: 할아버지 아보카도
+la: Persea americana ‘Hass’
+nl: Hass-avocados
+pt: Abacates hass
+ru: Авокадо Хасс
+sl: Avokado Hass
+sv: Hass-avokador
+uk: Авокадо Хасс
+zh: 哈斯酪梨, 哈斯牛油果
+wikidata:en: Q5679460
+wikipedia:en: https://en.wikipedia.org/wiki/Hass_avocado
 
 < en: Avocados
 en: Ready-to-eat avocados
+da: Spiseklare avokadoer
 nl: Eetrijpe avocados
+sv: Ätmogna avokador
+
+< en:Hass avocados
+< en:Ready-to-eat avocados
+en: Ready-to-eat Hass avocados
+da: Spiseklare hass-avokadoer
+nl: Eetrijpe hass-avocados
+sv: Ätmogna hass-avokador
 
 #### Bananas
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -56317,50 +56317,66 @@ wikipedia:en: https://en.wikipedia.org/wiki/Crudités
 < en:fruit vegetable
 en: avocado
 an: aguacate
-ar: الأفوكادو
-az: Avokado
+ar: الأفوكادو, افوكادو
+az: avokado
 bg: авокадо
 bn: আভোকাদো
 br: avoukez
 ca: alvocat
 cs: avokádo
+da: avokado, avocado
 de: Avocado
 el: αβοκάντο
 eo: avokado
 es: aguacate
-et: Avokaado
+et: avokaado
 eu: ahuakate
 fi: avokado
 fr: avocat
+ga: abhacád
 gl: aguacate
 he: אבוקדו
 hi: एवोकाडो
 hr: avokado
-ht: Zaboka
+ht: zaboka
 hu: avokádó
 hy: ավոկադո
-ia: Avocato
+ia: avocato
 id: alpukat
+ig: ube oyibo
 it: avocado
 ja: アボカド
 ka: ავოკადო
 ku: avokado
-lt: Avokadas
+kw: avokado
+lb: Avocado
+ln: sabúká
+lt: avokadas
 ma: rahopūru
+mi: rahopūru
 mk: авокадо
+ml: അവോക്കാഡോ
+ms: avokado
 nb: avokado
+ne: घ्यूँफल
 nl: avocado
+nn: avokado
 pl: awokado, smaczliwka, smaczliwki, awokada
 pt: abacate
+qu: palta
+ro: avocado
 ru: авокадо
 sk: avokádo
+sl: avokado
 sq: avokado
-sv: avokado
+sv: avokado, avocado
 te: అవోకాడో
-tr: Avokado
+tr: avokado
 uk: авокадо
 vo: Avokaado
+yi: אַװאָקאַדאָ
 zh: 鳄梨
+#nah: Āhuacatl
 carbon_footprint_fr_foodges_ingredient:fr: Avocat
 carbon_footprint_fr_foodges_value:fr: 2.4
 ciqual_food_code:en: 13004
@@ -56373,11 +56389,10 @@ description:fr: L'avocatier (Persea americana) est une espèce d'arbres fruitier
 description:it: L'avocado (Persea americana) è una specie arborea da frutto che appartiene alla famiglia delle Lauracee.
 description:nl: De avocado (Persea americana) is een boom uit Centraal-Amerika. Hij is bekend om zijn gelijknamige voor consumptie geschikte vrucht.
 ecobalyse:en: avocado-non-eu
-# 858 in 12 @2021-09-21
 eurocode_2_group_3:en: 8.40.60
-# nah:Āhuacatl
 wikidata:en: Q961769
 wikipedia:en: https://en.wikipedia.org/wiki/Avocado
+# 858 in 12 @2021-09-21
 
 en: Guacamole
 it: guacamole
@@ -56386,17 +56401,22 @@ ciqual_food_name:en: Guacamole, prepacked
 
 < en:avocado
 en: hass avocado, hass avocadoes
-de: hass-avocado, hass-avocados
+da: hass-avokado
+de: Hass-Avocado, Hass-Avocados
 es: aguacate Hass, aguacates Hass
+fa: آووکادوی هاس
 fr: avocat Hass, avocats Hass
 hr: hass avokado
 it: avocado hass
 ja: ハスアボカド
 ko: 할아버지 아보카도
+la: persea americana ‘Hass’
 pt: abacate hass, abacates hass
 ru: авокадо Хасс
+sl: avokado Hass
+sv: hass-avokado, avocado (hass)
 uk: авокадо Хасс
-zh: 哈斯牛油果
+zh: 哈斯牛油果, 哈斯酪梨
 wikidata:en: Q5679460
 wikipedia:en: https://en.wikipedia.org/wiki/Hass_avocado
 


### PR DESCRIPTION
- Adds Danish/Swedish/Norwegian translations.
- Imports some translations from Wikidata.
- Adds new combined Hass+Ready-to-eat avocado category.
- Normalises ingredients toward lower-case singular forms.
  - Except for one German name where I fixed German capitalisation. :)
- Normalises categories toward capitalised plural forms.

Needed-for: https://se.openfoodfacts.org/product/8717428109162/3-pack-%C3%A4tmogen-avocado