### PR TITLE
feat: add salt/sodium consistency data quality facet

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1160,33 +1160,33 @@ sub check_specific_nutrients_for_input_set ($product_ref, $nutrition_set_ref, $s
 
 	# Too small salt value? (e.g. g entered in mg)
 	# warning for salt < 0.1 was removed because it was leading to too much false positives (see #9346)
-my $per = deep_get($nutrition_set_ref, "per");
-if ((defined $per) and (($per eq "100g") or ($per eq "100ml"))) {
+	my $per = deep_get($nutrition_set_ref, "per");
+	if ((defined $per) and (($per eq "100g") or ($per eq "100ml"))) {
 
-	my $salt = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "salt");
+		my $salt = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "salt");
 
-	if ((defined $salt) and ($salt > 0)) {
+		if ((defined $salt) and ($salt > 0)) {
 
-		if ($salt < 0.001) {
-			push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-001-g-salt";
+			if ($salt < 0.001) {
+				push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-001-g-salt";
+			}
+			elsif ($salt < 0.01) {
+				push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-01-g-salt";
+			}
 		}
-		elsif ($salt < 0.01) {
-			push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-01-g-salt";
+
+		my $sodium = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "sodium");
+
+		if ((defined $salt) and (defined $sodium)) {
+			# Allow a 0.1 g difference because nutrition values on labels are rounded
+			if (abs(convert_sodium_to_salt($sodium) - $salt) > 0.1) {
+				push @{$product_ref->{$data_quality_tags}}, "en:${set_id}-salt-does-not-match-sodium";
+			}
 		}
 	}
-
-	my $sodium = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "sodium");
-
-	if ((defined $salt) and (defined $sodium)) {
-		# Allow a 0.1 g difference because nutrition values on labels are rounded
-		if (abs(convert_sodium_to_salt($sodium) - $salt) > 0.1) {
-			push @{$product_ref->{$data_quality_tags}},
-				"en:${set_id}-salt-does-not-match-sodium";
-		}
-	}
-}
 	return;
 }
