### PR TITLE
taxonomy(food): Prime Seedless grape categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -72230,6 +72230,23 @@ en: Fresh Thompson Seedless grapes
 da: Friske Thompson seedless-vindruer
 sv: Färska Thompson seedless-vindruvor
 
+< en: Green seedless grapes
+en: Prime Seedless grapes, Prime grapes
+da: Prime Seedless-vindruer
+sv: Prime Seedless-vindruvor
+
+< en: Fresh seedless green grapes
+< en: Prime Seedless grapes
+en: Fresh Prime Seedless grapes
+da: Friske Prime Seedless-vindruer
+sv: Färska Prime Seedless-vindruvor
+comment:en: https://goodfruitguide.co.uk/product/prime-seedless/
+sales_format:en: package, weight
+season_in_country_eg:en: 6
+season_in_country_es:en: 7
+season_in_country_na:en: 12
+season_in_country_za:en: 1,2,12
+
 < en: Fruits
 en: Kakis
 es: Caquis, Kakis


### PR DESCRIPTION
Adds categories for Prime Seedless grapes.

Needed-for: https://se.openfoodfacts.org/product/8718631000727/k%C3%A4rnfria-druvor-origin-fruit-europe
Source: https://grapeevolution.com/varieties/prime/
Source: https://goodfruitguide.co.uk/product/prime-seedless/