### PR TITLE
taxonomy: Puff pastry king cakes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -100257,7 +100257,7 @@ ciqual_food_name:en: Twelfth Night cake
 ciqual_food_name:fr: Galette des rois feuilletée
 wikidata:en: Q177166
 
-< en:Pastries
+< en:Puff pastry king cakes
 en: Classic almond puff pastry king cakes, Twelfth Night cake with almond paste, Twelfth Night cake puff pastry filled with almond paste
 fr: Galettes des rois classiques à l'amande, Galette des rois feuilletée fourrée à la frangipane, Pithiviers
 agribalyse_food_code:en: 23684


### PR DESCRIPTION
Put "Classic almond puff pastry king cakes" in the correct parent category. I didn't pay attention to it when I created the category
