### PR TITLE
taxonomy(food): more apples

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -70102,24 +70102,152 @@ ciqual_food_name:fr: Kumquat, sans pépin, cru
 
 < en:Fruits
 en: Apples
+af: Appel
+am: ፖም
+an: Mazana
+ar: تفاح
+as: আপেল
+av: Гӏеч
+az: Alma
+ba: Алма
+be: Яблык
+bg: Ябълка
+bi: Apol
+bn: আপেল
+bo: ཀུ་ཤུ།
+br: Aval
+bs: Jabuka
+ca: Poma
+ce: Ӏаж
+co: Mela
+cs: Jablko
+cu: Аблъко
+cv: Панулми
+cy: Afal
 da: Æbler
 de: Äpfel, Apfel
+dv: އާފަލް
+el: Μήλο
+eo: Pomoj
 es: Manzanas
-fi: omenat
+et: Õun
+eu: Sagar
+fa: سیب
+fi: Omenat
+fj: Yapolo
+fo: Súrepli
 fr: Pommes
-hr: Jabuke
-it: Mele
+fy: Appel
+ga: Úll
+gd: Ubhal
+gl: Mazá
+gn: Guavirana'a
+gu: સફરજન
+gv: Ooyl
+ha: Tuffa
+hi: सेब
+hr: Jabuke, Jabuka
+ht: Pòm
+hu: Alma
+hy: Խնձոր
+ia: Pomo
+id: Apel
+ie: Pom
+ig: Apple
+ik: Aapuq
+io: Pomo
+is: Epli
+it: Mele, Mela
+iu: ᑭᒻᒥᓇᐅᔭᖅ
 ja: リンゴ, りんご, 林檎, アップル
-la: Malus domestica
+jv: Apel
+ka: Ვაშლი
+ki: Mbirikicũ
+kk: Алма
+km: ប៉ុម
+kn: ಸೇಬು
+ko: 사과
+ks: ژوٗنٛٹھ
+ku: Sêv
+kw: Aval
+ky: Алма
+la: Malus domestica, Malum
+lb: Apel
+lg: Zegu
+li: Appel
+lo: ໝາກປົ່ມ
 lt: Obuoliai, Obuolys
+lv: Ābols
+mg: Paoma
+mi: Āporo
+mk: Јаболко
+ml: ആപ്പിൾ
+mn: Алим
+mr: सफरचंद
+ms: Epal
+mt: Tuffieħa
+my: ပန်းသီး
+nb: Epler
+ne: स्याउ
 nl: Appels
+nn: Eple
+nv: Bilasáana
+oc: Poma
+om: Appilii
+or: ସେଓ
+os: Фæткъуы
+pa: ਸੇਬ
+pi: Sītāphala
+pl: Jabłko
+ps: مڼه
 pt: Maçâs
-ro: Mere
-ru: Яблоки
+qu: Mansana
+ro: Măr, Mere
+ru: Яблоки, Яблоко
+rw: Pome
+sa: सेवफलम्
+sc: Mela
+sd: اَنبِڙِي
+sh: Jabuka
+si: ඇපල්
+sk: Jablká
+sl: Jabolko
+sm: Apu
+so: Tufaax
+sq: Mollë
+sr: Јабука
+st: Apole
+su: Apel
 sv: Äpplen
-agribalyse_proxy_food_code:en: 13085
-agribalyse_proxy_food_name:en: Apple, Canada, pulp, raw
-agribalyse_proxy_food_name:fr: Pomme Canada, pulpe, crue
+sw: Tofaa
+ta: ஆப்பிள்
+te: ఆపిల్
+tg: Себ
+th: แอปเปิล
+ti: ቱፋሕ
+tk: Alma
+tl: Mansanas
+tn: Apole
+tr: Elma
+tt: Алма
+ug: ئالما
+uk: Яблуко
+ur: سیب
+uz: Olma
+ve: Apula
+vi: Táo tây
+vo: Pod
+wa: Peme
+wo: Pom
+xh: Iapule
+yi: עפל
+yo: Èso òro òyìnbó
+za: Makbinzgoj
+zh: 苹果
+zu: Ihhabhula
+agribalyse_food_code:en: 13039
+ciqual_food_code:en: 13039
+ciqual_food_name:en: Apple, flesh and skin, raw
 google_product_taxonomy_id:en: 6566
 intake24_category_code:en: APLS
 sales_format:en: weight, package
@@ -70128,6 +70256,7 @@ wikidata:en: Q89
 < en:Apples
 < en:Fresh fruits
 en: Fresh apples
