### PR TITLE
fix: make ingredient list more legible

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -938,6 +938,12 @@ html[dir="rtl"] {
   font-size: 0.8em;
 }
 
+/* increased line-height for better legibility of ingredients list */
+.panel_ingredients_text {
+  line-height: 1.6;
+  font-size: 1.05em;
+}
+
 .ecoscore_panel {
   border-radius: 1rem;
 }

--- a/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
@@ -17,7 +17,7 @@
         {
             "element_type": "text",
             "text_element": {
-                "html": `[% panel.ingredients_text_with_allergens %]`,
+                "html": `<div class="panel_ingredients_text">[% panel.ingredients_text_with_allergens %]</div>`,
                 "lc": "[% panel.ingredients_text_lc %]",
                 "language": "[% panel.ingredients_text_language %]",
                 "edit_field_type": "ingredients_text",


### PR DESCRIPTION
Fixes #14083

This PR improves the legibility of the ingredients list in the Knowledge Panel by wrapping it in a `.panel_ingredients_text` class and slightly increasing the `line-height` and `font-size`.

This creates a more comfortable reading experience for users, especially on smaller screens or when the ingredient list is very dense.