### PR TITLE
feat: show nutrition facts per serving by default

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9220,6 +9220,17 @@ sub data_to_display_nutrition_table ($product_ref, $comparisons_ref, $request_re
 		};
 
 		push @cols, $preparation . "_" . $per;
+
+		$columns{$preparation . "_per_serving"} = {
+			scope => "product",
+			preparation => $preparation,
+			per => "serving",
+			name => $col_name . "<br>" . lang("nutrition_data_per_serving"),
+			short_name => lang("per_serving"),
+			class => "product",
+		};
+
+		push @cols, $preparation . "_per_serving";
 	}
 
 	# Comparisons with other products, categories, recommended daily values etc.
@@ -9514,7 +9525,24 @@ CSS
 					# otherwise: nutrition, aggregated_set, nutrients
 
 					my @nutrients_path = ("nutrition", "aggregated_set", "nutrients");
-					if ($col_id =~ /^input_set_(\d+)$/) {
+
+					if ($col_id =~ /_per_serving$/) {
+
+						my $input_sets = deep_get($product_ref, "nutrition", "input_sets");
+
+						if (defined $input_sets) {
+							for (my $i = 0; $i < @$input_sets; $i++) {
+
+								if (   ($input_sets->[$i]{preparation} eq $preparation)
+									&& ($input_sets->[$i]{per} eq "serving"))
+								{
+									@nutrients_path = ("nutrition", "input_sets", $i, "nutrients");
+									last;
+								}
+							}
+						}
+					}
+					elsif ($col_id =~ /^input_set_(\d+)$/) {
 						my $input_set_index = $1;
 						@nutrients_path = ("nutrition", "input_sets", $input_set_index, "nutrients");
 					}

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
@@ -2567,6 +2567,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -2577,6 +2584,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -2592,6 +2602,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -2601,6 +2614,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -2616,6 +2632,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -2625,6 +2644,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -2640,6 +2662,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -2649,6 +2674,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2664,6 +2692,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -2676,6 +2707,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -2685,6 +2719,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"
@@ -2732,6 +2769,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -2750,6 +2792,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -2776,6 +2821,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2786,6 +2834,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -2812,6 +2863,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2822,6 +2876,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -2848,6 +2905,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2858,6 +2918,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2881,6 +2944,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -2899,6 +2965,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -2912,6 +2981,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -3233,6 +3233,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -3243,6 +3250,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -3258,6 +3268,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -3267,6 +3280,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -3282,6 +3298,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -3291,6 +3310,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -3306,6 +3328,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -3315,6 +3340,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -3330,6 +3358,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -3342,6 +3373,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -3351,6 +3385,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"
@@ -3398,6 +3435,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -3416,6 +3458,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -3442,6 +3487,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -3452,6 +3500,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -3478,6 +3529,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -3488,6 +3542,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -3514,6 +3571,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -3524,6 +3584,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -3547,6 +3610,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -3565,6 +3631,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -3578,6 +3647,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_excluded-environment_card.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_excluded-environment_card.json
@@ -1035,6 +1035,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -1045,6 +1052,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1060,6 +1070,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -1069,6 +1082,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1084,6 +1100,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1093,6 +1112,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1108,6 +1130,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1117,6 +1142,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1132,6 +1160,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1144,6 +1175,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1153,6 +1187,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"
@@ -1200,6 +1237,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1218,6 +1260,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1244,6 +1289,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1254,6 +1302,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1280,6 +1331,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1290,6 +1344,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1316,6 +1373,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1326,6 +1386,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1349,6 +1412,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1367,6 +1433,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1380,6 +1449,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
@@ -1687,6 +1687,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -1697,6 +1704,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1712,6 +1722,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -1721,6 +1734,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1736,6 +1752,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1745,6 +1764,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1760,6 +1782,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1769,6 +1794,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1784,6 +1812,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1796,6 +1827,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1805,6 +1839,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"
@@ -1852,6 +1889,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1870,6 +1912,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1896,6 +1941,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1906,6 +1954,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1932,6 +1983,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1942,6 +1996,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1968,6 +2025,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1978,6 +2038,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2001,6 +2064,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -2019,6 +2085,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -2032,6 +2101,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
@@ -1739,6 +1739,13 @@
                            "text" : "Tel que vendu<br>pour 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "Tel que vendu<br>par portion",
+                           "text_for_small_screens" : "par portion",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -1749,6 +1756,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Énergie"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1764,6 +1774,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -1773,6 +1786,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Acides gras saturés"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1788,6 +1804,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1797,6 +1816,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sucres"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1812,6 +1834,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1821,6 +1846,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Protéines"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1836,6 +1864,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1848,6 +1879,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1857,6 +1891,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ légumes‚ légumes secs"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"
@@ -1904,6 +1941,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "Tel que vendu<br>par portion",
+                           "text_for_small_screens" : "par portion",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "Tel que vendu pour 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1922,6 +1964,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Énergie"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1948,6 +1993,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1958,6 +2006,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Acides gras saturés"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1984,6 +2035,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1994,6 +2048,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sucres"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -2020,6 +2077,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2030,6 +2090,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Protéines"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2053,6 +2116,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -2071,6 +2137,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -2084,6 +2153,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ légumes‚ légumes secs"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels.json
@@ -1732,6 +1732,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -1742,6 +1749,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1757,6 +1767,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -1766,6 +1779,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1781,6 +1797,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1790,6 +1809,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1805,6 +1827,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1814,6 +1839,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1829,6 +1857,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1841,6 +1872,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1850,6 +1884,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"
@@ -1897,6 +1934,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1915,6 +1957,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1941,6 +1986,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1951,6 +1999,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1977,6 +2028,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1987,6 +2041,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -2013,6 +2070,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2023,6 +2083,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2046,6 +2109,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -2064,6 +2130,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -2077,6 +2146,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 58.3333333333333 %"
                               },
                               {
                                  "text" : "~ 58.3333333333333 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-all-knowledge-panels.json
@@ -1460,6 +1460,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -1470,6 +1477,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1485,6 +1495,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -1494,6 +1507,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1509,6 +1525,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1518,6 +1537,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1533,6 +1555,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1542,6 +1567,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1557,6 +1585,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1569,6 +1600,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1578,6 +1612,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1625,6 +1662,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1643,6 +1685,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1669,6 +1714,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1679,6 +1727,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1705,6 +1756,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1715,6 +1769,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1741,6 +1798,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1751,6 +1811,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1774,6 +1837,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1792,6 +1858,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1805,6 +1874,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -2140,6 +2140,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -2150,6 +2157,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -2165,6 +2175,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -2174,6 +2187,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -2189,6 +2205,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -2198,6 +2217,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -2213,6 +2235,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -2222,6 +2247,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2237,6 +2265,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -2249,6 +2280,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -2258,6 +2292,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -2305,6 +2342,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -2323,6 +2365,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -2349,6 +2394,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2359,6 +2407,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -2385,6 +2436,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2395,6 +2449,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -2421,6 +2478,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -2431,6 +2491,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -2454,6 +2517,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -2472,6 +2538,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -2485,6 +2554,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_excluded-environment_card.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_excluded-environment_card.json
@@ -883,6 +883,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -893,6 +900,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -908,6 +918,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -917,6 +930,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -932,6 +948,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -941,6 +960,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -956,6 +978,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -965,6 +990,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -980,6 +1008,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -992,6 +1023,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1001,6 +1035,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1048,6 +1085,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1066,6 +1108,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1092,6 +1137,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1102,6 +1150,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1128,6 +1179,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1138,6 +1192,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1164,6 +1221,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1174,6 +1234,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1197,6 +1260,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1215,6 +1281,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1228,6 +1297,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
@@ -906,6 +906,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -916,6 +923,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -931,6 +941,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -940,6 +953,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -955,6 +971,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -964,6 +983,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -979,6 +1001,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -988,6 +1013,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1003,6 +1031,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1015,6 +1046,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1024,6 +1058,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1071,6 +1108,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1089,6 +1131,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1115,6 +1160,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1125,6 +1173,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1151,6 +1202,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1161,6 +1215,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1187,6 +1244,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1197,6 +1257,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1220,6 +1283,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1238,6 +1304,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1251,6 +1320,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
@@ -951,6 +951,13 @@
                            "text" : "Tel que vendu<br>pour 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "Tel que vendu<br>par portion",
+                           "text_for_small_screens" : "par portion",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -961,6 +968,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Énergie"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -976,6 +986,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -985,6 +998,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Acides gras saturés"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1000,6 +1016,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1009,6 +1028,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sucres"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1024,6 +1046,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1033,6 +1058,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Protéines"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1048,6 +1076,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1060,6 +1091,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1069,6 +1103,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ légumes‚ légumes secs"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1116,6 +1153,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "Tel que vendu<br>par portion",
+                           "text_for_small_screens" : "par portion",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "Tel que vendu pour 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1134,6 +1176,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Énergie"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1160,6 +1205,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1170,6 +1218,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Acides gras saturés"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1196,6 +1247,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1206,6 +1260,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sucres"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1232,6 +1289,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1242,6 +1302,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Protéines"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1265,6 +1328,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1283,6 +1349,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1296,6 +1365,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ légumes‚ légumes secs"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-simplified.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-simplified.json
@@ -1037,6 +1037,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -1047,6 +1054,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1062,6 +1072,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -1071,6 +1084,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1086,6 +1102,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1095,6 +1114,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1110,6 +1132,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1119,6 +1144,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1134,6 +1162,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1146,6 +1177,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1155,6 +1189,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1202,6 +1239,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1220,6 +1262,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1246,6 +1291,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1256,6 +1304,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1282,6 +1333,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1292,6 +1346,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1318,6 +1375,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1328,6 +1388,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1351,6 +1414,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1369,6 +1435,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1382,6 +1451,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels.json
@@ -951,6 +951,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -961,6 +968,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -976,6 +986,9 @@
                               },
                               {
                                  "text" : "8.5 g"
+                              },
+                              {
+                                 "text" : "8.5 g"
                               }
                            ]
                         },
