### PR TITLE
feat: salt sodium data quality check

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1160,24 +1160,33 @@ sub check_specific_nutrients_for_input_set ($product_ref, $nutrition_set_ref, $s
 
 	# Too small salt value? (e.g. g entered in mg)
 	# warning for salt < 0.1 was removed because it was leading to too much false positives (see #9346)
-	my $per = deep_get($nutrition_set_ref, "per");
-	if ((defined $per) and (($per eq "100g") or ($per eq "100ml"))) {
+my $per = deep_get($nutrition_set_ref, "per");
+if ((defined $per) and (($per eq "100g") or ($per eq "100ml"))) {
 
-		my $salt = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "salt");
-		if ((defined $salt) and ($salt > 0)) {
+	my $salt = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "salt");
 
-			if ($salt < 0.001) {
-				push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-001-g-salt";
-			}
-			elsif ($salt < 0.01) {
-				push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-01-g-salt";
-			}
+	if ((defined $salt) and ($salt > 0)) {
+
+		if ($salt < 0.001) {
+			push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-001-g-salt";
+		}
+		elsif ($salt < 0.01) {
+			push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-01-g-salt";
 		}
 	}
 
+	my $sodium = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "sodium");
+
+	if ((defined $salt) and (defined $sodium)) {
+		# Allow a 0.1 g difference because nutrition values on labels are rounded
+		if (abs(convert_sodium_to_salt($sodium) - $salt) > 0.1) {
+			push @{$product_ref->{$data_quality_tags}},
+				"en:${set_id}-salt-does-not-match-sodium";
+		}
+	}
+}
 	return;
 }
