### PR TITLE
taxonomy: frozen desserts modifications

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67895,9 +67895,9 @@ fr: Dessert glacé feuilleté vanille fruits rouges
 < en:Frozen dessert puff pastry
 fr: Dessert glacé feuilleté chocolat brownie
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Baked Alaska
-fr: Omelettes Norvégiennes glacées, Omelette norvégienne
+fr: Omelettes norvégiennes glacées, Omelette norvégienne
 agribalyse_food_code:en: 39518
 ciqual_food_code:en: 39518
 ciqual_food_name:en: baked Alaska
@@ -67913,7 +67913,7 @@ ciqual_food_code:en: 39519
 ciqual_food_name:en: Belle Helene pear dessert (cooked pear topped with hot chocolate sauce on a bed of vanilla ice cream)
 ciqual_food_name:fr: Poire belle Hélène
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Vacherin ice cream
 fr: Vacherin glacé
 agribalyse_food_code:en: 39502
@@ -67929,7 +67929,7 @@ ciqual_food_code:en: 39502
 ciqual_food_name:en: Frozen dessert, ice cream with meringue, vacherin ice cream or mystery ice cream type
 ciqual_food_name:fr: Dessert glacé type mystère ou vacherin
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Sundae ice cream
 fr: Sundae
 hr: Sundae sladoled
@@ -68892,7 +68892,7 @@ wikidata:en: Q133892366
 en: Chocolate soy ice creams
 sv: Kakaosojaglasser
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Ice pops, Popsicle, Freeze pop, Ice lolly, Ice block, Icy pole, Freezer pop
 de: Wassereis
 es: Helados de hielo, Helados de agua, Polos de hielo, Polos de agua, Paletas de hielo, Paletas de agua
@@ -68911,7 +68911,7 @@ intake24_category_code:en: ILOL
 who_id:en: 5
 wikidata:en: Q855373
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Frozen yogurts, Frozen yoghurts, Frozen yogurt
 bg: Замразено кисело мляко
 de: Gefrorener Joghurt
@@ -68930,7 +68930,7 @@ ciqual_food_name:fr: Glace au yaourt
 who_id:en: 5
 wikidata:en: Q13319
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Granizados
 es: Granizados
 fr: Granizados
@@ -68975,10 +68975,6 @@ it: Ravioli surgelati
 lt: Šaldyti ravioliai
 nl: Diepvriesraviolis, Bevroren ravioli
 
-< en:Frozen foods
-fr: Cônes et batonnets surgelés
-nl: Diepvriesijsjes
-
 < en:Biscuits and cakes
 < en:Frozen foods
 en: Frozen cakes and pastries, frozen cakes, frozen pastries
@@ -68999,7 +68995,7 @@ ja: 餅アイス, もちアイス
 lt: Mochi ledai
 wikidata:en: Q977539
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Iced nougat
 fr: Nougat glacé
 agribalyse_food_code:en: 39529

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67922,8 +67922,8 @@ ciqual_food_name:en: Frozen dessert, ice cream with meringue, vacherin ice cream
 ciqual_food_name:fr: Dessert glacé type mystère ou vacherin
 
 < en:Ice creams and sorbets
-en: Frozen dessert ice cream with meringue, Mystery ice cream
-fr: Mystère
+en: Ice cream ball filled and coated, Frozen dessert ice cream with meringue, Mystery ice cream
+fr: Boules de crème glacée fourrées et nappées, Mystère
 agribalyse_food_code:en: 39502
 ciqual_food_code:en: 39502
 ciqual_food_name:en: Frozen dessert, ice cream with meringue, vacherin ice cream or mystery ice cream type

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67872,27 +67872,27 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Desserts (Frozen)
 intake24_category_code:en: ICED
 
-< en:Frozen desserts
-en: Frozen dessert puff pastry, Frozen dessert puff pastry to share
-fr: Dessert glacé feuilleté, Dessert glacé feuilleté à partager
+< en:Ice creams and sorbets
+en: Layered ice cream blocks, Frozen dessert puff pastry, Frozen dessert puff pastry to share
+fr: Feuilletés glacés, Dessert glacé feuilleté, Dessert glacé feuilleté à partager
 agribalyse_food_code:en: 39516
 ciqual_food_code:en: 39516
 ciqual_food_name:en: Frozen dessert, puff pastry, to share
 ciqual_food_name:fr: Dessert glacé feuilleté, à partager
 
-< en:Frozen dessert puff pastry
+< en:Layered ice cream blocks
 fr: Dessert glacé feuilleté vanille
 
-< en:Frozen dessert puff pastry
+< en:Layered ice cream blocks
 fr: Dessert glacé feuilleté vanille caramel
 
