### PR TITLE
taxonomy(food): (sugar baby) watermelon edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -72898,16 +72898,111 @@ hr: Tendralne dinje
 
 < en: Melons
 en: Watermelons
+ab: Fкарпыжә
+af: Waatlemoen
+am: ሃብሃብ
+an: Melón d'augua
+ar: بطيخ أحمر
+az: Adi qarpız
+ba: Ҡарбуз
+be: Кавун
+bg: Диня
+bi: Watermelon
+bn: তরমুজ
+bo: ཆུ་ཀུབ།
+bs: Lubenica
+ca: Síndria
+co: Patecca
+cs: Vodní meloun
+cy: Melon dŵr
+da: Vandmeloner
 de: Wassermelonen
+dv: ކަރާ
+el: Καρπούζι
+eo: Akvomelonoj
 es: Sandías
+et: Arbuus
+eu: Angurri
+fa: هندوانه
 fi: Vesimelonit
 fr: Pastèques, Melons d’eau
-hr: Lubenice
+gl: Sandía
+gn: Sandía
+gu: તરબૂચ
+gv: Mellyn ushtey
+ha: Kankana
+hi: तरबूज
+hr: Lubenice, Lubenica
+ht: Melon dlo
+hu: Görögdinnye
+hy: Ձմերուկ
+id: Semangka
 it: Angurie, Anguria, Cocomero, Cocomeri, Meloni d'acqua, Meloni da pane
 ja: スイカ, 西瓜
+jv: Semangka
+ka: Საზამთრო
+kk: Қарбыз
+kn: ಕಲ್ಲಂಗಡಿ
+ko: 수박
+ku: Zebeş
+ky: Дарбыз
 la: Citrullus lanatus
-lt: Arbūzai
+lg: Sekazzi
+lt: Arbūzai, Tikrasis arbūzas
+lv: Arbūzi
+mk: Лубеница
+ml: തണ്ണിമത്തൻ
+mn: Тарвас
+mr: टरबूज
+ms: Tembikai
+my: ဖရဲသီး
+nb: Vannmeloner, Vassmeloner
+ne: खरबुजा
 nl: Watermeloenen
+nn: Vassmelonar
+nv: Chʼééhjiyáán
+or: ତରଭୁଜ
+os: Харбыз
+pa: ਹਦਵਾਣਾ
+pl: Arbuz
+ps: هندواڼه
+pt: Melancia
+ro: Pepene
+ru: Арбуз
+rw: Wota meloni
+sa: कलिङ्गफलम्
+sc: Sìndria
+sd: هنداڻو
+se: Čáhcemelovdna
+sh: Lubenica
+si: කොමඩු
+sl: Lubenica
+sn: Nwiwa
+so: Qare
+sq: Shalqiri
+sr: Лубеница
+su: Samangka
+sv: Vattenmeloner
+sw: Tikitimaji
+ta: தர்ப்பூசணி
+te: పుచ్చ
+tg: Тарбуз
+th: แตงโม
+tl: Pakwan
+to: Meleni
+tr: Karpuz
+tt: Карбыз
+uk: Кавун
+ur: تربوز
+vi: Dưa hấu
+wo: Xaal
+yi: ארבוז
+za: Gvehoengz
+zh: 西瓜
+agribalyse_proxy_food_code:en: 13036
+ciqual_proxy_food_code:en: 13036
+ciqual_proxy_food_name:en: Watermelon, pulp, raw
+ciqual_proxy_food_name:fr: Pastèque, pulpe, crue
 sales_format:en: weight, package
 wikidata:en: Q38645
 
@@ -72919,6 +73014,12 @@ agribalyse_food_code:en: 13036
 ciqual_food_code:en: 13036
 ciqual_food_name:en: Watermelon, pulp, raw
 ciqual_food_name:fr: Pastèque, pulpe, crue
+
+< en: Watermelons
+en: Sugar Baby watermelons
+da: Sugar Baby-vandmeloner
+la: Citrullus lanatus ‘Sugar Baby’
+sv: Sugar Baby-vattenmeloner
 
 < en: Frozen fruits
 < en: Muskmelons


### PR DESCRIPTION
- Adds Subar Baby watermelon category.
- Imports translations from Wikidata.
- Adds `ciqual`/`agribalyse` properties.

Needed-for: https://prices.openfoodfacts.org/prices/292747