+
 sub check_nutrition_data_for_input_set ($product_ref, $nutrition_set_ref, $set_id, $data_quality_tags) {
 
 	my $nutrients_ref = $nutrition_set_ref->{nutrients};

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1160,24 +1160,33 @@ sub check_specific_nutrients_for_input_set ($product_ref, $nutrition_set_ref, $s
 
 	# Too small salt value? (e.g. g entered in mg)
 	# warning for salt < 0.1 was removed because it was leading to too much false positives (see #9346)
-	my $per = deep_get($nutrition_set_ref, "per");
-	if ((defined $per) and (($per eq "100g") or ($per eq "100ml"))) {
+my $per = deep_get($nutrition_set_ref, "per");
+if ((defined $per) and (($per eq "100g") or ($per eq "100ml"))) {
 
-		my $salt = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "salt");
-		if ((defined $salt) and ($salt > 0)) {
+	my $salt = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "salt");
 
-			if ($salt < 0.001) {
-				push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-001-g-salt";
-			}
-			elsif ($salt < 0.01) {
-				push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-01-g-salt";
-			}
+	if ((defined $salt) and ($salt > 0)) {
+
+		if ($salt < 0.001) {
+			push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-001-g-salt";
+		}
+		elsif ($salt < 0.01) {
+			push @{$product_ref->{data_quality_warnings_tags}}, "en:${set_id}-value-under-0-01-g-salt";
 		}
 	}
 
+	my $sodium = get_nutrient_from_nutrient_set_in_default_unit($nutrients_ref, "sodium");
+
+	if ((defined $salt) and (defined $sodium)) {
+		# Allow a 0.1 g difference because nutrition values on labels are rounded
+		if (abs(convert_sodium_to_salt($sodium) - $salt) > 0.1) {
+			push @{$product_ref->{$data_quality_tags}},
+				"en:${set_id}-salt-does-not-match-sodium";
+		}
+	}
+}
 	return;
 }
-
 sub check_nutrition_data_for_input_set ($product_ref, $nutrition_set_ref, $set_id, $data_quality_tags) {
 
 	my $nutrients_ref = $nutrition_set_ref->{nutrients};

--- a/tests/integration/expected_test_results/export/export_database/rows/27096765.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/27096765.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3173990027337.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3173990027337.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium, en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3173990027337.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3173990027337.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium, en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium,en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3256220513173.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3256220513173.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium,",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3256220513173.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3256220513173.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium,",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3270160503070.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3270160503070.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3451790834080.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3451790834080.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium, en:nutrition-packaging-as-sold-100g-value-over-105-iron,en:nutrition-packaging-as-sold-100g-value-over-1000-iron",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium,en:nutrition-packaging-as-sold-100g-value-over-105-iron,en:nutrition-packaging-as-sold-100g-value-over-1000-iron",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/3451790834080.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3451790834080.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-value-over-105-iron,en:nutrition-packaging-as-sold-100g-value-over-1000-iron",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium, en:nutrition-packaging-as-sold-100g-value-over-105-iron,en:nutrition-packaging-as-sold-100g-value-over-1000-iron",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/5050083706622.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/5050083706622.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium, en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/integration/expected_test_results/export/export_database/rows/5050083706622.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/5050083706622.json
@@ -50,7 +50,7 @@
    "created_datetime" : "--ignore--",
    "created_t" : "--ignore--",
    "creator" : "test",
-   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium, en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
+   "data_quality_errors_tags" : "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium,en:nutrition-packaging-as-sold-100g-value-over-105-sodium",
    "dihomo-gamma-linolenic-acid_100g" : "",
    "docosahexaenoic-acid_100g" : "",
    "eicosapentaenoic-acid_100g" : "",

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1031,71 +1031,68 @@ check_quality_and_test_product_has_quality_tag(
 );
 # salt and sodium values should be aligned
 $product_ref = {
-    nutrition => {
-        input_sets => [
-            {
-                source => "producer",
-                preparation => "as_sold",
-                per => "100g",
-                nutrients => {
-                    "salt" => { value => 2.5, unit => "g" },
-                    "sodium" => { value => 2, unit => "g" },  
-                }
-            }
-        ]
-    }
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"salt" => {value => 2.5, unit => "g"},
+					"sodium" => {value => 2, unit => "g"},
+				}
+			}
+		]
+	}
 };
 
 check_quality_and_test_product_has_quality_tag(
-    $product_ref,
-    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
-    'salt and sodium values do not match',
-    1
+	$product_ref,
+	'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+	'salt and sodium values do not match', 1
 );
 $product_ref = {
-    nutrition => {
-        input_sets => [
-            {
-                source => "producer",
-                preparation => "as_sold",
-                per => "100g",
-                nutrients => {
-                    "salt" => {value => 2.5, unit => "g"},
-                    "sodium" => {value => 1, unit => "g"},
-                }
-            }
-        ]
-    }
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"salt" => {value => 2.5, unit => "g"},
+					"sodium" => {value => 1, unit => "g"},
+				}
+			}
+		]
+	}
 };
 
 check_quality_and_test_product_has_quality_tag(
-    $product_ref,
-    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
-    'salt and sodium values are consistent',
-    0
+	$product_ref,
+	'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+	'salt and sodium values are consistent', 0
 );
 
 $product_ref = {
-    nutrition => {
-        input_sets => [
-            {
-                source => "producer",
-                preparation => "as_sold",
-                per => "100g",
-                nutrients => {
-                    "salt" => {value => 2.5, unit => "g"},
-                    "sodium" => {value => 0.97, unit => "g"},
-                }
-            }
-        ]
-    }
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"salt" => {value => 2.5, unit => "g"},
+					"sodium" => {value => 0.97, unit => "g"},
+				}
+			}
+		]
+	}
 };
 
 check_quality_and_test_product_has_quality_tag(
-    $product_ref,
-    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
-    'salt and sodium values within 0.1g tolerance',
-    0
+	$product_ref,
+	'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+	'salt and sodium values within 0.1g tolerance', 0
 );
 
 # sum of fructose plus glucose plus maltose plus lactose plus sucrose cannot be greater than sugars

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1029,6 +1029,74 @@ check_quality_and_test_product_has_quality_tag(
 	'en:nutrition-producer-as-sold-100g-values-are-all-identical',
 	'all identical values and above 1 in the nutrition table BUT not enough nutrients given', 0
 );
