### PR TITLE
taxonomy: Breton and basque cakes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -39061,30 +39061,6 @@ en: Frozen doughnuts, Frozen donuts
 fr: Donuts surgelés
 
 < en: Cakes
-en: Breton cakes
-de: Bretonischer Kuche, Gâteau Breton
-fr: Gâteaux bretons, gâteau breton
-hr: Bretonski kolači
-lt: Breton pyragai
-nl: Bretons cakes
-
-< en: Cakes
-< en: Pastries
-en: Kouign-amann, Buttered and caramelized milk bread cake
-xx: Kouign-amann
-de: Kouign-amann
-es: Kouign-amann
-fr: Kouign-amann, Kouign amann, Kouign aman
-hr: Kouign-amann
-it: Kouign-amann
-nl: Kouign-amann
-agribalyse_food_code:en: 23122
-ciqual_food_code:en: 23122
-ciqual_food_name:en: Buttered and caramelized milk bread cake
-ciqual_food_name:fr: Kouign Amann
-wikidata:en: Q548319
-
-< en: Breton cakes
 en: Far Bretons, Fars, Far, Fars bretons, Breton fars
 xx: Far Bretons
 fr: Fars, Far, Fars bretons
@@ -101791,22 +101767,51 @@ ciqual_food_name:fr: Galette des rois feuilletée, fourrée frangipane, et Pithi
 nl: Vlaaien, Vlaai
 
 < en: Pastries
-en: Basque cake with custard, Basque shortbread with custard
-fr: Gâteau basque à la crème pâtissière
+en: Basques cakes
+fr: Gâteaux basques
+wikidata:en: Q683495
+
+< en: Basques cakes
+en: Basque cakes with custard, Basque cake with custard, Basque shortbread with custard
+fr: Gâteaux basques à la crème pâtissière, Gâteau basque à la crème pâtissière
 agribalyse_food_code:en: 23802
 ciqual_food_code:en: 23802
 ciqual_food_name:en: Basque cake (shortbread), with custard
 ciqual_food_name:fr: Gâteau basque, crème pâtissière
 
-< en: Pastries
-en: Basque cake with cherries, Shortbread with cherries
-fr: Gâteau basque aux cerises
+< en: Basques cakes
+en: Basque cakes with a cherry filling, Basque cake with cherries
+fr: Gâteaux basques à la cerise, Gâteau basque aux cerises
 agribalyse_food_code:en: 23803
 ciqual_food_code:en: 23803
 ciqual_food_name:en: Basque cake (shortbread), with cherries
 ciqual_food_name:fr: Gâteau basque, cerises
 
-< en: Cakes
+< en: Pastries
+en: Breton cakes
+de: Bretonischer Kuche, Gâteau Breton
+fr: Gâteaux bretons, gâteau breton
+hr: Bretonski kolači
+lt: Breton pyragai
+nl: Bretons cakes
+description:en: A thin and round dry pastry, which can be filled (generally with dried plum or caramel) or not.
+wikidata:en: Q16640733
+
+< en: Pastries
+en: Kouign-amann, Buttered and caramelized milk bread cake
+xx: Kouign-amann
+de: Kouign-amann
+es: Kouign-amann
+fr: Kouign-amann, Kouign amann, Kouign aman
+hr: Kouign-amann
+it: Kouign-amann
+nl: Kouign-amann
+agribalyse_food_code:en: 23122
+ciqual_food_code:en: 23122
+ciqual_food_name:en: Buttered and caramelized milk bread cake
+ciqual_food_name:fr: Kouign Amann
+wikidata:en: Q548319
+
 < en: Pastries
 en: Canelés, cannelés, Canelé cake
 fr: Canelés, cannelés, canelés de Bordeaux, cannelés de Bordeaux, Canelé, cannelé

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -495,6 +495,7 @@
 <li><a href="/facets/categories/Dorayaki" class="tag well_known">Dorayaki</a></li>
 <li><a href="/facets/categories/Doughnuts" class="tag well_known">Doughnuts</a></li>
 <li><a href="/facets/categories/Fairy cakes" class="tag well_known">Fairy cakes</a></li>
+<li><a href="/facets/categories/Far Bretons" class="tag well_known">Far Bretons</a></li>
 <li><a href="/facets/categories/Filled cakes" class="tag well_known">Filled cakes</a></li>
 <li><a href="/facets/categories/Filled sponge cake rolls" class="tag well_known">Filled sponge cake rolls</a></li>
 <li><a href="/facets/categories/Filled sponge cake slices" class="tag well_known">Filled sponge cake slices</a></li>

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -485,8 +485,6 @@
 <li><a href="/facets/categories/Apple Cakes" class="tag well_known">Apple Cakes</a></li>
 <li><a href="/facets/categories/Banana breads" class="tag well_known">Banana breads</a></li>
 <li><a href="/facets/categories/Black Forest gâteau" class="tag well_known">Black Forest gâteau</a></li>