-< en:Frozen dessert puff pastry
+< en:Layered ice cream blocks
 fr: Dessert glacé feuilleté menthe chocolat
 
-< en:Frozen dessert puff pastry
+< en:Layered ice cream blocks
 fr: Dessert glacé feuilleté vanille fruits rouges
 
-< en:Frozen dessert puff pastry
+< en:Layered ice cream blocks
 fr: Dessert glacé feuilleté chocolat brownie
 
 < en:Ice creams and sorbets

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -42166,7 +42166,7 @@ ru: Рождественские шоколадные конфеты
 < en:Christmas foods and drinks
 en: Yule log, Christmas log cake
 de: Weihnachtsbaumstamm Eisdessert
-fr: Bûches de Noël, Bûches de Noël pâtissières
+fr: Bûches de Noël
 hr: Badnjak
 it: torta tronchetto
 ja: ユールログ
@@ -42174,9 +42174,9 @@ agribalyse_food_code:en: 23030
 ciqual_food_code:en: 23030
 ciqual_food_name:en: Christmas log cake
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 < en:Yule log
-en: Ice cream log
+en: Ice cream logs, Ice cream log
 fr: Bûches glacées, Bûche glacée
 agribalyse_food_code:en: 39533
 ciqual_food_code:en: 39533
@@ -100384,7 +100384,8 @@ fr: Entremets macaron framboise
 < en:Desserts
 < en:Pastries
 < en:Yule log
-fr: Bûches pâtissières
+en: Pastry yule logs
+fr: Bûches pâtissières, Bûches de Noël pâtissières
 
 < en:Pastries
 en: Rum baba, baba au rhum

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67921,7 +67921,7 @@ ciqual_food_code:en: 39502
 ciqual_food_name:en: Frozen dessert, ice cream with meringue, vacherin ice cream or mystery ice cream type
 ciqual_food_name:fr: Dessert glacé type mystère ou vacherin
 
-< en:Frozen desserts
+< en:Ice creams and sorbets
 en: Frozen dessert ice cream with meringue, Mystery ice cream
 fr: Mystère
 agribalyse_food_code:en: 39502

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67972,6 +67972,15 @@ pnns_group_2:en: Ice cream
 who_id:en: 5
 
 < en:Ice creams and sorbets
+en: Frozen sticks
+fr: Bâtonnets glacés
+
+< en:Frozen sticks
+en: Frozen fruit puree sticks
+fr: Bâtonnets glacés à la purée de fruits
+description:en: Dessert made of 100% fruit puree on a stick
+
+< en:Ice creams and sorbets
 en: Frozen cones
 fr: Cônes glacés
 
@@ -68142,12 +68151,13 @@ description:en: Ice cream is a sweetened frozen food typically eaten as a snack 
 # usage:fr:glace (sucre, kirsch de Bâle-Campagne)
 nova:en: 3
 
+< en:Frozen sticks
 < en:Ice creams
 en: Ice cream bars, Ice creams on a stick
 de: Eis am Stiel, Stieleis
 es: Helados de palo, Polos de helado, Paletas de helado, Paletas heladas
 fi: jäätelöpuikot
-fr: Bâtonnets glacés, Bâtonnets, battonets, battonnets, eskimos, Glaces Batonnets
+fr: Bâtonnets à la crème glacée, Glaces Batonnets
 hr: Štanglice sladoleda
 hu: Fagylal szeletek, Fagylaltok pálcikán
 it: Gelati a stecco, Gelatti in barretta
@@ -68545,6 +68555,7 @@ ciqual_food_code:en: 39524
 ciqual_food_name:en: Sorbet, in box
 ciqual_food_name:fr: Sorbet, en bac
 
+< en:Frozen sticks
 < en:Sorbets
 en: Sorbets on stick
 fr: Sorbets en bâtonnet
@@ -68834,6 +68845,7 @@ it: Gelati di origine vegetale
 lt: Augaliniai ledai, ledai be pieno
 nl: Plantaardig IJs
 
+< en:Frozen sticks
 < en:Plant-based ice creams
 en: Plant-based ice cream bars, Plant-based ice creams on a stick
 es: Polos con leche vegetal, Helados de palo con leche vegetal

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67873,6 +67873,29 @@ gpc_category_name:en: Desserts (Frozen)
 intake24_category_code:en: ICED
 
 < en:Frozen desserts
