### PR TITLE
taxonomy(food): use “livsmedel” in Swedish

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -118816,7 +118816,7 @@ ro: Alimente și băuturi pe bază de plante
 ru: Еда и напитки из растительного сырья
 sk: Rastlinné potraviny a nápoje
 sl: Rastlinska hrana in pijače
-sv: Växtbaserad mat och dryck
+sv: Växtbaserade livsmedel, Växtbaserad mat och dryck
 th: อาหารและเครื่องดื่มจากพืช
 tr: Bitkisel yiyecek ve içecekler, Bitki kaynaklı yiyecek ve içecekler, Bitki yiyecek ve içecekleri
 uk: Їжа та напої на рослинній основі
@@ -118876,7 +118876,7 @@ nl: Voedsel en dranken op basis van groenten
 pl: Żywność i napoje na bazie warzyw
 pt: Alimentos e bebidas à base de vegetais
 ro: Alimente și băuturi pe bază de legume
-
+sv: Grönsaksbaserade livsmedel
 
 < en:Plant-based pickles
 en: Plant-based mixed pickles, Mixed pickles


### PR DESCRIPTION
The Swedish term “livsmedel” refers to both foods and beverages consumed by humans and seems like a better fit for ‘top‐level’ “foods and drinks” categories—but maybe not for lower‐level ones, like the holiday specific ones.