### PR TITLE
refactor: replace smartmatch usage in es-packagers-html2csv

### DIFF
--- a/scripts/packager-codes/es-packagers-html2csv.pl
+++ b/scripts/packager-codes/es-packagers-html2csv.pl
@@ -25,7 +25,7 @@ use open qw(:std :utf8);
 use Modern::Perl '2017';
 use experimental 'smartmatch';
 
-use List::Util qw( all );
+use List::Util qw( all any );
 
 use CHI ();
 use Data::Table ();
@@ -104,7 +104,10 @@ sub fill_cache {
 			quote_char => q{"}
 		);
 
-		return if not all {$_ ~~ @headers} @address_columns;
+		return if not all {
+			my $column = $_;
+			any {$_ eq $column} @headers;
+		} @address_columns;
 
 		foreach my $row_ref (@{$row_refs}) {
 			if ($row_ref->{'lat'} && $row_ref->{'lng'}) {

--- a/scripts/packager-codes/es-packagers-html2csv.pl
+++ b/scripts/packager-codes/es-packagers-html2csv.pl
@@ -23,7 +23,6 @@
 use utf8;
 use open qw(:std :utf8);
 use Modern::Perl '2017';
-use experimental 'smartmatch';
 
 use List::Util qw( all any );
 


### PR DESCRIPTION
### What

This PR replaces the remaining experimental Perl smartmatch (`~~`) usage in `scripts/packager-codes/es-packagers-html2csv.pl`.

The previous implementation used smartmatch to verify that all required address columns were present in the parsed CSV headers. It has been replaced with an equivalent implementation using `List::Util::all` and `List::Util::any`, preserving the existing behavior while removing the deprecated smartmatch operator.

### Large Language Models usage disclosure

- LLM used: ChatGPT (GPT-5.5)
- Usage: Assistance with understanding the deprecated smartmatch operator.
- The final implementation was reviewed before submission.
- I attempted to verify the script locally using `perl -c`, but my local development container is missing the `Encode::ZapCP1252` Perl module, so compilation could not be completed locally due to an environment dependency rather than a code issue.

### Screenshot or video

N/A (code-only change)


- Closes : #13658

---

### Checklist

- [x] Code is well documented where necessary
- [x] No new functionality introduced, so no additional unit tests were required
- [x] Commit history is squashed into a single commit
- [x] Read and understood the contribution guidelines