### PR TITLE
fix: CORS, allow credentials on any uri

### DIFF
--- a/conf/nginx/snippets/productopener-mappings.include
+++ b/conf/nginx/snippets/productopener-mappings.include
@@ -65,23 +65,11 @@ map $http_origin_main_domain!!$http_host_main_domain $valid_cors_origin {
 }
 
 # Determine if credentials are allowed based on origin validity
-map $valid_cors_origin $allow_credentials_origin {
+# Note: we allow this for any uri,
+# because apps might want to authenticate just to avoid rate limits
+map $valid_cors_origin $allow_credentials {
 	default "";
 	~. "true";
-}
-
-# Determine if credentials are allowed based on uri
-map $po_request_uri $allow_credentials_uri {
-    default "";
-    /cgi/auth.pl "true";
-    /cgi/product_image_move.pl "true";
-    ~^/api/.*/current-user "true";
-}
-
-# compile credentials allowed based on origin and uri
-map "$allow_credentials_origin:$allow_credentials_uri" $allow_credentials {
-    default "";
-    true:true "true";
 }
 
 # Determine the CORS origin to send

--- a/conf/nginx/snippets/productopener-server.include
+++ b/conf/nginx/snippets/productopener-server.include
@@ -153,8 +153,6 @@ location ~ ^/debug_vars/ {
     set $var_display "$var_display valid_cors_origin: $valid_cors_origin\n";
     set $var_display "$var_display cors_origin: $cors_origin\n";
     set $var_display "$var_display cors_vary: $cors_vary\n";
-    set $var_display "$var_display allow_credentials_origin: $allow_credentials_origin\n";
-    set $var_display "$var_display allow_credentials_uri: $allow_credentials_uri\n";
     set $var_display "$var_display allow_credentials: $allow_credentials\n";
     return 200 "$var_display";
 }

--- a/tests/integration/api_v3_product_write.t
+++ b/tests/integration/api_v3_product_write.t
@@ -675,8 +675,9 @@ my $tests_ref = [
 		path => '/api/v3/product/test',
 		body => '{"product": { "ingredients_text_en": "milk 80%, sugar, cocoa powder"}}',
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_status_code => 204,    # specific return code for OPTIONS requests
 		expected_type => "none",    # no body for OPTIONS requests

--- a/tests/integration/cors.t
+++ b/tests/integration/cors.t
@@ -96,8 +96,9 @@ my $tests_ref = [
 		path => '/api/v3/product/1234567890123',
 		expected_status_code => 204,
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # no body for OPTIONS requests
 	},
@@ -107,8 +108,9 @@ my $tests_ref = [
 		path => '/api/v3/product/test',
 		expected_status_code => 204,
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # no body for OPTIONS requests
 	},
@@ -118,8 +120,9 @@ my $tests_ref = [
 		path => '/api/v3/product/1234567890123',
 		expected_status_code => 404,
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # no body for OPTIONS requests
 	},
@@ -130,8 +133,9 @@ my $tests_ref = [
 		expected_status_code => 204
 		,    # Return 204 for OPTIONS requests, even if the product does not exist, to allow CORS preflight to succeed
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # no body for OPTIONS requests
 	},
@@ -141,8 +145,9 @@ my $tests_ref = [
 		path => '/api/v2/product/1234567890123',
 		expected_status_code => 404,
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 	},
 	# Test sending X-User-Agent: should be accepted
@@ -154,10 +159,11 @@ my $tests_ref = [
 		,    # Return 204 for OPTIONS requests, even if the product does not exist, to allow CORS preflight to succeed
 		headers_in => {"X-User-Agent" => "test"},
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
 			"Access-Control-Allow-Headers" =>
 				"DNT,User-Agent,X-User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match,Authorization",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # no body for OPTIONS requests
 	},
@@ -170,8 +176,9 @@ my $tests_ref = [
 			"Access-Control-Request-Method" => "GET",
 		},
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",
 	},
@@ -213,10 +220,11 @@ $tests_ref = [
 		path => '/cgi/search.pl?search_terms=&action=process&json=1',
 		expected_status_code => 200,
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
 			"Access-Control-Allow-Headers" =>
 				"DNT,User-Agent,X-User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match,Authorization",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # we only check CORS headers, not the search results body
 	},
@@ -226,10 +234,11 @@ $tests_ref = [
 		path => '/cgi/search.pl?search_terms=&action=process&json=1',
 		expected_status_code => 204,
 		headers => {
-			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Origin" => "http://world.openfoodfacts.localhost",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
 			"Access-Control-Allow-Headers" =>
 				"DNT,User-Agent,X-User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match,Authorization",
+			"Access-Control-Allow-Credentials" => "true",
 		},
 		expected_type => "none",    # no body for OPTIONS requests
 	}


### PR DESCRIPTION
So that apps can send authenticated requests to avoid global rate limiting

fixes: #13943