@@ -985,6 +998,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1000,6 +1016,9 @@
                               },
                               {
                                  "text" : "10.5 g"
+                              },
+                              {
+                                 "text" : "10.5 g"
                               }
                            ]
                         },
@@ -1009,6 +1028,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1024,6 +1046,9 @@
                               },
                               {
                                  "text" : "2 g"
+                              },
+                              {
+                                 "text" : "2 g"
                               }
                            ]
                         },
@@ -1033,6 +1058,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1048,6 +1076,9 @@
                               },
                               {
                                  "text" : "0.0502 g"
+                              },
+                              {
+                                 "text" : "0.0502 g"
                               }
                            ]
                         },
@@ -1060,6 +1091,9 @@
                               },
                               {
                                  "text" : "~ 0.02008 g"
+                              },
+                              {
+                                 "text" : "~ 0.02008 g"
                               }
                            ]
                         },
@@ -1069,6 +1103,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1116,6 +1153,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1134,6 +1176,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "400 kJ<br>(140 kcal)"
                               },
                               {
                                  "text" : "400 kJ<br>(140 kcal)"
@@ -1160,6 +1205,9 @@
                                  "text" : "8.5 g"
                               },
                               {
+                                 "text" : "8.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1170,6 +1218,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "5.6 g"
                               },
                               {
                                  "text" : "5.6 g"
@@ -1196,6 +1247,9 @@
                                  "text" : "10.5 g"
                               },
                               {
+                                 "text" : "10.5 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1206,6 +1260,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "12.5 g"
                               },
                               {
                                  "text" : "12.5 g"
@@ -1232,6 +1289,9 @@
                                  "text" : "2 g"
                               },
                               {
+                                 "text" : "2 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1242,6 +1302,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "4.5 g"
                               },
                               {
                                  "text" : "4.5 g"
@@ -1265,6 +1328,9 @@
                                  "text" : "0.0502 g"
                               },
                               {
+                                 "text" : "0.0502 g"
+                              },
+                              {
                                  "text" : "50.2 mg"
                               },
                               {
@@ -1283,6 +1349,9 @@
                                  "text" : "~ 0.02008 g"
                               },
                               {
+                                 "text" : "~ 0.02008 g"
+                              },
+                              {
                                  "text" : "?"
                               },
                               {
@@ -1296,6 +1365,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/data_quality_knowledge_panel/data-quality.json
+++ b/tests/integration/expected_test_results/data_quality_knowledge_panel/data-quality.json
@@ -909,6 +909,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -919,6 +926,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "1302 kJ<br>(1302 kcal)"
                               },
                               {
                                  "text" : "1302 kJ<br>(1302 kcal)"
@@ -934,6 +944,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -943,6 +956,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -958,6 +974,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -967,6 +986,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -982,6 +1004,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -991,6 +1016,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1006,6 +1034,9 @@
                               },
                               {
                                  "text" : "120 g"
+                              },
+                              {
+                                 "text" : "120 g"
                               }
                            ]
                         },
