### PR TITLE
taxonomy(food): elderflower cordial edits

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -501,6 +501,9 @@ wikidata:en: Q136929479
 xx: Brown Cow
 wikidata:en: Q4976116
 
+xx: Brunneby
+wikidata:en: Q10436398
+
 xx: Brussels Ketjep
 wikidata:en: Q109914347
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -13365,6 +13365,12 @@ da: Saftevand
 wikidata:en: Q1190923
 wikipedia:en: https://en.wikipedia.org/wiki/Squash_(drink)
 
+< en: Cordials
+en: Elderflower cordials
+da: Hyldeblomstsaftevand
+sv: Fläderblomssafter, Hyllesafter
+wikidata:en: Q3496824
+
 < en:Blackcurrant syrups
 < en:Cordials
 en: Blackcurrant cordials

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -45714,18 +45714,25 @@ it: succo di datteri concentrato
 ###################################################################################################
 
 #comment:en:This can refer to the flower of the berries
+< en: plant
 en: elder
 cs: černého bezu
+da: hyld
 de: Holunder
-es: Saúco
+es: saúco
 fi: selja
 fr: sureau
 hr: stariji
 it: sambuco
 la: sambuca nigra
+nb: hyll
 nl: vlier
+nn: hyll
 pl: czarny bez, czarnego bzu
 sv: fläder
+vegan:en: yes
+vegetarian:en: yes
+wikidata:en: Q22701
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sureau
 # 332 products @2018-09-29
 
@@ -45849,12 +45856,21 @@ fi: seljanmarjatiiviste
 
 < en:elder
 en: elderflower, elderflowers
-de: Holunderblüten, Holunderblüte
+da: hyldeblomst
+de: Holunderblüte, Holunderblüten
 fi: seljankukka
-fr: fleurs de sureau
+fr: fleur de sureau, fleurs de sureau
+ga: bláth troim
 hr: cvijet bazge, Sambucus nigra L
-it: fiori di sambuco
+it: fiori di sambuco, sambuco fiore
+la: sambuci flos
+nb: hylleblomst, hyllebærblomst
 nl: vlierbloesem
+nn: hylleblomster
+sl: bezgov cvet
+sv: fläderblom, blommor från fläderbusken
+zh: 接骨木花
+wikidata:en: Q67778134
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fleurs-de-sureau
 # 51 products @2018-09-29
 
@@ -45871,7 +45887,7 @@ fr: Extraits de fleurs de sureau
 hr: ekstrakt cvijeta bazge
 it: Estratto di sanbuco
 pl: ekstrakt z kwiatu czarnego bzu, ekstrakt z kwiatu bzu czarnego, ekstrakt kwiatu czarnego bzu, wyciąg z czarnego bzu
-sv: fläderblomsextrakt
+sv: fläderblomsextrakt, extrakt av blommor från fläderbusken
 
 < en:berries
 en: rowanberry, rowanberries

--- a/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
+++ b/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
@@ -264,6 +264,7 @@
       "en:date",
       "en:elderberry",
       "en:berries",
+      "en:plant",
       "en:elder",
       "en:fig",
       "en:grape",


### PR DESCRIPTION
- Adds “Elderflower cordials” category.
- Adds “Brunneby” brand.
- Adds translations/synonyms for elder, elderflower, and elderflower extract ingredients.
- Adds `wikidata` and other properties.
- Normalises ingredients towards lower-case singular forms.

Needed-for: https://se.openfoodfacts.org/product/7391603500015/fl%C3%A4derblomsaft-brunneby