### PR TITLE
taxonomy(food): vegan cheddar edits, pt. 2

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -2037,17 +2037,17 @@ wikidata:en: Q190156
 
 
 < en: E160a
-en: E160a(i), Beta-carotene
+en: E160a(i), Beta-carotene, b-carotene
 xx: E160a(i)
 bg: E160a(i), Бета-каротин
 cs: E160a(i), Beta-karoten
 da: E160a(i), Beta-caroten, Betacaroten
-de: E160a(i), Beta-Carotin
+de: E160a(i), Beta-Carotin, Betacarotin
 el: E160a(i), Β-καροτενιο
 es: E160a(i), Beta-caroteno, Betacaroteno, ß-caroteno
 et: E160a(i), Beetakaroteen
 fi: E160a(i), Beetakaroteeni, Beta-karoteeni, Betakaroteeni, Beetakaroteenia, Beta-karoteenia, Betakaroteenia, Betakarotiini
-fr: E160a(i), Bêta-carotène
+fr: E160a(i), Bêta-carotène, b-carotène
 hr: E160a(i), beta karoten, beta carotene
 hu: E160a(i), Béta-karotin
 it: E160a(i), Beta-carotene
@@ -8797,7 +8797,7 @@ ca: E333, Citrats de calci
 cs: E333, Citronany vápenaté
 de: E333, Calciumcitrat, Kalziumzitrat, Calciumcitrate, Calciumsalze der Zitronensäure
 el: E333, Κιτρικο ασβεστιο
-es: E333, Citratos de calcio, citrato cálcico, citrato de calcio, Sal amarga
+es: E333, Citratos de calcio, citrato cálcico, citrato de calcio, Sal amarga, sales cálcicas de ácido cítrico
 et: E333, Kaltsiumtsitraadid
 fi: E333, Kalsiumsitraatit, Kalsiumsitraatti, Kalsiumsitraattia
 fr: E333, Citrates de calcium, Citrate de calcium

--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -221,6 +221,9 @@ wikidata:en: Q97738125
 xx: Asahimame
 wikidata:en: Q11511859
 
+xx: Asda
+wikidata:en: Q297410
+
 xx: Asia Green Garden
 
 xx: Aubel
@@ -621,7 +624,7 @@ wikidata:en: Q55221138
 xx: Carrefour Classic
 wikidata:en: Q137731179
 
-xx: Cathedral City Cheddar
+xx: Cathedral City, Cathedral City Cheddar
 wikidata:en: Q5052218
 
 xx: Celebrations
@@ -2342,6 +2345,8 @@ xx: Moilas
 xx: Mon Chéri
 wikidata:en: Q1588515
 
+xx: Mondarella
+
 xx: Monster Munch
 wikidata:en: Q17118742
 
@@ -2521,6 +2526,10 @@ xx: NS Galletas
 
 xx: Nucrem
 wikidata:en: Q5573091
+
+xx: Nurishh
+comment:en: Discontinued Bel Brands brand.
+#web:en: https://www.nurishhbrand.com/
 
 xx: Nut Goodie
 wikidata:en: Q7070392

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -123824,8 +123824,10 @@ ciqual_food_name:en: Plant-based cheese, with cashew, prepacked
 
 < en: Cheese substitutes
 en: Sliced cheese substitutes, Sliced plant-based cheeses
-fr: Substituts de fromage en tranche
+de: Vegane Genuss-Scheiben
+fr: Substituts de fromage en tranche, Tranches végétales
 hr: Narezane zamjene za sir
+nl: Plantaardige plakken
 pl: Zastępniki sera w plastrach
 agribalyse_proxy_food_code:en: 1029_1
 ciqual_proxy_food_code:en: 1029
@@ -123833,8 +123835,8 @@ ciqual_proxy_food_name:en: Plant-based cheese, without soybean, prepacked, slice
 ciqual_proxy_food_name:fr: Spécialité végétale type fromage en tranche, sans soja, préemballée
 
 < en: Cheese substitutes
-en: Shredded cheese substitutes, Shredded plant-based cheeses
-fr: Susbtituts du fromage râpé
+en: Shredded cheese substitutes, Shredded plant-based cheeses, Grated cheese substitutes
+fr: Substituts du fromage râpé
 agribalyse_proxy_food_code:en: 1029_2
 ciqual_proxy_food_code:en: 1029
 ciqual_proxy_food_name:en: Plant-based cheese, without soybean, prepacked, shredded
@@ -123843,13 +123845,22 @@ ciqual_proxy_food_name:fr: Spécialité végétale type fromage râpé, sans soj
 < en: Cheese substitutes
 en: Cheddar cheese substitutes, Non-dairy cheddars, Vegan cheddars
 da: Veganske oste med cheddarsmag
