### PR TITLE
fix: "Join the food revolution" image overlaps Donorbox widget on donate page

### DIFF
--- a/html/donate/aa.html
+++ b/html/donate/aa.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ach.html
+++ b/html/donate/ach.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/af.html
+++ b/html/donate/af.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/ak.html
+++ b/html/donate/ak.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/am.html
+++ b/html/donate/am.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="የምግብ አብዮትን ይቀላቀሉ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="የምግብ አብዮትን ይቀላቀሉ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ar.html
+++ b/html/donate/ar.html
@@ -218,7 +218,7 @@ Anca، Éloïse، Florence، Léonore، Marie، Christian، Ludovic، Sébastien
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="انضم إلى ثورة الطعام!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="انضم إلى ثورة الطعام!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/as.html
+++ b/html/donate/as.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="খাদ্য বিপ্লৱত যোগদান কৰক!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="খাদ্য বিপ্লৱত যোগদান কৰক!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ast.html
+++ b/html/donate/ast.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/az.html
+++ b/html/donate/az.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Qida inqilabına qoşulun!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Qida inqilabına qoşulun!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/be.html
+++ b/html/donate/be.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Далучайцеся да харчовай рэвалюцыі!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Далучайцеся да харчовай рэвалюцыі!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ber.html
+++ b/html/donate/ber.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/bg.html
+++ b/html/donate/bg.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Присъедини се към хранителната революция!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Присъедини се към хранителната революция!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/bm.html
+++ b/html/donate/bm.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Aw ka fara dumuniko jiginni kan!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Aw ka fara dumuniko jiginni kan!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/bn.html
+++ b/html/donate/bn.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="খাদ্য বিপ্লবে যোগ দিন!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="খাদ্য বিপ্লবে যোগ দিন!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/bo.html
+++ b/html/donate/bo.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/br.html
+++ b/html/donate/br.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Kemerit perzh en dispac'h boued !" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Kemerit perzh en dispac'h boued !" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/bs.html
+++ b/html/donate/bs.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Pridružite se kulinarskoj revoluciji!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Pridružite se kulinarskoj revoluciji!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ca.html
+++ b/html/donate/ca.html
@@ -224,7 +224,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Uniu-vos a la revolució alimentària!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Uniu-vos a la revolució alimentària!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ce.html
+++ b/html/donate/ce.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/chr.html
+++ b/html/donate/chr.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/co.html
+++ b/html/donate/co.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Unisciti à a rivoluzione alimentaria!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Unisciti à a rivoluzione alimentaria!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/crs.html
+++ b/html/donate/crs.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/cs.html
+++ b/html/donate/cs.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Připojte se k potravinářské revoluci!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Připojte se k potravinářské revoluci!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/cv.html
+++ b/html/donate/cv.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Апат-ҫимӗҫ революцине хутшӑнӑр!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Апат-ҫимӗҫ революцине хутшӑнӑр!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/cy.html
+++ b/html/donate/cy.html
@@ -222,7 +222,7 @@ datblygu ac ychwanegu at nodweddion hynod  newydd ar gyfer yr app i declynnau mu
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Ymunwch â'r chwyldro bwyd!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Ymunwch â'r chwyldro bwyd!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/da.html
+++ b/html/donate/da.html
@@ -227,7 +227,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Deltag i fødevarerevolutionen!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Deltag i fødevarerevolutionen!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/de.html
+++ b/html/donate/de.html
@@ -214,7 +214,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Beteiligen Sie sich an der Lebensmittelrevolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Beteiligen Sie sich an der Lebensmittelrevolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/el.html
+++ b/html/donate/el.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Λάβετε μέρος στην επανάσταση των τροφίμων!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Λάβετε μέρος στην επανάσταση των τροφίμων!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/en_AU.html
+++ b/html/donate/en_AU.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/en_GB.html
+++ b/html/donate/en_GB.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/eo.html
+++ b/html/donate/eo.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Aliĝu al la manĝaĵa revolucio!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Aliĝu al la manĝaĵa revolucio!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/es.html
+++ b/html/donate/es.html
@@ -225,7 +225,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="¡Únete a la revolución alimentaria!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="¡Únete a la revolución alimentaria!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/et.html
+++ b/html/donate/et.html
@@ -221,7 +221,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Liituge toidurevolutsiooniga!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Liituge toidurevolutsiooniga!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/eu.html
+++ b/html/donate/eu.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Batu zaitez janari iraultzara!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Batu zaitez janari iraultzara!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/fa.html
+++ b/html/donate/fa.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="به انقلاب غذایی بپیوندید!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="به انقلاب غذایی بپیوندید!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/fi.html
+++ b/html/donate/fi.html
@@ -224,7 +224,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Liity ruokavallankumoukseen" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Liity ruokavallankumoukseen" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/fil.html
+++ b/html/donate/fil.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/fo.html
+++ b/html/donate/fo.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/fr.html
+++ b/html/donate/fr.html
@@ -218,12 +218,13 @@
             <p>Le formulaire de don est en cours de chargement.<br>Vous pouvez aussi y accéder en <a href="https://donorbox.org/help-open-food-facts-stay-afloat">cliquant ici</a>.</p>
           </noscript>
 
