### PR TITLE
taxonomy(food): plum (and prune) edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -72405,44 +72405,116 @@ wikidata:en: Q144412
 
 < en:Fruits
 en: Plums
+af: Pruim
+an: Cerolla
+ar: برقوق
 bg: Сливи
+ca: Pruna
+cs: Švestka
+cy: Eirinen
+da: Blommer
 de: Pflaumen
+el: Δαμάσκηνο
+eo: Prunoj
 es: Ciruelas
+et: Ploom
+eu: Aran
+fa: آلو
 fi: Luumut
 fr: Prunes
-hr: Šljive
+fy: Prom
+ga: Pluma
+gv: Plumbis
+hi: आलू बुख़ारा
+hr: Šljive, Šljiva
+hu: Szilva
+hy: Սալոր (միրգ)
+id: Prem
+io: Pruno
+is: Plóma
+it: Susina
 ja: すもも, プラム, プルーン
-lt: Slyvos
+jv: Plum
+kg: Mbalango
+kn: ಪ್ಲಮ್
+ko: 매실
+ks: ٲر
+ky: Кайналы
+la: Prunus
+lt: Slyvos, Slyva
+lv: Plūme
+mk: Слива
+ml: പ്ലം
+mn: Чавга
+mr: आलुबुखार
+ms: Plum
+my: ဇီးသီး
+nb: Plommer
 nl: Pruimen
-ru: Сливы
+nn: Plommer
+nv: Chʼil naʼatłʼoʼiitsoh
+oc: Pruna
+pa: ਆਲੂ ਬੁਖ਼ਾਰਾ
+pl: Śliwka
+ps: آلوچه
+pt: Ameixa
+ru: Сливы, Слива
+sd: آلو بخارو
+sh: Šljiva
+sk: Slivky
+sq: Kumbulla
+sr: Шљива
+sv: Plommon
+sw: Mplamu
+ta: கொத்துப்பேரி
+te: రేగి పండు
+th: พลัม
+tr: Erik
+tt: Караҗимеш
+uk: Слива
+ur: آلوچہ
+uz: Olxoʻri
+vi: Mận
+za: Makmaenj
+zh: 李子
 agribalyse_food_code:en: 13100
 ciqual_food_code:en: 13100
 ciqual_food_name:en: Plum, raw
 ciqual_food_name:fr: Prune, crue
 intake24_category_code:en: PLUM
+wikidata:en: Q12372598
 
 < en:Bulk
 < en:Fresh fruits
 < en:Plums
 en: Fresh plums
+da: Friske blommer
 de: Frische Pflaumen
 fr: Prunes fraîches
 hr: Svježe šljive
 lt: Šviežios slyvos
+sv: Färska plommon
 sales_format:en: weight, package
 season_in_country_fr:en: 7,8,9
 
 < en:Fresh plums
+< fr: Mirabelles de Lorraine
 fr: Mirabelles fraîches
 season_in_country_fr:en: 8,9
 
-< en:Fresh plums
+< en: Plums
 en: Greengage plums
-fr: Reine-Claudes fraîches, Prunes Reine-Claude
+fr: Prunes Reine-Claude
 agribalyse_food_code:en: 13041
 ciqual_food_code:en: 13041
 ciqual_food_name:en: Greengage plum, raw
 ciqual_food_name:fr: Prune Reine-Claude, crue
+wikidata:en: Q1283218
+
+< en: Fresh plums
+< en: Greengage plums
+en: Fresh Greengage plums
+fr: Reine-Claudes fraîches
 season_in_country_fr:en: 9
 
 < en:Fresh plums
@@ -72452,14 +72524,41 @@ season_in_country_fr:en: 8,9,10
 < en:Frozen fruits
 < en:Plums
 en: Frozen plums
+da: Frosne blommer
 fr: Prunes surgelées
+sv: Frysta plommon
+
+< en: Plums
+en: Red plums
+da: Røde blommer
+sv: Röda plommon
+description:en: Plums with red pulp.
+
+< en: Fresh plums
+< en: Red plums
+en: Fresh red plums
+da: Friske røde blommer
+sv: Färska röda plommon
 
 < en:Plums
 fr: Mirabelles de Lorraine
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0194
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q21427639
+
+< en: Red plums
+en: Black Splendor plums
+da: Black Splendor-blommer
+sv: Black Splendor-plommon
+wikidata:en: Q126645030
+
+< en: Black Splendor plums
+< en: Fresh red plums
+en: Fresh Black Splendor plums
+da: Friske Black Splendor-blommer
+sv: Färska Black Splendor-plommon
+season_in_country_us:en: 6,7
 
 < en:Fruits
 en: Pomegranates, Pomegranate pulp and pips

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -40159,32 +40159,81 @@ pt: Suco e polpa de pera, sumo e polpa de pera
 
 < en:prunus species fruit
 en: plum