+fr: Substituts de fromage saveur cheddar
 sv: Veganska ostar med smak av cheddar
 
 < en: Cheddar cheese substitutes
 < en: Sliced cheese substitutes
-en: Sliced cheddar cheese substitutes
+en: Sliced cheddar cheese substitutes, Plant-based slices cheddar flavour
 da: Veganske skiver med cheddarsmag
+de: Vegane Genuss-Scheiben Cheddar Geschmack
+fr: Tranches végétales saveur cheddar
+nl: Plantaardige plakken met cheddar-smaak
 sv: Veganska skivar med smak av cheddar
+
+< en: Cheddar cheese substitutes
+< en: Shredded cheese substitutes
+en: Shredded cheddar cheese substitutes
+fr: Substituts du fromage râpé saveur cheddar
 
 < en: Legumes and their products
 en: Puffed pulse cakes, pulse cakes, cakes of pulses

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -23287,8 +23287,13 @@ ro: aromă de brânză
 sv: ostsmak
 
 < en: cheese flavouring
-en: cheddar flavouring
+en: cheddar flavouring, cheddar flavour
+de: Cheddar Aroma
+fr: arôme de cheddar
 sv: cheddararom, cheddar aromer
+
+< en: cheddar flavouring
+en: smoky cheddar flavouring, smoky cheddar flavour
 
 < en: cheddar flavouring
 < en: natural cheese flavouring
@@ -30039,6 +30044,19 @@ pl: białko brązowego ryżu
 < en: rice protein
 en: concentrated rice protein, concentrated rice proteins
 it: concentrato di proteine del riso, concentrato di proteine di riso, concentrato di proteina del riso, concentrato di proteina di riso
+
+# <en:compound
+en: rice base
+de: Reisbasis
+es: base de arroz
+fr: base de riz
+it: base de riso
+nl: rijstbasis
+sv: risbas
+vegan:en: maybe
+vegetarian:en: maybe
+# usage:en:rice base (water, rice)
+# mainIngredient:en:water
 
 #<en:rice
 #en:organic rice
@@ -74099,7 +74117,7 @@ bo: རྒྱ་ཨར།
 ca: oliva
 cs: oliva, olivy
 da: oliven
-de: Oliven, Olive
+de: Oliven, Olive, Olivenfrucht
 eo: olivo
 es: aceituna
 et: Oliiv, oliivid

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1583,7 +1583,7 @@ da: ekstrakt
 de: extrakt, extrakte, extrakt aus, extrakte aus
 es: extracto, extracto de, extractos
 fi: uute, uutetta, uutteet, pähkinäuute
-fr: extrait de, extrait d'
+fr: extrait de, extrait d', extraît d'
 #fr:falsePositive:sels mineraux extraits des eaux du bassin de vichy, Sucres extraits de fruits, Extraits naturels et aromates, Extraits végétaux à pouvoir colorant, extrait sec
 hr: ekstrahirane, ekstrahirani, ekstrakt, ekstrakti, ekstrakata
 hu: kivonat, kivonatból

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -90,7 +90,7 @@ synonyms:sv: innehåller, källa till
 
 synonyms:en: without, 0%, free, contains no, free from
 synonyms:da: uden, ingen, intet, nul, 0%, fri for
-synonyms:de: ohne, 0%
+synonyms:de: ohne, 0%, frei von, frei
 synonyms:es: sin, 0%, libre de
 synonyms:fi: ilman, 0%, vapaa
 synonyms:fr: sans, 0%
@@ -1495,7 +1495,7 @@ ca: Lliure de gluten, Sense gluten, No gluten, Aliment sense gluten, Lliure de g
 cs: Bez lepku
 cz: Bez lepku
 da: Glutenfri, glutenfrit, glutenfrie
-de: Glutenfrei
+de: Glutenfrei, Frei von Gluten
 el: Χωρίς γλουτένη
 es: Sin gluten, Libre de gluten
 et: Gluteenivaba
@@ -1975,7 +1975,7 @@ en: Calcium source, Source of calcium, With calcium
 xx: Calcium source
 bg: Източник на калции
 ca: Font de calci
-de: Kalziumquelle
+de: Kalziumquelle, mit Calcium
 es: Fuente de calcio
 fi: Kalsiumin lähde, Sisältää kalsiumia
 fr: Source de calcium
@@ -2169,7 +2169,7 @@ xx: Vitamin B12 source
 bg: Източник на витамин B12
 ca: Font de vitamina B12
 da: Kilde til vitamin B12
-de: Vitamin B12-Quelle
+de: Vitamin B12-Quelle, Mit Vitamin B12
 es: Fuente de vitamina B12
 fi: B12-vitamiinin lähde
 fr: Source de vitamine B12, Avec vitamine B12
