### PR TITLE
build(docker): Use Node.js 22.x floating version

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,7 +3,7 @@
 ARG USER_UID=1000
 ARG USER_GID=1000
 
-FROM node:22.22.0 AS builder
+FROM node:22 AS builder
 ARG USER_UID
 ARG USER_GID
 RUN usermod --uid "$USER_UID" node && \


### PR DESCRIPTION
We currently don't update the image version regularly, and don't pin any other base image versions in this repository. Simply using the floating 22.x major tag makes more sense and is more consistent here, for now.