### PR TITLE
fix(taxonomy): fix orphan `usda` lines

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -38155,7 +38155,6 @@ usda_ndb_name:en: Mammy-apple, (mamey), raw
 en: mamey sapote
 la: Pouteria sapota
 description:en: Mamey Sapote (Pouteria sapota). It has a rough brown skin like a football, and vibrant salmon-pink to reddish flesh with a rich, creamy flavor often compared to a mix of sweet potato, pumpkin, and almond. Widely used in smoothies and ice cream in Latin America and the Caribbean.
-
 usda_ndb_proxy_code:en: 9314
 usda_ndb_proxy_name:en: Sapote, mamey, raw
 


### PR DESCRIPTION
Fixes this warning:
```
[ingredients] [2026/06/30 23:40:45] [WARN] discarding orphan line in taxonomy {"line":"9314...","property":"usda_ndb_proxy_code","tagtype":"ingredients"}
[ingredients] [2026/06/30 23:40:45] [WARN] discarding orphan line in taxonomy {"line":"Sapote, mamey, raw...","property":"usda_ndb_proxy_name","tagtype":"ingredients"}
```

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/13788
Follow-up-to: 4db96d5ea1bd0807ada488bb579a1ef31d5d4cdb