### PR TITLE
feat: add density to ingredients for volume quantity conversions to g - WIP

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -122,7 +122,7 @@ use ProductOpener::Products qw/remove_fields/;
 use ProductOpener::URL qw/:all/;
 use ProductOpener::Images qw/extract_text_from_image/;
 use ProductOpener::Lang qw/$lc %Lang lang/;
-use ProductOpener::Units qw/normalize_quantity/;
+use ProductOpener::Units qw/normalize_quantity get_standard_unit/;
 use ProductOpener::Food qw/is_fat_oil_nuts_seeds_for_nutrition_score/;
 use ProductOpener::APIProductServices qw/add_product_data_from_external_service/;
 use ProductOpener::Nutrition qw/get_non_estimated_nutrient_per_100g_or_100ml_for_preparation/;
@@ -847,14 +847,14 @@ sub parse_specific_ingredients_from_text ($product_ref, $text, $percent_or_quant
 			# Add percent and quantity fields
 
 			if (defined $percent_or_quantity_value) {
-				my ($percent, $quantity, $quantity_g)
-					= get_percent_or_quantity_and_normalized_quantity($percent_or_quantity_value,
-					$percent_or_quantity_unit);
+				my ($percent, $quantity, $quantity_g, $quantity_ml)
+					= get_ingredient_percent_or_quantity_and_normalized_quantity($ingredient_id,
+					$percent_or_quantity_value, $percent_or_quantity_unit);
 
 				defined $percent and $specific_ingredients_ref->{percent} = $percent + 0;
 				defined $quantity and $specific_ingredients_ref->{quantity} = $quantity;
 				defined $quantity_g and $specific_ingredients_ref->{quantity_g} = $quantity_g + 0;
-
+				defined $quantity_ml and $specific_ingredients_ref->{quantity_ml} = $quantity_ml + 0;
 			}
 
 			# Add origin field
@@ -1442,11 +1442,13 @@ sub get_or_select_ingredients_lc ($product_ref) {
 	return $product_ref->{ingredients_lc} || select_ingredients_lc($product_ref);
 }
 
-=head2 get_percent_or_quantity_and_normalized_quantity($percent_or_quantity_value, $percent_or_quantity_unit)
+=head2 get_ingredient_percent_or_quantity_and_normalized_quantity($ingredient_id, $percent_or_quantity_value, $percent_or_quantity_unit)
 
 Used to assign percent or quantity for strings parsed with $percent_or_quantity_regexp.
 
 =head3 Arguments
+
+=head3 ingredient_id Canonical id of the ingredient in the ingredients taxonomy. Needed to get density for liquids.
 
 =head4 percent_or_quantity_value
 
@@ -1464,7 +1466,12 @@ If the unit is not %, quantity is a concatenation of the quantity value and unit
 
 =head4 quantity_g
 
-Normalized quantity in grams.
+Normalized quantity in grams. For liquids, this is derived from quantity_ml.
+We default to a density of 1g per ml unless the ingredient has the density_g_per_ml:en: property defined.
+
+=head4 quantity_ml
+
+Normalized quantity in ml.
 
 =head3 Example
 
@@ -1475,23 +1482,38 @@ if ($ingredient =~ /\s$percent_or_quantity_regexp$/i) {
 	$percent_or_quantity_unit = $2;
 
 	my ($percent, $quantity, $quantity_g)
-		= get_percent_or_quantity_and_normalized_quantity($percent_or_quantity_value, $percent_or_quantity_unit);
+		= get_ingredient_percent_or_quantity_and_normalized_quantity($percent_or_quantity_value, $percent_or_quantity_unit);
 
 =cut
 
-sub get_percent_or_quantity_and_normalized_quantity ($percent_or_quantity_value, $percent_or_quantity_unit) {
+sub get_ingredient_percent_or_quantity_and_normalized_quantity ($ingredient_id, $percent_or_quantity_value,
+	$percent_or_quantity_unit)
+{
 
-	my ($percent, $quantity, $quantity_g);
+	my ($percent, $quantity, $quantity_g, $quantity_ml);
 
 	if ($percent_or_quantity_unit =~ /\%/) {
 		$percent = $percent_or_quantity_value;
 	}
 	else {
 		$quantity = $percent_or_quantity_value . " " . $percent_or_quantity_unit;
-		$quantity_g = normalize_quantity($quantity);
+		my $standard_unit = get_standard_unit($percent_or_quantity_unit);
+		if (defined $standard_unit) {
+			my $normalized_quantity = normalize_quantity($quantity);
+			if ($standard_unit eq 'g') {
+				$quantity_g = $normalized_quantity;
+			}
+			elsif ($standard_unit eq 'ml') {
+				$quantity_ml = $normalized_quantity;
+				# Check if the ingredient or its parent have the density_g_per_ml:en property
+				my $ingredient_density
+					= get_inherited_property("ingredients", $ingredient_id, "density_g_per_ml:en") || 1;
+				$quantity_g = $quantity_ml * $ingredient_density;
+			}
+		}
 	}
 
-	return ($percent, $quantity, $quantity_g);
+	return ($percent, $quantity, $quantity_g, $quantity_ml);
 }
 
 =head2 parse_ingredients_text_service ( $product_ref, $updated_product_fields_ref, $errors_ref )
@@ -2809,18 +2831,14 @@ Text to analyze
 				$ingredient{is_in_taxonomy} = $is_in_taxonomy;
 
 				if (defined $percent_or_quantity_value) {
-					my ($percent, $quantity, $quantity_g)
-						= get_percent_or_quantity_and_normalized_quantity($percent_or_quantity_value,
-						$percent_or_quantity_unit);
-					if (defined $percent) {
-						$ingredient{percent} = $percent + 0;
-					}
-					if (defined $quantity) {
-						$ingredient{quantity} = $quantity;
-					}
-					if (defined $quantity_g) {
-						$ingredient{quantity_g} = $quantity_g;
-					}
+					my ($percent, $quantity, $quantity_g, $quantity_ml)
+						= get_ingredient_percent_or_quantity_and_normalized_quantity($ingredient_id,
+						$percent_or_quantity_value, $percent_or_quantity_unit);
+
+					defined $percent and $ingredient{percent} = $percent + 0;
+					defined $quantity and $ingredient{quantity} = $quantity;
+					defined $quantity_g and $ingredient{quantity_g} = $quantity_g + 0;
+					defined $quantity_ml and $ingredient{quantity_ml} = $quantity_ml + 0;
 				}
 				if (defined $origin) {
 					$ingredient{origins} = $origin;

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -14734,11 +14734,9 @@ zh: 油
 # yue:油
 # zh-hans:油
 # zh-hant:油
+density_g_per_ml:en: 0.92
 wikidata:en: Q42962
 wikipedia:en: https://en.wikipedia.org/wiki/Cooking_oil
-
-# description:en:Hydrogenation converts liquid vegetable oils into solid or semi-solid fats, such as those present in margarine. Changing the degree of saturation of the fat changes some important physical properties, such as the melting range, which is why liquid oils become semi-solid.
-
 
 # nova:en:hydrogenated-oil
 # processing:en: en:hydrogenated
@@ -14754,6 +14752,7 @@ hu: hidrogénezett olaj
 it: olio idrogenato
 nb: hydrogenert olje
 nl: Gehydrogeneerde olie
+description:en: Hydrogenation converts liquid vegetable oils into solid or semi-solid fats, such as those present in margarine. Changing the degree of saturation of the fat changes some important physical properties, such as the melting range, which is why liquid oils become semi-solid.
 wikidata:en: Q57656844
 wikipedia:en: https://en.wikipedia.org/wiki/Hydrogenation#Food_industry
 # ingredient/hydrogenated-oil has 283 products in 9 languages @2019-07-10

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -19,7 +19,6 @@
 # vegetarian:en     can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
 # from_palm_oil:en  can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
 
-
 # density_g_per_ml:en:  Used to compute weight for ingredients indicated by volume (e.g. 5cl sunflower oil, 1L milk)
 # unless otherwise noted, densities listed come from https://www.fao.org/fileadmin/templates/food_composition/documents/density_DB_v2_0_01.pdf
 # only densities significantly different from 1 are included, as there is often a lot of variation in densities in different sources
@@ -15294,7 +15293,6 @@ tr: Bitkisel yağ
 uk: Рослинні жири й олії
 vi: Dầu thực vật
 zh: 植物油
-# ingredient/vegetable oil has 103341 products @2019-07-10
 density_g_per_ml:en: 0.92
 # roa-rup:Untulemnu
 # sco:Vegetable ile
@@ -38672,8 +38670,6 @@ ro: Suc de fructe
 ru: Фруктовый сок
 sv: Fruktjuice
 uk: Фруктовий сік
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruits
-# 1687 products in 6 languages @2018-10-04
 density_g_per_ml:en: 1.06
 vegan:en: yes
 vegetarian:en: yes

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -19,6 +19,11 @@
 # vegetarian:en     can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
 # from_palm_oil:en  can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
 
+
+# density_g_per_ml:en:  Used to compute weight for ingredients indicated by volume (e.g. 5cl sunflower oil, 1L milk)
+# unless otherwise noted, densities listed come from https://www.fao.org/fileadmin/templates/food_composition/documents/density_DB_v2_0_01.pdf
+# only densities significantly different from 1 are included, as there is often a lot of variation in densities in different sources
+
 ## Eurocode properties
 
 # e.g. for palm heart
@@ -2836,6 +2841,7 @@ carbon_footprint_fr_foodges_value:fr: 1.2
 ciqual_proxy_food_code:en: 19051
 ciqual_proxy_food_name:en: Milk, skimmed, pasteurised
 ciqual_proxy_food_name:fr: Lait écrémé, pasteurisé
+density_g_per_ml:en: 1.03
 ecobalyse:en: 8f3863e7-f981-4367-90a2-e1aaa096a6e0
 ecobalyse_labels_en_organic:en: 2bf307e8-8cb0-400b-a4f1-cf615d9e96f4
 vegan:en: no
@@ -15288,10 +15294,11 @@ tr: Bitkisel yağ
 uk: Рослинні жири й олії
 vi: Dầu thực vật
 zh: 植物油
+# ingredient/vegetable oil has 103341 products @2019-07-10
+density_g_per_ml:en: 0.92
 # roa-rup:Untulemnu
 # sco:Vegetable ile
 wikipedia:en: https://en.wikipedia.org/wiki/Vegetable_oil
-# ingredient/vegetable oil has 103341 products @2019-07-10
 
 < en: vegetable oil
 fr: huile végétale raffinée
@@ -15938,6 +15945,7 @@ tr: palmiye yağı ve yağ
 uk: Пальмова олія і жири
 ciqual_proxy_food_code:en: 16129
 ciqual_proxy_food_name:en: Palm oil
+density_g_per_ml:en: 0.89
 ecobalyse:en: 45658c32-66d9-4305-a34b-21d6a4cef89c
 from_palm_oil:en: yes
 
@@ -17976,6 +17984,7 @@ vi: Dầu hướng dương
 zh: 葵花籽植物油
 ciqual_food_code:en: 17440
 ciqual_food_name:en: Sunflower oil
+density_g_per_ml:en: 0.96
 description:en: SUNFLOWER OIL is the non-volatile oil pressed from the seeds of sunflower (Helianthus annuus).
 ecobalyse:en: 3cfab110-363e-442a-9170-1af337fe9ea3
 ecobalyse_labels_en_organic:en: 64fb23f2-0cac-403c-bbfa-1973c9a0ea40
@@ -28048,6 +28057,8 @@ carbon_footprint_fr_foodges_value:fr: 1.2
 # this better reflects what is used in practice
 ciqual_proxy_food_code:en: 9435
 ciqual_proxy_food_name:fr: Farine de blé
+# density of flour varies a lot depending on sources, even for a specific type of flour like wheat flour. 0.6 is a rough average from https://www.fao.org/fileadmin/templates/food_composition/documents/density_DB_v2_0_01.pdf
+density_g_per_ml:en: 0.6
 #ciqual_proxy_food_code:en: 9410
 #ciqual_proxy_food_name:fr: Farine de blé tendre ou froment T110
 # Ecobalyse flour is Wheat flour at industrial mill
@@ -31671,6 +31682,8 @@ ciqual_proxy_food_code:en: 31016
 ciqual_proxy_food_name:en: Sugar, white
 ciqual_proxy_food_name:fr: Sucre blanc
 comment:en: Generic sugar is vegan:maybe because some cane sugar is refined using bone char (charred cattle bones) as a decolorizing filter. This is primarily a North American practice. Beet sugar, organic sugar, and unrefined sugars never use bone char. Vegetarian status remains yes as bone char is a processing aid and the final product contains no animal-derived material.
+# density of sugar varies a lot depending on sources. 0.9 is one of the values from https://www.fao.org/fileadmin/templates/food_composition/documents/density_DB_v2_0_01.pdf
+density_g_per_ml:en: 0.9
 ecobalyse:en: 8f075c25-9ebf-430c-b41d-51d165c6e0d8
 vegan:en: maybe
 vegetarian:en: yes
@@ -38659,11 +38672,12 @@ ro: Suc de fructe
 ru: Фруктовый сок
 sv: Fruktjuice
 uk: Фруктовий сік
+# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruits
+# 1687 products in 6 languages @2018-10-04
+density_g_per_ml:en: 1.06
 vegan:en: yes
 vegetarian:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Juice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruits
-# 1687 products in 6 languages @2018-10-04
 
 < en: fruit juice
 en: berry juice

--- a/taxonomies/units.txt
+++ b/taxonomies/units.txt
@@ -626,6 +626,16 @@ it: cucchiaino metrico
 conversion_factor:en: 5
 standard_unit:en: ml
 
+# US legal cup (used in nutrition facts) is 240ml, different from the metric cup 250ml used in Canada, Australia, New-Zealand etc.
+# and from the traditional US cup
+# for "cups", we default to US legal cups.
+en: cup, cups
+es: taza, tazas
+fr: tasse, tasses
+it: tazza, tazze
+conversion_factor:en: 240
+standard_unit:en: ml
+
 # Fluid ounces
 xx: fl oz, floz, fl.oz, fl. oz, fl. oz., fl.oz., OZA
 en: fluid ounce, fluid ounces

--- a/taxonomies/units.txt
+++ b/taxonomies/units.txt
@@ -639,6 +639,7 @@ en: pinch, pinches
 fr: pincée, pincées
 conversion_factor:en: 1
 description:en: There is no universal definition of the weight or volume of a pinch, but for salt and spices, 1g is a common conversion factor.
+standard_unit:en: g
 
 # Fluid ounces
 xx: fl oz, floz, fl.oz, fl. oz, fl. oz., fl.oz., OZA

--- a/taxonomies/units.txt
+++ b/taxonomies/units.txt
@@ -635,6 +635,11 @@ conversion_factor:en: 240
 description:en: US legal cup (used in nutrition facts) is 240ml, different from the US customary cup (8 fluid ounces, about 237ml) and the metric cup (250ml) used in Canada, Australia, South-Africa etc.
 standard_unit:en: ml
 
+en: pinch, pinches
+fr: pincée, pincées
+conversion_factor:en: 1
+description:en: There is no universal definition of the weight or volume of a pinch, but for salt and spices, 1g is a common conversion factor.
+
 # Fluid ounces
 xx: fl oz, floz, fl.oz, fl. oz, fl. oz., fl.oz., OZA
 en: fluid ounce, fluid ounces

--- a/taxonomies/units.txt
+++ b/taxonomies/units.txt
@@ -626,14 +626,13 @@ it: cucchiaino metrico
 conversion_factor:en: 5
 standard_unit:en: ml
 
-# US legal cup (used in nutrition facts) is 240ml, different from the metric cup 250ml used in Canada, Australia, New-Zealand etc.
-# and from the traditional US cup
 # for "cups", we default to US legal cups.
 en: cup, cups
 es: taza, tazas
 fr: tasse, tasses
 it: tazza, tazze
 conversion_factor:en: 240
+description:en: US legal cup (used in nutrition facts) is 240ml, different from the US customary cup (8 fluid ounces, about 237ml) and the metric cup (250ml) used in Canada, Australia, South-Africa etc.
 standard_unit:en: ml
 
 # Fluid ounces

--- a/tests/unit/expected_test_results/ingredients/en-ingredients-with-a-specific-density.json
+++ b/tests/unit/expected_test_results/ingredients/en-ingredients-with-a-specific-density.json
@@ -1,0 +1,139 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "ingredients" : [
+      {
+         "id" : "en:cooking oil 25 fl oz",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 60,
+         "percent_max" : 100,
+         "percent_min" : 20,
+         "text" : "cooking oil 25 fl oz"
+      },
+      {
+         "ciqual_proxy_food_code" : "19051",
+         "ecobalyse_code" : "8f3863e7-f981-4367-90a2-e1aaa096a6e0",
+         "id" : "en:milk",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 20,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "quantity" : "1 dl",
+         "quantity_g" : 103,
+         "quantity_ml" : 100,
+         "text" : "milk",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "31016",
+         "ecobalyse_code" : "8f075c25-9ebf-430c-b41d-51d165c6e0d8",
+         "id" : "en:granulated-sugar",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 10,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "quantity" : "5 cl",
+         "quantity_g" : 45,
+         "quantity_ml" : 50,
+         "text" : "granulated sugar",
+         "vegan" : "maybe",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_food_code" : "18066",
+         "ecobalyse_code" : "36b3ffec-51e7-4e26-b1b5-7d52554e0aa6",
+         "id" : "en:water",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 5,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "quantity" : "1 l",
+         "quantity_g" : 1000,
+         "quantity_ml" : 1000,
+         "text" : "water",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_food_code" : "2074",
+         "id" : "en:apple-juice",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 5,
+         "percent_max" : 20,
+         "percent_min" : 0,
+         "quantity" : "20 ml",
+         "quantity_g" : 21.2,
+         "quantity_ml" : 20,
+         "text" : "apple juice",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:non-vegan" : [
+         "en:milk"
+      ],
+      "en:palm-oil-content-unknown" : [
+         "en:cooking oil 25 fl oz"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:cooking oil 25 fl oz"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:cooking oil 25 fl oz"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_lc" : "en",
+   "ingredients_n" : 5,
+   "ingredients_n_tags" : [
+      "5",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:cooking oil 25 fl oz",
+      "en:milk",
+      "en:granulated-sugar",
+      "en:water",
+      "en:apple-juice"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:cooking oil 25 fl oz",
+      "en:milk",
+      "en:dairy",
+      "en:granulated-sugar",
+      "en:added-sugar",
+      "en:disaccharide",
+      "en:sugar",
+      "en:water",
+      "en:apple-juice",
+      "en:fruit",
+      "en:juice",
+      "en:fruit-juice"
+   ],
+   "ingredients_text" : "cooking oil 25 fl oz, milk 1dl, 5cl granulated sugar, water 1l, apple juice 20ml",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 5,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:cooking oil 25 fl oz"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:apple-juice",
+      "en:cooking oil 25 fl oz"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 2,
+   "known_ingredients_n" : 4,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/tests/unit/expected_test_results/ingredients/en-quantity-of-ingredient.json
+++ b/tests/unit/expected_test_results/ingredients/en-quantity-of-ingredient.json
@@ -37,6 +37,7 @@
          "percent_min" : 0,
          "quantity" : "20 cl",
          "quantity_g" : 200,
+         "quantity_ml" : 200,
          "text" : "water",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -52,6 +53,7 @@
          "percent_min" : 0,
          "quantity" : "10 ml",
          "quantity_g" : 10,
+         "quantity_ml" : 10,
          "text" : "rapeseed oil",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/tests/unit/expected_test_results/ingredients/fr-quantity-of-ingredient.json
+++ b/tests/unit/expected_test_results/ingredients/fr-quantity-of-ingredient.json
@@ -37,6 +37,7 @@
          "percent_min" : 0,
          "quantity" : "20 cl",
          "quantity_g" : 200,
+         "quantity_ml" : 200,
          "text" : "eau",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -52,6 +53,7 @@
          "percent_min" : 0,
          "quantity" : "10 ml",
          "quantity_g" : 10,
+         "quantity_ml" : 10,
          "text" : "huile de colza",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/tests/unit/expected_test_results/ingredients/fr-recipes-with-ingredients-by-weight-and-volume.json
+++ b/tests/unit/expected_test_results/ingredients/fr-recipes-with-ingredients-by-weight-and-volume.json
@@ -1,0 +1,147 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "ingredients" : [
+      {
+         "id" : "fr:5 tasses de farine",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 58.3333333333333,
+         "percent_max" : 100,
+         "percent_min" : 16.6666666666667,
+         "text" : "5 tasses de farine"
+      },
+      {
+         "ciqual_proxy_food_code" : "31016",
+         "ecobalyse_code" : "8f075c25-9ebf-430c-b41d-51d165c6e0d8",
+         "id" : "en:sugar",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 20.8333333333333,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "quantity" : "30 g",
+         "quantity_g" : 30,
+         "text" : "sucre",
+         "vegan" : "maybe",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "19051",
+         "ecobalyse_code" : "8f3863e7-f981-4367-90a2-e1aaa096a6e0",
+         "id" : "en:milk",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 10.4166666666667,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "quantity" : "20 cl",
+         "quantity_g" : 206,
+         "quantity_ml" : 200,
+         "text" : "lait",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "from_palm_oil" : "maybe",
+         "id" : "en:oil",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 5.20833333333333,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "quantity" : "10 ml",
+         "quantity_g" : 9.2,
+         "quantity_ml" : 10,
+         "text" : "huile",
+         "vegan" : "maybe",
+         "vegetarian" : "maybe"
+      },
+      {
+         "id" : "fr:2 pincées de poivre",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 2.60416666666666,
+         "percent_max" : 20,
+         "percent_min" : 0,
+         "text" : "2 pincées de poivre"
+      },
+      {
+         "id" : "fr:une pincée de sel",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 2.60416666666666,
+         "percent_max" : 16.6666666666667,
+         "percent_min" : 0,
+         "text" : "une pincée de sel"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:may-contain-palm-oil" : [
+         "en:oil"
+      ],
+      "en:non-vegan" : [
+         "en:milk"
+      ],
+      "en:vegan-status-unknown" : [
+         "fr:5 tasses de farine",
+         "fr:2 pincées de poivre",
+         "fr:une pincée de sel"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "fr:5 tasses de farine",
+         "fr:2 pincées de poivre",
+         "fr:une pincée de sel"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:may-contain-palm-oil",
+      "en:non-vegan",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_n" : 6,
+   "ingredients_n_tags" : [
+      "6",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "fr:5 tasses de farine",
+      "en:sugar",
+      "en:milk",
+      "en:oil",
+      "fr:2 pincées de poivre",
+      "fr:une pincée de sel"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "fr:5 tasses de farine",
+      "en:sugar",
+      "en:added-sugar",
+      "en:disaccharide",
+      "en:milk",
+      "en:dairy",
+      "en:oil",
+      "en:oil-and-fat",
+      "fr:2 pincées de poivre",
+      "fr:une pincée de sel"
+   ],
+   "ingredients_text" : "5 tasses de farine, 30 g de sucre, 20 cl de lait, 10 ml d’huile, 2 pincées de poivre, une pincée de sel",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 6,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:oil",
+      "fr:2 pincées de poivre",
+      "fr:5 tasses de farine",
+      "fr:une pincée de sel"
+   ],
+   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:oil",
+      "fr:2 pincées de poivre",
+      "fr:5 tasses de farine",
+      "fr:une pincée de sel"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 4,
+   "known_ingredients_n" : 3,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 3
+}

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-different-quantities.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-different-quantities.json
@@ -2,8 +2,8 @@
    {
       "id" : "en:lemon",
       "is_in_taxonomy" : 1,
-      "percent" : 45.3514636391239,
-      "percent_estimate" : 45.3514636391239,
+      "percent" : 44.0334557390014,
+      "percent_estimate" : 44.0334557390014,
       "quantity" : "1 KG",
       "quantity_g" : 1000,
       "text" : "lemon"
@@ -11,17 +11,18 @@
    {
       "id" : "en:orange-juice",
       "is_in_taxonomy" : 1,
-      "percent" : 4.53514636391239,
-      "percent_estimate" : 4.53514636391239,
+      "percent" : 4.66754630833415,
+      "percent_estimate" : 4.66754630833415,
       "quantity" : "10 cl",
-      "quantity_g" : 100,
+      "quantity_g" : 106,
+      "quantity_ml" : 100,
       "text" : "orange juice"
    },
    {
       "id" : "en:sugar",
       "is_in_taxonomy" : 1,
-      "percent" : 0.226757318195619,
-      "percent_estimate" : 0.226757318195619,
+      "percent" : 0.220167278695007,
+      "percent_estimate" : 0.220167278695007,
       "quantity" : "5 g",
       "quantity_g" : 5,
       "text" : "sugar"
@@ -29,8 +30,8 @@
    {
       "id" : "en:salt",
       "is_in_taxonomy" : 1,
-      "percent" : 2.26757318195619e-05,
-      "percent_estimate" : 2.26757318195619e-05,
+      "percent" : 2.20167278695007e-05,
+      "percent_estimate" : 2.20167278695007e-05,
       "quantity" : "0.5 mg",
       "quantity_g" : 0.0005,
       "text" : "salt"
@@ -38,19 +39,21 @@
    {
       "id" : "en:apple-juice",
       "is_in_taxonomy" : 1,
-      "percent" : 45.3514636391239,
-      "percent_estimate" : 45.3514636391239,
+      "percent" : 46.6754630833415,
+      "percent_estimate" : 46.6754630833415,
       "quantity" : "1 L",
-      "quantity_g" : 1000,
+      "quantity_g" : 1060,
+      "quantity_ml" : 1000,
       "text" : "apple juice"
    },
    {
       "id" : "en:ice-cream",
       "is_in_taxonomy" : 1,
-      "percent" : 4.53514636391239,
-      "percent_estimate" : 4.53514636391239,
+      "percent" : 4.40334557390014,
+      "percent_estimate" : 4.40334557390014,
       "quantity" : "100 ml",
       "quantity_g" : 100,
+      "quantity_ml" : 100,
       "text" : "ice cream"
    }
 ]

--- a/tests/unit/expected_test_results/taxonomies/eurocodes.csv
+++ b/tests/unit/expected_test_results/taxonomies/eurocodes.csv
@@ -70,7 +70,7 @@ eurocode_2_group_2	eurocode_2_group_3	ingredient
 8.15	8.15.20	en:cabbage
 8.15	8.15.20	en:savoy-cabbage
 8.15	8.15.24	en:red-cabbage
-8.15	8.15.28	en:napa-cabbage
+8.15	8.15.28	en:chinese-cabbage
 8.15	8.15.28	en:pak-choi
 8.15	8.15.40	en:brussels-sprouts
 8.15	8.15.50	en:kohlrabi

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -957,13 +957,20 @@ puffed orange and caramelized unknown_fruit4.",
 			ingredients_text => 'svensk jordgubbe, svenska jordgubbar',
 		}
 
-	]
-		# Recipes with ingredients by weight and volume
+	],
+	# Recipes with ingredients by weight and volume
+	[
+		'en-ingredients-with-a-specific-density',
+		{
+			lc => 'en',
+			ingredients_text => 'cooking oil 25 fl oz, milk 1dl, 5cl granulated sugar, water 1l, apple juice 20ml',
+		}
+	],
 	[
 		'fr-recipes-with-ingredients-by-weight-and-volume',
 		{
 			lc => 'fr',
-			ingredients_text => '50 g de farine, 30 g de sucre, 20 cl de lait, 10 ml d’huile, une pincée de sel',
+			ingredients_text => '5 tasses de farine, 30 g de sucre, 20 cl de lait, 10 ml d’huile, 2 pincées de poivre, une pincée de sel',
 		}
 	]
 );

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -970,7 +970,8 @@ puffed orange and caramelized unknown_fruit4.",
 		'fr-recipes-with-ingredients-by-weight-and-volume',
 		{
 			lc => 'fr',
-			ingredients_text => '5 tasses de farine, 30 g de sucre, 20 cl de lait, 10 ml d’huile, 2 pincées de poivre, une pincée de sel',
+			ingredients_text =>
+				'5 tasses de farine, 30 g de sucre, 20 cl de lait, 10 ml d’huile, 2 pincées de poivre, une pincée de sel',
 		}
 	]
 );

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -958,6 +958,14 @@ puffed orange and caramelized unknown_fruit4.",
 		}
 
 	]
+		# Recipes with ingredients by weight and volume
+	[
+		'fr-recipes-with-ingredients-by-weight-and-volume',
+		{
+			lc => 'fr',
+			ingredients_text => '50 g de farine, 30 g de sucre, 20 cl de lait, 10 ml d’huile, une pincée de sel',
+		}
+	]
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
Needed in particular to analyze recipe ingredients that can be listed by volume (e.g. 500ml of milk).

Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/14087

WIP, still need to add some tests, and to add support for common units in food recipes