### PR TITLE
fix(taxonomy): fix unclosed parenthesis

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -38244,12 +38244,12 @@ ciqual_food_name:fr: Cacao, non sucré, poudre soluble
 wikidata:en: Q1062396
 
 
-< en: cocoa-powders
-en: Instant cocoa or chocolate beverage with sugar fortified with vitamins and chemical elements ready-to-drink (reconstituted with standard semi-skimm
+< en: Cocoa powders
+en: Instant cocoa or chocolate beverage with sugar(s) fortified with vitamins ready-to-drink (reconstituted with semi-skimmed milk), Instant cocoa or chocolate beverage with sugar fortified with vitamins and chemical elements ready-to-drink (reconstituted with standard semi-skimm
 fr: Boisson cacaotée ou au chocolat instantanée sucrée enrichie en vitamines prête à boire (reconstituée avec du lait demi-écrémé standard)
 agribalyse_food_code:en: 18106
 ciqual_food_code:en: 18106
-ciqual_food_name:en: Instant cocoa or chocolate beverage, with sugar, fortified with vitamins and chemical elements, ready-to-drink (reconstituted with standard semi-skimm
+ciqual_food_name:en: Instant cocoa or chocolate beverage, with sugar(s), fortified with vitamins, ready-to-drink (reconstituted with semi-skimmed milk)
 ciqual_food_name:fr: Boisson cacaotée ou au chocolat, instantanée, sucrée, enrichie en vitamines, prête à boire (reconstituée avec du lait demi-écrémé standard)
 
 < en: Cocoa and chocolate powders


### PR DESCRIPTION
Whether the error was with Ciqual or it was a botched copy/paste, this entry had its parenthetical note cut off before closing.

This fixes the missing closing parenthesis by updating the Ciqual English name and adapting that as the canonical name for the category, similar to how the former Ciqual name was adapted.

Report: https://openfoodfacts.slack.com/archives/C02VDSWHT/p1783154114333259
Reference: https://ciqual.anses.fr/#/aliments/18106/instant-cocoa-or-chocolate-beverage-with-sugar(s)-fortified-with-vitamins-ready-to-drink-(reconstituted-with-semi-skimmed-milk)