### PR TITLE
taxonomy(food): lemon edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -71066,8 +71066,8 @@ sv: Eureka-citron
 description:en: This is the common supermarket lemon, also known as "Four Seasons" (Quatre Saisons) because of its ability to produce fruit and flowers together throughout the year. (Wikipedia)
 wikidata:en: Q140329924
 
-< en: Fresh lemons
 < en: Eureka lemons
+< en: Fresh lemons
 en: Fresh Eureka lemons
 da: Friske eureka-citroner
 fr: Citrons Eureka frais

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -70910,24 +70910,79 @@ sales_format:en: weight, package
 
 < en:Citrus
 en: Lemons
+an: Limón
+ar: ليمون
+az: Limon
+be: Лімон
 bg: Лимони
+bi: Lemon
+br: Sitroñs
+ca: Llimona
+cs: Citron
+da: Citroner
 de: Zitronen
-es: Limones
-fi: sitruunat
+el: Λεμόνι
+eo: Citronoj
+es: Limones, Limón
+et: Sidrun
+eu: Limoi
+fi: Sitruunat
 fr: Citrons
+fy: Sitroen
+gl: Limón
 hr: Limunovi
-it: Limoni
+ht: Sitron
+hu: Citrom
+hy: Լիմոն
+id: Lemon
+it: Limoni, Limone
 ja: レモン, 檸檬
-la: Citrus x limon
+ka: Ლიმონი
+kg: Dilala ya ngayi
+ko: 레몬
+la: Citrus × limon, Citrus x limon
 lt: Citrinos
+mg: Voasarimakirana
+mi: Rēmana
+mk: Лимон
+ml: ചെറുനാരങ്ങ
+mn: Нимбэг
+mr: लिंबू
+mt: Lumija
+my: သံပယိုသီး
+nb: Sitron
+ne: कागती
 nl: Citroenen
-ro: Lămâi
-ru: Лимоны
-sv: Citroner, citron
+nn: Sitron
+nv: Chʼil łitsooí díkʼǫ́zhígíí
+oc: Citron
+or: ଲେମ୍ବୂ
+pl: Cytryna
+ps: ليمو
+pt: Limão
+ro: Lămâi, Lămâie
+ru: Лимоны, Лимон
+sc: Limone
+sk: Citrón
+sl: Limona
+sq: Limon
+sv: Citroner, Citron
+sw: Limau
+tg: Лимӯ
 tr: Limon
+tt: Лимун
+uk: Лимон
+uz: Limon
+wa: Limon
+za: Makningzmungx
+zh: 檸檬
 agribalyse_proxy_food_code:en: 13009
 agribalyse_proxy_food_name:en: Lemon, pulp, raw
 agribalyse_proxy_food_name:fr: Citron, pulpe, cru
+ciqual_proxy_food_code:en: 13009
+ciqual_proxy_food_name:en: Lemon, pulp, raw
+ciqual_proxy_food_name:fr: Citron, pulpe, cru
+wikidata:en: Q1093742
 
 < en:Lemons
 en: Lemons Primofiori, Lemons Mesero, Lemons Blanco
@@ -70937,20 +70992,32 @@ origins:en: en:spain
 < en:Fresh fruits
 < en:Lemons
 en: Fresh lemons
+da: Friske citroner
 de: Frische Zitronen
 es: Limones frescos
 fr: Citrons frais
 hr: Svježi limuni
 lt: Šviežios citrinos
 nl: Verse citroen
+sv: Färska citroner
 sales_format:en: weight, package
 season_in_country_fr:en: 1,2,11,12
 
-< en: Fresh lemons
+< en: Lemons
 en: Verna lemons, Verna
 xx: Verna
+da: Verna-citroner
 fr: Citrons Verna
 nl: Verna citroenen
+sv: Verna-citroner
+
+< en: Fresh lemons
+< en: Verna lemons
+en: Fresh Verna lemons
+da: Friske verna-citroner
+fr: Citrons Verna frais
+nl: Verse Verna citroenen
+sv: Färska verna-citroner
 
 < en:Lemons
 en: Unwaxed lemons
@@ -70961,7 +71028,7 @@ fr: Citron de Menton
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-1299
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q37970325
 
 < en:Lemons
 en: Lemon pulp
@@ -70972,6 +71039,7 @@ agribalyse_food_code:en: 13009
 ciqual_food_code:en: 13009
 ciqual_food_name:en: Lemon, pulp, raw
 ciqual_food_name:fr: Citron, pulpe, cru
+wikidata:en: Q140290322
 
 < en:Lemons
 en: Lemon zest
@@ -70982,6 +71050,7 @@ agribalyse_food_code:en: 13125
 ciqual_food_code:en: 13125
 ciqual_food_name:en: Lemon zest, raw
 ciqual_food_name:fr: Citron, zeste, cru
+wikidata:en: Q206454
 
 < en:Dried fruits
 < en:Lemons
@@ -70991,57 +71060,68 @@ fr: Citrons séchés
 < en:Lemons
 en: Eureka lemons
 da: Eureka-citroner
+fr: Citrons Eureka
+nl: Eureka citroenen
 sv: Eureka-citron
 description:en: This is the common supermarket lemon, also known as "Four Seasons" (Quatre Saisons) because of its ability to produce fruit and flowers together throughout the year. (Wikipedia)
