### PR TITLE
taxonomy(food): better Latvian chutney translation

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -56083,7 +56083,7 @@ kn: ಚಟ್ನಿ
 ko: 차트니
 ks: ژؠٹِنؠ
 lt: Čatnis
-lv: Čatnijs
+lv: Čatniji, Čatnijs
 ml: ചമ്മന്തി
 mr: चटणी
 ms: Cutni


### PR DESCRIPTION
Normalise Latvian translation of “Chutneys” category to plural form, courtesy of Jurijs Ivanovs.