+da: Friske æbler
 de: Frische Äpfel
 es: Manzanas frescas
 fr: Pommes fraîches
@@ -70135,6 +70264,7 @@ hr: Svježe jabuke
 it: Mele fresche
 lt: Švieži obuoliai
 nl: Verse appels
+sv: Färska äpplen
 bulk_proxy:en: en:apples
 sales_format:en: weight, package
 season_in_country_fr:en: 1,2,3,4,8,9,10,11,12
@@ -70153,13 +70283,66 @@ hr: Elstar jabuke
 nl: Elstar
 sales_format:en: weight, package
 
+< en: Apples
+en: Giga apples
+da: Giga-æbler
+sv: Giga-äpplen
+#web:en: https://www.giga-apple.com/
+wikidata:en: Q140393522
+
+< en: Fresh apples
+< en: Giga apples
+en: Fresh Giga apples
+da: Friske Giga-æbler
+sv: Färska Giga-äpplen
+
 < en:Apples
 en: Story apples
 fr: Pommes story
 
+< en: Apples
+en: Jonagold apples
+xx: Jonagold
+da: Jonagold-æbler
+fa: جوناگلد
+ja: ジョナゴールド
+ko: 조너골드
+mk: Јонаголд
+ru: Джонаголд
+sv: Jonagold-äpplen
+uk: Джонаголд
+vi: Táo Jonagold
+zh: 乔纳金苹果
+description:en: A cultivar of apple that is a cross between the crisp Golden Delicious and the blush-crimson Jonathan; the name Jonagold is a portmanteau of these two variety names. (Wikipedia)
+wikidata:en: Q41778389
+
+< en: Fresh apples
+< en: Jonagold apples
+en: Fresh Jonagold apples
+da: Friske Jonagold-æbler
+sv: Färska Jonagold-äpplen
+
 < en:Apples
 en: Juliet apples
 fr: Pommes juliet
+
+< en: Apples
+en: Royal Gala apples
+xx: Royal Gala
+da: Royal Gala-æbler
+la: Malus domestica 'Tenroy'
+sv: Royal Gala-äpplen
+agribalyse_proxy_food_code:en: 13191
+ciqual_proxy_food_code:en: 13191
+ciqual_proxy_food_name:en: Apple, var. Gala, flesh without skin, raw
+comment:en: Royal Gala is mutated from Gala apples, hence using Gala as a proxy food.
+wikidata:en: Q41781176
+
+< en: Fresh apples
+< en: Royal Gala apples
+en: Fresh Royal Gala apples
+da: Friske Royal Gala-æbler
+sv: Färska Royal Gala-äpplen
 
 < en:Apples
 en: Top red apples

--- a/tests/unit/expected_test_results/nutriscore/en-apple-estimated-nutrients.json
+++ b/tests/unit/expected_test_results/nutriscore/en-apple-estimated-nutrients.json
@@ -16,17 +16,19 @@
    ],
    "categories_lc" : "en",
    "categories_properties" : {
-      "agribalyse_proxy_food_code:en" : "13085"
+      "agribalyse_food_code:en" : "13039",
+      "ciqual_food_code:en" : "13039"
    },
    "categories_properties_tags" : [
       "all-products",
       "categories-known",
-      "agribalyse-food-code-unknown",
-      "agribalyse-proxy-food-code-13085",
-      "agribalyse-proxy-food-code-known",
-      "ciqual-food-code-unknown",
+      "agribalyse-food-code-13039",
+      "agribalyse-food-code-known",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-13039",
+      "ciqual-food-code-known",
       "agribalyse-known",
-      "agribalyse-13085"
+      "agribalyse-13039"
    ],
    "categories_tags" : [
       "en:plant-based-foods-and-beverages",


### PR DESCRIPTION
- Adds categories for additional apple cultivars:
  - Giga
  - Jonagold
  - Royal Gala
  - plus fresh variants
- Imports some translations from Wikidata.
- Adds Danish/Swedish/Norwegian translations.
- Updates `ciqual` code for Apples category.

Needed-for: https://prices.openfoodfacts.org/prices/288927
Needed-for: https://prices.openfoodfacts.org/prices/288931
Needed-for: https://prices.openfoodfacts.org/prices/288932
Needed-for: https://prices.openfoodfacts.org/prices/288935
Needed-for: https://se.openfoodfacts.org/product/8008757016048/%C3%A4pple-r%C3%B6da-kl-1