@@ -1018,6 +1049,9 @@
                               },
                               {
                                  "text" : "~ 48 g"
+                              },
+                              {
+                                 "text" : "~ 48 g"
                               }
                            ]
                         },
@@ -1027,6 +1061,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -1074,6 +1111,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (packaging)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1092,6 +1134,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "1302 kJ<br>(1302 kcal)"
                               },
                               {
                                  "text" : "1302 kJ<br>(1302 kcal)"
@@ -1119,6 +1164,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1128,6 +1176,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1155,6 +1206,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1164,6 +1218,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1191,6 +1248,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1200,6 +1260,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1226,6 +1289,9 @@
                                  "text" : "120 g"
                               },
                               {
+                                 "text" : "120 g"
+                              },
+                              {
                                  "text" : "?"
                               }
                            ]
@@ -1236,6 +1302,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Sodium"
+                              },
+                              {
+                                 "text" : "~ 48 g"
                               },
                               {
                                  "text" : "~ 48 g"
@@ -1254,6 +1323,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/data_quality_knowledge_panel/no-data-quality.json
+++ b/tests/integration/expected_test_results/data_quality_knowledge_panel/no-data-quality.json
@@ -834,6 +834,13 @@
                            "text" : "As sold<br>for 100 g / 100 ml",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
+                        },
+                        {
+                           "column_group_id" : "product",
+                           "shown_by_default" : false,
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
                         }
                      ],
                      "id" : "nutrition_facts_table",
@@ -844,6 +851,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -859,6 +869,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -868,6 +881,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -883,6 +899,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -892,6 +911,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -907,6 +929,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -916,6 +941,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -931,6 +959,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -940,6 +971,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"
@@ -987,6 +1021,11 @@
                            "type" : "text"
                         },
                         {
+                           "text" : "As sold<br>per serving",
+                           "text_for_small_screens" : "per serving",
+                           "type" : "text"
+                        },
+                        {
                            "text" : "As sold for 100 g (estimate)",
                            "text_for_small_screens" : "100g",
                            "type" : "text"
@@ -1000,6 +1039,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Energy"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1021,6 +1063,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1030,6 +1075,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Saturated fat"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1051,6 +1099,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1060,6 +1111,9 @@
                                  "level" : 1,
                                  "style" : "max-width:15rem",
                                  "text" : "Sugars"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1081,6 +1135,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1090,6 +1147,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Proteins"
+                              },
+                              {
+                                 "text" : "?"
                               },
                               {
                                  "text" : "?"
@@ -1111,6 +1171,9 @@
                               },
                               {
                                  "text" : "?"
+                              },
+                              {
+                                 "text" : "?"
                               }
                            ]
                         },
@@ -1120,6 +1183,9 @@
                                  "level" : 0,
                                  "style" : "max-width:15rem",
                                  "text" : "Fruits‚ vegetables‚ legumes"