+af: pruim
+an: cerolla
+ar: برقوق
 bg: слива, сливи
 ca: pruna
 cs: švestka
+cy: eirinen
 da: blomme, blommer
 de: Pflaume, Pflaumen
-el: Δαμάσκηνο
+el: δαμάσκηνο
+eo: pruno
 es: ciruela
 et: ploom
+eu: aran
+fa: آلو
 fi: luumu
 fr: prune, prunes
+fy: prom
+ga: pluma
+gv: plumbis
+hi: आलू बुख़ारा
 hr: šljiva, šljive
 hu: szilva
+hy: սալոր (միրգ)
+id: prem
+io: pruno
+is: plóma
 it: prugna, prugne
-ms: plum, Prun
+ja: プラム
+jv: plum
+kg: mbalango
+kn: ಪ್ಲಮ್
+ko: 매실
+ks: ٲر
+ky: кайналы
+la: prunus
+lt: slyva
+lv: plūme
+mk: слива
+ml: പ്ലം
+mn: чавга
+mr: आलुबुखार
+ms: plum, prun
+my: ဇီးသီး
+nb: plomme
 nl: pruim, pruimen
+nv: chʼil naʼatłʼoʼiitsoh
+oc: pruna
+pa: ਆਲੂ ਬੁਖ਼ਾਰਾ
 pl: śliwka, śliwki, śliwkowy, śliwkowa, śliwkowe, śliwkowej, śliwkowego, śliwkowych
+ps: آلوچه
 pt: ameixa
 ro: prună
 ru: слива, сливы
-sk: slivka
+sd: آلو بخارو
+sh: šljiva
+sk: slivka, slivky
 sl: sliva
-sr: Шљива, šljiva
+sq: kumbulla
+sr: шљива, šljiva
 sv: plommon
-th: พรุน
+sw: mplamu
+ta: கொத்துப்பேரி
+te: రేగి పండు
+th: พรุน, พลัม
+tr: erik
+tt: караҗимеш
 uk: слива, сливи
+ur: آلوچہ
+uz: olxoʻri
+vi: mận
 wa: pronne
+za: makmaenj
+zh: 李子
+agribalyse_proxy_food_code:en: 13100
 ciqual_proxy_food_code:en: 13100
 ciqual_proxy_food_name:en: Plum, raw
 ciqual_proxy_food_name:fr: Prune, crue
@@ -40218,51 +40267,76 @@ en: organic plum
 hr: eko šljiva
 it: prugna biologica
 
+< en: plum
+en: red plum
+da: rød blomme
+sv: röd plommon
+comment:en: is this the same as en:black plum? the red here refers to the pulp of the plum, but the black seems to refer to the skin.
+description:en: Plums with red pulp.
+
+< en: red plum
+en: Black Splendor plum
+xx: Black Splendor
+da: Black Splendor-blomme
+sv: Black Splendor-plommon
+wikidata:en: Q126645030
+
 # Some languages seem to give the specific plum cultivars used for making "dried plums" a name
 # similar to "prune", and then have the concept of "dried prune".
 # Also some languages call the tree "plum", and the fruit "prune".
 
 # This is the dried fruit, whether it has its own name, or is "dried plum/prune".
-# description:fr:Le pruneau est le fruit séché d'une variété de prunier cultivé, nommé prunier d'Ente.
 < en:plum
 en: prune, dried plum
 ar: برقوق مجفف, خوخ مجفف
 bg: сини сливи, синя слива
+ca: pruna seca
+cy: prŵn
 da: sveske, svesker
-de: Trockenpflaumen, Dörrpflaumen
+de: Trockenpflaume, Trockenpflaumen, Dörrpflaumen
+el: αποξηραμένο δαμάσκηνο
+eo: sekpruno
 es: ciruela pasa, ciruelas pasas
+eu: aranpasa
 fa: آلو بخارا
 fi: kuivattu luumu
 fr: pruneau, pruneaux, pruneaux séchés
-# hr:suhe šljive # see ingredients_processing.txt
-it: prugne secche
+#hr: suhe šljive # see ingredients_processing.txt
+hy: սալորաչիր
+id: prune
+is: sveskja
+it: prugne secche, prugna secca
 ja: プルーン
