### PR TITLE
feat: enable unwanted ingredients attribute for OPF and OPFF

### DIFF
--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -575,8 +575,11 @@ $options{import_export_fields_groups} = [
 
 # Used to generate the list of possible product attributes, which is
 # used to display the possible choices for user preferences
-$options{attribute_groups}
-	= [["labels", ["labels_organic", "labels_fair_trade"]], ["environment", ["repairability_index_france",]], ["ingredients_analysis",["unwanted_ingredients"]]];
+$options{attribute_groups} = [
+	["labels", ["labels_organic", "labels_fair_trade"]],
+	["environment", ["repairability_index_france",]],
+	["ingredients_analysis", ["unwanted_ingredients"]]
+];
 
 # default preferences for attributes
 $options{attribute_default_preferences} = {

--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -576,7 +576,7 @@ $options{import_export_fields_groups} = [
 # Used to generate the list of possible product attributes, which is
 # used to display the possible choices for user preferences
 $options{attribute_groups}
-	= [["labels", ["labels_organic", "labels_fair_trade"]], ["environment", ["repairability_index_france",]],];
+	= [["labels", ["labels_organic", "labels_fair_trade"]], ["environment", ["repairability_index_france",]], ["ingredients_analysis",["unwanted_ingredients"]]];
 
 # default preferences for attributes
 $options{attribute_default_preferences} = {

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -615,7 +615,8 @@ $options{import_export_fields_groups} = [
 
 # Used to generate the list of possible product attributes, which is
 # used to display the possible choices for user preferences
-$options{attribute_groups} = [["labels", ["labels_organic", "labels_fair_trade"]], ["ingredients_analysis",["unwanted_ingredients"]]];
+$options{attribute_groups}
+	= [["labels", ["labels_organic", "labels_fair_trade"]], ["ingredients_analysis", ["unwanted_ingredients"]]];
 
 # default preferences for attributes
 $options{attribute_default_preferences} = {

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -615,7 +615,7 @@ $options{import_export_fields_groups} = [
 
 # Used to generate the list of possible product attributes, which is
 # used to display the possible choices for user preferences
-$options{attribute_groups} = [["labels", ["labels_organic", "labels_fair_trade"]],];
+$options{attribute_groups} = [["labels", ["labels_organic", "labels_fair_trade"]], ["ingredients_analysis",["unwanted_ingredients"]]];
 
 # default preferences for attributes
 $options{attribute_default_preferences} = {


### PR DESCRIPTION
## What

Enabled the `unwanted_ingredients` attribute for OPF and OPFF by adding the `ingredients_analysis` attribute group to their configuration.

## Changes

- Added the `ingredients_analysis` attribute group to `Config_opf.pm`.
- Added the `ingredients_analysis` attribute group to `Config_opff.pm`.

## Testing

- Verified the `/api/v3.4/attribute_groups` endpoint locally for OPF and OPFF and confirmed that the `ingredients_analysis` group with the `unwanted_ingredients` attribute is returned.

Fixes: #13830 