### PR TITLE
taxonomy: Brittany-style biscuits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -35270,10 +35270,16 @@ ciqual_food_name:fr: Sablé pâtissier
 wikidata:en: Q2915670
 
 < en:Shortbread cookies
-en: Shortbread cookies from Brittany
+en: Shortbread
+xx: Shortbread
+wikidata:en: Q652695
+
+< en:Shortbread cookies
+en: Brittany-style galette biscuits, Shortbread cookies from Brittany
 fr: Galettes bretonnes au beurre, galettes bretonnes
 
 < en:Shortbread cookies
+en: Brittany-style palet biscuits
 fr: Palets, Palet, Palets sablés, Palet sablé, Palet breton, Palets bretons
 
 < en:Shortbread cookies
@@ -35352,11 +35358,8 @@ ciqual_food_name:en: Biscuit shortbread, with fruits
 ciqual_food_name:fr: Biscuit sec, sablé, galette ou palet, aux fruits
 
 < en:Shortbread cookies
-fr: Sablés au beurre
-
-< en:Biscuits
-en: Shortbread biscuit with butter
-fr: Biscuit sec au beurre
+en: Plain butter shortbreads, Shortbread biscuit with butter
+fr: Sablés nature au beurre, Sablés au beurre
 agribalyse_food_code:en: 24049
 ciqual_food_code:en: 24049
 ciqual_food_name:en: Biscuit shortbread, with butter
@@ -35477,11 +35480,6 @@ ciqual_food_name:fr: Biscuit de Savoie
 < en:Biscuits and cakes
 en: Brookies
 fr: Brookies
-
-< en:Shortbread cookies
-en: Shortbread
-xx: Shortbread
-wikidata:en: Q652695
 
 < en:Biscuits
 en: Krumiri


### PR DESCRIPTION
* Renamed "Shortbread cookies from Brittany" --> "Brittany-style galette biscuits". Those biscuits are not always made in Brittany, saying they are "from Brittany" is then incorrect. Moreover, other biscuits originated in Brittany, such as the palets. I replaced shortbread cookies by biscuits, because this first expression is already made to distinguish "real" shortbreads from Scottland from "shortbread-style cookies". "Galette shortbread cookies" would mean "cookies in the style of shortbread, in the style of palets", which is redundant.
* Translated "fr:palets" as "en:Brittany-style palet biscuits" 