-
 sub check_nutrition_data_for_input_set ($product_ref, $nutrition_set_ref, $set_id, $data_quality_tags) {
 
 	my $nutrients_ref = $nutrition_set_ref->{nutrients};

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5648,7 +5648,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 
 					push @{$template_data_ref->{current_drilldown_fields}},
 						{
-						current_link => get_owner_pretty_path($Owner_id) . "/facets",
+						current_link => get_owner_pretty_path($Owner_id) . $request_ref->{current_link},
 						tag_type_plural => $tag_type_plural{$newtagtype}{$lc},
 						nofollow => $nofollow,
 						tagtype => $newtagtype,

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5648,7 +5648,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 
 					push @{$template_data_ref->{current_drilldown_fields}},
 						{
-						current_link => get_owner_pretty_path($Owner_id) . $request_ref->{current_link},
+						current_link => get_owner_pretty_path($Owner_id) . "/facets",
 						tag_type_plural => $tag_type_plural{$newtagtype}{$lc},
 						nofollow => $nofollow,
 						tagtype => $newtagtype,

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -249,8 +249,8 @@ sub index_route($request_ref) {
 
 	# Root, ex: https://world.openfoodfacts.org/
 	$request_ref->{text} = 'index';
-	$request_ref->{current_link} = '';
-
+	$request_ref->{current_link} = '/facets';
+	
 	# Root + page number, ex: https://world.openfoodfacts.org/2
 	if (exists $request_ref->{param}{page}) {
 		$request_ref->{page} = $request_ref->{param}{page};

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -249,7 +249,7 @@ sub index_route($request_ref) {
 
 	# Root, ex: https://world.openfoodfacts.org/
 	$request_ref->{text} = 'index';
-	$request_ref->{current_link} = '/facets';
+	$request_ref->{current_link} = '';
 	
 	# Root + page number, ex: https://world.openfoodfacts.org/2
 	if (exists $request_ref->{param}{page}) {

--- a/templates/web/common/includes/list_of_products.tt.html
+++ b/templates/web/common/includes/list_of_products.tt.html
@@ -88,7 +88,7 @@
           <ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
           [% FOREACH newtagtype IN current_drilldown_fields %]
             <li>
-              <a href="[% newtagtype.current_link %]/[% newtagtype.tag_type_plural %]"[% newtagtype.nofollow %]>[% lang("${newtagtype.tagtype}_p") FILTER ucfirst %]</a>
+              <a href="[% IF newtagtype.current_link == '' %]/facets[% ELSE %][% newtagtype.current_link %][% END %]/[% newtagtype.tag_type_plural %]"[% newtagtype.nofollow %]>[% lang("${newtagtype.tagtype}_p") FILTER ucfirst %]</a>
             </li>
           [% END %]
           </ul>

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1029,6 +1029,74 @@ check_quality_and_test_product_has_quality_tag(
 	'en:nutrition-producer-as-sold-100g-values-are-all-identical',
 	'all identical values and above 1 in the nutrition table BUT not enough nutrients given', 0
 );
+# salt and sodium values should be aligned
+$product_ref = {
+    nutrition => {
+        input_sets => [
+            {
+                source => "producer",
+                preparation => "as_sold",
+                per => "100g",
+                nutrients => {
+                    "salt" => { value => 2.5, unit => "g" },
+                    "sodium" => { value => 2, unit => "g" },  
+                }
+            }
+        ]
+    }
+};
+
+check_quality_and_test_product_has_quality_tag(
+    $product_ref,
+    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+    'salt and sodium values do not match',
+    1
+);
+$product_ref = {
+    nutrition => {
+        input_sets => [
+            {
+                source => "producer",
+                preparation => "as_sold",
+                per => "100g",
+                nutrients => {
+                    "salt" => {value => 2.5, unit => "g"},
+                    "sodium" => {value => 1, unit => "g"},
+                }
+            }
+        ]
+    }
+};
+
+check_quality_and_test_product_has_quality_tag(
+    $product_ref,
+    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+    'salt and sodium values are consistent',
+    0
+);
+
+$product_ref = {
+    nutrition => {
+        input_sets => [
+            {
+                source => "producer",
+                preparation => "as_sold",
+                per => "100g",
+                nutrients => {
+                    "salt" => {value => 2.5, unit => "g"},
+                    "sodium" => {value => 0.97, unit => "g"},
+                }
+            }
+        ]
+    }
+};
+
+check_quality_and_test_product_has_quality_tag(
+    $product_ref,
+    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+    'salt and sodium values within 0.1g tolerance',
+    0
+);
 
 # sum of fructose plus glucose plus maltose plus lactose plus sucrose cannot be greater than sugars
 $product_ref = {

--- a/tests/unit/expected_test_results/dataqualityfood/all-types-of-errors-in-nutrition.json
+++ b/tests/unit/expected_test_results/dataqualityfood/all-types-of-errors-in-nutrition.json
@@ -39,7 +39,9 @@
       "en:nutrition-packaging-as-sold-100g-saturated-fat-greater-than-fat",
       "en:nutrition-packaging-as-sold-100g-soluble-fiber-plus-insoluble-fiber-greater-than-fiber",
       "en:nutrition-packaging-as-sold-100g-value-over-105-saturated-fat",
-      "en:nutrition-packaging-as-sold-100g-value-total-over-105"
+      "en:nutrition-packaging-as-sold-100g-value-total-over-105",
+      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium"
+      
    ],
    "data_quality_info_tags" : [
       "en:no-packaging-data",
@@ -76,7 +78,8 @@
       "en:nutrition-packaging-as-sold-100g-saturated-fat-greater-than-fat",
       "en:nutrition-packaging-as-sold-100g-soluble-fiber-plus-insoluble-fiber-greater-than-fiber",
       "en:nutrition-packaging-as-sold-100g-value-over-105-saturated-fat",
-      "en:nutrition-packaging-as-sold-100g-value-total-over-105"
+      "en:nutrition-packaging-as-sold-100g-value-total-over-105",
+      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium"
    ],
    "data_quality_warnings_tags" : [
       "en:nutrition-packaging-as-sold-100g-value-under-0-001-g-salt"


### PR DESCRIPTION
## What

Add a new data quality tag/facet that detects when the declared salt value is inconsistent with the declared sodium value.

When both nutrients are present for nutrition data per 100 g or 100 ml, the check compares the declared salt value with the salt value calculated from sodium (`salt = sodium × 2.5`). If the difference is greater than 0.1 g, the following tag is added:

- `en:<set_id>-salt-does-not-match-sodium`

## Why

Detecting inconsistencies will help identify potential data entry errors and improves nutrition data quality.

## Changes

- Added the `salt-does-not-match-sodium` data quality tag.
- Added the corresponding consistency check in `DataQualityFood.pm`.
- Added unit tests.
- Updated expected test results where the new tag is expected.

## Notes

- The check only runs for nutrition values per **100 g** or **100 ml**.
- A tolerance of **0.1 g** is used to account for rounding on nutrition labels.

Fixes: #13531 