### PR TITLE
taxonomy(food): small juice edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -7892,7 +7892,7 @@ sv: Ingefärs- och gurkmejashots med apelsin\, äpple och citron
 en: Fruit juices
 bg: Плодови сокове
 ca: Sucs de fruita
-da: Frugtjuice
+da: Frugtjuicer
 de: Fruchsäfte, Fruchtsaft
 es: Zumos de frutas, Zumo de frutas, Jugos de frutas
 fi: Hedelmämehut
@@ -7907,7 +7907,7 @@ nl_be: Vruchtensappen, Fruitsappen
 pl: Soki owocowe
 pt: Sumos de fruta
 ru: Фруктовые соки
-sv: Fruktsafter, fruktsaft
+sv: Fruktjuicer, Fruktsafter, fruktsaft
 th: น้ำผลไม้
 tr: Meyve suyu
 zh: 水果汁, 果汁
@@ -7924,6 +7924,7 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Fruit Juice - Ready to Drink (Shelf Stable)
 intake24_category_code:en: FJCE
 pnns_group_2:en: Fruit juices
+wikidata:en: Q20932605
 
 < en: Fruit juices
 en: Mixed red fruits juice pure juice
@@ -8504,31 +8505,69 @@ nl: Gekoelde Verse Multivruchtensappen, Gekoelde Verse Multivruchtensap
 
 < en: Fruit juices
 en: Orange juices
+ar: عصير برتقال
+ba: Әфлисун һуты
+be: Апельсінавы сок
 bg: Сок от портокал, Портокалов сок
-ca: Sucs de taronja
-da: Appelsinjuice
+bo: ཚ་ལུ་མའི་ཁུ་བ།
+br: Chug orañjez
+ca: Sucs de taronja, Suc de taronja
+cs: Pomerančový džus
+cy: Sudd oren
+da: Appelsinjuicer
 de: Orangensäfte, Orangensaft
-es: Zumos de naranja, zumos de naranjas, zumo de naranja
-fi: appelsiinimehut
+el: Πορτοκαλάδα
+eo: Oranĝsukoj
+es: Zumos de naranja, zumos de naranjas, zumo de naranja, Jugo de naranja
+et: Apelsinimahl
+eu: Laranja-zuku
+fa: آب پرتقال
+fi: Appelsiinimehut, Appelsiinimehu
 fr: Jus d'orange, jus d'oranges
+ga: Sú oráistí
+gl: Zume de laranxa
 he: מיצי תפוזים
-hr: Sokovi od naranče
+hr: Sokovi od naranče, Sok od naranče
 hu: Narancslevek, Narancslé, Narancsdzsúsz
+hy: Նարնջի հյութ
+id: Jus jeruk
+is: Appelsínusafi
 it: Succo di arancia, Succo d'arancia
-ja: オレンジジュース
+ja: オレンジジュース, エドウィン・コリンズ
+jv: Jus jeruk
+ka: Ფორთოხლის წვენი
+ko: 오렌지 주스
 lt: Apelsinų sultys, sultys iš apelsinų
+mi: Wai ārani
+mk: Сок од портокал
+my: လိမ္မော်ရည်
+nb: Appelsinjuicer, Appelsinjuser
 nl: Sinaasappelsappen, Jus d'Oranges, Sinaasappelsap, Jus d'Orange, Sinasappelsap
-pl: Soki pomarańczowe
-pt: Sumos de laranja
-ru: Апельсиновые соки
-sv: Apfelsinjuice
+nn: Appelsinjusar, Appelsinjuicar
+oc: Jus d'arange
+pa: ਸੰਤਰੇ ਦਾ ਰਸ
+pl: Soki pomarańczowe, Sok pomarańczowy
+pt: Sumos de laranja, Suco de laranja
+ru: Апельсиновые соки, Апельсиновый сок
+sa: नारङ्गफलरसः
+sk: Pomarančový džús
+sl: Pomarančni sok
+sr: Sok od pomorandže
+sv: Apelsinjuicer
+ta: ஆரஞ்சுச் சாறு
+th: น้ำส้ม
 tr: Portakal suyu
