### PR TITLE
taxonomy(food): (prickly) pear edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -72359,16 +72359,106 @@ fr: Melons surgelés
 
 < en:Fruits
 en: Pears
-bg: Круши
+af: Peer
+ar: إجاص
+az: Armud
+be: Груша
+bg: Круши, Круша
+bn: নাশপাতি
+bo: ལི།
+br: Per
+bs: Kruška
+ca: Pera
+co: Pera
+cs: Hruška
+cy: Gellygen
+da: Pærer
 de: Birnen
+el: Αχλάδι
+eo: Piroj
 es: Peras
-fi: päärynät
+et: Pirn
+eu: Udare
+fa: گلابی
+fi: Päärynät
+fo: Pera
 fr: Poires
-hr: Kruške
+fy: Par
+ga: Piorra
+gd: Peur
+gl: Pera
+gv: Peear
+hi: नाशपाती
+hr: Kruške, Kruška
+ht: Pwar
+hu: Körte
+hy: Տանձ
+id: Buah pir
+ig: Ùbé
+io: Piro
+is: Pera
+it: Pera
+ja: 梨
+ka: Მსხალი
+kk: Алмұрт
+km: ផ្លែភា
+ko: 배
+ku: Hirmê
+kw: Per
+ky: Алмурут
+la: Pirum
+lb: Bier
+li: Paer
+lo: ໝາກຈອງ
 lt: Kriaušės
-nl: Peren
-ru: Груши
+lv: Bumbieris
+mi: Pea
+mk: Кру́ша
+ml: പിയർ
+mt: Lanġasa
+my: သစ်တောသီး
+nb: Pærer
+nl: Peren, Peer
+nn: Pærer
+nv: Bilasáana bitseeʼ nineezígíí
+oc: Pera
+or: ନାସ୍ପାତି
+os: Кӕрдо
+pa: ਨਾਸ਼ਪਾਤੀ
+pl: Gruszka
+pt: Pêra
+rm: Pair
+ro: Pară
+ru: Груши, Груша
+sc: Pira
+se: Beron
+sh: Kruška
+sk: Hruška
+sl: Hruška
+sq: Dardha
+sr: Крушка
+st: Pere
+sv: Päron
+sw: Pea
+ta: பேரிக்காய்
+tg: Мурӯд
+th: ลูกแพร์
+tk: Armyt
+tl: Peras
 tr: Armut
+tt: Армут
+ug: نەشپۈت
+uk: Груша
+ur: ناشپاتی
+uz: Nok
+vi: Lê
+vo: Bün
+wa: Poere
+yi: באר
+zh: 梨
+agribalyse_proxy_food_code:en: 13037
+ciqual_proxy_food_code:en: 13037
+ciqual_proxy_food_name:en: Pear, flesh and skin, raw
 google_product_taxonomy_id:en: 6665
 intake24_category_code:en: PEAR
 wikidata:en: Q13099586
@@ -72376,11 +72466,13 @@ wikidata:en: Q13099586
 < en:Fresh fruits
 < en:Pears
 en: Fresh pears
+da: Friske pærer
 de: Frische Birnen
 es: Peras frescas
 fr: Poires fraîches
 hr: Svježe kruške
 lt: Šviežios kriaušės
+sv: Färska päron
 sales_format:en: weight, package
 season_in_country_fr:en: 1,2,3,8,9,10,11,12
 
@@ -72394,8 +72486,22 @@ fr: Poires Abate, Poires Abbé Fétel, Abbé Fétel, Abate Fétel
 wikidata:en: Q306912
 
 < en:Pears
-en: Asian pears, Apple pears, Sand pears
+en: Asian pears, Nashi pears, Apple pears, Sand pears
+ca: Pera asiàtica
+da: Nashipærer
+de: Nashibirnen
+eo: Azia piroj
+fr: Nashi
+sl: Naši
+sv: Nashipäron, Päron nashi
 comment:en: https://www.webmd.com/diet/health-benefit-asian-pears