+                              },
+                              {
+                                 "text" : "~ 0 %"
                               },
                               {
                                  "text" : "~ 0 %"

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -1059,6 +1059,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                     As sold<br>for 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -1075,6 +1079,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1121,6 +1137,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1135,6 +1163,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1181,6 +1221,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1195,6 +1247,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1241,6 +1305,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1255,6 +1331,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1301,6 +1389,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1315,6 +1415,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0 %
         </span>
     
                     </td>
@@ -1390,6 +1502,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 </th>
                 
                 <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
+                <th scope="col">
                     As sold for 100 g (estimate)
                 </th>
                 
@@ -1409,6 +1525,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1479,6 +1607,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1493,6 +1633,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1563,6 +1715,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1577,6 +1741,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1647,6 +1823,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1661,6 +1849,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1731,6 +1931,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1745,6 +1957,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -1059,6 +1059,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                     As sold<br>for 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -1075,6 +1079,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1121,6 +1137,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1135,6 +1163,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1181,6 +1221,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1195,6 +1247,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1241,6 +1305,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1255,6 +1331,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1301,6 +1389,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1315,6 +1415,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0 %
         </span>
     
                     </td>
@@ -1390,6 +1502,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 </th>
                 
                 <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
+                <th scope="col">
                     As sold for 100 g (estimate)
                 </th>
                 
@@ -1409,6 +1525,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1479,6 +1607,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1493,6 +1633,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1563,6 +1715,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1577,6 +1741,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1647,6 +1823,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1661,6 +1849,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
         </span>
     
                     </td>
@@ -1731,6 +1931,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ?
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1745,6 +1957,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -2221,6 +2221,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                     As sold<br>for 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -2237,6 +2241,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 558.75 kJ<br>(134 kcal)
         </span>
     
                     </td>
@@ -2283,6 +2299,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 10.4134375 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2297,6 +2325,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 4.903125 g
         </span>
     
                     </td>
@@ -2343,6 +2383,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 7.6484375 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2357,6 +2409,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 7.2621875 g
         </span>
     
                     </td>
@@ -2403,6 +2467,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.8125 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2417,6 +2493,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 1.974375 g
         </span>
     
                     </td>
@@ -2463,6 +2551,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.0496875 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2477,6 +2577,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 62.5 %
         </span>
     
                     </td>
@@ -2552,6 +2664,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 </th>
                 
                 <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
+                <th scope="col">
                     As sold for 100 g (estimate)
                 </th>
                 
@@ -2571,6 +2687,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 558.75 kJ<br>(134 kcal)
         </span>
     
                     </td>
@@ -2641,6 +2769,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 10.4134375 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2655,6 +2795,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 4.903125 g
         </span>
     
                     </td>
@@ -2725,6 +2877,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 7.6484375 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2739,6 +2903,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 7.2621875 g
         </span>
     
                     </td>
@@ -2809,6 +2985,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.8125 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2823,6 +3011,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 1.974375 g
         </span>
     
                     </td>
@@ -2893,6 +3093,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.0496875 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2907,6 +3119,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 62.5 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -2137,6 +2137,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                     Tel que vendu<br>pour 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    Tel que vendu<br>par portion
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -2153,6 +2157,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Énergie
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1200 kJ<br>(300 kcal)
         </span>
     
                     </td>
@@ -2199,6 +2215,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            12 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2213,6 +2241,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Acides gras saturés
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
         </span>
     
                     </td>
@@ -2259,6 +2299,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            30 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2273,6 +2325,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sucres
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            25 g
         </span>
     
                     </td>
@@ -2319,6 +2383,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            4 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2333,6 +2409,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Protéines
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2379,6 +2467,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2409,6 +2509,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.4 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2423,6 +2535,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Fruits‚ légumes‚ légumes secs
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 37.5 %
         </span>
     
                     </td>
@@ -2498,6 +2622,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                 </th>
                 
                 <th scope="col">
+                    Tel que vendu<br>par portion
+                </th>
+                
+                <th scope="col">
                     Tel que vendu pour 100 g (packaging)
                 </th>
                 
@@ -2521,6 +2649,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Énergie
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1200 kJ<br>(300 kcal)
         </span>
     
                     </td>
@@ -2610,6 +2750,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            12 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 5.7873 g
         </span>
     
@@ -2629,6 +2781,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Acides gras saturés
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
         </span>
     
                     </td>
@@ -2718,6 +2882,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            30 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 39.78295 g
         </span>
     
@@ -2737,6 +2913,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sucres
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            25 g
         </span>
     
                     </td>
@@ -2826,6 +3014,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            4 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 3.8815 g
         </span>
     
@@ -2845,6 +3045,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Protéines
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2934,6 +3146,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            1 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 0.532565 g
         </span>
     
@@ -2953,6 +3177,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sodium
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.4 g
         </span>
     
                     </td>
@@ -3007,6 +3243,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Fruits‚ légumes‚ légumes secs
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 37.5 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -2139,6 +2139,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                     Tel que vendu<br>pour 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    Tel que vendu<br>par portion
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -2155,6 +2159,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Énergie
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1200 kJ<br>(300 kcal)
         </span>
     
                     </td>
@@ -2201,6 +2217,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            12 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2215,6 +2243,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Acides gras saturés
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
         </span>
     
                     </td>
@@ -2261,6 +2301,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            30 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2275,6 +2327,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sucres
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            25 g
         </span>
     
                     </td>
@@ -2321,6 +2385,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            4 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2335,6 +2411,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Protéines
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2381,6 +2469,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2411,6 +2511,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.4 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2425,6 +2537,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Fruits‚ légumes‚ légumes secs
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 37.5 %
         </span>
     
                     </td>
@@ -2500,6 +2624,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                 </th>
                 
                 <th scope="col">
+                    Tel que vendu<br>par portion
+                </th>
+                
+                <th scope="col">
                     Tel que vendu pour 100 g (packaging)
                 </th>
                 
@@ -2523,6 +2651,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Énergie
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1200 kJ<br>(300 kcal)
         </span>
     
                     </td>
@@ -2612,6 +2752,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            12 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 5.7873 g
         </span>
     
@@ -2631,6 +2783,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Acides gras saturés
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
         </span>
     
                     </td>
@@ -2720,6 +2884,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            30 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 39.78295 g
         </span>
     
@@ -2739,6 +2915,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sucres
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            25 g
         </span>
     
                     </td>
@@ -2828,6 +3016,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            4 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 3.8815 g
         </span>
     
@@ -2847,6 +3047,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Protéines
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2936,6 +3148,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            1 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 0.532565 g
         </span>
     
@@ -2955,6 +3179,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sodium
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.4 g
         </span>
     
                     </td>
@@ -3009,6 +3245,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Fruits‚ légumes‚ légumes secs
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 37.5 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -2152,6 +2152,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                     Tel que vendu<br>pour 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    Tel que vendu<br>par portion
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -2168,6 +2172,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Énergie
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -2214,6 +2230,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            10 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2228,6 +2256,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Acides gras saturés
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -2274,6 +2314,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            30 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2288,6 +2340,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sucres
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2334,6 +2398,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2348,6 +2424,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Protéines
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2394,6 +2482,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2424,6 +2524,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2438,6 +2550,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Fruits‚ légumes‚ légumes secs
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>
@@ -2513,6 +2637,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                 </th>
                 
                 <th scope="col">
+                    Tel que vendu<br>par portion
+                </th>
+                
+                <th scope="col">
                     Tel que vendu pour 100 g (packaging)
                 </th>
                 
@@ -2536,6 +2664,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Énergie
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -2625,6 +2765,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            10 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 6.47869444444445 g
         </span>
     
@@ -2644,6 +2796,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Acides gras saturés
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -2733,6 +2897,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            30 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 50.5321388888889 g
         </span>
     
@@ -2752,6 +2928,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sucres
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2841,6 +3029,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            2 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 4.06666666666667 g
         </span>
     
@@ -2860,6 +3060,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Protéines
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2949,6 +3161,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          <span
          
          >
+            0.5 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 0.293362222222222 g
         </span>
     
@@ -2968,6 +3192,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Sodium
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
         </span>
     
                     </td>
@@ -3022,6 +3258,18 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
          
          >
             Fruits‚ légumes‚ légumes secs
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/web_html/world-product-content-only.html
+++ b/tests/integration/expected_test_results/web_html/world-product-content-only.html
@@ -1854,6 +1854,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                     As sold<br>for 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -1870,6 +1874,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -1916,6 +1932,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            10 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1930,6 +1958,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -1976,6 +2016,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            30 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1990,6 +2042,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2036,6 +2100,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2050,6 +2126,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2096,6 +2184,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2126,6 +2226,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2140,6 +2252,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>
@@ -2215,6 +2339,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 </th>
                 
                 <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
+                <th scope="col">
                     As sold for 100 g (packaging)
                 </th>
                 
@@ -2238,6 +2366,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -2327,6 +2467,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            10 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 6.47869444444445 g
         </span>
     
@@ -2346,6 +2498,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -2435,6 +2599,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            30 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 50.5321388888889 g
         </span>
     
@@ -2454,6 +2630,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2543,6 +2731,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            2 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 4.06666666666667 g
         </span>
     
@@ -2562,6 +2762,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2651,6 +2863,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            0.5 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 0.293362222222222 g
         </span>
     
@@ -2670,6 +2894,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sodium
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
         </span>
     
                     </td>
@@ -2724,6 +2960,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/web_html/world-product-smoothie.html
+++ b/tests/integration/expected_test_results/web_html/world-product-smoothie.html
@@ -1854,6 +1854,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                     As sold<br>for 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -1870,6 +1874,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -1916,6 +1932,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            10 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1930,6 +1958,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -1976,6 +2016,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            30 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -1990,6 +2042,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2036,6 +2100,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2050,6 +2126,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2096,6 +2184,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2126,6 +2226,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2140,6 +2252,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>
@@ -2215,6 +2339,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 </th>
                 
                 <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
+                <th scope="col">
                     As sold for 100 g (packaging)
                 </th>
                 
@@ -2238,6 +2366,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -2327,6 +2467,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            10 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 6.47869444444445 g
         </span>
     
@@ -2346,6 +2498,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -2435,6 +2599,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            30 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 50.5321388888889 g
         </span>
     
@@ -2454,6 +2630,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2543,6 +2731,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            2 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 4.06666666666667 g
         </span>
     
@@ -2562,6 +2762,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2651,6 +2863,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            0.5 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 0.293362222222222 g
         </span>
     
@@ -2670,6 +2894,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sodium
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
         </span>
     
                     </td>
@@ -2724,6 +2960,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -2146,6 +2146,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                     As sold<br>for 100 g / 100 ml
                 </th>
                 
+                <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
             </tr>
         </thead>
         <tbody>
@@ -2162,6 +2166,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -2208,6 +2224,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            10 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2222,6 +2250,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -2268,6 +2308,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            30 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2282,6 +2334,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2328,6 +2392,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2342,6 +2418,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2388,6 +2476,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            0.5 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2418,6 +2518,18 @@ The score is calculated from the data of the nutrition facts table and the compo
     
                     </td>
                 
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
+        </span>
+    
+                    </td>
+                
             </tr>
             
             <tr>
@@ -2432,6 +2544,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>
@@ -2507,6 +2631,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 </th>
                 
                 <th scope="col">
+                    As sold<br>per serving
+                </th>
+                
+                <th scope="col">
                     As sold for 100 g (packaging)
                 </th>
                 
@@ -2530,6 +2658,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Energy
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            1000 kJ<br>(240 kcal)
         </span>
     
                     </td>
@@ -2619,6 +2759,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            10 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 6.47869444444445 g
         </span>
     
@@ -2638,6 +2790,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Saturated fat
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            5 g
         </span>
     
                     </td>
@@ -2727,6 +2891,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            30 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 50.5321388888889 g
         </span>
     
@@ -2746,6 +2922,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sugars
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            20 g
         </span>
     
                     </td>
@@ -2835,6 +3023,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            2 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 4.06666666666667 g
         </span>
     
@@ -2854,6 +3054,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Proteins
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            3 g
         </span>
     
                     </td>
@@ -2943,6 +3155,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          <span
          
          >
+            0.5 g
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
             ~ 0.293362222222222 g
         </span>
     
@@ -2962,6 +3186,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Sodium
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 0.2 g
         </span>
     
                     </td>
@@ -3016,6 +3252,18 @@ The score is calculated from the data of the nutrition facts table and the compo
          
          >
             Fruits‚ vegetables‚ legumes
+        </span>
+    
+                    </td>
+                
+                    <td >
+                      
+
+     
+         <span
+         
+         >
+            ~ 22.2222222222222 %
         </span>
     
                     </td>

--- a/tests/unit/expected_test_results/display/nutrition-facts-table-liquid.json
+++ b/tests/unit/expected_test_results/display/nutrition-facts-table-liquid.json
@@ -10,6 +10,15 @@
                "preparation" : "as_sold",
                "scope" : "product",
                "short_name" : "100ml"
+            },
+            {
+               "class" : "product",
+               "col_id" : "as_sold_per_serving",
+               "name" : "As sold<br>per serving",
+               "per" : "serving",
+               "preparation" : "as_sold",
+               "scope" : "product",
+               "short_name" : "per serving"
             }
          ],
          "name" : "Nutrition facts"
