### PR TITLE
fix: use localized F-Droid badges

### DIFF
--- a/po/common/am.po
+++ b/po/common/am.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-am.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -7640,7 +7640,7 @@ msgstr "هل الرمز الشريطي {barcode} خاص بمنتج لديك؟ إ
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ar.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/az.po
+++ b/po/common/az.po
@@ -7642,7 +7642,7 @@ msgstr "{barcode} sizin məhsulunuzun barkoddurmu? Əgər belədirsə, zəhmət 
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-az.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/be.po
+++ b/po/common/be.po
@@ -7626,7 +7626,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-be.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -7642,7 +7642,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-bg.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-bn.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/bs.po
+++ b/po/common/bs.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-bs.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -7642,7 +7642,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ca.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/cy.po
+++ b/po/common/cy.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-cy.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -7640,7 +7640,7 @@ msgstr "Er {barcode} stregkoden for et produkt, du har? Hvis ja, bedes du tilfø
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-da.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -7641,7 +7641,7 @@ msgstr "Είναι το {barcode} ο γραμμωτός κώδικας ενός 
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-el.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -7642,7 +7642,7 @@ msgstr "Is {barcode} the barcode of a product you have? If so, please add it to 
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-en-au.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -7642,7 +7642,7 @@ msgstr "Is {barcode} the barcode of a product you have? If so, please add it to 
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-en-gb.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/eo.po
+++ b/po/common/eo.po
@@ -7642,7 +7642,7 @@ msgstr "Ĉu {barcode} estas la strekkodo de produkto, kiun vi havas? Se jes, bon
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/bildoj/misc/f-droid/svg/get-it-on-eo.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-eo.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -7639,7 +7639,7 @@ msgstr "¿Es {barcode} el código de barras de un producto que tienes? Si es as�
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-es.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/et.po
+++ b/po/common/et.po
@@ -7632,7 +7632,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-et.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-eu.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -7641,7 +7641,7 @@ msgstr "آیا {barcode} بارکد محصولی است که دارید؟ اگر
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-fa.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -7640,7 +7640,7 @@ msgstr "Onko {barcode} tuotteesi viivakoodi? Jos se on, lisääthän sen tietoka
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-XX.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-fi.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -7644,7 +7644,7 @@ msgstr "Est-ce que {barcode} est le code-barres d'un produit que vous avez ? Si 
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-fr.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ga.po
+++ b/po/common/ga.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ga.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/gd.po
+++ b/po/common/gd.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-gd.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/gl.po
+++ b/po/common/gl.po
@@ -7624,7 +7624,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-gl.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/gu.po
+++ b/po/common/gu.po
@@ -7625,7 +7625,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-gu.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -7640,7 +7640,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-he.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/hi.po
+++ b/po/common/hi.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-hi.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/hr.po
+++ b/po/common/hr.po
@@ -7642,7 +7642,7 @@ msgstr "Je li {barcode} barkod proizvoda koji imate? Ako jest, dodajte ga u bazu
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-hr.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/hy.po
+++ b/po/common/hy.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-hy.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/id.po
+++ b/po/common/id.po
@@ -7640,7 +7640,7 @@ msgstr "Apakah {barcode} adalah kode batang dari produk yang Anda miliki? Jika y
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-id.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/is.po
+++ b/po/common/is.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-is.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -7640,7 +7640,7 @@ msgstr "{barcode} はお持ちの商品のバーコードですか？もしそ�
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ja.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ka.po
+++ b/po/common/ka.po
@@ -7639,7 +7639,7 @@ msgstr "{barcode} თქვენი პროდუქტის შტრიხ
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ka.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/kk.po
+++ b/po/common/kk.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-kk.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/km.po
+++ b/po/common/km.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-km.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/kn.po
+++ b/po/common/kn.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-kn.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -7640,7 +7640,7 @@ msgstr "{barcode} 이 보유하신 제품의 바코드인가요? 그렇다면 �
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ko.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ky.po
+++ b/po/common/ky.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ky.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/lb.po
+++ b/po/common/lb.po
@@ -7624,7 +7624,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-lb.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-lo.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/lt.po
+++ b/po/common/lt.po
@@ -7639,7 +7639,7 @@ msgstr "Ar {barcode} yra jūsų turimo produkto brūkšninis kodas? Jei taip, pr
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-lt.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/lv.po
+++ b/po/common/lv.po
@@ -7637,7 +7637,7 @@ msgstr "Vai {barcode} ir jūsu produkta svītrkods? Ja tā, lūdzu, pievienojiet
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-lv.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ml.po
+++ b/po/common/ml.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ml.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/mn.po
+++ b/po/common/mn.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-mn.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/mr.po
+++ b/po/common/mr.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-mr.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -7640,7 +7640,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ms.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/my.po
+++ b/po/common/my.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-my.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ne.po
+++ b/po/common/ne.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ne.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/nl.po
+++ b/po/common/nl.po
@@ -7547,7 +7547,7 @@ msgstr "Is {barcode} de streepjescode van een product dat u heeft? Zo ja, voeg d
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-nl.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/nn.po
+++ b/po/common/nn.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-nn.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/no.po
+++ b/po/common/no.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-no.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/pa.po
+++ b/po/common/pa.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-pa.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -7641,7 +7641,7 @@ msgstr "Czy {barcode} to kod kreskowy produktu, który posiadasz? Jeśli tak, do
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-pl.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/pt.po
+++ b/po/common/pt.po
@@ -7546,7 +7546,7 @@ msgstr "O {barcode} é o código de barras de um produto que possui? Se sim, adi
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-pt.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -7639,7 +7639,7 @@ msgstr "{barcode} é o código de barras de um produto que você possui? Se sim,
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-pt-br.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -7639,7 +7639,7 @@ msgstr "Este {barcode} codul de bare al unui produs pe care îl aveți? Dacă da
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ro.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -7643,7 +7643,7 @@ msgstr "{barcode} Штрихкод продукта, который у вас е
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ru.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/si.po
+++ b/po/common/si.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-si.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -7640,7 +7640,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-sk.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -7637,7 +7637,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-sl.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/sq.po
+++ b/po/common/sq.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-sq.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/sr.po
+++ b/po/common/sr.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-sr.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -7642,7 +7642,7 @@ msgstr "Är {barcode} streckkoden för en produkt du har? Om så är fallet, vä
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-sv.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/sw.po
+++ b/po/common/sw.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-sw.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ta.po
+++ b/po/common/ta.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ta.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/te.po
+++ b/po/common/te.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-te.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -7640,7 +7640,7 @@ msgstr "{barcode} เป็นบาร์โค้ดของผลิตภ�
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-th.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -7638,7 +7638,7 @@ msgstr "{barcode} sahip olduğunuz bir ürünün barkodu mu? Öyleyse, lütfen v
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-tr.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -7654,7 +7654,7 @@ msgstr "Чи є {barcode} штрих-кодом товару? Якщо так, �
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-ua.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/ur.po
+++ b/po/common/ur.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-ur.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -7623,7 +7623,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-uz.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -7641,7 +7641,7 @@ msgstr "{barcode} có phải là mã vạch của sản phẩm bạn đang bán 
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr "/images/misc/f-droid/svg/get-it-on-en.svg"
+msgstr "/images/misc/f-droid/svg/get-it-on-vi.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -7634,7 +7634,7 @@ msgstr "{barcode} 是您产品的条形码吗？如果是，请将其添加到�
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-zh-cn.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -7631,7 +7631,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-zh-hk.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -7637,7 +7637,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-zh-tw.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/po/common/zu.po
+++ b/po/common/zu.po
@@ -7622,7 +7622,7 @@ msgstr ""
 # Please change get-it-on-en.svg to get-it-on-XX.svg. check the url https://static.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-XX.svg
 msgctxt "f_droid_app_icon_url"
 msgid "/images/misc/f-droid/svg/get-it-on-en.svg"
