### PR TITLE
taxonomy(food): prime and starlight grape edits

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -48767,7 +48767,7 @@ usda_ndb_name:en: Sugar-apples, (sweetsop), raw
 #
 ###################################################################################################
 
-# 
+#
 # Note that in french often 'raisin' is used to indicate the dried one
 
 < en:berries
@@ -49072,15 +49072,17 @@ sv: flame-vindruva
 comment:en: https://goodfruitguide.co.uk/product/flame/
 
 < en: white seedless grape
-en: Prime Seedless grape, Prime Seedless
+en: Prime Seedless grape
+xx: Prime Seedless
 da: prime seedless-vindrue
 sv: Prime Seedless-vindruva
 comment:en: https://goodfruitguide.co.uk/product/prime-seedless/
 
 < en: red seedless grape
-en: Starlight grape, red seedless grape (Starlight)
-da: starlight-vindrue
-sv: starlight-vindruva
+en: Starlight grape, Starlight red seedless grape
+xx: Starlight
+da: Starlight-vindrue
+sv: Starlight-vindruva
 comment:en: https://goodfruitguide.co.uk/product/starlight-red-grape/
 
 < en:grape juice


### PR DESCRIPTION
Needed-for: https://se.openfoodfacts.org/product/8718631000734/red-seedless-grapes-origin-fruit-europe