### PR TITLE
taxonomy(food): nectarine edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -71961,23 +71961,60 @@ ciqual_food_name:fr: Pêche, pulpe et peau, crue
 
 < en:Peaches
 en: Nectarines
-bg: Нектарини
+ar: زليقة
+bg: Нектарини, Нектарина
+ca: Nectarina
+cs: Nektarinka
+da: Nektariner
 de: Nektarinen
+el: Νεκταρίνι
+eo: Nektarinoj
 es: Nectarinas
+et: Nektariin
+eu: Brinoi
+fa: شلیل
 fi: Nektariinit
 fr: Nectarines
+gv: Naghtyreen
 hr: Nektarine
+hy: Նեկտարին
+it: Pesca noce
+ja: ネクタリン
+ka: Ვაშლატამა
+kv: Нектарин
 la: Prunus persica var. nucipersica, Prunus persica var. nectarina
-lt: Nektarinai
+lb: Nektarinn
+lt: Nektarinai, Nektarinas
+nb: Nektariner
 nl: Nectarines
+nn: Nektarinar
+pl: Nektarynka
+pt: Nectarina
+ru: Нектарин
+se: Nektariidna
+sk: Broskyňa obyčajná
+sl: Nektarina
+sv: Nektariner
+tl: Nektarina
+tr: Nektarin
+uk: Нектарин
+vi: Du đào
+zh: 桃駁李
+agribalyse_proxy_food_code:en: 13030
+ciqual_proxy_food_code:en: 13030
+ciqual_proxy_food_name:en: Nectarine, pulp and peel, raw
+ciqual_proxy_food_name:fr: Nectarine ou brugnon, pulpe et peau, crue
 sales_format:en: weight, package
+wikidata:en: Q841156
 
 < en:Fresh peaches
 < en:Nectarines
 en: Fresh nectarines
+da: Friske nektariner
 fr: Nectarines fraîches
 hr: Svježe nektarine
 lt: Švieži nektarinai
+sv: Färska nektariner
 season_in_country_fr:en: 7,8
 
 < en:Nectarines
@@ -71987,6 +72024,21 @@ agribalyse_food_code:en: 13030
 ciqual_food_code:en: 13030
 ciqual_food_name:en: Nectarine, pulp and peel, raw
 ciqual_food_name:fr: Nectarine ou brugnon, pulpe et peau, crue
+
+< en: Nectarines
+en: Garofa nectarines
+xx: Garofa
+da: Garofa-nektariner
+sv: Garofa-nektariner
+comment:en: CPVO patent: GAROFA-cov CEE Nº 2003/1892
+description:en: Yellow-fleshed early season nectarine variety.
+
+< en: Fresh nectarines
+< en: Garofa nectarines
+en: Fresh Garofa nectarines
+da: Friske Garofa-nektariner
+sv: Färska Garofa-nektariner
+season_in_country_es:en: 5,6
 
 < en:Fruits
 en: Pitayas, Pitaya, Dragon Fruits, Dragon Fruit

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -47034,6 +47034,7 @@ de: Nektarine
 el: νεκταρίνι
 eo: nektarino
 es: melocotonero, nectarina, pelón
+et: nektariin
 eu: brinoi
 fa: شلیل
 fi: nektariini
@@ -47041,7 +47042,7 @@ fr: nectarine
 ga: neachtairín
 gv: naghtyreen
 he: נקטרינה
-hr: nektarina
+hr: nektarina, nektarine
 hu: kopaszbarack, nektarin, csupaszbarack
 hy: նեկտարին
 it: nettarina, pesca noce
@@ -47049,6 +47050,7 @@ ja: ネクタリン
 ka: ვაშლატამა
 kv: нектарин
 la: prunus persica var. nucipersica
+lb: Nektarinn
 lt: nektarinas, nektarininis abrikosas
 lv: nektarīns
 mt: nuċipriska
@@ -47058,6 +47060,7 @@ pl: nektarynka
 pt: nectarina
 ro: nectarin
 ru: нектарин
+se: nektariidna
 sk: nektárinka, broskyňa obyčajná, broskyňa obyčajná hladká
 sl: nektarina
 sv: nektarin
@@ -47066,13 +47069,14 @@ tr: nektarin
 uk: нектарин
 vi: du đào
 zh: 桃駁李
-#aeb:خوخ
-#koi:нектарин
-#lbe:нектарин
-#mrj:нектарин
-#scn:pèrsica
-#udm:нектарин
-#yue:桃駁李
+#aeb: خوخ
+#koi: нектарин
+#lbe: нектарин
+#mrj: нектарин
+#scn: pèrsica
+#udm: нектарин
+#yue: 桃駁李
+agribalyse_proxy_food_code:en: 13030
 ciqual_proxy_food_code:en: 13030
 ciqual_proxy_food_name:en: Nectarine, pulp and peel, raw
 ciqual_proxy_food_name:fr: Nectarine ou brugnon, pulpe et peau, crue
@@ -47088,14 +47092,31 @@ en: raw nectarine
 usda_ndb_code:en: 9191
 usda_ndb_name:en: Nectarines, raw
 
-< en:nectarine
+< en: raw nectarine
 en: raw nectarine pulp and skin
 ciqual_food_code:en: 13030
 ciqual_food_name:en: Nectarine, pulp and peel, raw
 ciqual_food_name:fr: Nectarine ou brugnon, pulpe et peau, crue
 
 < en:nectarine
+en: nectarine pulp
 de: Nektarinenmark
+
+##################### Nectarine cultivars/varieties/types
+
+< en: nectarine
+en: Garofa nectarine, nectarine Garofa
+xx: Garofa
+da: Garofa-nektarin
+sv: Garofa-nektarin, nektariner Garofa
+comment:en: CPVO patent: GAROFA-cov CEE Nº 2003/1892
+description:en: Yellow-fleshed early season nectarine variety.
+
+###################################################################################################
+#
+#                                Ōhelo berry
+#
+###################################################################################################
 
 < en:fruit
 en: ōhelo berry, ōheloberries, oheloberries
@@ -48767,7 +48788,7 @@ usda_ndb_name:en: Sugar-apples, (sweetsop), raw
 #
 ###################################################################################################
 
-# 
+#
 # Note that in french often 'raisin' is used to indicate the dried one
 
 < en:berries


### PR DESCRIPTION
- Adds Garofa nectarine ingredient and categories.
- Imports some translations from Wikidata.
- Adds some Danish/Swedish/Norwegian translations.
- Adds `wikidata` and `agribalyse`/`ciqual` properties.
- Adds visual separator between nectarine and ōhelo berry ingredients.

Source: https://psbproduccionvegetal.com/en/productos/nectarine-garofa/
Source: https://www.marsagroplant.com/nectarines/garofa
Needed-for: https://se.openfoodfacts.org/product/7311041049358/nektarin-fruit-appetite