### PR TITLE
taxonomy: Dried sweet potatoes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -110182,7 +110182,6 @@ wikidata:en: Q1072192
 
 < en: Plant-based spreads
 < en: Salted spreads
-< en: Sweet potato dishes
 en: Sweet potato spreads
 de: Süßkartoffel-Aufstriche, Süßkartoffel-Aufstrich
 fr: Tartinades de patates douces
@@ -116364,7 +116363,10 @@ en: Sweet potatoes and their products
 food_groups:en: en:potatoes
 pnns_group_2:en: Potatoes
 
-< en: Root vegetables
+< en:Snacks
+< en: Sweet potatoes and their products
+en: Dried sweet potatoes
+
 < en: Sweet potatoes and their products
 en: Sweet potatoes, Sweet potato
 bg: Сладки картофи
@@ -116388,7 +116390,6 @@ pnns_group_2:en: Potatoes
 sales_format:en: package, weight
 wikidata:en: Q37937
 
-< en: Fresh vegetables
 < en: Sweet potatoes
 en: Peeled sweet potatoes
 nl: Zoete aardappelen (schoongemaakt)
@@ -116398,7 +116399,6 @@ agribalyse_proxy_food_name:fr: Patate douce, crue
 expected_ingredients:en: en:sweet-potatoes
 wikidata:en: Q37937
 
-< en: Fresh vegetables
 < en: Sweet potatoes
 en: Fresh sweet potatoes
 nl: Zoete aardappelen (vers)
@@ -116409,7 +116409,6 @@ ciqual_food_name:fr: Patate douce, crue
 expected_ingredients:en: en:sweet-potatoes
 sales_format:en: package, weight
 
-< en: Cooked vegetables
 < en: Sweet potatoes
 en: Cooked sweet potatoes
 fr: Patates douces cuites
@@ -116420,7 +116419,7 @@ ciqual_food_name:en: Sweet potato, cooked
 ciqual_food_name:fr: Patate douce, cuite
 expected_ingredients:en: en:sweet-potatoes
 
-< en: Frozen vegetables
+< en: Frozen plant-based foods
 < en: Sweet potatoes
 en: Frozen sweet potatoes
 fr: Patates douces surgelées


### PR DESCRIPTION
* Created a category for dried sweet potatoes
* Removed sweet potato categories from vegetable categories, they are not vegetables.

