### PR TITLE
taxonomy(food): vegan cheddar edits

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -965,7 +965,7 @@ sub match_origin_of_the_ingredient_origin ($ingredients_lc, $text_ref, $matched_
 		ro => "(?:tara de origine)",
 		rs => "(?:zemlja porekla)",
 		sl => "(?:(?:država|krajina) porekla|gojeno(?: v))",
-		sv => "(?:ursprung(?:sland)?|odlade inom)",
+		sv => "(?:ursprung(?:sland)?|odla(?:de|t) i(?:nom)?)",
 		uk => "(?:kраїна походження)",
 	);
 

--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -1466,6 +1466,10 @@ wikidata:en: Q5598107
 
 xx: Green Star
 
+xx: Green Vie, GreenVie
+comment:en: EUIPO registration: https://euipo.europa.eu/eSearch/#details/trademarks/015378094
+#web:en: https://greenviefoods.com/
+
 xx: Grey Poupon
 wikidata:en: Q3116568
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -47122,6 +47122,7 @@ tr: Çedar peyniri
 agribalyse_food_code:en: 12726
 ciqual_food_code:en: 12726
 ciqual_food_name:en: Cheddar cheese, from cow's milk
+plant_alternative:en: en:cheddar-cheese-substitutes
 wikidata:en: Q217525
 
 < en: Cheddar cheese
@@ -47180,6 +47181,7 @@ hr: Kriške cheddara
 hu: Szeletelt cheddar sajt
 it: Fette di cheddar
 nl: Cheddarplakken
+plant_alternative:en: en:sliced-cheddar-cheese-substitutes
 
 < en: Cow cheeses
 < en: French cheeses
@@ -123676,14 +123678,27 @@ sv: Växtbaserade tonfiskar, Veganska tonfiskar
 < en: Plant-based foods
 < en: Vegan products
 en: Cheese substitutes, Non-dairy cheeses, Plant cheeses, Vegan cheeses
-de: Milchfreie Käse, Pflanzliche Käse, Käseersatz, Vegane Käse
-es: Quesos vegetales
-fi: vegaanijuustot
-fr: Substituts du fromage, fromages végétaux
+ar: جبن نباتي
+da: Veganske oste
+de: Milchfreie Käse, Pflanzliche Käse, Käseersatz, Vegane Käse, Vegane Käsealternative
+eo: Veganaj fromaĝoj
+es: Quesos vegetales, Queso vegano
+fa: پنیر گیاهی
+fi: Vegaanijuustot
+fr: Substituts du fromage, Fromages végétaux, Fromage végétal
 hr: Zamjene za sir
-it: Formaggi vegani
-nl: Veganistische kazen, Kaasvervangers, Plantaardige kazen
+id: Keju vegan
+it: Formaggi vegani, Formaggio vegetale
+ja: ビーガン・チーズ
+jv: Kèju vegan
+ko: 식물성 치즈
+nb: Vegansk ost
+nl: Veganistische kazen, Kaasvervangers, Plantaardige kazen, Veganistische kaas
 pl: Zastępniki sera
+pt: Queijo vegano
+ru: Веганский сыр
+sv: Veganska ostar, Veganost
+zh: 純素起司
 agribalyse_proxy_food_code:en: 1029
 ciqual_proxy_food_code:en: 1029
 ciqual_proxy_food_name:en: Plant-based cheese, without soybean, prepacked
@@ -123691,6 +123706,7 @@ ciqual_proxy_food_name:fr: Spécialité végétale type fromage, sans soja, pré
 gpc_category_code:en: 10006996
 gpc_category_description:en: Definition: Includes any products that can be described/observed as food made from non-dairy products, separated from the whey, sometimes fermented, and usually pressed, cooked, smoked, matured, or heated and mixed with artificial ingredients, such as emulsifiers, colourings and flavourings. These products must be refrigerated to extend their consumable life. These products can be with added ingredients, such as herbs and nuts, in blocks, rolls, slices, grated, cubes, spreadable and portions. Definition Excludes: Excludes products such as Frozen, Shelf Stable and Perishable Cheeses, and Shelf Stable and Frozen Cheese Substitutes and Cheese-Based/Flavoured Meals.
 gpc_category_name:en: Cheese Substitutes (Perishable)
+wikidata:en: Q21384881
 
 < en: Cheese substitutes
 en: Cashew-based cheese substitutes, Cashew-based cheeses
@@ -123715,6 +123731,17 @@ agribalyse_proxy_food_code:en: 1029_2
 ciqual_proxy_food_code:en: 1029
 ciqual_proxy_food_name:en: Plant-based cheese, without soybean, prepacked, shredded
 ciqual_proxy_food_name:fr: Spécialité végétale type fromage râpé, sans soja, préemballée
+
+< en: Cheese substitutes
+en: Cheddar cheese substitutes, Non-dairy cheddars, Vegan cheddars
+da: Veganske oste med cheddarsmag
+sv: Veganska ostar med smak av cheddar
+
+< en: Cheddar cheese substitutes
+< en: Sliced cheese substitutes
+en: Sliced cheddar cheese substitutes
+da: Veganske skiver med cheddarsmag
+sv: Veganska skivar med smak av cheddar
 
 < en: Legumes and their products
 en: Puffed pulse cakes, pulse cakes, cakes of pulses

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -23218,7 +23218,12 @@ pt: sabor a queijo
 ro: aromă de brânză
 sv: ostsmak
 