@@ -18,6 +27,13 @@
       "rows" : [
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:energyPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 kJ<br>(0 kcal)"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -38,6 +54,13 @@
                   "rdfa" : " property=\"food:fatPer100g\" content=\"0\"",
                   "type" : "normal",
                   "value" : "0 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:fatPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
                }
             ],
             "level" : 0,
@@ -46,6 +69,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -66,6 +96,13 @@
                   "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
                   "type" : "normal",
                   "value" : "0 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
                }
             ],
             "level" : 0,
@@ -74,6 +111,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -94,6 +138,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -102,6 +153,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:proteinsPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -122,6 +180,13 @@
                   "rdfa" : " property=\"food:saltPer100g\" content=\"3.75\"",
                   "type" : "normal",
                   "value" : "3.75 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:saltPer100g\" content=\"3.75\"",
+                  "type" : "normal",
+                  "value" : "3.75 g"
                }
             ],
             "level" : 0,
@@ -130,6 +195,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,

--- a/tests/unit/expected_test_results/display/nutrition-facts-table-no-nutrition-data.json
+++ b/tests/unit/expected_test_results/display/nutrition-facts-table-no-nutrition-data.json
@@ -10,6 +10,15 @@
                "preparation" : "as_sold",
                "scope" : "product",
                "short_name" : null
+            },
+            {
+               "class" : "product",
+               "col_id" : "as_sold_per_serving",
+               "name" : "As sold<br>per serving",
+               "per" : "serving",
+               "preparation" : "as_sold",
+               "scope" : "product",
+               "short_name" : "per serving"
             }
          ],
          "name" : "Nutrition facts"