+wikidata:en: Q104821115
+
+< en: Asian pears
+< en: Fresh pears
+en: Fresh Asian pears
+da: Friske nashipærer
+sv: Färska nashipäron
 
 < en:Pears
 en: Comice pears, Pears (Comice)
@@ -72404,10 +72510,30 @@ sales_format:en: package, weight
 
 < en:Pears
 en: Conference pears, Pears (Conference)
+xx: Conference
+cs: Konference
+da: Conference-pærer
+eu: Konferentzia madaria
 fr: Poires Conférence, Conférence
 hr: Konferencijske kruške
+ig: Conference pear
+la: Pyrus communis ‘Conference’
 nl: Conference peren
+pl: Konferencja
+sk: Konferencia (hruška)
+sv: Conference-päron
+zh: 展會梨
+agribalyse_proxy_food_code:en: 13188
+ciqual_proxy_food_code:en: 13188
+ciqual_proxy_food_name:en: Pear, var. Conférence, flesh without skin, raw
 sales_format:en: weight, package
+wikidata:en: Q747247
+
+< en: Conference pears
+< en: Fresh pears
+en: Fresh Conference pears
+da: Friske Conference-pærer
+sv: Färska Conference-päron
 
 < en:Pears
 en: Guyot pears, Pears (Guyot)
@@ -72418,33 +72544,65 @@ wikidata:en: Q3033517
 < en:Pears
 en: Harrow Sweet pears
 xx: Harrow Sweet
+da: Harrow Sweet-pærer
 fr: Poires Harrow Sweet
+sv: Harrow Sweet-päron
+wikidata:en: Q109311874
 
 < en:Pears
-en: Packham's pears, Packham's Triumph pears
+en: Packham's Triumph pears, Packham's pears
 fr: Poires Packham's, Poires Packham's Triumph
+la: Pyrus communis 'Packham's Triumph'
+wikidata:en: Q25381272
 
 < en:Pears
 en: Rocha pears, Pears (Rocha)
+xx: Pêra Rocha
 fr: Poires Rocha
+pt: Pêra Rocha do Oeste
+origins:en: en:portugal
+#protected_name_file_number:en: PGI-PT-
+protected_name_type:en: pgi
 sales_format:en: weight, package
+wikidata:en: Q1548510
 
 < en:Pears
-en: Williams pears
-xx: Williams
+en: Williams' bon chrétien pears, Williams pears, Bartlett pears
+xx: Williams, Bartlett
+bg: Вилямова масловка
+cs: Williamsova
 de: Williams Christ, Williams Christbirne, Williamsbirne
-fr: Poires Williams, Williams
+eo: Vilhelmopiroj
+es: Williams' Bon Chretien (pera)
+eu: Williams udarea
+fr: Poires Williams, Bon-Chrétien Williams
+it: Pera Williams
+ja: バートレット
+ka: Ვილიამსი
+la: Pyrus communis ‘Williams Bon Chrétien’
+nl: Williams pear
+pl: Bonkreta Williamsa
+ru: Груша ʽВильямс’
+sl: Viljamovka
+sv: Williamspäron
+tg: Вилямс (навъи нок)
+zh: 威廉斯梨
+#en_ca: Bartlett pears
+#en_us: Bartlett pears
+agribalyse_proxy_food_code:en: 13189
+ciqual_proxy_food_code:en: 13189
+ciqual_proxy_food_name:en: Pear, var. Williams, flesh without skin, raw
 wikidata:en: Q498862
 
 ########### Pear origins
 
 < en:Apples
+< en:French fruits
 fr: Pommes de Savoie
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0196
 protected_name_type:en: pgi
-#wikidata:en:Q21427804 (amalgame)
-
+wikidata:en: Q140361674
 
 < en:Pears
 it: Pera dell'Emilia Romagna