+ka: შავქლიავი
 ko: 프룬
+lv: žāvēta plūme
 ms: prun kering, plum kering
 nb: sviske
-nl: pruimedant
+nl: pruimedant, gedroogde pruim
 nn: sviske
 pl: śliwki suszone
+pt: ameixa seca
 ru: чернослив
 sl: suhe slive
-sr: суве шљиве, suve šljive, suva šljiva
+sr: суве шљиве, suve šljive, suva šljiva, сува шљива
 sv: sviskon
 tl: pruno
 uk: чорнослив
 vi: mận khô
 wa: souwêye pronne
-zh: 梅乾
-# chy:náhkôhematôtse
-# de-ch:Trockenpflaume
-# en-ca:prune
-# en-gb:prune
-# pcd:pronnieu
-# yue:西梅乾
+zh: 梅乾, 李子乾
+#chy: náhkôhematôtse
+#de-ch: Trockenpflaume
+#en-ca: prune
+#en-gb: prune
+#pcd: pronnieu
+#yue: 西梅乾
+agribalyse_food_code:en: 13042
 ciqual_food_code:en: 13042
 ciqual_food_name:en: Prune
 ciqual_food_name:fr: Pruneau, sec
-comment:en: wikidata has an issue not distinguishing between the fresh fruit and the dried fruit
 description:en: A prune is a dried plum of any cultivar, mostly Prunus domestica or European Plum.
+description:fr: Le pruneau est le fruit séché d'une variété de prunier cultivé, nommé prunier d'Ente.
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:pruneau
 usda_ndb_proxy_code:en: 9291
 usda_ndb_proxy_name:en: Plums, dried (prunes), uncooked
@@ -40298,13 +40372,14 @@ usda_ndb_name:en: Prunes, dehydrated (low-moisture), uncooked
 en: prunes from Agen
 fr: pruneaux d'agen
 it: prugne di Agen
-wikidata:en: Q21093818
 # 141 in fr @2021-09-15
 
 < en:prunes from Agen
 en: prunes from Ente
 fr: prunes d'Ente
 it: prugne di Ente
+ka: აჟანის უნგრულა
+wikidata:en: Q3408620
 
 #processing:en: en:puree
 < en:prune
@@ -48767,7 +48842,7 @@ usda_ndb_name:en: Sugar-apples, (sweetsop), raw
 #
 ###################################################################################################
 
-# 
+#
 # Note that in french often 'raisin' is used to indicate the dried one
 
 < en:berries

--- a/tests/unit/products_tags.t
+++ b/tests/unit/products_tags.t
@@ -153,7 +153,7 @@ is(
 ) or diag Dumper $product_ref->{categories_tags};
 
 is($product_ref->{categories},
-	"Alimentos y bebidas de origen vegetal, Alimentos de origen vegetal, Frutas y verduras y sus productos, Frutas y sus productos, Frutas, Frutas tropicales, Manzanas, Plátanos, Frutas del bosque, Ciruelas, Frambuesas, Fresas, naranjas, limones"
+	"Alimentos y bebidas de origen vegetal, Alimentos de origen vegetal, Frutas y verduras y sus productos, Frutas y sus productos, Frutas, Ciruelas, Frutas tropicales, Manzanas, Plátanos, Frutas del bosque, Frambuesas, Fresas, naranjas, limones"
 );
 
 add_tags_to_field($product_ref, "it", "categories", "bogus, mele");


### PR DESCRIPTION
- Adds red plum categories and ingredients.
- Adds Black Splendor plum categories and ingredients.
- Imports some translations from Wikidata.
- Adds some Danish/Swedish/Norwegian translations.
- Adds some `wikidata` properties.
- Removes a `wikidata` property.
  - The WD item Q21093818 “Pruneaux d'Agen” is for a French women’s cycling team, not the fruit.
- Separates out and cleans up separation of base and fresh plum cultivars already in the taxonomy.
- Moves some comments into `description`s.
- Removes outdated comment about Wikidata.

Source: https://www.davewilson.com/growers/products/fruit-trees/plum/black_splendor/
Source: https://www.weekand.com/home-garden/article/varieties-sweet-black-plums-18061822.php
Source: https://www.fruittreenursery.com/plum-varieties/black-splendor-plum
Needed-for: https://se.openfoodfacts.org/product/6410405153555/r%C3%B6d-plommon-fruit-value