@@ -18,6 +27,13 @@
       "rows" : [
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -38,6 +54,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -46,6 +69,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -66,6 +96,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -74,6 +111,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -94,6 +138,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -102,6 +153,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -122,6 +180,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -130,6 +195,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,

--- a/tests/unit/expected_test_results/display/nutrition-facts-table-pet-food.json
+++ b/tests/unit/expected_test_results/display/nutrition-facts-table-pet-food.json
@@ -10,6 +10,15 @@
                "preparation" : "as_sold",
                "scope" : "product",
                "short_name" : "100g"
+            },
+            {
+               "class" : "product",
+               "col_id" : "as_sold_per_serving",
+               "name" : "As sold<br>per serving",
+               "per" : "serving",
+               "preparation" : "as_sold",
+               "scope" : "product",
+               "short_name" : "per serving"
             }
          ],
          "name" : "Analytical constituents"
@@ -18,6 +27,13 @@
       "rows" : [
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:energyPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 kJ<br>(0 kcal)"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -38,6 +54,13 @@
                   "rdfa" : " property=\"food:fatPer100g\" content=\"2\"",
                   "type" : "normal",
                   "value" : "2 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:fatPer100g\" content=\"2\"",
+                  "type" : "normal",
+                  "value" : "2 g"
                }
             ],
             "level" : 0,
@@ -46,6 +69,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -66,6 +96,13 @@
                   "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
                   "type" : "normal",
                   "value" : "0 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
                }
             ],
             "level" : 0,
@@ -74,6 +111,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -94,6 +138,13 @@
                   "rdfa" : " property=\"food:fiberPer100g\" content=\"0.25\"",
                   "type" : "normal",
                   "value" : "0.25 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:fiberPer100g\" content=\"0.25\"",
+                  "type" : "normal",
+                  "value" : "0.25 g"
                }
             ],
             "level" : 0,
@@ -102,6 +153,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -122,6 +180,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -130,6 +195,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,

--- a/tests/unit/expected_test_results/display/nutrition-facts-table-with-comparisons.json
+++ b/tests/unit/expected_test_results/display/nutrition-facts-table-with-comparisons.json
@@ -21,6 +21,15 @@
                "short_name" : "100g"
             },
             {
+               "class" : "product",
+               "col_id" : "as_sold_per_serving",
+               "name" : "As sold<br>per serving",
+               "per" : "serving",
+               "preparation" : "as_sold",
+               "scope" : "product",
+               "short_name" : "per serving"
+            },
+            {
                "class" : "compare_0",
                "col_id" : "compare_0",
                "name" : "Compared to: Spreads",
@@ -33,6 +42,13 @@
       "rows" : [
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:energyPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 kJ<br>(0 kcal)"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -62,6 +78,13 @@
                   "value" : "0 g"
                },
                {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:fatPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
+               },
+               {
                   "class" : "compare_0",
                   "percent" : null,
                   "rdfa" : "",
@@ -75,6 +98,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -104,6 +134,13 @@
                   "value" : "0 g"
                },
                {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
+               },
+               {
                   "class" : "compare_0",
                   "percent" : null,
                   "rdfa" : "",
@@ -117,6 +154,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -146,6 +190,13 @@
                   "value" : "?"
                },
                {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
+               {
                   "class" : "compare_0",
                   "percent" : null,
                   "rdfa" : "",
@@ -159,6 +210,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -188,6 +246,13 @@
                   "value" : "3.75 g"
                },
                {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:saltPer100g\" content=\"3.75\"",
+                  "type" : "normal",
+                  "value" : "3.75 g"
+               },
+               {
                   "class" : "compare_0",
                   "percent" : null,
                   "rdfa" : "",
@@ -201,6 +266,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,

--- a/tests/unit/expected_test_results/display/nutrition-facts-table.json
+++ b/tests/unit/expected_test_results/display/nutrition-facts-table.json
@@ -10,6 +10,15 @@
                "preparation" : "as_sold",
                "scope" : "product",
                "short_name" : "100g"
+            },
+            {
+               "class" : "product",
+               "col_id" : "as_sold_per_serving",
+               "name" : "As sold<br>per serving",
+               "per" : "serving",
+               "preparation" : "as_sold",
+               "scope" : "product",
+               "short_name" : "per serving"
             }
          ],
          "name" : "Nutrition facts"
@@ -18,6 +27,13 @@
       "rows" : [
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:energyPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 kJ<br>(0 kcal)"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -38,6 +54,13 @@
                   "rdfa" : " property=\"food:fatPer100g\" content=\"0\"",
                   "type" : "normal",
                   "value" : "0 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:fatPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
                }
             ],
             "level" : 0,
@@ -46,6 +69,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -66,6 +96,13 @@
                   "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
                   "type" : "normal",
                   "value" : "0 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:carbohydratesPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
                }
             ],
             "level" : 0,
@@ -74,6 +111,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -94,6 +138,13 @@
                   "rdfa" : "",
                   "type" : "normal",
                   "value" : "?"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
                }
             ],
             "level" : 0,
@@ -102,6 +153,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:proteinsPer100g\" content=\"0\"",
+                  "type" : "normal",
+                  "value" : "0 g"
+               },
                {
                   "class" : "product",
                   "percent" : null,
@@ -122,6 +180,13 @@
                   "rdfa" : " property=\"food:saltPer100g\" content=\"3.75\"",
                   "type" : "normal",
                   "value" : "3.75 g"
+               },
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : " property=\"food:saltPer100g\" content=\"3.75\"",
+                  "type" : "normal",
+                  "value" : "3.75 g"
                }
             ],
             "level" : 0,
@@ -130,6 +195,13 @@
          },
          {
             "columns" : [
+               {
+                  "class" : "product",
+                  "percent" : null,
+                  "rdfa" : "",
+                  "type" : "normal",
+                  "value" : "?"
+               },
                {
                   "class" : "product",
                   "percent" : null,

--- a/tests/unit/expected_test_results/knowledge_panels/en-ingredients-with-added-sugar.json
+++ b/tests/unit/expected_test_results/knowledge_panels/en-ingredients-with-added-sugar.json
@@ -1034,6 +1034,13 @@
                         "text" : "As sold<br>for 100 g / 100 ml",
                         "text_for_small_screens" : "100g",
                         "type" : "text"
+                     },
+                     {
+                        "column_group_id" : "product",
+                        "shown_by_default" : false,
+                        "text" : "As sold<br>per serving",
+                        "text_for_small_screens" : "per serving",
+                        "type" : "text"
                      }
                   ],
                   "id" : "nutrition_facts_table",
@@ -1044,6 +1051,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Energy"
+                           },
+                           {
+                              "text" : "~ 1890 kJ<br>(448 kcal)"
                            },
                            {
                               "text" : "~ 1890 kJ<br>(448 kcal)"
@@ -1059,6 +1069,9 @@
                            },
                            {
                               "text" : "~ 14.0666666666667 g"
+                           },
+                           {
+                              "text" : "~ 14.0666666666667 g"
                            }
                         ]
                      },