-          <div class="text-center">
-            <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Rejoignez la révolution alimentaire !" style="margin-top: -15%; margin-bottom: -20%; width:80%"
-            >
-            <!-- 
-            <h3>Where your donation goes</h3>
+    <div class="text-center">
+      <img
+        src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
+        alt="Rejoignez la révolution alimentaire !"
+        style="margin-top: 1rem; width:80%"
+      >
+            <!-- h3>Where your donation goes</h3>
 
             <p>
               <strong>Technology:</strong> Development, maintenance, servers to keep the

--- a/html/donate/ga.html
+++ b/html/donate/ga.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Bígí linn sa réabhlóid bia!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Bígí linn sa réabhlóid bia!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/gd.html
+++ b/html/donate/gd.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Thig còmhla ris an ar-a-mach bìdh!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Thig còmhla ris an ar-a-mach bìdh!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/gl.html
+++ b/html/donate/gl.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Únete á revolución alimentaria!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Únete á revolución alimentaria!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/gu.html
+++ b/html/donate/gu.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ખાદ્ય ક્રાંતિમાં જોડાઓ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ખાદ્ય ક્રાંતિમાં જોડાઓ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ha.html
+++ b/html/donate/ha.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Shiga juyin juya halin abinci!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Shiga juyin juya halin abinci!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/he.html
+++ b/html/donate/he.html
@@ -223,7 +223,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="מזמינים אותך להצטרף למהפכת המזון!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="מזמינים אותך להצטרף למהפכת המזון!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/hi.html
+++ b/html/donate/hi.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="खाद्य क्रांति में शामिल हों!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="खाद्य क्रांति में शामिल हों!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/hr.html
+++ b/html/donate/hr.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Pridružite se kulinarskoj revoluciji!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Pridružite se kulinarskoj revoluciji!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ht.html
+++ b/html/donate/ht.html
@@ -225,7 +225,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Vin patisipe nan revolisyon manje a!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Vin patisipe nan revolisyon manje a!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/hu.html
+++ b/html/donate/hu.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Csatlakozz az élelmiszer-forradalomhoz!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Csatlakozz az élelmiszer-forradalomhoz!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/hy.html
+++ b/html/donate/hy.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Միացե՛ք սննդի հեղափոխությանը։" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Միացե՛ք սննդի հեղափոխությանը։" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/id.html
+++ b/html/donate/id.html
@@ -225,7 +225,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Bergabunglah dengan revolusi makanan!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Bergabunglah dengan revolusi makanan!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ii.html
+++ b/html/donate/ii.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/is.html
+++ b/html/donate/is.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Taktu þátt í matarbyltingunni!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Taktu þátt í matarbyltingunni!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/it.html
+++ b/html/donate/it.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Unisciti alla rivoluzione alimentare!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Unisciti alla rivoluzione alimentare!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/iu.html
+++ b/html/donate/iu.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ja.html
+++ b/html/donate/ja.html
@@ -218,7 +218,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="食の革命に参加しましょう！" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="食の革命に参加しましょう！" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/jv.html
+++ b/html/donate/jv.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Gabung karo revolusi panganan!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Gabung karo revolusi panganan!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ka.html
+++ b/html/donate/ka.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="შემოუერთდით კვების რევოლუციას!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="შემოუერთდით კვების რევოლუციას!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/kab.html
+++ b/html/donate/kab.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/kk.html
+++ b/html/donate/kk.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Азық-түлік революциясына қосылыңыз!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Азық-түлік революциясына қосылыңыз!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/km.html
+++ b/html/donate/km.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ចូលរួមបដិវត្តន៍អាហារ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ចូលរួមបដិវត្តន៍អាហារ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/kmr_TR.html
+++ b/html/donate/kmr_TR.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Tevlî şoreşa xwarinê bibin!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Tevlî şoreşa xwarinê bibin!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/kn.html
+++ b/html/donate/kn.html
@@ -227,7 +227,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ಆಹಾರ ಕ್ರಾಂತಿಯಲ್ಲಿ ಸೇರಿ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ಆಹಾರ ಕ್ರಾಂತಿಯಲ್ಲಿ ಸೇರಿ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ko.html
+++ b/html/donate/ko.html
@@ -224,7 +224,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="식품 혁명에 참여하세요!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="식품 혁명에 참여하세요!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/kw.html
+++ b/html/donate/kw.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ky.html
+++ b/html/donate/ky.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Азык-түлүк революциясына кошулуңуз!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Азык-түлүк революциясына кошулуңуз!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/la.html
+++ b/html/donate/la.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Revolutioni cibariae te adiunge!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Revolutioni cibariae te adiunge!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/lb.html
+++ b/html/donate/lb.html
@@ -218,7 +218,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Maach mat bei der Liewensmëttelrevolutioun!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Maach mat bei der Liewensmëttelrevolutioun!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/lo.html
+++ b/html/donate/lo.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ເຂົ້າຮ່ວມການປະຕິວັດອາຫານ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ເຂົ້າຮ່ວມການປະຕິວັດອາຫານ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/lt.html
+++ b/html/donate/lt.html
@@ -227,7 +227,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Prisijunkite prie maisto revoliucijos!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Prisijunkite prie maisto revoliucijos!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/lv.html
+++ b/html/donate/lv.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Pievienojies pārtikas revolūcijai!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Pievienojies pārtikas revolūcijai!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/mg.html
+++ b/html/donate/mg.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Midira amin'ny revolisionina sakafo!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Midira amin'ny revolisionina sakafo!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/mi.html
+++ b/html/donate/mi.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Hono atu ki te hurihanga kai!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Hono atu ki te hurihanga kai!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ml.html
+++ b/html/donate/ml.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ഭക്ഷ്യ വിപ്ലവത്തിൽ പങ്കുചേരൂ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ഭക്ഷ്യ വിപ്ലവത്തിൽ പങ്കുചേരൂ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/mn.html
+++ b/html/donate/mn.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Хүнсний хувьсгалд нэгдээрэй!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Хүнсний хувьсгалд нэгдээрэй!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/mr.html
+++ b/html/donate/mr.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="अन्न क्रांतीमध्ये सामील व्हा!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="अन्न क्रांतीमध्ये सामील व्हा!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ms.html
+++ b/html/donate/ms.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Sertai revolusi makanan!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Sertai revolusi makanan!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/mt.html
+++ b/html/donate/mt.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Ingħaqad mar-rivoluzzjoni tal-ikel!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Ingħaqad mar-rivoluzzjoni tal-ikel!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/my.html
+++ b/html/donate/my.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="အစားအသောက်တော်လှန်ရေးတွင် ပါဝင်လိုက်ပါ။" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="အစားအသောက်တော်လှန်ရေးတွင် ပါဝင်လိုက်ပါ။" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/nb.html
+++ b/html/donate/nb.html
@@ -221,7 +221,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Bli med på matrevolusjonen!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Bli med på matrevolusjonen!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ne.html
+++ b/html/donate/ne.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="खाद्य क्रान्तिमा सामेल हुनुहोस्!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="खाद्य क्रान्तिमा सामेल हुनुहोस्!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/nl_BE.html
+++ b/html/donate/nl_BE.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Doe mee met de voedselrevolutie!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Doe mee met de voedselrevolutie!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/nl_NL.html
+++ b/html/donate/nl_NL.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Doe mee met de voedselrevolutie!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Doe mee met de voedselrevolutie!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/nn.html
+++ b/html/donate/nn.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Bli med på matrevolusjonen!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Bli med på matrevolusjonen!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/no.html
+++ b/html/donate/no.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Bli med på matrevolusjonen!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Bli med på matrevolusjonen!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/nr.html
+++ b/html/donate/nr.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/oc.html
+++ b/html/donate/oc.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="¡Unete a la revolucion alimentaria!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="¡Unete a la revolucion alimentaria!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/or.html
+++ b/html/donate/or.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ଖାଦ୍ୟ ବିପ୍ଳବରେ ଯୋଗଦାନ କରନ୍ତୁ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ଖାଦ୍ୟ ବିପ୍ଳବରେ ଯୋଗଦାନ କରନ୍ତୁ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/pa.html
+++ b/html/donate/pa.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ਭੋਜਨ ਕ੍ਰਾਂਤੀ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਵੋ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ਭੋਜਨ ਕ੍ਰਾਂਤੀ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਵੋ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/pl.html
+++ b/html/donate/pl.html
@@ -215,7 +215,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Dołącz do naszej żywnościowej rewolucji już dziś!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Dołącz do naszej żywnościowej rewolucji już dziś!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/pt_BR.html
+++ b/html/donate/pt_BR.html
@@ -225,7 +225,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Junte-se à revolução dos alimentos!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Junte-se à revolução dos alimentos!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/pt_PT.html
+++ b/html/donate/pt_PT.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Junte-se à revolução alimentar!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Junte-se à revolução alimentar!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/qu.html
+++ b/html/donate/qu.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="¡Mikhuy revolución nisqaman hukllawakuy!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="¡Mikhuy revolución nisqaman hukllawakuy!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/rm.html
+++ b/html/donate/rm.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ro.html
+++ b/html/donate/ro.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Alăturați-vă revoluției alimentare!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Alăturați-vă revoluției alimentare!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ru.html
+++ b/html/donate/ru.html
@@ -225,7 +225,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Присоединяйтесь к пищевой революции!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Присоединяйтесь к пищевой революции!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sa.html
+++ b/html/donate/sa.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="खाद्यक्रान्तिं सम्मिलितं कुर्वन्तु !" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="खाद्यक्रान्तिं सम्मिलितं कुर्वन्तु !" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sat.html
+++ b/html/donate/sat.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/sc.html
+++ b/html/donate/sc.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/sco.html
+++ b/html/donate/sco.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/sd.html
+++ b/html/donate/sd.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="کاڌي جي انقلاب ۾ شامل ٿيو!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="کاڌي جي انقلاب ۾ شامل ٿيو!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sg.html
+++ b/html/donate/sg.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/si.html
+++ b/html/donate/si.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ආහාර විප්ලවයට එක්වන්න!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ආහාර විප්ලවයට එක්වන්න!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sk.html
+++ b/html/donate/sk.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Pridajte sa k potravinovej revolúcii!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Pridajte sa k potravinovej revolúcii!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sl.html
+++ b/html/donate/sl.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Pridružite se kulinarični revoluciji!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Pridružite se kulinarični revoluciji!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sma.html
+++ b/html/donate/sma.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/sn.html
+++ b/html/donate/sn.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food Revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food Revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/so.html
+++ b/html/donate/so.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Ku biir kacaanka cuntada!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Ku biir kacaanka cuntada!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/son.html
+++ b/html/donate/son.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/sq.html
+++ b/html/donate/sq.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Bashkohuni me revolucionin ushqimor!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Bashkohuni me revolucionin ushqimor!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sr.html
+++ b/html/donate/sr.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sr_CS.html
+++ b/html/donate/sr_CS.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Придружите се револуцији хране!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Придружите се револуцији хране!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sr_RS.html
+++ b/html/donate/sr_RS.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Придружите се револуцији хране!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Придружите се револуцији хране!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ss.html
+++ b/html/donate/ss.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Hlanganyela nekugucuka kwekudla!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Hlanganyela nekugucuka kwekudla!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/st.html
+++ b/html/donate/st.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Kenela phetoho ea lijo!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Kenela phetoho ea lijo!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sv.html
+++ b/html/donate/sv.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Gå med i matrevolutionen!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Gå med i matrevolutionen!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/sw.html
+++ b/html/donate/sw.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Jiunge na mapinduzi ya chakula!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Jiunge na mapinduzi ya chakula!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ta.html
+++ b/html/donate/ta.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="உணவுப் புரட்சியில் இணையுங்கள்!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="உணவுப் புரட்சியில் இணையுங்கள்!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/te.html
+++ b/html/donate/te.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ఆహార విప్లవంలో చేరండి!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ఆహార విప్లవంలో చేరండి!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tg.html
+++ b/html/donate/tg.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Ба инқилоби ғизо ҳамроҳ шавед!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Ба инқилоби ғизо ҳамроҳ шавед!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/th.html
+++ b/html/donate/th.html
@@ -231,7 +231,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ร่วมปฏิวัติอาหาร!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ร่วมปฏิวัติอาหาร!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ti.html
+++ b/html/donate/ti.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="ኣብ ሰውራ መግቢ ተጸንበሩ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="ኣብ ሰውራ መግቢ ተጸንበሩ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tl.html
+++ b/html/donate/tl.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Sumali sa food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Sumali sa food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tn.html
+++ b/html/donate/tn.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Tsenela phetogo ya dijo!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Tsenela phetogo ya dijo!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tr.html
+++ b/html/donate/tr.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Gıda devrimine katılın!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Gıda devrimine katılın!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ts.html
+++ b/html/donate/ts.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Hlanganyela eka nhluvuko wa swakudya!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Hlanganyela eka nhluvuko wa swakudya!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tt.html
+++ b/html/donate/tt.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Азык революциясенә кушылыгыз!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Азык революциясенә кушылыгыз!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tw.html
+++ b/html/donate/tw.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Kɔka aduan ho nsakrae no ho!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Kɔka aduan ho nsakrae no ho!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ty.html
+++ b/html/donate/ty.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/tzl.html
+++ b/html/donate/tzl.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/ug.html
+++ b/html/donate/ug.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="يېمەكلىك ئىنقىلابىغا قوشۇلۇڭ!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="يېمەكلىك ئىنقىلابىغا قوشۇلۇڭ!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/uk.html
+++ b/html/donate/uk.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Приєднуйся до харчової революції!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Приєднуйся до харчової революції!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/ur.html
+++ b/html/donate/ur.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/uz.html
+++ b/html/donate/uz.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Oziq-ovqat inqilobiga qo'shiling!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Oziq-ovqat inqilobiga qo'shiling!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/val.html
+++ b/html/donate/val.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/ve.html
+++ b/html/donate/ve.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/vec.html
+++ b/html/donate/vec.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/vi.html
+++ b/html/donate/vi.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Tham gia cuộc cách mạng thực phẩm!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Tham gia cuộc cách mạng thực phẩm!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/vls.html
+++ b/html/donate/vls.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/wa.html
+++ b/html/donate/wa.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/wo.html
+++ b/html/donate/wo.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/xh.html
+++ b/html/donate/xh.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Joyina inguqu yokutya!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Joyina inguqu yokutya!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/yi.html
+++ b/html/donate/yi.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="קומט אריין אין דער עסן רעוואלוציע!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="קומט אריין אין דער עסן רעוואלוציע!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/yo.html
+++ b/html/donate/yo.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Da ounje Iyika!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Da ounje Iyika!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/zea.html
+++ b/html/donate/zea.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- h3>Where your donation goes</h3>
 