-zh: 橙子汁, 橙汁
+tt: Әфлисун суы
+uk: Апельсиновий сік
+uz: Apelsin sharbati
+vi: Nước cam
+yi: מאראנצן זאפט
+zh: 橙子汁, 橙汁, 柳橙汁
 agribalyse_proxy_food_code:en: 2011
 agribalyse_proxy_food_name:en: Mixed fruits juice, orange based, multivitamin
 #expected_ingredients:en: en:orange
 opposite:en: en:orange-nectars
-wikidata:en: Q1781317
+wikidata:en: Q219059
 # Note: do not put the Agribalyse for home made orange juice, it is not relevant for industrial orange juice.
 
 < en: Orange juices
@@ -8591,19 +8630,28 @@ ciqual_food_name:fr: Jus d'orange, à base de concentré
 
 < en: Orange juices
 en: Orange juices without pulp
+da: Appelsinjuicer uden frugtkød
+es: Zumos de naranja sin pulpa
 fr: Jus d'orange sans pulpe, Jus d'orange filtrés
+nb: Appelsinjuicer uten fruktkjøtt
+nn: Appelsinjusar utan fruktkjøt
+sv: Apelsinjuicer utan fruktkött
 opposite:en: en:orange-juices-with-pulp
 
 < en: Orange juices
 en: Orange juices with pulp
+da: Appelsinjuicer med frugtkød
 de: Orangensaft mit Fruchtfleisch
 es: Zumos de naranja con pulpa
 fr: Jus d'orange avec pulpe
 hr: Sokovi od naranče s pulpom
 it: Succo d'arancia con polpa
 lt: Apelsinų sultys su minkštimu
+nb: Appelsinjuicer med fruktkjøtt
 nl: Sinaasappelsappen met vruchtvlees
+nn: Appelsinjusar med fruktkjøt
 pl: Soki pomarańczowe z miąższem
+sv: Apelsinjuicer med fruktkött
 opposite:en: en:orange-juices-without-pulp
 
 < en: Orange juices

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -7939,27 +7939,52 @@ ciqual_food_name:fr: Jus de fruits rouges
 < en: Fruit juices
 < en: Unsweetened beverages
 en: Apple juices
+ar: عصير تفاح
+az: Alma şirəsi
 bg: Ябълков сок, сок от ябълка
-ca: Sucs de poma
-da: Æblejuice
+ca: Sucs de poma, Suc de poma
+cs: Jablečný mošt
+da: Æblejuicer, Æblemoster
 de: Apfelsaft, Apfelsäfte
-es: Zumos de manzana
-fi: omenamehut
+el: Χυμός μήλου
+eo: Pomaj sukoj
+es: Zumos de manzana, Jugo de manzana
+et: Õunamahl
+fa: آب سیب
+fi: Omenamehut
 fr: Jus de pomme, jus de pommes
+ga: Sú úll
 he: מיצי תפוחים
 hr: Sokovi od jabuke
 hu: Almalevek, Almalé
+hy: Խնձորի հյութ
+id: Jus apel
 it: Succo di mela, Spremuta di mela
 ja: リンゴジュース, りんごジュース, アップルジュース, アップル・ジュース
+jv: Jus apel
+ko: 사과 주스
 lt: Obuolių sultys
+lv: Ābolu sula
+mk: Сок од јаболко
+nb: Eplemost
 nl: Appelsappen, Appelsap
 nl_be: Appelsappen, Appelsap
-pl: Soki jabłkowe
-pt: Sumos de macã
+nn: Eplemost
+pl: Soki jabłkowe, Sok jabłkowy
+pt: Sumos de macã, Suco de maçã
 ru: Яблочные соки, Яблочный сок
+sa: सेवफलरसः
+sl: Jabolčni sok
+sq: Lëngu i mollës
+sr: Јабуков сок
+sv: Äppeljuicer, Äppelmust
 th: น้ำเอปเปิ้
+tl: Yago ng mansanas
 tr: Elma suyu
