### PR TITLE
fix: restore nutrition table in OPF

### DIFF
--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -384,6 +384,7 @@ HTML
 	origins
 	packaging_shapes packaging_materials packaging_recycling packaging
 	labels categories
+	nutrients
 	misc
 	periods_after_opening
 	data_quality data_quality_bugs data_quality_info data_quality_warnings data_quality_errors data_quality_warnings_producers data_quality_errors_producers


### PR DESCRIPTION
## What

Fix the broken nutrients table on Open Products Facts.

### Before
The nutrients table is rendered without nutrient names because the `nutrients` taxonomy was not included in `@taxonomy_fields` in `Config_opf.pm`.

### After
Added `nutrients` to `@taxonomy_fields` in `Config_opf.pm`, restoring the nutrient labels in the nutrition table.

fixes #13761 