### PR TITLE
refactor: replace smartmatch usages in fix_mongodb_collections.pl

### DIFF
--- a/scripts/fix_mongodb_collections.pl
+++ b/scripts/fix_mongodb_collections.pl
@@ -29,6 +29,7 @@ use ProductOpener::Data qw/get_collection/;
 use ProductOpener::Store qw/retrieve_object store_object/;
 use ProductOpener::Redis qw/push_product_update_to_redis/;
 use ProductOpener::Checkpoint;
+use List::Util qw(any);
 
 use experimental qw/switch smartmatch/;
 use Time::HiRes qw/sleep/;
@@ -38,7 +39,7 @@ use Time::HiRes qw/sleep/;
 my $checkpoint = ProductOpener::Checkpoint->new;
 my $last_processed_path = $checkpoint->{value};
 
-my $do_update = not 'preview' ~~ @ARGV;
+my $do_update = not any {$_ eq 'preview'} @ARGV;
 if (not $do_update) {
 	$checkpoint->log("Running in preview mode");
 }
@@ -133,7 +134,7 @@ while (my $path = $next->()) {
 	if (not $deleted) {
 		$expected_collection = $product_type . $obsolete_suffix;
 
-		if (not $expected_collection ~~ @collection_ids) {
+		if (not any {$_ eq $expected_collection} @collection_ids) {
 			if ($do_update) {
 				$collections{$expected_collection}->insert_one($product_ref);
 				$made_change = 1;


### PR DESCRIPTION
### What

This PR replaces the deprecated Perl smartmatch (`~~`) usages in `scripts/fix_mongodb_collections.pl`.

Changes made:
- Replaced the smartmatch used to check for the `preview` argument in `@ARGV` with `List::Util::any`.
- Replaced the smartmatch used to check whether the expected MongoDB collection exists in `@collection_ids` with `List::Util::any`.
- Added the required `List::Util` import.

The behavior of the script remains unchanged while removing the deprecated smartmatch usage from this file.

---

### Large Language Models usage disclosure

I used ChatGPT (GPT-5.5) for assistance in understanding the codebase, evaluating replacement approaches for the deprecated smartmatch operator, and reviewing the implementation.

The code changes were implemented, verified, and tested locally by me.

Verification command:

```bash
docker exec -it po_off-backend-1 \
perl -c /opt/product-opener/scripts/fix_mongodb_collections.pl
```

Output:

```text
/opt/product-opener/scripts/fix_mongodb_collections.pl syntax OK
```

---

### Screenshot or video

N/A (code-only change)

---

### Related issue(s) and discussion

Related to: #13658