### PR TITLE
fix: show Wikidata weblinks on facet pages

### DIFF
--- a/templates/web/pages/tag/tag.tt.html
+++ b/templates/web/pages/tag/tag.tt.html
@@ -28,7 +28,7 @@
                 </div>
                 [% END %]
 
-                [% IF weblinks and not facets_kp_url.defined %]
+                [% IF weblinks %]
                 <div class="weblinks">
                     [% weblinks %]
                 </div>

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Weblinks</h3><ul><li><a href="//www.wikidata.org/wiki/Q13276" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
                 <div class="parents_and_children">

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Weblinks</h3><ul><li><a href="//www.wikidata.org/wiki/Q13276" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
                 <div class="parents_and_children">

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Weblinks</h3><ul><li><a href="//www.wikidata.org/wiki/Q424" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Weblinks</h3><ul><li><a href="//www.wikidata.org/wiki/Q89" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
                 <div class="parents_and_children">

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Liens Web</h3><ul><li><a href="//www.wikidata.org/wiki/Q182940" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
                 <div class="parents_and_children">

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Weblinks</h3><ul><li><a href="//www.wikidata.org/wiki/Q182940" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
                 <div class="parents_and_children">

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -475,6 +475,10 @@
                 
 
                 
+                <div class="weblinks">
+                    <div class="weblinks" style="float:right;width:300px;margin-left:20px;margin-bottom:20px;padding:10px;border:1px solid #cbe7ff;background-color:#f0f8ff;"><h3>Weblinks</h3><ul><li><a href="//www.wikidata.org/wiki/Q380778" itemprop="sameAs">Wikidata</a></li></ul></div>
+                </div>
+                
 
                 
                 <div class="parents_and_children">


### PR DESCRIPTION
## What
This restores Wikidata weblinks on facets pages. Previously, the template only displayed the weblinks when `facets_kp_url` was not defined. This caused the Wikidata links to not appear when this condition was present.

## Changes
This change removes that condition so that Wikidata weblinks are displayed whenever they are available.

Before: `[% IF weblinks and not facets_kp_url.defined %]`
After: `[% IF weblinks %]`

Fixes: #13810 