@@ -5397,7 +5397,7 @@ ca: Sense lactosa, lliure de lactosa
 cs: Bez laktózy, Přirozeně bez laktózy
 cz: Bez laktozy
 da: Laktosefri
-de: Laktosefrei, Lactosefrei
+de: Laktosefrei, Lactosefrei, frei von Laktose
 el: Χωρίς λακτόζη
 es: Sin lactosa, Sin lácteos
 et: Laktoosivaba
@@ -5481,7 +5481,7 @@ en: No milk, milk-free, dairy-free, no dairy, without milk, free from dairy
 bg: Без мляко
 ca: Sense llet, Lliure de llet, Lliure de làctics, Sense làctics
 da: Mælkefri, Fri for mælkebestanddele
-de: Ohne Milch, Milchfrei
+de: Ohne Milch, Milchfrei, Frei von Milch
 es: Sin leche
 fi: maidoton, maitotuotteeton, ei maitoa, ilman maitoa
 fr: sans lait, sans produits laitiers
@@ -5540,7 +5540,7 @@ bg: Без консерванти
 ca: Sense conservants, sense conservants afegits, lliure de conservants artificials
 cs: Bez konzervantů
 da: Uden konserveringsmiddel
-de: Ohne Konservierungsstoffe, Ohne Zusatz von Konservierungsstoffen
+de: Ohne Konservierungsstoffe, Ohne Zusatz von Konservierungsstoffen, Frei von Konservierungsstoffen
 el: Χωρίς συντηρητικά
 es: Sin conservantes, Sin conservantes añadidos, Sin conservadores, Sin conservadores añadidos
 et: Ilma säilitusaineteta
@@ -5616,7 +5616,7 @@ en: No soy, soy free, without soy, free from soya
 bg: Без соя, не сърържа соя
 ca: Lliure de soja, Sense soja
 da: Uden soja
-de: Sojafrei
+de: Sojafrei, frei von Soja
 es: Sin soja, Sin soya, Libre de soja, Libre de soya
 fi: soijaton, ei soijaa, ilman soijaa
 fr: sans soja, sans soya
@@ -20881,13 +20881,15 @@ it: Senza arachidi, Non contiene arachidi
 pt: Sem amendoim, sem amendoins, 0% amendoim, 0% amendoins
 th: ไม่มีส่วนผสมของถั่วลิสงค์
 
-en: No nuts, nut free
-de: Ohne Nüsse, nussfrei
+en: No nuts, nut free, free from nuts
+da: Uden nødder
+de: Ohne Nüsse, nussfrei, frei von Nüssen
 es: Sin frutos secos, sin nueces
 fr: Sans fruits à coque, sans fruits secs, Sans noix
 it: Senza noci, senza frutta secca, senza frutta a guscio
 nl: Zonder noten
 pt: Sem nozes, livre de nozes
+sv: Utan nötter
 
 # French label
 fr: Saveurs de l'Année


### PR DESCRIPTION
Adds a variety of different additives, brands, categories, ingredients, processing items, and labels needed for a number of different vegan cheddars.

Needed-for: https://world.openfoodfacts.org/product/0871459003214/cheddar-shreds-daiya
Needed-for: https://world.openfoodfacts.org/product/3073781155198/nurishh-sabor-cheddar
Needed-for: https://world.openfoodfacts.org/product/3073781170221/nurishh
Needed-for: https://world.openfoodfacts.org/product/4056924000554/scheiben-cheddar-style-bedda
Needed-for: https://world.openfoodfacts.org/product/4260710352486/cheddar-style-mondarella
Needed-for: https://world.openfoodfacts.org/product/4335619121553/plant-grated-mature-cheddar-vemondo
Needed-for: https://world.openfoodfacts.org/product/5000295159853/extra-mature-cheddar-flavour-cathedral-city
Needed-for: https://world.openfoodfacts.org/product/5054781763482/grated-cheddar-alternative-asda
Needed-for: https://world.openfoodfacts.org/product/5202390017049/cheddar-geschmack-scheiben-violife
Needed-for: https://world.openfoodfacts.org/product/5202390017599/mature-cheddar-flavour-violife
Needed-for: https://world.openfoodfacts.org/product/5202390021671/cheddar-vegan-violife
Needed-for: https://world.openfoodfacts.org/product/5202390025563/smoky-cheddar-flavour-violife
Needed-for: https://world.openfoodfacts.org/product/5202390030888/cheddar-geschmack-violife
Needed-for: https://world.openfoodfacts.org/facets/categories/Shredded%20cheddar%20cheese%20substitutes