-<li><a href="/facets/categories/Breton cakes" class="tag well_known">Breton cakes</a></li>
-<li><a href="/facets/categories/Canelés" class="tag well_known">Canelés</a></li>
 <li><a href="/facets/categories/Carrot cakes" class="tag well_known">Carrot cakes</a></li>
 <li><a href="/facets/categories/Cheesecakes" class="tag well_known">Cheesecakes</a></li>
 <li><a href="/facets/categories/Chocolate cakes" class="tag well_known">Chocolate cakes</a></li>
@@ -502,7 +500,6 @@
 <li><a href="/facets/categories/Financiers" class="tag well_known">Financiers</a></li>
 <li><a href="/facets/categories/Fresh cakes" class="tag well_known">Fresh cakes</a></li>
 <li><a href="/facets/categories/Fruit cakes" class="tag well_known">Fruit cakes</a></li>
-<li><a href="/facets/categories/Kouign-amann" class="tag well_known">Kouign-amann</a></li>
 <li><a href="/facets/categories/Lemon cake" class="tag well_known">Lemon cake</a></li>
 <li><a href="/facets/categories/Makowiec" class="tag well_known">Makowiec</a></li>
 <li><a href="/facets/categories/Marble cakes" class="tag well_known">Marble cakes</a></li>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -495,6 +495,7 @@
 <li><a href="/facets/categories/Dorayaki" class="tag well_known">Dorayaki</a></li>
 <li><a href="/facets/categories/Doughnuts" class="tag well_known">Doughnuts</a></li>
 <li><a href="/facets/categories/Fairy cakes" class="tag well_known">Fairy cakes</a></li>
+<li><a href="/facets/categories/Far Bretons" class="tag well_known">Far Bretons</a></li>
 <li><a href="/facets/categories/Filled cakes" class="tag well_known">Filled cakes</a></li>
 <li><a href="/facets/categories/Filled sponge cake rolls" class="tag well_known">Filled sponge cake rolls</a></li>
 <li><a href="/facets/categories/Filled sponge cake slices" class="tag well_known">Filled sponge cake slices</a></li>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -485,8 +485,6 @@
 <li><a href="/facets/categories/Apple Cakes" class="tag well_known">Apple Cakes</a></li>
 <li><a href="/facets/categories/Banana breads" class="tag well_known">Banana breads</a></li>
 <li><a href="/facets/categories/Black Forest gâteau" class="tag well_known">Black Forest gâteau</a></li>
-<li><a href="/facets/categories/Breton cakes" class="tag well_known">Breton cakes</a></li>
-<li><a href="/facets/categories/Canelés" class="tag well_known">Canelés</a></li>
 <li><a href="/facets/categories/Carrot cakes" class="tag well_known">Carrot cakes</a></li>
 <li><a href="/facets/categories/Cheesecakes" class="tag well_known">Cheesecakes</a></li>
 <li><a href="/facets/categories/Chocolate cakes" class="tag well_known">Chocolate cakes</a></li>
@@ -502,7 +500,6 @@
 <li><a href="/facets/categories/Financiers" class="tag well_known">Financiers</a></li>
 <li><a href="/facets/categories/Fresh cakes" class="tag well_known">Fresh cakes</a></li>
 <li><a href="/facets/categories/Fruit cakes" class="tag well_known">Fruit cakes</a></li>
-<li><a href="/facets/categories/Kouign-amann" class="tag well_known">Kouign-amann</a></li>
 <li><a href="/facets/categories/Lemon cake" class="tag well_known">Lemon cake</a></li>
 <li><a href="/facets/categories/Makowiec" class="tag well_known">Makowiec</a></li>
 <li><a href="/facets/categories/Marble cakes" class="tag well_known">Marble cakes</a></li>


### PR DESCRIPTION
Removed "Far bretons" from "Breton cakes", because Breton cake refers to a specific type of cake, not any cake from Brittany (see https://fr.wikipedia.org/wiki/G%C3%A2teau_breton).
Added the description and wikidata link to "Breton cakes"

EDIT: Moved "Breton cakes" to pastries actually, since it is really similar to Basque cakes, which are in pastries. The French wikipedia of breton cake also says it is a pastry
Created a parent category for "basque cake with cherry" and "basque cake with custard", which I renamed "basque cakes with a cherry filling" and "basque cakes with custard"