@@ -1068,6 +1081,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Saturated fat"
+                           },
+                           {
+                              "text" : "~ 9.27833333333333 g"
                            },
                            {
                               "text" : "~ 9.27833333333333 g"
@@ -1083,6 +1099,9 @@
                            },
                            {
                               "text" : "~ 78.1166666666667 g"
+                           },
+                           {
+                              "text" : "~ 78.1166666666667 g"
                            }
                         ]
                      },
@@ -1092,6 +1111,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Sugars"
+                           },
+                           {
+                              "text" : "~ 66.9383333333333 g"
                            },
                            {
                               "text" : "~ 66.9383333333333 g"
@@ -1107,6 +1129,9 @@
                            },
                            {
                               "text" : "~ 1.13333333333333 g"
+                           },
+                           {
+                              "text" : "~ 1.13333333333333 g"
                            }
                         ]
                      },
@@ -1116,6 +1141,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Proteins"
+                           },
+                           {
+                              "text" : "~ 1.71833333333333 g"
                            },
                            {
                               "text" : "~ 1.71833333333333 g"
@@ -1131,6 +1159,9 @@
                            },
                            {
                               "text" : "~ 0.0246 g"
+                           },
+                           {
+                              "text" : "~ 0.0246 g"
                            }
                         ]
                      },
@@ -1140,6 +1171,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fruits‚ vegetables‚ legumes"
+                           },
+                           {
+                              "text" : "~ 0 %"
                            },
                            {
                               "text" : "~ 0 %"
@@ -1187,6 +1221,11 @@
                         "type" : "text"
                      },
                      {
+                        "text" : "As sold<br>per serving",
+                        "text_for_small_screens" : "per serving",
+                        "type" : "text"
+                     },
+                     {
                         "text" : "As sold for 100 g (estimate)",
                         "text_for_small_screens" : "100g",
                         "type" : "text"
@@ -1200,6 +1239,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Energy"
+                           },
+                           {
+                              "text" : "~ 1890 kJ<br>(448 kcal)"
                            },
                            {
                               "text" : "~ 1890 kJ<br>(448 kcal)"
@@ -1221,6 +1263,9 @@
                            },
                            {
                               "text" : "~ 14.0666666666667 g"
+                           },
+                           {
+                              "text" : "~ 14.0666666666667 g"
                            }
                         ]
                      },
@@ -1230,6 +1275,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Saturated fat"
+                           },
+                           {
+                              "text" : "~ 9.27833333333333 g"
                            },
                            {
                               "text" : "~ 9.27833333333333 g"
@@ -1251,6 +1299,9 @@
                            },
                            {
                               "text" : "~ 78.1166666666667 g"
+                           },
+                           {
+                              "text" : "~ 78.1166666666667 g"
                            }
                         ]
                      },
@@ -1260,6 +1311,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Sugars"
+                           },
+                           {
+                              "text" : "~ 66.9383333333333 g"
                            },
                            {
                               "text" : "~ 66.9383333333333 g"
@@ -1281,6 +1335,9 @@
                            },
                            {
                               "text" : "~ 1.13333333333333 g"
+                           },
+                           {
+                              "text" : "~ 1.13333333333333 g"
                            }
                         ]
                      },
@@ -1290,6 +1347,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Proteins"
+                           },
+                           {
+                              "text" : "~ 1.71833333333333 g"
                            },
                            {
                               "text" : "~ 1.71833333333333 g"
@@ -1311,6 +1371,9 @@
                            },
                            {
                               "text" : "~ 0.0246 g"
+                           },
+                           {
+                              "text" : "~ 0.0246 g"
                            }
                         ]
                      },
@@ -1320,6 +1383,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fruits‚ vegetables‚ legumes"
+                           },
+                           {
+                              "text" : "~ 0 %"
                            },
                            {
                               "text" : "~ 0 %"

--- a/tests/unit/expected_test_results/knowledge_panels/en-nutriscore-serving-size-error.json
+++ b/tests/unit/expected_test_results/knowledge_panels/en-nutriscore-serving-size-error.json
@@ -1525,6 +1525,13 @@
                         "text" : "As sold<br>for 100 g / 100 ml",
                         "text_for_small_screens" : "100g",
                         "type" : "text"
+                     },
+                     {
+                        "column_group_id" : "product",
+                        "shown_by_default" : false,
+                        "text" : "As sold<br>per serving",
+                        "text_for_small_screens" : "per serving",
+                        "type" : "text"
                      }
                   ],
                   "id" : "nutrition_facts_table",
@@ -1535,6 +1542,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Energy"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1550,6 +1560,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1559,6 +1572,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Saturated fat"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1574,6 +1590,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1583,6 +1602,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Sugars"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1598,6 +1620,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1607,6 +1632,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Proteins"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1622,6 +1650,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1631,6 +1662,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fruits‚ vegetables‚ legumes"
+                           },
+                           {
+                              "text" : "~ 100 %"
                            },
                            {
                               "text" : "~ 100 %"
@@ -1678,6 +1712,11 @@
                         "type" : "text"
                      },
                      {
+                        "text" : "As sold<br>per serving",
+                        "text_for_small_screens" : "per serving",
+                        "type" : "text"
+                     },
+                     {
                         "text" : "As sold for 100 g (estimate)",
                         "text_for_small_screens" : "100g",
                         "type" : "text"
@@ -1691,6 +1730,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Energy"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1712,6 +1754,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1721,6 +1766,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Saturated fat"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1742,6 +1790,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1751,6 +1802,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Sugars"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1772,6 +1826,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1781,6 +1838,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Proteins"
+                           },
+                           {
+                              "text" : "?"
                            },
                            {
                               "text" : "?"
@@ -1802,6 +1862,9 @@
                            },
                            {
                               "text" : "?"
+                           },
+                           {
+                              "text" : "?"
                            }
                         ]
                      },
