### PR TITLE
refactor: replace smartmatch usage in Display

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -193,6 +193,7 @@ use Log::Log4perl;
 use Tie::IxHash;
 
 use Log::Any '$log', default_adapter => 'Stderr';
+use List::Util qw(any);
 
 use Apache2::Request ();
 use Apache2::RequestUtil ();
@@ -732,7 +733,7 @@ sub init_request ($request_ref = {}) {
 	# If lc is not one of the official languages of the country and if the request comes from
 	# a bot crawler, don't index the webpage (return an empty noindex HTML page)
 	# We also disable indexing for all subdomains that don't have the format world, cc or cc-lc
-	if ((!($lc ~~ $country_languages{$cc})) or $subdomain =~ /^(ssl-)?api/) {
+	if ((!any {$_ eq $lc} @{$country_languages{$cc}}) or $subdomain =~ /^(ssl-)?api/) {
 		# Use robots.txt with disallow: / for all agents
 		$request_ref->{deny_all_robots_txt} = 1;
 


### PR DESCRIPTION
### What

This PR replaces the deprecated Perl smartmatch operator (`~~`) in `lib/ProductOpener/Display.pm`.

Specifically:
- Added `List::Util::any`.
- Replaced the smartmatch expression used to check whether the requested language is one of the country's official languages with an equivalent `any`-based check.
- Preserved the existing behavior while removing the dependency on Perl's deprecated experimental smartmatch feature.

### Checklist

- [x] Code is well documented
- [ ] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in my branch
- [x] This PR contains a single commit
- [x] Read and understood the contribution guidelines

### Large Language Models usage disclosure

I used ChatGPT (GPT-5.5) for assistance during the refactoring process. I implemented the changes locally and verified the modified file by running `perl -c` and `perltidy`.

### Screenshot or video

N/A (code-only change).

### Related issue(s) and discussion

- Fixes: #13658