+# salt and sodium values should be aligned
+$product_ref = {
+    nutrition => {
+        input_sets => [
+            {
+                source => "producer",
+                preparation => "as_sold",
+                per => "100g",
+                nutrients => {
+                    "salt" => { value => 2.5, unit => "g" },
+                    "sodium" => { value => 2, unit => "g" },  
+                }
+            }
+        ]
+    }
+};
+
+check_quality_and_test_product_has_quality_tag(
+    $product_ref,
+    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+    'salt and sodium values do not match',
+    1
+);
+$product_ref = {
+    nutrition => {
+        input_sets => [
+            {
+                source => "producer",
+                preparation => "as_sold",
+                per => "100g",
+                nutrients => {
+                    "salt" => {value => 2.5, unit => "g"},
+                    "sodium" => {value => 1, unit => "g"},
+                }
+            }
+        ]
+    }
+};
+
+check_quality_and_test_product_has_quality_tag(
+    $product_ref,
+    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+    'salt and sodium values are consistent',
+    0
+);
+
+$product_ref = {
+    nutrition => {
+        input_sets => [
+            {
+                source => "producer",
+                preparation => "as_sold",
+                per => "100g",
+                nutrients => {
+                    "salt" => {value => 2.5, unit => "g"},
+                    "sodium" => {value => 0.97, unit => "g"},
+                }
+            }
+        ]
+    }
+};
+
+check_quality_and_test_product_has_quality_tag(
+    $product_ref,
+    'en:nutrition-producer-as-sold-100g-salt-does-not-match-sodium',
+    'salt and sodium values within 0.1g tolerance',
+    0
+);
 
 # sum of fructose plus glucose plus maltose plus lactose plus sucrose cannot be greater than sugars
 $product_ref = {

--- a/tests/unit/expected_test_results/dataqualityfood/all-types-of-errors-in-nutrition.json
+++ b/tests/unit/expected_test_results/dataqualityfood/all-types-of-errors-in-nutrition.json
@@ -38,9 +38,10 @@
       "en:nutrition-packaging-as-sold-100g-fructose-plus-glucose-plus-maltose-plus-lactose-plus-sucrose-greater-than-sugars",
       "en:nutrition-packaging-as-sold-100g-saturated-fat-greater-than-fat",
       "en:nutrition-packaging-as-sold-100g-soluble-fiber-plus-insoluble-fiber-greater-than-fiber",
+      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium",
       "en:nutrition-packaging-as-sold-100g-value-over-105-saturated-fat",
-      "en:nutrition-packaging-as-sold-100g-value-total-over-105",
-      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium"
+      "en:nutrition-packaging-as-sold-100g-value-total-over-105"
+      
       
    ],
    "data_quality_info_tags" : [
@@ -77,9 +78,10 @@
       "en:nutrition-packaging-as-sold-100g-fructose-plus-glucose-plus-maltose-plus-lactose-plus-sucrose-greater-than-sugars",
       "en:nutrition-packaging-as-sold-100g-saturated-fat-greater-than-fat",
       "en:nutrition-packaging-as-sold-100g-soluble-fiber-plus-insoluble-fiber-greater-than-fiber",
+      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium",
       "en:nutrition-packaging-as-sold-100g-value-over-105-saturated-fat",
-      "en:nutrition-packaging-as-sold-100g-value-total-over-105",
-      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium"
+      "en:nutrition-packaging-as-sold-100g-value-total-over-105"
+      
    ],
    "data_quality_warnings_tags" : [
       "en:nutrition-packaging-as-sold-100g-value-under-0-001-g-salt"

--- a/tests/unit/expected_test_results/dataqualityfood/all-types-of-errors-in-nutrition.json
+++ b/tests/unit/expected_test_results/dataqualityfood/all-types-of-errors-in-nutrition.json
@@ -39,7 +39,9 @@
       "en:nutrition-packaging-as-sold-100g-saturated-fat-greater-than-fat",
       "en:nutrition-packaging-as-sold-100g-soluble-fiber-plus-insoluble-fiber-greater-than-fiber",
       "en:nutrition-packaging-as-sold-100g-value-over-105-saturated-fat",
-      "en:nutrition-packaging-as-sold-100g-value-total-over-105"
+      "en:nutrition-packaging-as-sold-100g-value-total-over-105",
+      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium"
+      
    ],
    "data_quality_info_tags" : [
       "en:no-packaging-data",
@@ -76,7 +78,8 @@
       "en:nutrition-packaging-as-sold-100g-saturated-fat-greater-than-fat",
       "en:nutrition-packaging-as-sold-100g-soluble-fiber-plus-insoluble-fiber-greater-than-fiber",
       "en:nutrition-packaging-as-sold-100g-value-over-105-saturated-fat",
-      "en:nutrition-packaging-as-sold-100g-value-total-over-105"
+      "en:nutrition-packaging-as-sold-100g-value-total-over-105",
+      "en:nutrition-packaging-as-sold-100g-salt-does-not-match-sodium"
    ],
    "data_quality_warnings_tags" : [
       "en:nutrition-packaging-as-sold-100g-value-under-0-001-g-salt"


### PR DESCRIPTION
## What

Add a new data quality tag/facet that detects when the declared salt value is inconsistent with the declared sodium value.

When both nutrients are present for nutrition data per 100 g or 100 ml, the check compares the declared salt value with the salt value calculated from sodium (salt = sodium × 2.5). If the difference is greater than 0.1 g, the following tag is added:

`en:<set_id>-salt-does-not-match-sodium`

## Why

Detecting inconsistencies will help identify potential data entry errors and improves nutrition data quality.

## Changes

- Added the `salt-does-not-match-sodium` data quality tag.
- Added the corresponding consistency check in `DataQualityFood.pm`.
- Added unit tests.
- Updated expected test results where the new tag is expected.

## Notes

- The check only runs for nutrition values per 100 g or 100 ml.
- A tolerance of 0.1 g is used to account for rounding on nutrition labels.

Fixes: #13531 