@@ -1811,6 +1874,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fruits‚ vegetables‚ legumes"
+                           },
+                           {
+                              "text" : "~ 100 %"
                            },
                            {
                               "text" : "~ 100 %"

--- a/tests/unit/expected_test_results/knowledge_panels/en-nutrition-facts-added-sugars.json
+++ b/tests/unit/expected_test_results/knowledge_panels/en-nutrition-facts-added-sugars.json
@@ -1032,6 +1032,13 @@
                         "text" : "As sold<br>for 100 g / 100 ml",
                         "text_for_small_screens" : "100g",
                         "type" : "text"
+                     },
+                     {
+                        "column_group_id" : "product",
+                        "shown_by_default" : false,
+                        "text" : "As sold<br>per serving",
+                        "text_for_small_screens" : "per serving",
+                        "type" : "text"
                      }
                   ],
                   "id" : "nutrition_facts_table",
@@ -1042,6 +1049,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Energy"
+                           },
+                           {
+                              "text" : "~ 1890 kJ<br>(448 kcal)"
                            },
                            {
                               "text" : "~ 1890 kJ<br>(448 kcal)"
@@ -1057,6 +1067,9 @@
                            },
                            {
                               "text" : "~ 14.0666666666667 g"
+                           },
+                           {
+                              "text" : "~ 14.0666666666667 g"
                            }
                         ]
                      },
@@ -1066,6 +1079,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Saturated fat"
+                           },
+                           {
+                              "text" : "~ 9.27833333333333 g"
                            },
                            {
                               "text" : "~ 9.27833333333333 g"
@@ -1081,6 +1097,9 @@
                            },
                            {
                               "text" : "~ 78.1166666666667 g"
+                           },
+                           {
+                              "text" : "~ 78.1166666666667 g"
                            }
                         ]
                      },
@@ -1090,6 +1109,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Sugars"
+                           },
+                           {
+                              "text" : "~ 66.9383333333333 g"
                            },
                            {
                               "text" : "~ 66.9383333333333 g"
@@ -1105,6 +1127,9 @@
                            },
                            {
                               "text" : "20 g"
+                           },
+                           {
+                              "text" : "20 g"
                            }
                         ]
                      },
@@ -1114,6 +1139,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fiber"
+                           },
+                           {
+                              "text" : "~ 1.13333333333333 g"
                            },
                            {
                               "text" : "~ 1.13333333333333 g"
@@ -1129,6 +1157,9 @@
                            },
                            {
                               "text" : "~ 1.71833333333333 g"
+                           },
+                           {
+                              "text" : "~ 1.71833333333333 g"
                            }
                         ]
                      },
@@ -1141,6 +1172,9 @@
                            },
                            {
                               "text" : "~ 0.0246 g"
+                           },
+                           {
+                              "text" : "~ 0.0246 g"
                            }
                         ]
                      },
@@ -1150,6 +1184,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fruits‚ vegetables‚ legumes"
+                           },
+                           {
+                              "text" : "~ 0 %"
                            },
                            {
                               "text" : "~ 0 %"
@@ -1197,6 +1234,11 @@
                         "type" : "text"
                      },
                      {
+                        "text" : "As sold<br>per serving",
+                        "text_for_small_screens" : "per serving",
+                        "type" : "text"
+                     },
+                     {
                         "text" : "As sold for 100 g (packaging)",
                         "text_for_small_screens" : "100g",
                         "type" : "text"
@@ -1220,6 +1262,9 @@
                               "text" : "~ 1890 kJ<br>(448 kcal)"
                            },
                            {
+                              "text" : "~ 1890 kJ<br>(448 kcal)"
+                           },
+                           {
                               "text" : "?"
                            },
                            {
@@ -1233,6 +1278,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fat"
+                           },
+                           {
+                              "text" : "~ 14.0666666666667 g"
                            },
                            {
                               "text" : "~ 14.0666666666667 g"
@@ -1256,6 +1304,9 @@
                               "text" : "~ 9.27833333333333 g"
                            },
                            {
+                              "text" : "~ 9.27833333333333 g"
+                           },
+                           {
                               "text" : "?"
                            },
                            {
@@ -1274,6 +1325,9 @@
                               "text" : "~ 78.1166666666667 g"
                            },
                            {
+                              "text" : "~ 78.1166666666667 g"
+                           },
+                           {
                               "text" : "?"
                            },
                            {
@@ -1287,6 +1341,9 @@
                               "level" : 1,
                               "style" : "max-width:15rem",
                               "text" : "Sugars"
+                           },
+                           {
+                              "text" : "~ 66.9383333333333 g"
                            },
                            {
                               "text" : "~ 66.9383333333333 g"
@@ -1313,6 +1370,9 @@
                               "text" : "20 g"
                            },
                            {
+                              "text" : "20 g"
+                           },
+                           {
                               "text" : "~ 66.6666666666667 g"
                            }
                         ]
@@ -1323,6 +1383,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fiber"
+                           },
+                           {
+                              "text" : "~ 1.13333333333333 g"
                            },
                            {
                               "text" : "~ 1.13333333333333 g"
@@ -1346,6 +1409,9 @@
                               "text" : "~ 1.71833333333333 g"
                            },
                            {
+                              "text" : "~ 1.71833333333333 g"
+                           },
+                           {
                               "text" : "?"
                            },
                            {
@@ -1364,6 +1430,9 @@
                               "text" : "~ 0.0246 g"
                            },
                            {
+                              "text" : "~ 0.0246 g"
+                           },
+                           {
                               "text" : "?"
                            },
                            {
@@ -1377,6 +1446,9 @@
                               "level" : 0,
                               "style" : "max-width:15rem",
                               "text" : "Fruits‚ vegetables‚ legumes"
+                           },
+                           {
+                              "text" : "~ 0 %"
                            },
                            {
                               "text" : "~ 0 %"


### PR DESCRIPTION
## What

- Show the per serving nutrition column by default.
- Fall back to the per 100 g / 100 ml values when no per serving nutrition data is available.

## Fixes

Fixes #13466