### PR TITLE
taxonomy(food): fair trade edits

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1179,17 +1179,60 @@ label_categories:en: en:Social responsibility
 
 en: Fair trade
 xx: Fair trade
+af: regverdige handel
+ar: تجارة عادلة
 bg: Справедлива търговия
+bn: ন্যায্য বাণিজ্য
 ca: Comerç Just
+cy: masnach deg
+da: Bæredygtig handel
 de: Fairer Handel
+el: Δίκαιο εμπόριο
+eo: justa komerco
 es: Comercio justo, Fairtrade-Comercio Justo
+et: õiglane kaubandus
+eu: Bidezko merkataritza
+fa: تجارت منصفانه
 fi: Reilu kauppa
 fr: Commerce équitable, équitable, issu du commerce équitable, issus du commerce équitable, issue du commerce équitable, issues du commerce équitable, ingrédients issus du commerce équitable, produits issus du commerce équitable, ingrédient issu du commerce équitable, Ingrédients conformes aux standards du commerce équitable Fairtrade/Max Havelaar, ingrédients conformes aux standards du commerce équitable, 100% du total des ingrédients d'origine agricole sont conformes aux standards du commerce équitable
+ga: trádáil chóir
+gl: Comercio xusto
 he: סחר הוגן
-hu: Méltányos kereskedelem, Fair trade, becsületes kereskedelem
-it: Commercio equo
-nl: Fairtrade, Rechtvaardige handel, fair trade
-pt: Comércio justo, fair trade
+hr: Pravedna trgovina
+hu: Méltányos kereskedelem, becsületes kereskedelem
+hy: Արդար արևտուր
+id: Perdagangan adil
+ig: ahia ziri ezi
+io: Equitatoza komerco
+is: Sanngjörn viðskipti
+it: Commercio equo, commercio equo e solidale
+ja: 公正取引
+kk: Әділ сауда
+ko: 공정 무역
+lt: Sąžininga prekyba
+mk: праведна трговија
+ml: ന്യായവ്യാപാരം
+ms: Perdagangan adil
+nb: rettferdig handel
+nl: Eerlijke handel, Fairtrade, Rechtvaardige handel
+nn: rettferdig handel
+pl: sprawiedliwy handel
+pt: Comércio justo
+ro: comerț echitabil
+ru: Справедливая торговля
+sh: Pravedna trgovina
+sk: Fair Trade
+sl: pravična trgovina
+sr: праведна трговина
+sv: rättvis handel, Fairtradecertifierad
+ta: நியாய வணிகம்
+th: การค้าโดยชอบธรรม
+tl: Patas na kalakalan
+tr: Adil ticaret
+uk: справедлива торгівля
+vi: Thương mại công bằng
+wa: Comiece å droet pris
+zh: 公平貿易
 description:en: Fair trade is an arrangement designed to help producers in developing countries achieve sustainable and equitable trade relationships. Members of the fair trade movement add the payment of higher prices to exporters, as well as improved social and environmental standards.
 description:de: Als Fairer Handel (englisch fair trade) wird ein kontrollierter Handel bezeichnet, bei dem die Erzeuger für ihre Produkte einen Mindestpreis erhalten, der von einer Fair-Trade-Organisation bestimmt wird. Damit soll den Produzenten auch bei niedrigeren Marktpreisen ein höheres und verlässlicheres Einkommen als im herkömmlichen Handel ermöglicht werden.
 description:es: El comercio justo es una forma alternativa de comercio promovida por varias ONG (organizaciones no gubernamentales), por la Organización de las Naciones Unidas y por los movimientos sociales y políticos (como el pacifismo y el ecologismo) que promueven una relación comercial voluntaria y justa entre productores y consumidores.
@@ -1215,11 +1258,8 @@ en: Fairtrade International, Fairtrade, FLO international, FLO
 xx: Fairtrade International, Fairtrade, FLO international, FLO
 bg: Fairtrade International, Fairtrade
 ca: Fairtrade Internacional, FLO International
-fi: Fairtrade International, FLO
 it: Commercio Equo Internazionale
-nl: Fairtrade International, Eerlijke handel
-pt: Fairtrade International
-ru: Честная торговля, FLO
+ru: Честная торговля
 wikipedia:en: https://en.wikipedia.org/wiki/Fairtrade_certification
 
 < en: Fair trade


### PR DESCRIPTION
Imports translations from Wikidata and moves some around, with the assumption that label:en:fair-trade is a generic term used for organisations/certifications other than only Fairtrade International/Max Havelaar.

E.g., `nl`’s name in Wikidata matched the first term in `description:nl:`, so I opted to use that as the primary Dutch synonym.

Also cleans up “Fair trade” and “Fairtrade” used as non-primary synonyms, since they’re both (now) in the `xx` list.

Needed-for: https://se.openfoodfacts.org/product/7311043023752/ekologisk-kokosolja-kallpressad-virgin-garant