--- a/html/donate/zh_CN.html
+++ b/html/donate/zh_CN.html
@@ -227,7 +227,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="加入食品革命！" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="加入食品革命！" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/zh_HK.html
+++ b/html/donate/zh_HK.html
@@ -234,7 +234,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Join the food revolution!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Join the food revolution!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/zh_TW.html
+++ b/html/donate/zh_TW.html
@@ -231,7 +231,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="加入這場食物革命！" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="加入這場食物革命！" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>

--- a/html/donate/zu.html
+++ b/html/donate/zu.html
@@ -226,7 +226,7 @@
 
           <div class="text-center">
             <img src="https://static.openfoodfacts.org/images/misc/2023-donation/join-the-food-rev.png"
-                 alt="Joyina uguquko lokudla!" style="margin-top: -15%; margin-bottom: -20%; width:80%"
+                 alt="Joyina uguquko lokudla!" style="margin-top: 1rem; width:80%"
             >
             <!-- 
             <h3>Where your donation goes</h3>


### PR DESCRIPTION
## What
Fixes the "Join the food revolution!" image overlapping the Donorbox 
donation widget on the donate page.

## Root cause
In `html/donate/*.html`, the image had an inline style with 
`margin-top: -15%`, which pulled it upward regardless of the actual 
widget height. This affected all ~150 language files (same inline style, 
just translated `alt` text).

## Fix
Replaced the negative margin with a normal positive spacing value:
`margin-top: -15%; margin-bottom: -20%; width:80%` → `margin-top: 1rem; width:80%`

## Before
<img width="1508" height="341" alt="Screenshot 2026-07-16 at 1 00 46 PM" src="https://github.com/user-attachments/assets/5e42ee15-81a3-4e84-b71a-0aa78619e2cc" />

## After
<img width="1508" height="752" alt="Screenshot 2026-07-16 at 5 33 32 PM" src="https://github.com/user-attachments/assets/d9b3d3f5-27d7-4b29-868d-96242965b845" />

## Testing
Verified locally on `openfoodfacts.localhost/donate/en.html` — image 
now sits cleanly below the widget with no overlap.

Fixes #14013