@@ -72453,12 +72611,13 @@ protected_name_file_number:en: PGI-IT-1534
 protected_name_type:en: pgi
 wikidata:en: Q3899627
 
+< en: French fruits
 < en:Pears
 fr: Poires de Savoie
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0196
 protected_name_type:en: pgi
-#wikidata:en:
+wikidata:en: Q140361697
 
 < en:Pears
 en: Pear pulp and peel
@@ -72476,14 +72635,23 @@ ciqual_food_code:en: 13107
 ciqual_food_name:en: Pear, peeled, raw
 ciqual_food_name:fr: Poire, pulpe, crue
 
-< en:Pears
-en: Prickly pears, Prickly pear pulp and seeds
-fr: Figues de Barbarie, Figue de Barbarie pulpe et graines
+< en: Fruits
+en: Prickly pears
+fr: Figues de Barbarie
+agribalyse_proxy_food_code:en: 13063
+ciqual_proxy_food_code:en: 13063
+ciqual_proxy_food_name:en: Prickly pear, pulp and seeds, raw
+ciqual_proxy_food_name:fr: Figue de Barbarie, pulpe et graines, crue
+comment:en: Prickly pears are wholly unrelated to pears other than vaguely having the same shape.
+#wikidata_plant:en: Q158991
+
+< en: Prickly pears
+en: Prickly pear pulp and seeds
+fr: Figue de Barbarie pulpe et graines
 agribalyse_food_code:en: 13063
 ciqual_food_code:en: 13063
 ciqual_food_name:en: Prickly pear, pulp and seeds, raw
 ciqual_food_name:fr: Figue de Barbarie, pulpe et graines, crue
-wikidata:en: Q144412
 
 < en:Fruits
 en: Plums

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -39868,12 +39868,11 @@ pt: pêssegos em calda
 #                                Pear
 #
 ###################################################################################################
-# description:en:The PEAR is any of several tree and shrub species of genus Pyrus, in the family Rosaceae. Note this refers to the tree and not the fruit
 
 < en:fruit
 en: pear, pears
 af: peer
-ar: بواويد
+ar: بواويد, إجاص
 az: armud
 be: груша
 bg: круша, круши
@@ -39891,24 +39890,25 @@ el: αχλάδι
 eo: piro
 es: pera
 et: pirn
-eu: Madari
+eu: madari, udare
 fa: گلابی
 fi: päärynä
 fo: pera
 fr: poire, poires
 fy: par
-ga: péire
+ga: péire, piorra
 gd: peur
-gl: Pera
+gl: pera
 gv: peear
 he: אגס
 hi: नाशपाती
 hr: kruška, kruške
+ht: pwar
 hu: körte
 hy: տանձ
 id: buah pir
-ig: Ube
-io: Piro
+ig: ùbé, ube
+io: piro
 is: pera
 it: pera, pere
 ja: 梨
@@ -39920,20 +39920,21 @@ ku: hirmê
 kw: per
 ky: алмурут
 la: pirum
-lb: Bir
+lb: Bir, Bier
 li: paer
 lo: ໝາກຈອງ
 lt: kriaušė
 lv: bumbieris
 mi: pea
 mk: кру́ша
+ml: പിയർ
 mt: lanġasa
 my: သစ်တောသီး
 nb: pære
 nl: peer, peren
 nn: pære
 nv: bilasáana bitseeʼ nineezígíí
-oc: Pera
+oc: pera
 or: ନାସ୍ପାତି
 os: кӕрдо
 pa: ਨਾਸ਼ਪਾਤੀ
@@ -39944,6 +39945,7 @@ ro: pară
 ru: груша
 sc: pira
 se: beron
+sh: kruška
 sk: hruška
 sl: hruška
 sq: dardha
@@ -39965,22 +39967,27 @@ uz: nok
 vi: lê
 vo: bün
 wa: poere
+yi: באר
 zh: 梨