-zh: 苹果汁
+tt: Алма суы
+uk: Яблучний сік
+vi: Nước táo
+zh: 苹果汁, 蘋果汁
 agribalyse_proxy_food_code:en: 2074
 agribalyse_proxy_food_name:en: Apple juice, pure juice
 agribalyse_proxy_food_name:fr: Jus de pomme, pur jus

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -48533,13 +48533,58 @@ usda_ndb_name:en: Custard-apple, (bullock's-heart), raw
 
 < en: fruit
 en: persimmon, sharon fruit, khaki, kaki
+af: boomtamatie
+ar: كاكي
 bg: райска ябълка
+bn: পার্সিমন
+ca: caqui
+cs: kaki
+da: kakifrugt
 de: Kaki, Sharonfrucht
+el: λωτός
+eo: persimono
 es: caqui
+et: hurmaa
+eu: kaki
+fa: خرمالو
 fr: kaki
-hr: dragun
+ga: dátphluma
+gu: ટીમરુ
+hi: तेंदू
+hr: dragun, kaki jabuka
+hy: խուրմա
+id: persimmon
+is: döðluplóma
 it: cachi
-pl: kaki
+ja: 柿
+ko: 감
+ks: تینٛدٕ
+lt: persimonas
+mk: јапонско јаболко
+ml: പെഴ്സിമെൻ
+ms: pisang kaki
+my: တည်
+nb: kaki
+ne: हलुवावेद
+nl: kaki
+pa: ਤੇਂਦੂ
+pl: kaki, persymona
+ps: املوک
+pt: dióspiro
+ro: hurma
+ru: хурма
+sl: kaki
+so: yanmood
+sq: hurma
+sr: персимон
+sv: persimon, kaki
+ta: சீமைப் பனிச்சை
+th: พลับ
+tt: хөрмә
+uk: хурма
+za: lwgndae
+zh: 柿
+agribalyse_proxy_food_code:en: 13066
 ciqual_proxy_food_code:en: 13066
 ciqual_proxy_food_name:en: Persimmon, pulp, raw
 ciqual_proxy_food_name:fr: Kaki, pulpe, cru
@@ -48547,7 +48592,8 @@ eurocode_2_group_2:en: 9.25
 eurocode_2_group_3:en: 9.25.44
 usda_ndb_proxy_code:en: 9265
 usda_ndb_proxy_name:en: Persimmons, native, raw
-wikipedia:en: https://en.wikipedia.org/wiki/Diospyros_kaki
+wikidata:en: Q29526
+wikipedia:en: https://en.wikipedia.org/wiki/Persimmon
 
 < en: persimmon
 en: dried japanese persimmon
@@ -48564,12 +48610,14 @@ en: raw native persimmon
 usda_ndb_code:en: 9265
 usda_ndb_name:en: Persimmons, native, raw
 
+< en: fruit juice
 < en: persimmon
 en: persimmon juice
 de: Kaki Saft
 es: zumo de caqui, jugo de caqui
 hr: sok od kakija
 it: succo di cachi
+sv: kakijuice
 
 < en: persimmon
 en: raw persimmon pulp, persimmon pulp

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -43951,6 +43951,7 @@ hr: sok od naranče s voćnom pulpom
 it: succo d'arancia con polpa
 nb: appelsinjuice med fruktkjøtt
 nl: sinaasappelsap met vruchtvlees
+nn: appelsinjus med fruktkjøt
 pl: sok pomarańczowy z miąższem
 ifct_food_code:en: E047
 ifct_food_name:en: Orange, pulp
@@ -43974,7 +43975,10 @@ es: zumo de naranjas sin pulpa, jugo de naranjas sin pulpa
 fr: Jus d'orange sans pulpe
 hr: sok od naranče bez pulpe
 it: succo d'arancia senza polpa
-nl: Sinaasappelsap zonder vruchtvlees
+nb: appelsinjuice uten fruktkjøtt
+nl: sinaasappelsap zonder vruchtvlees
+nn: appelsinjus utan fruktkjøt
+sv: apelsinjuice utan fruktkött
 # ingredient/fr:jus-d-orange-sans-pulpe products has 12 in french @2019-05-23
 
 < en: orange juice from concentrate

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -43949,7 +43949,8 @@ de: Orangensaft mit Fruchtfleisch
 fr: jus d'orange avec pulpe, jus d'orange dont pulpe
 hr: sok od naranče s voćnom pulpom
 it: succo d'arancia con polpa
-nl: Sinaasappelsap met vruchtvlees
+nb: appelsinjuice med fruktkjøtt
+nl: sinaasappelsap met vruchtvlees
 pl: sok pomarańczowy z miąższem
 ifct_food_code:en: E047
 ifct_food_name:en: Orange, pulp
@@ -43968,6 +43969,7 @@ nl: geperste sinaasappelsap met vruchtvlees
 < en: orange juice
 en: orange juice without pulp
 bg: сок от портокал без пулп
+da: appelsinjuice uden frugtkød
 es: zumo de naranjas sin pulpa, jugo de naranjas sin pulpa
 fr: Jus d'orange sans pulpe
 hr: sok od naranče bez pulpe
@@ -52320,7 +52322,7 @@ usda_ndb_name:en: Water convolvulus,raw
 #
 ###################################################################################################
 
-# comment:en:Cress can mean Garden Cress, Watercress, or the group of all cresses. And seemingly different things in different languages. 
+# comment:en:Cress can mean Garden Cress, Watercress, or the group of all cresses. And seemingly different things in different languages.
 < en: leaf vegetable
 en: cress
 de: Kresse

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -19374,6 +19374,7 @@ it: Ricco di vitamina C
 nl: Rijk aan vitamine C
 pt: Rico em vitamina C
 ro: Bogat in vitamina C
+sv: rik på vitamin C
 th: แหล่งของวิตามินซี
 description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. (https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496)
 xx:en: Rich in vitamin C

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -19405,6 +19405,14 @@ nl: rijk aan vitamine E
 pt: Rico em vitamina E
 description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. (https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496)
 
+< en: Rich in vitamin C
+en: naturally rich in vitamin C, naturally rich in vit C
+es: ricamente natural en vitamina C
+fr: naturellement riche en vitamine C
+hr: prirodno bogato vitaminom C
+it: naturalmente ricco di vitamina C
+pt: rico naturalmente em vitamina C
+
 < en: Rich in vitamin E
 en: naturally rich in vitamin E
 es: ricamente natural en vitamina E

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -1257,8 +1257,6 @@ sv: L-askorbyl-6-palmitat
 vegan:en: yes
 vegetarian:en: yes
 
-# description:en:Thiamine, also known as thiamin or vitamin B1, is a vitamin found in food, and manufactured as a dietary supplement and medication.
-
 < en: vitamins
 en: Thiamin, thiamine, vitamin b1, B1
 af: Tiamien
@@ -1320,6 +1318,7 @@ sl: Tiamin, vitamin B1
 sq: Tiamina, Vitamina B1
 sr: vitamin B1
 su: Tiamin
+sv: vitamin B1
 sw: Tiamin, B1-vitamin
 ta: தயமின்
 tg: Тиамин
@@ -1329,15 +1328,16 @@ uk: Тіамін, Вітамін B1
 vi: Thiamin
 wa: Tiyamene
 zh: 硫胺, 維他命B1
-# ast:Vitamina B1
-# de-ch:Thiamin
-# en-ca:Thiamine
-# en-gb:Thiamine
-# pt-br:Tiamina
-# sco:Thiamine
-# sr-ec:Тиамин, витамин Б1
-# tyv:Витамин B1
-# yue:維他命B1
+#ast: Vitamina B1
+#de-ch: Thiamin
+#en-ca: Thiamine
+#en-gb: Thiamine
+#pt-br: Tiamina
+#sco: Thiamine
+#sr-ec: Тиамин, витамин Б1
+#tyv: Витамин B1
+#yue: 維他命B1
+description:en: Thiamine, also known as thiamin or vitamin B1, is a vitamin found in food, and manufactured as a dietary supplement and medication.
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q83187


### PR DESCRIPTION
Some edits needed for a few products.

- Imports Wikidata translations.
- Adds/fixes some Danish/Swedish/Norwegian translations.
- Adds/updates some `wikidata` and other properties.
  - WD:Q1781317 is for a band called “Orange Juice” :)
- Normalises category names towards sentence-cased plural forms.
- Normalises ingredient names towards lower-cased singular forms.

Needed-for: https://se.openfoodfacts.org/product/5410188036664/presset-appelsin-med-fruktkj%C3%B8tt-tropicana
Needed-for: https://se.openfoodfacts.org/product/5410188036688/pressed-orange-without-pulp-tropicana
Needed-for: https://se.openfoodfacts.org/product/1210002014397/apple-100-pressed-pink-lady-tropicana
Needed-for: https://se.openfoodfacts.org/product/1210002014243/multi-fruit-tropicana
Needed-for: https://se.openfoodfacts.org/product/7350000550573/bl%C3%A5b%C3%A4r-proviva