### PR TITLE
fix: nutrition image overlap on adding nutrients (#14053)

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -888,6 +888,7 @@ $(function () {
         const inputRow = $('#add_nutrient_tr');
         nutrientRow.insertBefore(inputRow);
         nutrientRow.show();
+        update_nutrition_image_copy(); 
 
         // remove the selected nutrient from the other_nutrients array
         other_nutrients = other_nutrients.filter(function (item) {


### PR DESCRIPTION
## What
Fixes #14053 — the nutrition image copy on the product edit page overlapped the nutrition table when new nutrients were added.

## Root cause
`update_nutrition_image_copy()` in `html/js/product-multilingual.js` recalculates the image's position/visibility based on the live table width, but it was only called on page load and window resize — never after a nutrient row was added via the "Add a nutrient" dropdown. This left the image at a stale position while the table grew wider underneath it.

## Fix
Added a call to `update_nutrition_image_copy()` inside the `select2:select` handler, right after the new nutrient row is inserted and shown.

## Testing
- Added multiple nutrients on a product with an uploaded nutrition photo
- Confirmed the image repositions correctly when there's enough space
- Confirmed the image hides gracefully (existing threshold logic) when the table grows too wide
- Verified no overlap in either case, at both normal and narrow window widths

## Screenshots

-Before
<img width="771" height="685" alt="625531149-2bc932fb-ee1d-402e-a536-534bbaa35b43" src="https://github.com/user-attachments/assets/24f3eecf-e66c-466b-8a3f-24424ecb6b86" />

-After
<img width="743" height="790" alt="Screenshot 2026-07-28 at 2 56 45 PM" src="https://github.com/user-attachments/assets/ed71d11d-269f-4e1c-b143-4ebfefa4fa46" />

<img width="1124" height="746" alt="Screenshot 2026-07-28 at 2 50 20 PM" src="https://github.com/user-attachments/assets/ee432bc4-3419-462a-89ac-a4d25f46a7fb" />