-# ast:pera
-# dsb:Kšuška
-# fur:piruç
-# hsb:krušwa
-# krc:кертме
-# lah:ناشپاتی
-# mdf:Груша
-# pap:per
-# rup:pearã
-# sco:peer
-# zh-min-nan:梨
+#ast: pera
+#dsb: Kšuška
+#fur: piruç
+#hsb: krušwa
+#krc: кертме
+#lah: ناشپاتی
+#mdf: Груша
+#pap: per
+#rup: pearã
+#sco: peer
+#zh-min-nan: 梨
+agribalyse_proxy_food_code:en: 13037
 #carbon_footprint_fr_foodges_ingredient:fr:Poire (Belgique)
 #carbon_footprint_fr_foodges_value:fr:0.5
 carbon_footprint_fr_foodges_ingredient:fr: Poire (Argentine)
 carbon_footprint_fr_foodges_value:fr: 1
+ciqual_proxy_food_code:en: 13037
+ciqual_proxy_food_name:en: Pear, flesh and skin, raw
+description:en: The PEAR is any of several tree and shrub species of genus Pyrus, in the family Rosaceae. Note this refers to the tree and not the fruit
 ecobalyse:en: bb00f430-ffda-46a3-ba45-267b0064a43e
 ecobalyse_origins_en_france:en: eab762ca-1edc-4fcc-ba6d-c247bbab0ec8
 ifct_food_code:en: E051
@@ -39989,8 +39996,8 @@ usda_ndb_proxy_code:en: 9252
 usda_ndb_proxy_name:en: Pears, raw
 wikidata:en: Q13099586
 wikipedia:en: https://en.wikipedia.org/wiki/Pear
-# 130 products in 5 languages @2018-09-28
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/pear
+# 130 products in 5 languages @2018-09-28
 
 < en:pear
 en: raw pear
@@ -39998,49 +40005,128 @@ usda_ndb_code:en: 9252
 usda_ndb_name:en: Pears, raw
 
 < en:pear
-en: raw asian pears
+en: Asian pear, nashi pear, apple pear
+ca: pera asiàtica
+da: nashipære, nashi-pære, asiatisk pære
+de: Nashibirne
+eo: azia piro
+fr: nashi
+sl: naši
+sv: nashipäron, nashi-päron
+usda_ndb_proxy_code:en: 9340
+usda_ndb_proxy_name:en: Pears, asian, raw
+wikidata:en: Q104821115
+
+< en: Asian pear
+en: raw Asian pear
 usda_ndb_code:en: 9340
 usda_ndb_name:en: Pears, asian, raw
 
