### PR TITLE
taxonomy(food): yuzu categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -111760,7 +111760,7 @@ wikidata:en: Q154389
 < en: Simple syrups
 en: Treacle
 
-< en: Simple syrups
+< en: Syrups
 en: Yuzu syrups
 
 < en: Fruits and vegetables based foods

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -109866,6 +109866,7 @@ it: Marmellate di mandarini tangerini, Confetture di mandarini tangerini
 
 < en: Citrus jams
 en: Yuzu jams
+fr: Confitures de Yuzu
 
 #################### jellies and extra jellies in alphebetical order for English ####################
 # in eu, jellies should have specific

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -71643,8 +71643,27 @@ ciqual_food_name:en: Lime, pulp, raw
 ciqual_food_name:fr: Citron vert ou Lime, pulpe, cru
 
 < en: Citrus
-en: Yuzu
-fr: Yuzu
+en: Yuzu, Yuzu fruits
+xx: Yuzu
+ar: يوزو
+bg: Юзу
+bn: ইয়ুজু
+el: Γιούζου
+eo: Juzuoj
+et: Juunosidrunipuu
+fa: یوزو
+ja: 柚子, ユズ
+ko: 유자나무
+la: Citrus × junos
+lt: Kvapusis citrinmedis
+ml: സിട്രസ് ജൂനോസ്
+ms: Limau Yuzu
+pa: ਯੂਜ਼ੂ
+pl: Owoc juzu
+th: ยูซุ
+uk: Юдзу
+zh: 香橙
+wikidata:en: Q103772657
 
 < en: Citrus
 en: Mandarins, Mandarines, Mandarin oranges
@@ -109845,6 +109864,8 @@ wikidata:en: Q43669016
 en: Tangerine jams
 it: Marmellate di mandarini tangerini, Confetture di mandarini tangerini
 
+< en: Citrus jams
+en: Yuzu jams
 
 #################### jellies and extra jellies in alphebetical order for English ####################
 # in eu, jellies should have specific
@@ -111738,6 +111759,9 @@ wikidata:en: Q154389
 
 < en: Simple syrups
 en: Treacle
+
+< en: Simple syrups
+en: Yuzu syrups
 
 < en: Fruits and vegetables based foods
 < en: Vegetable-based foods and beverages


### PR DESCRIPTION
- Adds `wikidata` and translations for Yuzu fruit category.
- Adds “Yuzu jams” and “Yuzu syrups” categories.

Needed-for: https://se.openfoodfacts.org/product/8800242940391/yuzu-syrup-delief
Needed-for: https://world.openfoodfacts.org/product/8594215380092/yuzu