+en: Frozen dessert puff pastry, Frozen dessert puff pastry to share
+fr: Dessert glacé feuilleté, Dessert glacé feuilleté à partager
+agribalyse_food_code:en: 39516
+ciqual_food_code:en: 39516
+ciqual_food_name:en: Frozen dessert, puff pastry, to share
+ciqual_food_name:fr: Dessert glacé feuilleté, à partager
+
+< en:Frozen dessert puff pastry
+fr: Dessert glacé feuilleté vanille
+
+< en:Frozen dessert puff pastry
+fr: Dessert glacé feuilleté vanille caramel
+
+< en:Frozen dessert puff pastry
+fr: Dessert glacé feuilleté menthe chocolat
+
+< en:Frozen dessert puff pastry
+fr: Dessert glacé feuilleté vanille fruits rouges
+
+< en:Frozen dessert puff pastry
+fr: Dessert glacé feuilleté chocolat brownie
+
+< en:Frozen desserts
 en: Baked Alaska
 fr: Omelettes Norvégiennes glacées, Omelette norvégienne
 agribalyse_food_code:en: 39518
@@ -67948,32 +67971,16 @@ intake24_category_code:en: ICEC
 pnns_group_2:en: Ice cream
 who_id:en: 5
 
-< en:Frozen desserts
-en: Frozen dessert puff pastry, Frozen dessert puff pastry to share
-fr: Dessert glacé feuilleté, Dessert glacé feuilleté à partager
-agribalyse_food_code:en: 39516
-ciqual_food_code:en: 39516
-ciqual_food_name:en: Frozen dessert, puff pastry, to share
-ciqual_food_name:fr: Dessert glacé feuilleté, à partager
+< en:Ice creams and sorbets
+en: Frozen cones
+fr: Cônes glacés
 
-< en:Frozen dessert puff pastry
-fr: Dessert glacé feuilleté vanille
-
-< en:Frozen dessert puff pastry
-fr: Dessert glacé feuilleté vanille caramel
-
-< en:Frozen dessert puff pastry
-fr: Dessert glacé feuilleté menthe chocolat
-
-< en:Frozen dessert puff pastry
-fr: Dessert glacé feuilleté vanille fruits rouges
-
-< en:Frozen dessert puff pastry
-fr: Dessert glacé feuilleté chocolat brownie
-
+# do not put under sorbets, some products have a really low fruit content
+< en:Frozen cones
+fr: Cônes au sorbet
 
 < en:Ice creams and sorbets
-en: ice creams, ice cream
+en: Ice creams, ice cream
 ab: аршәы
 af: Roomys
 am: አይስ ክሬም
@@ -68134,7 +68141,6 @@ description:en: Ice cream is a sweetened frozen food typically eaten as a snack 
 # usage:fr:glace (sucre, kirsch de Bâle-Campagne)
 nova:en: 3
 
-
 < en:Ice creams
 en: Ice cream bars, Ice creams on a stick
 de: Eis am Stiel, Stieleis
@@ -68208,13 +68214,14 @@ en: Vanilla ice cream bars coated with white chocolate and almonds
 de: Vanilleeis am Stiel überzogen mit weiße Schokolade und Mandeln
 fr: Bâtonnets glacés vanille enrobés de chocolat blanc aux amandes
 
+< en:Frozen cones
 < en:Ice creams
 en: Ice cream cones, Ice cream cone
 ca: Cons de gelat
-de: Eistüten
+de: Speiseeis Hörnchen, Eistüten
 es: Conos de helado
 fi: jäätelötuutit
-fr: Cônes glacés, Cônes à la crème glacée
+fr: Cônes à la crème glacée
 he: גביעי גלידה
 hr: Korneti za sladoled
 hu: Tölcséres jégkrém
@@ -68855,6 +68862,7 @@ hr: Kadice za sladoled na biljnoj bazi
 lt: Augaliniai ledai indeliuose
 nl: Plantaardig roomijs
 
+< en:Frozen cones
 < en:Plant-based ice creams
 en: Plant-based ice cream cones
 es: Conos de helado con leche vegetal

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67977,6 +67977,7 @@ fr: Cônes glacés
 
 # do not put under sorbets, some products have a really low fruit content
 < en:Frozen cones
+en: Sorbet cones
 fr: Cônes au sorbet
 
 < en:Ice creams and sorbets

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -511,6 +511,7 @@
 <li><a href="/facets/categories/Desserts végétaliens" class="tag well_known">Desserts végétaliens</a></li>
 <li><a href="/facets/categories/Macarons aux fruits à coques" class="tag well_known">Macarons aux fruits à coques</a></li>
 <li><a href="/facets/categories/Panforte" class="tag well_known">Panforte</a></li>
+<li><a href="/facets/categories/Bûches pâtissières" class="tag well_known">Bûches pâtissières</a></li>
 <li><a href="/facets/categories/Pêche melba" class="tag well_known">Pêche melba</a></li>
 <li><a href="/facets/categories/Puddings" class="tag well_known">Puddings</a></li>
 <li><a href="/facets/categories/en:Refrigerated desserts" class="tag well_known" lang="en">en:Refrigerated desserts</a></li>
