### PR TITLE
fix: allow CORS credentials on /facets/ endpoints (#13943)

### DIFF
--- a/conf/nginx/snippets/productopener-mappings.include
+++ b/conf/nginx/snippets/productopener-mappings.include
@@ -76,7 +76,9 @@ map $po_request_uri $allow_credentials_uri {
     /cgi/auth.pl "true";
     /cgi/product_image_move.pl "true";
     ~^/api/.*/current-user "true";
+    ~^/facets/ "true";    # allow logged-in requests to facet pages (e.g. user contribution stats)
 }
+
 
 # compile credentials allowed based on origin and uri
 map "$allow_credentials_origin:$allow_credentials_uri" $allow_credentials {

--- a/tests/integration/cors.t
+++ b/tests/integration/cors.t
@@ -170,8 +170,22 @@ my $tests_ref = [
 			"Access-Control-Request-Method" => "GET",
 		},
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
+			"Access-Control-Allow-Credentials" => "true",
+			"Vary" => "Origin",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+		},
+		expected_type => "none",
+	},
+	{
+		test_case => 'get-facet-editor-credentials',
+		method => 'GET',
+		path => '/facets/editors/alice.json',
+		expected_status_code => 200,
+		headers => {
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
+			"Access-Control-Allow-Credentials" => "true",
+			"Vary" => "Origin",
 		},
 		expected_type => "none",
 	},


### PR DESCRIPTION
Closes #13943

What is happening
- A few days ago, in PR 13756, all CORS handling moved from the Perl backend into nginx.
- nginx now decides, for every browser request, whether to reply with the caller's exact web address or a wildcard star, and whether to allow the login cookie.
- It decides this from a short allow list of URLs, and the facets URLs were not on that list.

Why it breaks logged in users
- When a logged in user on hunger openfoodfacts org asks for a facet like the editor page for a username, the browser sends the login cookie with the request.
- For a request that carries a cookie, the browser demands that the server reply with the exact site address, not the wildcard, plus a header saying credentials are allowed.
- Because facets were not on the allow list, nginx replied with the wildcard and said nothing about cookies, so the browser threw the response away. That is the CORS error in this issue.

The fix
- Add the facets paths to the nginx credentials allow list.
- Now a logged in facet request coming from an Open Food Facts site gets the exact origin and the credentials allowed header, so the browser accepts it.
- The origin still has to be a real Open Food Facts subdomain to receive credentials, so external sites keep getting the plain wildcard. This is safe by design.

Changes
- In the nginx mappings file, added a facets rule to the credentials allow list.
- In the cors test file, updated the existing facet preflight case, which now returns the exact origin plus credentials.
- In the cors test file, added a new facet editor case that checks a facet request comes back with the exact origin, credentials allowed, and vary origin.

About the OFF Explorer case in the issue
- The Explorer is an external site and the user is not logged in, and the brand data it wants is public, so it does not need the cookie.
- If it fetches that data without credentials, nginx already replies with the wildcard and it works.
- So that case is fixed on the Explorer side by not sending credentials. A non Open Food Facts domain intentionally never gets cookie backed access.

Note for reviewers
- This allows credentials on all facets paths. It is simple and safe, but it does make facet responses per origin for in app browser fetches.
- If you would rather scope it to only the user and contributor facets, I can narrow the rule to just editors, contributors, informers, correctors, photographers, checkers, and users.

Testing
- Verified the nginx logic and that the test file parses cleanly.
- The full live cors test runs in CI. The backend image does not build locally on Apple Silicon because of an unrelated packaging issue.
