### PR TITLE
taxonomy: classify orphan mineral additives E170, E545, potassium iodide vegan/vegetarian

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -3417,6 +3417,8 @@ vi: E170, Cacbonat canxi
 zh: E170, 碳酸钙
 anses_additives_of_interest:en: yes
 comment:en: enter the synonyms in plural.
+vegan:en: yes
+vegetarian:en: yes
 
 #comment:en:This entry must be doubled in the minerals and additives taxonomy (for the time being).
 #<en:calcium
@@ -13477,6 +13479,8 @@ tr: E545, Amonyum polifosfat
 uk: E545, Поліфосфат амонію
 zh: E545, 聚磷酸铵
 e_number:en: 545
+vegan:en: yes
+vegetarian:en: yes
 wikidata:en: Q2770473
 
 en: E546, Magnesium pyrophosphate
@@ -26518,6 +26522,8 @@ sv: Kaliumjodid
 tr: Potasyum iyodür
 uk: Йодид калію
 zh: 碘化钾
+vegan:en: yes
+vegetarian:en: yes
 wikidata:en: Q121874
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium_iodide
 


### PR DESCRIPTION
### What
Adds `vegan:en: yes` / `vegetarian:en: yes` to three additive entries in `taxonomies/additives.txt` that currently carry no vegan/vegetarian classification and have no parent entry to inherit one from:

- **E170 (Calcium carbonates)** — inorganic mineral. The equivalent "Calcium carbonate" entry in `minerals.txt` already carries `vegan: yes` / `vegetarian: yes` (added in #13146); this brings the parallel additives.txt entry into line with it.
- **E545 (Ammonium polyphosphate)** — inorganic salt, no animal-derived production route.
- **potassium iodide** — inorganic mineral salt (iodine fortificant).

Each is a standalone top-level entry (no `<` parent line), so this declares the property where it is genuinely missing rather than duplicating an inherited one.