### PR TITLE
taxonomy: Ice creams

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -68197,6 +68197,10 @@ ciqual_food_code:en: 39512
 ciqual_food_name:en: Frozen dessert, Sundae ice cream type
 ciqual_food_name:fr: Dessert glacé, type sundae
 
+< en: Ice creams and sorbets
+de: Wassereisbecher
+fr: Glaces à l'eau en pot
+
 < en: Frozen desserts
 en: Ice creams and sorbets, Flavoured ice creams, Flavoured sorbets, Flavoured ice pops
 bg: Сладолед и сорбе

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -69271,7 +69271,7 @@ it: Torte e pasticcini congelati
 lt: Šaldyti tortai ir pyragaičiai, šaldyti pyragaičiai
 nl: Diepvriesgebak
 
-< en: Frozen desserts
+< en: Ice creams and sorbets
 en: Mochi ice cream
 es: Helado de mochi
 fr: Mochi glacés

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -68435,14 +68435,22 @@ nl: IJsjesassortimenten
 #description:en:A package with icecream bars with bars with different flavours
 
 < en: Ice cream bars
+en: Non-coated ice cream bars
+fr: Bâtonnets à la crème glacée sans enrobage
+
+< en: Ice cream bars
+en: Coated ice cream bars
+fr: Bâtonnets à la crème glacée enrobés
+
+< en: Coated ice cream bars
 en: Ice cream bars coated with fat-reduced cocoa
 fr: Bâtonnets glacés enrobés de cacao maigre
 
-< en: Ice cream bars
+< en: Coated ice cream bars
 en: Ice cream bars coated with fruit sorbet
 fr: Bâtonnets glacés enrobés de sorbet aux fruits
 
-< en: Ice cream bars
+< en: Coated ice cream bars
 en: Ice cream bars coated with chocolate, Chocolate ice cream bars, Chocolate ice creams on a stick, Ice cream on stick with chocolate coating
 de: Eis am Stiel überzogen mit Schokolade, Schokoladeneis am Stiel, Stieleis Schokolade
 es: Helados de palo de chocolate, Polos de chocolate, Paletas de chocolate
@@ -68548,6 +68556,10 @@ en: Chocolate-Mint ice cream cones
 fr: Cônes menthe chocolat, Cônes chocolat menthe
 hr: Korneti sladoleda čokolada-menta
 lt: Šokolado-mėtų ledai vafliniame ragelyje
+
+< en: Ice cream cones
+en: Rum and raisins ice cream cones
+fr: Cônes rhum et raisins
 
 < en: Ice cream cones
 en: Mini ice cream cone
@@ -122558,7 +122570,7 @@ hr: Smrznute šipke
 nl: IJsrepen
 
 < en: Bars
-< en: Ice creams
+< en: Ice creams and sorbets
 en: Ice cream candy chocolate bars, Frozen candy chocolate bars, Chocolate coated ice cream
 fr: Barres chocolatées glacées, Barre glacée chocolatée
 hr: Smrznute bombone čokoladice


### PR DESCRIPTION
* created coated ice cream bars and non-coated ice cream bars to differentiate this kind of product: https://world.openfoodfacts.org/product/4044564752803/hexen-zauber-hexen-eis from this one https://world.openfoodfacts.org/product/20548445/gelatelli-pistazie-eis
* created rum and raisins ice cream cones
* moved "Ice cream candy chocolate bars" out of "Ice creams", they generally only have around 50-60% ice cream only, which is less than "Baked Alaska" for example, and similar to "mochi ice creams"
* Moved "mochi ice creams" from "frozen desserts" to "ice creams and sorbets" since it is ice cream-based
* created a category for "Wassereisbecher" (which could be translated as "ice pop tubs or water ice tubs) for water-based ice cream sold in Germany