-< en:pear
-en: raw bartlett pear
+< en: Williams' bon chrétien pear
+en: raw Bartlett pear
 usda_ndb_code:en: 9412
 usda_ndb_name:en: Pears, raw, bartlett (Includes foods for USDA's Food Distribution Program)
 
 < en:pear
+en: Bosc pear, Beurré Bosc pear
+xx: Calebasse Bosc, Beurré Bosc
+cs: Boscova lahvice
+da: Bosc-pære
+de: Boscs Flaschenbirne
+eu: Bosc udarea
+fr: poire Beurré Bosc
+hr: Boskova bočica
+hy: Բերե Բոսկ
+ka: ბერე ბოსკი
+la: Pyrus communis ‘Calebasse Bosc’
+pl: Bera Boska
+sv: Bosc-päron
+tg: Береи Боск
+vi: Lê Bosc
+usda_ndb_proxy_code:en: 9414
+usda_ndb_proxy_name:en: Pears, raw, bosc (Includes foods for USDA's Food Distribution Program)
+wikidata:en: Q894405
+
+< en: Bosc pear
 en: raw bosc pear
 usda_ndb_code:en: 9414
 usda_ndb_name:en: Pears, raw, bosc (Includes foods for USDA's Food Distribution Program)
 
 < en:pear
-en: raw green anjou pears
+en: d'Anjou pear, Anjou pear
+xx: d'Anjou, Anjou, Beurré d'Anjou, Nec Plus Meuris
+da: anjoupære
+es: pera de Anjou
+fr: beurré d'Anjou
+ru: Анжу
+sv: anjoupäron
+usda_ndb_proxy_code:en: 9415
+usda_ndb_proxy_name:en: Pears, raw, green anjou (Includes foods for USDA's Food Distribution Program)
+wikidata:en: Q2745252
+
+< en: d'Anjou pear
+en: raw green Anjou pears
 usda_ndb_code:en: 9415
 usda_ndb_name:en: Pears, raw, green anjou (Includes foods for USDA's Food Distribution Program)
 
-en: pears, raw, red anjou
+< en: d'Anjou pear
+en: raw red Anjou pears
 usda_ndb_code:en: 9413
 usda_ndb_name:en: Pears, raw, red anjou
 
 < en:pear
-en: conference pear
+en: Conference pear
+xx: Conference
+da: conferencepære
 de: Conference-Birne
 es: pera conferencia
+eu: konferentzia madaria
 fr: poire conférence
 hr: konferencijska kruška
+ig: conference pear
 it: pera conferenza
-nl: conference peer, conference
-pl: gruszka konferencyjna
+la: pyrus communis ‘Conference’
+nl: conference peer
+pl: gruszka konferencyjna, konferencja
 pt: pêra conferência
 ru: груша конференция
+sk: konferencia
+sv: conferencepäron
+zh: 展會梨
+agribalyse_proxy_food_code:en: 13188
+ciqual_proxy_food_code:en: 13188
+ciqual_proxy_food_name:en: Pear, var. Conférence, flesh without skin, raw
+wikidata:en: Q747247
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/conference-pear
 # 3 products in 1 language @2018-09-28
 
 < en:pear
+en: Williams' bon chrétien pear, Williams pear, Bartlett pear
+xx: Williams' bon chrétien
+bg: Вилямова масловка
+cs: Williamsova
 de: Williamsbirnen, Walliser Williamsbirnen
+eo: vilhelmopiro
 es: pera Williams, peras Williams de los coteaux du Lyonnais
+eu: Williams udarea
 fr: poire Williams, poires Williams des coteaux du Lyonnais
 it: pera Williams, pere Williams dei coteaux du Lyonnais
+ja: バートレット
+ka: ვილიამსი
+la: Pyrus communis 'Williams Bon Chrétien'
 nl: Williams peren, Walliser Williams peren
+pl: Bonkreta Williamsa
+ru: Груша ʽВильямс’
+sl: viljamovka
+sv: williamspäron
+tg: Вилямс (навъи нок)
+zh: 威廉斯梨
+agribalyse_proxy_food_code:en: 13189
+ciqual_proxy_food_code:en: 13189
+ciqual_proxy_food_name:en: Pear, var. Williams, flesh without skin, raw
+usda_ndb_proxy_code:en: 9412
+usda_ndb_proxy_name:en: Pears, raw, bartlett (Includes foods for USDA's Food Distribution Program)
+wikidata:en: Q498862
 
 < en:pear
 en: pears in cubes
@@ -40052,6 +40138,7 @@ fr: poires en cubes
 hr: kruške u kockama
 it: pere a cubetti
 nl: perenblokjes
+#processing:en: en:cubes
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/pears-in-cubes
 # 38 products in 1 language @2018-09-28
 
@@ -40069,12 +40156,10 @@ nl: perenpuree
 pl: przecier gruszkowy
 pt: Puré de pêra
 ro: piure de pere
-# In process de:Birnenpüree
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-poires
 # 233 products in 5 langauges @2018-09-28
-ciqual_food_code:en: 13037
-ciqual_food_name:en: Pear, pulp and peel, raw
 
+< en: Williams' bon chrétien pear
 < en:pear puree
 en: Williams pear puree
 de: Williams Birnenpüree
@@ -40112,11 +40197,12 @@ pl: Sok gruszkowy
 ru: сок грушевый
 sv: päronjuice
 tr: armut suyu
-# yue:梨汁
+#yue: 梨汁
 wikidata:en: Q2461726
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/pear-juice
 # 132 products in 4 languages @2018-09-28
 
+< en: fruit juice concentrate
 < en:pear juice
 en: pear juice concentrate
 cs: hruškový koncentrát
@@ -40129,6 +40215,7 @@ pl: koncentrat soku z gruszki
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-poire-concentré
 # 25 products in 3 languages @2018-09-28
 
+< en: fruit juice from concentrate
 < en:pear juice
 en: pear juice from concentrate
 de: Birnensaft aus Birnensaftkonzentrat
@@ -40149,6 +40236,13 @@ fr: jus et purée de poire
 hr: sok od kruške i pire
 it: succo e purea di pera
 pt: Suco e polpa de pera, sumo e polpa de pera
+
+< en: pear
+en: pear nectar
+agribalyse_food_code:en: 2054
+ciqual_food_code:en: 2054
+ciqual_food_name:en: Pear nectar
+comment:en: is this ciqual entry actually the same as en:pear juice?
 
 ###################################################################################################
 #
@@ -48003,8 +48097,13 @@ ciqual_food_name:fr: Kaki, pulpe, cru
 
 < en:fruit
 en: prickly pear
+agribalyse_proxy_food_code:en: 13063
+ciqual_proxy_food_code:en: 13063
+ciqual_proxy_food_name:en: Prickly pear, flesh and skin, with seeds, raw
+description:en: Fruit from plants in the Opuntia (or prickly pear cactus) genus.
 usda_ndb_proxy_code:en: 9287
 usda_ndb_proxy_name:en: Prickly pears, raw
+#wikidata_plant:en: Q158991
 
 < en:prickly pear
 en: raw prickly pears

--- a/tests/unit/expected_test_results/ingredients/en-fruits-sub-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/en-fruits-sub-ingredients.json
@@ -18,6 +18,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "13037",
                "ecobalyse_code" : "bb00f430-ffda-46a3-ba45-267b0064a43e",
                "id" : "en:pear",
                "is_in_taxonomy" : 1,
@@ -118,10 +119,9 @@
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 65,
    "ingredients_without_ciqual_codes" : [
-      "en:fruit",
-      "en:pear"
+      "en:fruit"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "ingredients_without_ecobalyse_ids" : [
       "en:cranberry",
       "en:fruit"

--- a/tests/unit/expected_test_results/ingredients/en-ingredient-ending-with-a.json
+++ b/tests/unit/expected_test_results/ingredients/en-ingredient-ending-with-a.json
@@ -42,6 +42,7 @@
          "vegetarian" : "no"
       },
       {
+         "ciqual_proxy_food_code" : "13037",
          "ecobalyse_code" : "bb00f430-ffda-46a3-ba45-267b0064a43e",
          "id" : "en:pear",
          "is_in_taxonomy" : 1,
@@ -93,10 +94,9 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:e120",
-      "en:e124",
-      "en:pear"
+      "en:e124"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 2,
    "ingredients_without_ecobalyse_ids" : [
       "en:e120",
       "en:e124"


### PR DESCRIPTION
Prickly pears are a fruit from a cactus plant, non-prickly pears are apple-like fruits from trees.

- Adds new fresh categories for Asian and Conference pears.
- Imports translations from Wikidata.
- Adds Danish/Swedish(/Norwegian) translations.
- Adds `wikidata` and `agribalyse`/`ciqual` properties.
- Adds missing pear cultivars for “raw” pears added for `usda_ndb_code`s.
- Adds/improves(/fixes) parents for better inheritance.
- Adds pear nectar ingredient from Ciqual.
- Normalises categories to sentence-cased plural forms.
- Normalises ingredients to lower-cased singular forms.
  - Still keeps capitalisation of proper nouns etc.

Needed-for: https://se.openfoodfacts.org/product/7311041050781/sort-conference