### PR TITLE
taxonomy(beauty): edits for idomin

### DIFF
--- a/taxonomies/beauty/labels.txt
+++ b/taxonomies/beauty/labels.txt
@@ -2394,7 +2394,7 @@ zh-CN: 不含皂
 zh-TW: 不含皂
 
 en: Without perfume, no perfume, perfume free
-da: Uden parfume, Uparfumeret
+da: Uden parfume, Uparfumeret, Parfumefri
 de: Ohne Parfüm
 es: Sin perfume
 fr: Sans parfum
@@ -2403,7 +2403,7 @@ ja: 無香料
 ko: 향료 없음
 nl: Zonder parfum
 pt: Sem perfume
-sv: Utan parfym, Oparfymerad
+sv: Utan parfym, Oparfymerad, Parfymfri
 zh-CN: 无香精
 zh-TW: 無香精
 


### PR DESCRIPTION
I have looked at other sources than the ones given below to determine whether ingredients might not be `vegan`, but these are the main ones I looked over.

Needed-for: https://se.openbeautyfacts.org/product/7310610011345/idomin-orkla
Source: https://www.fitveganguide.com/is-canola-oil-vegan/
Source: https://vegetarian-vacations.com/is-citric-acid-vegan/
Source: https://veganfoundry.com/what-is-tocopherol-and-is-it-vegan/
Source: https://foodisgood.com/is-zinc-oxide-vegan/
Source: https://vegomm.com/ingredient/zinc-oxide
Source: https://canveganseat.com/is-petroleum-jelly-vegan/