@@ -527,7 +528,6 @@
 <li><a href="/facets/categories/Tartufo" class="tag well_known">Tartufo</a></li>
 <li><a href="/facets/categories/en:Trifles" class="tag well_known" lang="en">en:Trifles</a></li>
 <li><a href="/facets/categories/fi:Mämmi" class="tag user_defined" lang="fi">fi:Mämmi</a></li>
-<li><a href="/facets/categories/Bûches pâtissières" class="tag well_known">Bûches pâtissières</a></li>
 <li><a href="/facets/categories/Entremets macaron framboise" class="tag well_known">Entremets macaron framboise</a></li>
 <li><a href="/facets/categories/Pastel de nata" class="tag well_known">Pastel de nata</a></li>
 <li><a href="/facets/categories/Tangyuan" class="tag well_known">Tangyuan</a></li>

--- a/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
@@ -501,8 +501,8 @@
 <td style="text-align:right"><a href="/facets/categories/Fruit-based%20beverages" class="tag known">2</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/Fruit%20juices" class="tag known">Fruit juices</a></td>
 <td style="text-align:right"><a href="/facets/categories/Fruit%20juices" class="tag known">2</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td><a href="/facets/categories/ice%20creams" class="tag known">ice creams</a></td>
-<td style="text-align:right"><a href="/facets/categories/ice%20creams" class="tag known">2</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td><a href="/facets/categories/Ice%20creams" class="tag known">Ice creams</a></td>
+<td style="text-align:right"><a href="/facets/categories/Ice%20creams" class="tag known">2</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/Ice%20creams%20and%20sorbets" class="tag known">Ice creams and sorbets</a></td>
 <td style="text-align:right"><a href="/facets/categories/Ice%20creams%20and%20sorbets" class="tag known">2</a></td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td><a href="/facets/categories/Juices%20and%20nectars" class="tag known">Juices and nectars</a></td>

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -511,6 +511,7 @@
 <li><a href="/facets/categories/Non-dairy desserts" class="tag well_known">Non-dairy desserts</a></li>
 <li><a href="/facets/categories/Nut macarons" class="tag well_known">Nut macarons</a></li>
 <li><a href="/facets/categories/Panforte" class="tag well_known">Panforte</a></li>
+<li><a href="/facets/categories/Pastry yule logs" class="tag well_known">Pastry yule logs</a></li>
 <li><a href="/facets/categories/Peach melba with vanilla ice cream and raspberry sauce" class="tag well_known">Peach melba with vanilla ice cream and raspberry sauce</a></li>
 <li><a href="/facets/categories/Puddings" class="tag well_known">Puddings</a></li>
 <li><a href="/facets/categories/Refrigerated desserts" class="tag well_known">Refrigerated desserts</a></li>
@@ -527,7 +528,6 @@
 <li><a href="/facets/categories/Tartufo" class="tag well_known">Tartufo</a></li>
 <li><a href="/facets/categories/Trifles" class="tag well_known">Trifles</a></li>
 <li><a href="/facets/categories/fi:Mämmi" class="tag user_defined" lang="fi">fi:Mämmi</a></li>
-<li><a href="/facets/categories/fr:Bûches pâtissières" class="tag user_defined" lang="fr">fr:Bûches pâtissières</a></li>
 <li><a href="/facets/categories/fr:Entremets macaron framboise" class="tag user_defined" lang="fr">fr:Entremets macaron framboise</a></li>
 <li><a href="/facets/categories/fr:Pastel de nata" class="tag user_defined" lang="fr">fr:Pastel de nata</a></li>
 <li><a href="/facets/categories/Tangyuan" class="tag well_known">Tangyuan</a></li>


### PR DESCRIPTION
* Created "Sorbet cones" and "Frozen cones" to go on top of it.
* Created "Frozen fruit puree sticks" and its parent "Frozen sticks". Put "Ice cream bars" and "sorbets on stick" in "Frozen sticks"
* Renamed "Frozen dessert puff pastry" to "Layered ice cream blocks". Example of a product: https://world.openfoodfacts.org/product/3256226386702/feuillete-glace-parfum-creme-brulee-350g-u
* Renamed "Frozen dessert ice cream with meringue". Now this dessert can be filled with anything. See the original recipe https://world.openfoodfacts.org/product/3228872540470/le-mystere-vanille-coeur-meringue-nestle, a variation https://world.openfoodfacts.org/product/8051369002558/mystere-coco-coeur-framboise
* Moved all milk-based and water-based frozen dessert under "Ice creams and sorbets" to fit the gpc category description: 
>  Includes any products that can be described/observed as a sweet prepared food made from animal milk, milk substitute or water, which is frozen...