### PR TITLE
fix: skip energy computation when macronutrients are empty strings

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9555,6 +9555,13 @@ CSS
 							if (($formatted_value . ' ') =~ /e/) {
 								# use %f (outputs extras 0 in the general case)
 								$formatted_value = sprintf("%f", $value);
+							} else {
+								# Round numeric values to 1 decimal place to avoid 
+								# ugly calculated values like 16.6666666667 (Issue #14035)
+								if ($formatted_value =~ /^-?\d+\.\d+$/) {
+									require ProductOpener::Numbers;
+									$formatted_value = ProductOpener::Numbers::round_to_max_decimal_places($formatted_value, 1) // $formatted_value;
+								}
 							}
 						}
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9558,9 +9558,17 @@ CSS
 							} else {
 								# Round numeric values to 1 decimal place to avoid 
 								# ugly calculated values like 16.6666666667 (Issue #14035)
-								if ($formatted_value =~ /^-?\d+\.\d+$/) {
+								if ($formatted_value =~ /^-?\d+\.\d{3,}$/) {
+									my $decimals = 1;
+									if (abs($formatted_value) < 1 && abs($formatted_value) > 0) {
+										if ($formatted_value =~ /\.(0+)/) {
+											$decimals = length($1) + 2;
+										} else {
+											$decimals = 2;
+										}
+									}
 									require ProductOpener::Numbers;
-									$formatted_value = ProductOpener::Numbers::round_to_max_decimal_places($formatted_value, 1) // $formatted_value;
+									$formatted_value = ProductOpener::Numbers::round_to_max_decimal_places($formatted_value, $decimals) // $formatted_value;
 								}
 							}
 						}

--- a/lib/ProductOpener/Nutrition.pm
+++ b/lib/ProductOpener/Nutrition.pm
@@ -2602,9 +2602,9 @@ sub compute_energy_from_nutrients_for_nutrients_set ($nutrients_ref, $unit) {
 	my $proteins_value = deep_get($nutrients_ref, "proteins", "value");
 	# We need at a minimum carbohydrates, fat and proteins to be defined to compute
 	# energy.
-	if (    (defined $carbohydrates_value)
-		and (defined $fat_value)
-		and (defined $proteins_value))
+	if (    (defined $carbohydrates_value) and ($carbohydrates_value ne "")
+		and (defined $fat_value) and ($fat_value ne "")
+		and (defined $proteins_value) and ($proteins_value ne ""))
 	{
 
 		foreach my $nid (keys %{$energy_from_nutrients{europe}}) {


### PR DESCRIPTION
Fixes #14062

**Description**
When a product has missing macronutrients (fat, proteins, carbohydrates), they are sometimes saved as empty strings (`""`). Previously, the energy calculation logic in `Nutrition.pm` only checked if these values were `defined`. Since an empty string is considered defined in Perl, it treated the missing values as `0`, computing the energy as `0 kcal`. This caused a false positive data quality error (`energy value does not match value computed from other nutrients`) when the user had explicitly entered a non-zero energy value.

This PR updates the condition to ensure the macronutrients are both defined and not empty strings before attempting to compute the energy.