### PR TITLE
taxonomy: add groundnut synonyms for en:peanuts

### DIFF
--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -224,7 +224,7 @@ ja: ゼラチン
 en: matsutake
 ja: まつたけ, 松茸, マツタケ
 
-en: peanuts, peanut, arachis hypogaea
+en: peanuts, peanut, arachis hypogaea, groundnut, groundnuts
 ar: فول سوداني
 bg: фъстъци, arachis hypogaea
 ca: cacauets, cacauet


### PR DESCRIPTION
The en:peanuts entry has `peanuts, peanut, arachis hypogaea` but not "groundnut", which is the standard term in UK and Indian English. UK FSA allergen guidance phrases the allergen as "peanuts (also known as groundnuts)", and UK labels commonly say "groundnut oil" rather than peanut oil.

I hit this building an allergen cross-check tool that canonicalizes names through this taxonomy: "Groundnut" from a UK spec sheet failed to match a peanut declaration. For an allergen, a missed synonym is the dangerous direction, so adding both singular and plural.

One line changed: `en: peanuts, peanut, arachis hypogaea, groundnut, groundnuts`