-msgstr ""
+msgstr "/images/misc/f-droid/svg/get-it-on-zu.svg"
 
 msgctxt "f_droid_app_icon_alt_text"
 msgid "Available on F-Droid"

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
@@ -501,7 +501,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -477,7 +477,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -537,7 +537,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"><img src="//static.openfoodfacts.org/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_Spanish.svg" alt="Disponible en Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible en F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-es.svg" alt="Disponible en F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -998,7 +998,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -998,7 +998,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -998,7 +998,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -578,7 +578,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"><img src="//static.openfoodfacts.org/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_Spanish.svg" alt="Disponible en Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible en F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-es.svg" alt="Disponible en F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="Android APK" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -518,7 +518,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -761,7 +761,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -532,7 +532,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -34389,7 +34389,7 @@ Vous acceptez d'être crédité par les ré-utilisateurs par un lien vers le pro
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -745,7 +745,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -518,7 +518,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -6603,7 +6603,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -6851,7 +6851,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -6574,7 +6574,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -2167,7 +2167,7 @@ sur les deux axes pour obtenir un nuage de produits.</p>
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -607,7 +607,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -607,7 +607,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -607,7 +607,7 @@
 								<!-- android_app_link - //play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=en -->
 								<a  href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner&utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_fr"><img src="/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_French.svg" alt="Disponible sur Google Play" loading="lazy" height="40" width="120"></a>
 
-								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-en.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
+								<a href="//f-droid.org/packages/openfoodfacts.github.scrachx.openfood"><img src="/images/misc/f-droid/svg/get-it-on-fr.svg" alt="Disponible sur F-Droid" loading="lazy" height="40" width="120"></a>
 
 								<!-- android_apk_app_link - //world.openfoodfacts.org/images/apps/off.apk -->
 								<a href="//github.com/openfoodfacts/smooth-app/releases/latest?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_fr"><img src="/images/misc/app-landing-page/download-apk/download-apk_en.svg" alt="APK Android" loading="lazy" height="40" width="120"></a>

--- a/tests/unit/expected_test_results/taxonomies/eurocodes.csv
+++ b/tests/unit/expected_test_results/taxonomies/eurocodes.csv
@@ -70,7 +70,7 @@ eurocode_2_group_2	eurocode_2_group_3	ingredient
 8.15	8.15.20	en:cabbage
 8.15	8.15.20	en:savoy-cabbage
 8.15	8.15.24	en:red-cabbage
-8.15	8.15.28	en:napa-cabbage
+8.15	8.15.28	en:chinese-cabbage
 8.15	8.15.28	en:pak-choi
 8.15	8.15.40	en:brussels-sprouts
 8.15	8.15.50	en:kohlrabi


### PR DESCRIPTION
Fixes #14104

This PR updates the PO translations to use the localized F-Droid SVG badges instead of falling back to the English version (`get-it-on-en.svg`) in all languages. The SVGs were already present in the repository, but the PO files still contained empty or `-en` fallback strings. This script maps each PO file to its corresponding `-<lang>.svg` file.