### PR TITLE
taxonomy(food): (canned) peaches edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -72318,18 +72318,52 @@ protected_name_file_number:en: PGI-FR-02433
 protected_name_type:en: pgi
 
 < en:Fruits
-en: Peaches, peach
+en: Peaches, Peach
+ar: دراق
 bg: Праскови
+br: Pechez
+ca: Préssec
+ce: ГӀаммагӀа
+cs: Broskev
+da: Ferskner, Ferskener, Ferskenfrugter
 de: Pfirsiche
-es: Melocotones
-fi: persikat
+el: Ροδάκινο
+eo: Persikoj
+es: Melocotones, Melocotón
+eu: Mertxika
+fi: Persikat, Persikka
 fr: Pêches
+gl: Pexego
 hr: Breskve
-it: Pesche
+hy: Դեղձ
+ia: Persica
+it: Pesche, Pesca
 ja: モモ, もも, 桃, ピーチ
+kk: Шабдалы
+ko: 복숭아
+lb: Piisch
 lt: Persikai
+mg: Paiso
+my: မက်မွန်
+nb: Ferskener
 nl: Perziken
+nn: Ferskenar
+oc: Persec
+pl: Brzoskwinia
+ru: Персик
+se: Persihkka
+sk: Broskyňa
+sl: Breskev
+sv: Persikor, Persika
+tg: Шафтолу
+tr: Şeftali
+tt: Шәфталу
+zh: 桃
+agribalyse_proxy_food_code:en: 13043
+ciqual_proxy_food_code:en: 13043
+ciqual_proxy_food_name:en: Peach, flesh and skin, pitted, raw
 intake24_category_code:en: PCHS
+wikidata:en: Q13202263
 
 < en:Peaches
 it: Pesca di Delia
@@ -72341,10 +72375,12 @@ protected_name_type:en: pgi
 < en:Fresh fruits
 < en:Peaches
 en: Fresh peaches
+da: Friske ferskner
 es: Melocotones frescos
 fr: Pêches fraîches
 hr: Svježe breskve
 lt: Švieži persikai
+sv: Färska persikor
 sales_format:en: weight, package
 season_in_country_fr:en: 6,7,8,9
 
@@ -75083,6 +75119,21 @@ ciqual_food_code:en: 13719
 ciqual_food_name:en: Pineapple, in light syrup, canned, not drained
 ciqual_food_name:fr: Ananas au sirop léger, appertisé, non égoutté
 
+< en: Canned fruits
+< en: Peaches
+en: Canned peaches
+da: Dåseferskner
+de: Dosenpfirsich
+sv: Burkpersikor
+wikidata:en: Q67891942
+
+< en: Canned fruits in juice
+< en: Canned peaches
+en: Canned peaches in juice
+da: Dåseferskner i juice
+sv: Burkpersikor i juice, Persikor i juice
+
+< en: Canned peaches
 < en:Fruits in syrup
 en: Peaches in syrup
 bg: Праскови в сироп


### PR DESCRIPTION
- Adds categories:
  - Canned peaches
  - Canned peaches in juice
- Imports some translations from Wikidata.
- Adds Danish/Swedish(/Norwegian) translations.
- Adds `wikidata` and other properties.

Needed-for: https://se.openfoodfacts.org/product/0024000124948/halve-perziken-op-sap-del-monte