-< en: natural flavouring
+< en: cheese flavouring
+en: cheddar flavouring
+sv: cheddararom, cheddar aromer
+
+< en: cheddar flavouring
+< en: natural cheese flavouring
 en: natural cheddar flavouring
 de: natürliches Cheddararoma, natürliches Cheddar-Aroma
 fi: luontainen cheddar-aromi, luontainen cheddarjuustoaromi
@@ -23230,6 +23235,7 @@ sv: naturlig cheddarostarom
 vegan:en: no
 vegetarian:en: maybe
 
+< en: cheese flavouring
 < en: natural flavouring
 en: natural cheese flavouring
 de: natürliches Käsearoma

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -3263,7 +3263,7 @@ nl: niet gehydrogeneerd, niet gehydrogeneerde
 pl: nieuwodorniony, nieutwardzony, nieutwardzone
 pt: nâo hidrogenada
 ro: nehidrogenate, nehidrogenat
-sv: ohärdad
+sv: ohärdad, icke-hydrogenerad
 
 en: hydrolysed, hydrolized
 de: hydrolisiert, hydrolisierte, hydrolisierten, hydrolisiertem, hydrolisierter, hydrolisiertes

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -88,7 +88,7 @@ synonyms:da: indeholder, kilde til
 synonyms:fr: contient, source de
 synonyms:sv: innehåller, källa till
 
-synonyms:en: without, 0%, free, contains no
+synonyms:en: without, 0%, free, contains no, free from
 synonyms:da: uden, ingen, intet, nul, 0%, fri for
 synonyms:de: ohne, 0%
 synonyms:es: sin, 0%, libre de
@@ -2332,7 +2332,7 @@ en: Enriched with vitamin D
 sv: Berikad med vitamin D
 
 < en: Enriched with vitamins
-en: Enriched with vitamin B12
+en: Enriched with vitamin B12, B12 enriched
 fr: Enrichi en vitamine B12
 sv: Berikad med vitamin B12
 
@@ -5456,7 +5456,7 @@ ru: Без соевого лецитина
 label_categories:en: en:Soy
 
 #instruction:en:Do NOT change the english key.
-en: No milk, milk-free, dairy-free, no dairy, without milk
+en: No milk, milk-free, dairy-free, no dairy, without milk, free from dairy
 bg: Без мляко
 ca: Sense llet, Lliure de llet, Lliure de làctics, Sense làctics
 da: Mælkefri, Fri for mælkebestanddele
@@ -5473,7 +5473,7 @@ nl: Melkvrij
 pl: Bez mleka, Bez zawartości mleka
 pt: Sem leite, 0% leite, sem produtos lácteos, sem produtos láteos, sem lacticínios, sem laticínios
 ru: Без молока
-sv: Mjölkfri, Fri från mjölk, Fri från mjölkprodukter
+sv: Mjölkfri, Fri från mjölk, Fri från mjölkprodukter, icke mejeriingrediens
 th: ไม่มีส่วนผสมของนม
 incompatible_with:en: labels:en:contains-milk
 label_categories:en: en:Allergens
@@ -5591,7 +5591,7 @@ th: ไม่เติมสีและวัตถุกันเสีย
 # 57 products in English that are not taxonomized with Without dyes or preservatives
 
 #instruction:en:Do NOT change the english key.
-en: No soy, soy free, without soy
+en: No soy, soy free, without soy, free from soya
 bg: Без соя, не сърържа соя
 ca: Lliure de soja, Sense soja
 da: Uden soja
@@ -19337,6 +19337,7 @@ hu: B12-vitaminban gazdag
 it: Ricco di vitamina B12
 nl: rijk aan vitamine B12
 pt: Rico en vitamina B12
+sv: Rik på vitamin B12
 description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. (https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496)
 
 en: Rich in vitamin C
@@ -20196,7 +20197,7 @@ nl: Veganistisch, plantaardig, niet dierlijk
 pl: Wegańskie, przyjazne weganom, wegański, wegańska
 pt: Vegano, produto vegano, vegan, adequado para veganos, adequado a veganos, adequado a uma dieta vegan, adequado a uma dieta vegana, adequado a vegetarianos e veganos, odpowiedni dla wegan
 sq: vegan
-sv: Vegansk, Passar för veganer, vegetabilisk, vegetabiliskt, vegetabiliskt ursprung
+sv: Vegansk, Passar för veganer, vegetabilisk, vegetabiliskt, vegetabiliskt ursprung, veganska
 th: สูตรเจ
 tr: Vegan
 zh: 纯素


### PR DESCRIPTION
- Adds “Green Vie” label.
- Adds cheddar cheese substitute categories.
- Adds some `plant_alternative` and `wikidata` properties.
- Imports some translations from Wikidata.
- Adds cheddar flavour ingredient.
- Adds a number of synonyms across taxonomies.
- Expands on the Swedish ingredient origin regular expression.

Needed-for: https://se.openfoodfacts.org/product/7318690683599/veganska-skivor-med-smak-av-cheddar-ica
Needed-for: https://se.openfoodfacts.org/product/5292874000148/vegansk-cheddar-smak-skivad-green-vie