+wikidata:en: Q140329924
+
+< en: Fresh lemons
+< en: Eureka lemons
+en: Fresh Eureka lemons
+da: Friske eureka-citroner
+fr: Citrons Eureka frais
+nl: Verse Eureka citroenen
+sv: Färska eureka-citron
 
 < en:Lemons
 it: Limone dell'Etna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02444
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q124813958
 
 < en:Lemons
 it: Limone di Rocca Imperiale
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0818
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q118819153
 
 < en:Lemons
 it: Limone Costa d'Amalfi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0116
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q3241198
 
 < en:Lemons
 it: Limone di Sorrento
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0098
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q3241200
 
 < en:Lemons
 it: Limone Femminello del Gargano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0297
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q3832521
 
 < en:Lemons
 it: Limone Interdonato Messina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0558
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q64549298
 
 < en:Lemons
 it: Limone di Siracusa
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0502
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q3832520
 
 < en:Citrus
 en: Limes

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -41964,28 +41964,72 @@ it: estratto di chinotto
 
 < en:citrus fruit
 en: lemon
+an: limón
+ar: ليمون
+az: limon
+be: лімон
 bg: лимон
-ca: Llimona
-cs: Citron
-da: Citron, Citroner
+bi: lemon
+br: sitroñs
+ca: llimona
+cs: citron
+da: citron, citroner
 de: Zitrone, Zitronen
+el: λεμόνι
+eo: citrono
 es: limón, limones
+et: sidrun
+eu: limoi
 fi: sitruuna, sitruunaa
 fr: citron, citrons, citron jaune, citrons jaunes
+fy: sitroen
+gl: limón
 he: לימון
 hr: limun, limuna, ploda limuna, citrus limon
+ht: sitron
 hu: citrom
+hy: լիմոն
+id: lemon
 it: limone, limoni
 ja: レモン
+ka: ლიმონი
+kg: dilala ya ngayi
+ko: 레몬
+la: citrus × limon
+mg: voasarimakirana
+mi: rēmana
+mk: лимон
+ml: ചെറുനാരങ്ങ
+mn: нимбэг
+mr: लिंबू
+mt: lumija
+my: သံပယိုသီး
 nb: sitron
+ne: कागती
 nl: citroen
-pl: Cytryna, cytryny, cytryn, cytrynowa, cytrynowy, cytrynowe
-pt: Limão
-ro: Lamaie
-ru: Лимон
-sv: citron, citron frukt
+nn: sitron
+nv: chʼil łitsooí díkʼǫ́zhígíí
+oc: citron
+or: ଲେମ୍ବୂ
+pl: cytryna, cytryny, cytryn, cytrynowa, cytrynowy, cytrynowe
+ps: ليمو
+pt: limão
+ro: lămâie, lamaie
+ru: лимон
+sc: limone
+sk: citrón
+sl: limona
+sq: limon
+sv: citron, citron frukt, citroner
+sw: limau
+tg: лимӯ
 tr: limon
-zh: 柠檬
+tt: лимун
+uk: лимон
+uz: limon
+wa: limon
+za: makningzmungx
+zh: 柠檬, 檸檬
 ciqual_proxy_food_code:en: 13009
 ciqual_proxy_food_name:en: Lemon, pulp, raw
 ciqual_proxy_food_name:fr: Citron, pulpe, cru
@@ -41993,7 +42037,6 @@ ecobalyse:en: 6ece5452-42de-4e0a-8c70-1d305e614cc8
 ecobalyse_labels_en_organic:en: ed5c98fd-6fe5-43ca-b938-1dde919794b7
 wikidata:en: Q1093742
 
-# en:description:The skin or outer layer of a fruit, vegetable, etc.
 < en:lemon
 en: lemon peel, lemon rind
 ca: pell de llimona
@@ -42010,6 +42053,7 @@ pl: skórka cytryny, skórka z cytryny, skórka cytrynowa
 pt: casca de limão
 ro: coajă de lămâie
 sv: citronskal
+description:en: The skin or outer layer of a lemon.
 usda_ndb_proxy_code:en: 9156
 usda_ndb_proxy_name:en: Lemon peel, raw
 wikidata:en: Q104037650
@@ -42030,7 +42074,6 @@ nn: citronskalextract
 ro: extract de coaja de lamaie
 sv: citronskalextract
 
-# en:description:The outer skin of a citrus fruit, removed through a zester.
 < en:lemon
 en: lemon zest
 de: Zitronenzeste, Zitronenabrieb
@@ -42044,6 +42087,7 @@ sv: citronzest
 ciqual_food_code:en: 13125
 ciqual_food_name:en: Lemon zest, raw
 ciqual_food_name:fr: Citron, zeste, cru
+description:en: The outer skin of a citrus fruit, removed through a zester.
 wikidata:en: Q26879249
 # 872 @2021-10-09
 
@@ -42329,6 +42373,19 @@ it: preparazione miele torta al limone
 en: lemon filling
 hr: punjenje s okusom limuna
 it: ripieno al limone
+
+##################### Lemon cultivars/varieties/types
+
+< en: lemon
+en: Eureka lemon
+da: eureka-citron
+sv: eureka-citron, citroner (eureka)
+wikidata:en: Q140329924
+
+< en: lemon
+en: Verna lemon, lemon Verna
+da: verna-citron
+sv: verna-citron, citroner verna
 
 ###################################################################################################
 #


### PR DESCRIPTION
- Adds new Fresh variant categories for Eureka and Verna lemons.
- Adds new Eureka and Verna lemon ingredients.
- Imports some translations from Wikidata.
- Adds Danish/Swedish translations.
- Adds `wikidata` and some `ciqual` properties.
- Moves some comments into `description` properties.
- Normalises categories towards capitalised names.
- Normalises ingredients towards lowercased names.

Source: https://www.thedailymeal.com/1197844/varieties-of-lemons-explained/
Needed-for: https://se.openfoodfacts.org/product/8713807008484/citroner
Needed-for: https://se.openfoodfacts.org/product/7311041051610/citroner-verna