### PR TITLE
taxonomy(food): drop “Bulk” category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -206,12 +206,6 @@ tr: Sigara
 google_product_taxonomy_id:en: 3151
 wikidata:en: Q1578
 
-en: Bulk
-fr: Vrac
-hr: Rasuti
-nl: Verpakkingsvrij
-pt: Massa
-
 en: Artisan products
 ca: Prouctes artesans
 de: Handgefertigte Produkte, Artisanale Produkte, Handgemachte Produkte
@@ -58193,7 +58187,6 @@ fr: Noix de cajou crues
 expected_ingredients:en: en:cashew-nuts
 sales_format:en: weight, package
 
-< en:Bulk
 < en:Cashew nuts
 < en:Roasted nuts
 en: Roasted cashew nuts
@@ -72345,7 +72338,6 @@ protected_name_file_number:en: PGI-IT-02469
 protected_name_type:en: pgi
 #wikidata:en:
 
-< en:Bulk
 < en:Fresh fruits
 < en:Peaches
 en: Fresh peaches
@@ -73118,7 +73110,6 @@ ciqual_food_name:fr: Prune, crue
 intake24_category_code:en: PLUM
 wikidata:en: Q12372598
 
-< en:Bulk
 < en:Fresh fruits
 < en:Plums
 en: Fresh plums
@@ -73493,7 +73484,6 @@ lt: Bananų miltai
 nl: Bananenmelen
 comment:en: Bananas is restricted to whole fresh ones
 
-< en:Bulk
 < en:Cavendish Bananas
 < en:Fresh Bananas
 en: Fresh Cavendish Bananas, Bananas (fresh Cavendish)
@@ -73504,7 +73494,6 @@ comment:en: assume that most bananas sold in the shop are fresh Cavendish banana
 expected_ingredients:en: en:banana
 sales_format:en: package, weight, item
 
-< en:Bulk
 < en:Frecinette Bananas
 < en:Fresh bananas
 en: Fresh Frecinette Bananas, Bananas (fresh frecinette)
@@ -73514,7 +73503,6 @@ bulk_proxy_category:en: en:frecinette-bananas
 expected_ingredients:en: en:banana
 sales_format:en: package, weight, item
 
-< en:Bulk
 < en:Fresh Bananas
 < en:Red Bananas
 en: Fresh Red Bananas
@@ -73525,7 +73513,6 @@ expected_ingredients:en: en:banana
 sales_format:en: package, weight, item
 
 < en:Bananas from the Canary Islands
-< en:Bulk
 < en:Fresh bananas
 en: Fresh Bananas from the Canary Islands
 fr: Bananes fraîches des Canaries
@@ -112077,7 +112064,6 @@ ciqual_food_code:en: 20181
 ciqual_food_name:en: Parsnip, raw
 ciqual_food_name:fr: Panais, cru
 
-< en:Bulk
 < en:Fresh vegetables
 < en:Parsnip
 en: Fresh parsnip
@@ -113541,7 +113527,6 @@ google_product_taxonomy_id:en: 6597
 wikidata:en: Q157954
 wikipedia:en: https://en.wikipedia.org/wiki/Chard
 
-< en:Bulk
 < en:Chards
 < en:Fresh vegetables
 en: Fresh chards


### PR DESCRIPTION
Dropping the “Bulk” category after discussion at the 2026-07-02 Taxonomy community call.

See-also: https://openfoodfacts.slack.com/archives/C02VDSWHT/p1782295961716529