### PR TITLE
chore(taxonomy): drop product counts

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -336,7 +336,6 @@ zh: E102, :柠檬黄
 additives_classes:en: en:colour
 colour_index:en: CI 19140
 description:en: TARTRAZINE is a synthetic lemon yellow azo dye primarily used as a food coloring.
-# ingredient/fr:tartrazine has 196 products in 3 languages @2019-02-09
 e_number:en: 102
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/1331.pdf
 efsa_evaluation:en: Scientific Opinion on the re-evaluation Tartrazine (E 102)
@@ -605,8 +604,6 @@ zh: E120, 胭脂红
 additives_classes:en: en:colour
 colour_index:en: CI 75470
 description:en: CARMINE, also called cochineal, cochineal extract, crimson lake or carmine lake, natural red 4, C.I. 75470, or E120, is a pigment of a bright-red color obtained from the aluminium salt of carminic acid
-# en:carminic-acid has 4 products in english @2018-11-17
-# additive/e120-cochineal has 3909 products in 18 languages @2018-11-17
 e_number:en: 120
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of cochineal, carminic acid, carmines (E 120) as a food additive
 efsa_evaluation_date:en: 2015-11-18
@@ -826,8 +823,6 @@ uk: E127, Еритрозин
 zh: E127, 赤藓红
 additives_classes:en: en:colour
 description:en: ERYTHROSINE, is an organoiodine compound, specifically a derivative of fluorone. It is cherry or melon-pink synthetic, primarily used for food coloring.
-# ingredient/fr:érythrosine has 47 products in 3 languages @2019-02-22
-# additive/e127-erythrosine has 592 products in 8 languages @2019-02-22
 e_number:en: 127
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/1854.pdf
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of Erythrosine (E 127) as a food additive
@@ -984,8 +979,6 @@ uk: E131, Синій патентований V
 zh: E131, 專利藍V
 colour_index:en: CI 42051
 description:en: PATENT BLUE V is a dark bluish synthetic triphenylmethane dye used as a food coloring. It is not widely used, but in Europe it can be found in Scotch eggs, certain jelly sweets, blue Curaçao, certain jello varieties (though not in actual Jell-O brand products), among others.
-# ingredient/fr:bleu-patenté-v has 219 products @2019-05-15
-# additive/e131-patent-blue-v has 548 products in 9 languages @2019-05-15
 e_number:en: 131
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/2818.pdf
 efsa_evaluation:en: Scientific Opinion on the re‐evaluation of Patent Blue V (E 131) as a food additive
@@ -1077,8 +1070,6 @@ uk: E133, Діамантовий синій
 additives_classes:en: en:colour
 colour_index:en: CI 42090
 description:en: BRILLIANT BLUE FCF (Blue 1) is an organic compound classified as a blue triarylmethane dye, reflecting its chemical structure. Known under various commercial names, it is a colorant for foods and other substances.
-# ingredient/fr:colorant%20e133 has 36 products in french @2019-03-27
-# additive/e133-brilliant-blue-fcf has 8106 products in 18 languages @2019-03-27
 e_number:en: 133
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/1853.pdf
 efsa_evaluation:en: Scientific Opinion on the re‐evaluation of Brilliant Blue FCF (E 133) as a food additive
@@ -1216,8 +1207,6 @@ zh: E140(i), 叶绿素
 additives_classes:en: en:colour
 colour_index:en: CI 75810
 description:en: CHLOROPHYLL is any of several related green pigments found in cyanobacteria and the chloroplasts of algae and plants. Chefs use chlorophyll to color a variety of foods and beverages green, such as pasta and spirits.
-# ingredient/fr:chlorophylles has 78 products in 5 languages @2019-04-06
-# additive/e140i-chlorophylls has 147 products in 6 languages @2019-04-07
 # usage:en:colours (chlorophylls, curcumin)
 # usage:fr:de couleurs (chlorophylles, curcumine)
 e_number:en: 140
@@ -1309,7 +1298,6 @@ efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2015.4151
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q18967203
-# ingredient/fr:complexes-cuivre has 86 products in 4 languages @2019-02-25
 
 < en: E141
 en: E141(i), Copper complexes of chlorophylls, CI Natural Green 3, Copper Chlorophyll
@@ -1380,7 +1368,6 @@ efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2015.4151
 wikidata:en: Q18967203
 # ingredient/fr:chlorophyllines has  51 products in french @2019-02-03
 # colorants :complexe cuivre - chlorophylline
-# additive/e141ii-copper-complexes-of-chlorophyllins has 138 products in 4 languages @2019-02-03
 
 
 en: E142, Green s, CI Food Green 4
@@ -1416,8 +1403,6 @@ sv: E142, Grön s, CI Food Green 4, E 142
 uk: E142, Зелений S
 colour_index:en: CI 5
 description:en: GREEN S is a green synthetic coal tar triarylmethane dye with the molecular formula C27H25N2O7S2Na. It can be used in mint sauce, desserts, gravy granules, sweets, ice creams, and tinned peas.
-# ingredient/fr:colorant-e142 has 23 products in 3 languages @2019-03-27
-# additive/e142-green-s has 152 products in 9 languages @2019-03-27
 # usage:es:espesante (E-142)
 e_number:en: 142
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/1851.pdf
@@ -1527,7 +1512,6 @@ uz: E150, Karamel
 vi: E150, Nước caramen
 zh: E150, 焦糖
 description:en: CARAMEL is a medium to dark-orange confectionery product made by heating a variety of sugars.
-# ingredient/caramel has 3422 products in 19 languages @2019-03-09
 # caramel (sucre, eau)
 # caramel (sirop de glucose, sucre, eau)
 # Colour (Caramel, Phosphoric Acid )
@@ -1594,8 +1578,6 @@ vi: E150a, Màu caramel
 zh: E150a, 焦糖色素
 additives_classes:en: en:colour
 anses_additives_of_interest:en: yes
-# ingredient/fr:caramel-ordinaire has 1547 products in 7 languages @2019-03-09
-# ingredient/fr:caramel-aromatique has 279 products in 9 languages @2019-03-09
 # caramel aromatique (sirop de glucose, sucre, eau)
 description:en: Caramel color or caramel coloring is a water-soluble food coloring.
 e_number:en: 150a
@@ -1653,8 +1635,6 @@ efsa_evaluation_overexposure_risk:en: en:no
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2011.2004
 vegan:en: yes
 vegetarian:en: yes
-# ingredient/fr:caramel-e150b has 29 products in 3 languages @2019-03-09
-# additive/e150b-caustic-sulphite-caramel has 332 products in 9 languages @2019-03-09
 
 en: E150c, Ammonia caramel, baker's caramel, confectioner's caramel, beer caramel, Caramel Color Ammonia, Ammonia caramel, Caramel Color
 xx: E150c
@@ -1685,7 +1665,6 @@ sv: E150c, ammoniakprocessen
 additives_classes:en: en:colour
 anses_additives_of_interest:en: yes
 e_number:en: 150c
-# ingredient/fr:caramel-ammoniacal has 123 products in 6 languages @2019-03-09
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/2004.pdf
 efsa_evaluation:en: Refined exposure assessment for caramel colours (E 150a, c, d)
 efsa_evaluation_adi:en: 100
@@ -1730,7 +1709,6 @@ tr: E150d, Sülfit amonyak karamel
 additives_classes:en: en:colour
 anses_additives_of_interest:en: yes
 e_number:en: 150d
-# ingredient/fr:caramel-au-sulfite-d’ammonium has 147 products in 5 languages @2019-03-09
 efsa:en: http://www.efsa.europa.eu/fr/efsajournal/doc/2004.pdf
 efsa_evaluation:en: Refined exposure assessment for caramel colours (E 150a, c, d)
 efsa_evaluation_adi:en: 300
@@ -1850,7 +1828,6 @@ organic_eu:en: authorized
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q59557415
-# ingredient/fr:charbon%20végétal%20médicinal has 82 products in 6 languages @2019-04-05
 # comment:en:E153 can be consumed by all religious groups, vegans and vegetarians.
 
 en: E154, Brown FK, Kipper Brown
@@ -2489,7 +2466,6 @@ zh: E161b, 葉黃素
 additives_classes:en: en:colour
 anses_additives_of_interest:en: yes
 description:en: LUTEIN is a xanthophyll and one of 600 known naturally occurring carotenoids. Lutein is extracted from the petals of African marigold (Tagetes erecta). It is approved for use in the EU and Australia and New Zealand. In the United States lutein may not be used as a food coloring for foods intended for human consumption, but can be added to animal feed.
-# additive/e161b-lutein has 1408 products in 14 languages @2019-04-27
 e_number:en: 161b
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of lutein (E 161b) as a food additive
 efsa_evaluation_date:en: 2010-07-28
@@ -2854,7 +2830,6 @@ sk: E162, Cviklová červená, betanín
 sl: E162, Betalain, betanin
 sv: E162, Rödbetsrött, betanin
 additives_classes:en: en:colour
-# fr:rouge-de-betterave has 426 products in 7 languages @2018-10-21
 carbon_footprint_fr_foodges_ingredient:fr: Betteraves
 carbon_footprint_fr_foodges_value:fr: 0.2
 # azb:E162, بتانین
@@ -3465,8 +3440,6 @@ additives_classes:en: en:colour, en:stabiliser
 # wuu:E170(i), 碳酸钙
 # yue:E170(i), 碳酸鈣
 description:en: CALCIUM CARBONATE is a chemical compound with the formula CaCO3.
-# ingredient/calcium-carbonate has 4220 products in 10 languages @2019-02-03
-# mineral/calcium-carbonate has 4301 products @2019-02-03
 e_number:en: 170
 efsa_evaluation:en: Scientific Opinion on re‐evaluation of calcium carbonate (E 170) as a food additive
 efsa_evaluation_date:en: 2011/07/26
@@ -3586,7 +3559,6 @@ anses_additives_of_interest:en: yes
 e_number:en: 171
 efsa_evaluation:en: Re-evaluation of titanium dioxide (E 171) as a food additive
 efsa_evaluation_date:en: 2016-09-14
-# additive/e171-titanium-dioxide has 4518 products in 15 languages @2019-03-27
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2016.4545
 vegan:en: yes
 vegetarian:en: yes
@@ -3597,7 +3569,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Titanium_dioxide
 #<en:E171
 #en:colorant E171
 #fr:colorant e171
-# ingredient/fr:colorant-e171 has 75 products in 2 languages @2019-03-27
 
 en: E172, Iron oxides and iron hydroxides
 xx: E172
@@ -4039,8 +4010,6 @@ efsa_evaluation_date:en: 2015/06/30
 efsa_evaluation_exposure_95th_greater_than_adi:en: en:adults, en:elderly, en:adolescents, en:children, en:toddlers
 efsa_evaluation_exposure_mean_greater_than_adi:en: en:adults, en:elderly, en:adolescents, en:children, en:toddlers
 efsa_evaluation_overexposure_risk:en: en:high
-# fr:acide-sorbique has 498 products @2018-11-18
-# additive/e200-sorbic-acid has 3081 products in 21 languages @2018-11-18
 efsa_evaluation_url:en: https://efsa.onlinelibrary.wiley.com/doi/epdf/10.2903/j.efsa.2015.4144
 vegan:en: yes
 vegetarian:en: yes
@@ -4119,7 +4088,6 @@ vi: E202, Kali Sorbate
 zh: E202, 山梨酸钾
 additives_classes:en: en:preservative
 description:en: POTASSIUM SORBATE is the potassium salt of sorbic acid, chemical formula CH3CH=CH−CH=CH−CO2K.
-# ingredient/potassium-sorbate has 9927 products in 21 languages @2019-02-02
 e_number:en: 202
 efsa_evaluation:en: Scientific Opinion on the re‐evaluation of sorbic acid (E 200), potassium sorbate (E 202) and calcium sorbate (E 203) as food additives
 efsa_evaluation_adi:en: 3
@@ -4149,8 +4117,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Potassium_sorbate
 #fr:conservateur sorbate de potassium, conservateur e 202, conservateurs e202
 #it:conservante sorbati di pottassio
 #nl:conserveermiddelen E202
-# ingredient/fr:conservateur-sorbate-de-potassium has 70 products in 5 languages @2019-02-02
-# ingredient/fr:conservateurs-e202 has 233 products in 5 languages @2019-03-27
 
 
 en: E203, Calcium sorbate
@@ -4187,7 +4153,6 @@ ta: E203, கால்சியம் சார்பேட்டு
 vi: E203, Canxi sorbat
 additives_classes:en: en:preservative
 description:en: CALCIUM SORBATE  is the calcium salt of sorbic acid. Calcium sorbate is a polyunsaturated fatty acid salt.
-# ingredient/fr:sorbate-de-calcium has 38 products in french @2019-03-03
 # conservateur : sorbate de calcium (papier traité)
 e_number:en: 203
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of sorbic acid (E 200), potassium sorbate (E 202) and calcium sorbate (E 203) as food additives
@@ -4308,7 +4273,6 @@ zh: E211, 苯甲酸钠
 additives_classes:en: en:preservative
 anses_additives_of_interest:en: yes
 description:en: SODIUM BENZOATE is a substance which has the chemical formula NaC7H5O2
-# ingredient/fr:benzoate-de-sodium has 688 products in 7 languages @2019-01-23
 e_number:en: 211
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of benzoic acid (E 210), sodium benzoate (E 211), potassium benzoate (E 212) and calcium benzoate (E 213) as food additives
 efsa_evaluation_adi:en: 5
@@ -4658,7 +4622,6 @@ zh: 二氧化硫
 additives_classes:en: en:antioxidant, en:preservative
 anses_additives_of_interest:en: yes
 description:en: SULPHUR DIOXIDE is the chemical compound with the formula SO2.
-# ingredient/e-220 has 136 products in 14 languages @2019-03-25
 # conservateur (E220 [sulfite])
 e_number:en: 220
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of sulfur dioxide (E 220), sodium sulfite (E 221), sodium bisulfite (E 222), sodium metabisulfite (E 223), potassium metabisulfite (E 224), calcium sulfite (E 226), calcium bisulfite (E 227) and potassium bisulfite (E 228) as food additives
@@ -4727,8 +4690,6 @@ zh: E221, 亚硫酸钠
 additives_classes:en: en:antioxidant, en:preservative
 anses_additives_of_interest:en: yes
 description:en: SODIUM SULFITE is a soluble sodium salt of sulfurous acid (sulfite) with the chemical formula Na2SO3.
-# ingredient/fr:sulfite-de-sodium has 39 products in 10 languages @2109-02-07
-# additive/e221-sodium-sulphite has 272 products in 10 languages @2019-02-07
 e_number:en: 221
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of sulfur dioxide (E 220), sodium sulfite (E 221), sodium bisulfite (E 222), sodium metabisulfite (E 223), potassium metabisulfite (E 224), calcium sulfite (E 226), calcium bisulfite (E 227) and potassium bisulfite (E 228) as food additives
 efsa_evaluation_adi:en: 0.7
@@ -4789,7 +4750,6 @@ zh: E222, 亚硫酸氢钠
 additives_classes:en: en:antioxidant, en:preservative
 anses_additives_of_interest:en: yes
 description:en: SODIUM BISULFITE is a chemical compound with the chemical formula NaHSO3.
-# ingredient/fr:disulfite-de-sodium has 651 products in 11 languages @2019-03-02
 e_number:en: 222
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of sulfur dioxide (E 220), sodium sulfite (E 221), sodium bisulfite (E 222), sodium metabisulfite (E 223), potassium metabisulfite (E 224), calcium sulfite (E 226), calcium bisulfite (E 227) and potassium bisulfite (E 228) as food additives
 efsa_evaluation_adi:en: 0.7
@@ -4905,8 +4865,6 @@ vi: E224, Kali metabisunfit
 additives_classes:en: en:antioxidant, en:preservative
 anses_additives_of_interest:en: yes
 description:en: POTASSIUM METABISULFITE, K2S2O5, also known as potassium pyrosulfite, is a white crystalline powder with a pungent sulfur odour. The main use for the chemical is as an antioxidant or chemical sterilant.
-# ingredient/fr:métabisulfite-de-potassium has 113 products in 4 languages @2019-05-07
-# additive/e224-potassium-metabisulphite has 2227 products in 10 languages @2019-03-26
 e_number:en: 224
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of sulfur dioxide (E 220), sodium sulfite (E 221), sodium bisulfite (E 222), sodium metabisulfite (E 223), potassium metabisulfite (E 224), calcium sulfite (E 226), calcium bisulfite (E 227) and potassium bisulfite (E 228) as food additives
 efsa_evaluation_adi:en: 0.7
@@ -4924,7 +4882,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Potassium_metabisulfite
 
 #<en:E224
 #fr:conservateur e224
-# ingredient/fr:conservateur-e224 has 25 products in french @2019-03-26
 
 en: E225, Calcium Disulphite, Calcium Disulfite, Calcium Pyrosulphite, Calcium Pyrosulfite, Potassium sulfite, Potassium sulphite
 xx: E225
@@ -5297,7 +5254,6 @@ uk: E235, Натаміцин
 vi: E235, Natamycin
 additives_classes:en: en:preservative
 description:en: NATAMYCIN is used in the food industry as a preservative.
-# ingredient/fr:natamycine has 445 products in 7 languages @2019-05-07
 e_number:en: 235
 efsa_evaluation:en: Scientific Opinion on the use of natamycin (E 235) as a food additive
 efsa_evaluation_date:en: 2009-12-14
@@ -5562,8 +5518,6 @@ sr: E242, Dimetil dikarbonat
 sv: E242, Dimetyldikarbonat, DMDC
 additives_classes:en: en:preservative
 description:en: DIMETHYL DICARBONATE is an organic compound which is a colorless liquid with a pungent odor at high concentration at room temperature. It is primarily used as a beverage preservative, processing aid, or sterilant
-# ingredient/fr:dicarbonate-de-dimethyle has 30 products in french @2019-02-21
-# additive/e242-dimethyl-dicarbonate has 84 products @2019-02-21
 # conservadores (E202, E242)
 e_number:en: 242
 efsa_evaluation:en: Scientific opinion on the re-evaluation of dimethyl dicarbonate (DMDC, E 242) as a food additive
@@ -5736,7 +5690,6 @@ zh: E250, 亚硝酸钠
 additives_classes:en: en:preservative
 anses_additives_of_interest:en: yes
 description:en: SODIUM NITRITE is an inorganic compound with the chemical formula NaNO2. it is a food additive used in processed meats and (in some countries) in fish products.
-# ingredient/fr:nitrite-de-sodium has 6137 products in 11 languages @2019-05-07
 # usage:de:Stabilisator (Natriumnitrit)
 e_number:en: 250
 efsa_evaluation:en: Re-evaluation of potassium nitrite (E 249) and sodium nitrite (E 250) as food additives
@@ -5768,7 +5721,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sodium_nitrite
 #de:Konservierungsmittel Natriumnitrit
 #fr:conservateur nitrite de sodium, conservateur e 250
 #it:nitrito di sodio conservante
-# ingredient/fr:conservateur-nitrite-de-sodium has 132 products in 4 languages @2019-02-13
 
 
 en: E251, Sodium nitrate
@@ -5825,7 +5777,6 @@ vi: E251, Natri nitrat
 zh: E251, 硝酸鈉
 additives_classes:en: en:preservative
 description:en: SODIUM NITRATE is the chemical compound with the formula NaNO3. Sodium nitrate is a food additive used as a preservative and colour fixative in cured meats and poultry
-# ingredient/fr:nitrate-de-sodium has 138 products in 5 languages @2019-05-07
 e_number:en: 251
 efsa_evaluation:en: Re‐evaluation of sodium nitrate (E 251) and potassium nitrate (E 252) as food additives
 efsa_evaluation_adi:en: 3.7
@@ -5921,8 +5872,6 @@ vi: E252, kali nitrat
 zh: E252, 硝酸钾
 additives_classes:en: en:preservative
 description:en: POTASSIUM NITRATE is a chemical compound with the chemical formula KNO3. The widespread adoption of nitrate use is more recent and is linked to the development of large-scale meat processing. potassium nitrate is still used in some food applications, such as salami, dry-cured ham, charcuterie.
-# ingredient/fr:salpêtre has 167 products in french @2019-05-02
-# additive/e252-potassium-nitrate has 2820 products in 21 languages @2019-05-02
 e_number:en: 252
 efsa_evaluation:en: Re‐evaluation of sodium nitrate (E 251) and potassium nitrate (E 252) as food additives
 efsa_evaluation_adi:en: 3.7
@@ -6034,8 +5983,6 @@ vi: E260, axit axetic
 zh: E260, 乙酸
 additives_classes:en: en:preservative
 description:en: ACETIC ACID, systematically named ethanoic acid, is a colourless liquid organic compound with the chemical formula CH3COOH (also written as CH3CO2H or C2H4O2).
-# en:acetic-acid has 1571 products in 8 languages @2018-11-18
-# additive/e260-acetic-acid has 2143 products in 14 languages @2018-11-18
 e_number:en: 260
 vegan:en: yes
 vegetarian:en: yes
@@ -6094,8 +6041,6 @@ uk: E261, Ацетат калію
 vi: E261, Kali axetat
 zh: E261, 乙酸钾
 additives_classes:en: en:preservative
-# ingredient/fr:acétate-de-potassium has 31 products in 3 languages @2019-02-09
-# additive/e261-potassium-acetate has 235 products @2019-02-09
 e_number:en: 261
 vegan:en: yes
 vegetarian:en: yes
@@ -6130,7 +6075,6 @@ ru: E262, ацетат натрия
 sl: E262, Natrijev acetats
 sv: E262, Natriumacetater
 additives_classes:en: en:preservative, en:sequestrant
-# additive/e262-sodium-acetates has 4654 products @2018-11-18
 e_number:en: 262
 vegan:en: yes
 vegetarian:en: yes
@@ -6182,7 +6126,6 @@ vi: E262(i), Natri axetat
 zh: E262(i), 乙酸钠
 additives_classes:en: en:preservative, en:sequestrant
 description:en: SODIUM ACETATE, also abbreviated NaOAc,[8] is the sodium salt of acetic acid.
-# additive/e262i-sodium-acetate has 1024 products in 8 languages @2018-11-18
 e_number:en: 262
 # azb:E262(i),سودیوم استات
 # sco:E262(i),Sodium acetate
@@ -6228,7 +6171,6 @@ sv: E262(ii), Natriumdiacetat
 ta: E262(ii), சோடியம் ஈரசிட்டேட்டு
 zh: E262(ii), 双乙酸钠
 additives_classes:en: en:preservative, en:sequestrant
-# additive/e262ii-sodium-diacetate has 2204 products in 9 languages @2018-11-18
 e_number:en: 262
 wikidata:en: Q409655
 wikipedia:en: https://en.wikipedia.org/wiki/Sodium_diacetate
@@ -6243,7 +6185,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sodium_diacetate
 #pt:regulador de acidez E262
 #pl:regulator kwasowości E262
 #ru:регулятор кислотности E262
-# correcteur d'acidité E262 has 8 products in 3 languages @2018-11-18
 
 
 en: E263, Calcium acetate
@@ -6284,8 +6225,6 @@ vi: E263, Canxi axetat
 zh: E263, 乙酸钙
 additives_classes:en: en:preservative, en:stabiliser
 description:en: CALCIUM ACETATE is a chemical compound which is a calcium salt of acetic acid. Calcium acetate is used as a food additive, as a stabilizer, buffer and sequestrant, mainly in candy products.
-# ingredient/fr:acétate-de-calcium has 63 products @2019-04-06
-# additive/e263-calcium-acetate has 293 products @2019-04-06
 e_number:en: 263
 vegan:en: yes
 vegetarian:en: yes
@@ -6465,7 +6404,6 @@ uz: E270, Sut kislota
 vi: E270, axit lactic
 zh: E270, 乳酸
 description:en: LACTIC ACID is an organic compound with the formula CH3CH(OH)CO2H. In the form of its conjugate base called lactate (this is thus different and kept as a separate ingredient). Lactic acid is chiral, consisting of two optical isomers. One is known as L-(+)-lactic acid or (S)-lactic acid and the other, its mirror image, is D-(−)-lactic acid or (R)-lactic acid in food the L-variant is used
-# en:lactic-acid has 7496 products in 20 languages@2018-11-17
 # wikidata:en:Q161249
 organic_eu:en: authorized
 vegan:en: yes
@@ -6569,8 +6507,6 @@ vi: E281, Natri propionat
 zh: E281, 丙酸钠
 additives_classes:en: en:preservative
 description:en: Sodium propanoate or SODIUM PROPIONATE is the sodium salt of propionic acid.
-# ingredient/fr:e281 has 45 products in 7 languages @2019-03-25
-# additive/e281-sodium-propionate has 532 products in 10 languages @2019-02-25
 # preservative (E202, E281)
 e_number:en: 281
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of propionic acid (E 280), sodium propionate (E 281), calcium propionate (E 282) and potassium propionate (E 283) as food additives
@@ -6635,8 +6571,6 @@ efsa_evaluation:en: Scientific Opinion on the re-evaluation of propionic acid (E
 efsa_evaluation_adi_established:en: en:no
 efsa_evaluation_date:en: 2014-07-22
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2014.3779
-# additive/e282-calcium-propionate has 3549 products in 25 languages @2019-05-19
-# ingredient/fr:propionate-de-calcium has 833 products @2019-05-19
 # usage:es:conservador:propionato cálcico
 vegan:en: yes
 vegetarian:en: yes
@@ -6840,8 +6774,6 @@ za: E290, Ngeihyangjvaqdanq
 zh: E290, 二氧化碳
 additives_classes:en: en:preservative, en:propellent-gas
 description:en: CARBON DIOXIDE chemical formula CO2) is a colorless gas with a density about 60% higher than that of dry air.
-# ingredient/fr:anhydride-carbonique has 17 products in 4 languages @2019-02-05
-# additive/e290-carbon-dioxide has 1474 products in 20 languages @2019-02-05
 e_number:en: 290
 organic_eu:en: authorized
 vegan:en: yes
@@ -6953,8 +6885,6 @@ uk: E296, Яблучна кислота
 vi: E296, Axit malic
 zh: E296, 苹果酸
 description:en: MALIC ACID is an organic compound with the molecular formula C4H6O5. Malic acid has two stereoisomeric forms (L- and D-enantiomers), though only the L-isomer exists naturally.
-# en:malic-acid has 5097 products in 17 languages @2018-11-17
-# additive/e296-malic-acid has 6016 products in 23 languages @018-11-17
 e_number:en: 296
 organic_eu:en: authorized
 vegan:en: yes
@@ -7082,8 +7012,6 @@ tr: E301, Sodyum askorbat, Askorbin, Askorbik asidin sodyum tuzu
 uk: E301, Аскорбат натрію
 additives_classes:en: en:antioxidant
 description:en: SODIUM ASCORBATE is one of a number of mineral salts of ascorbic acid (vitamin C).
-# additive/e301-sodium-ascorbate has 5340 products in 17 languages @2018-11-10
-# en:sodium-ascorbate has 4161 products in 7 languages @2018-11-10
 e_number:en: 301
 efsa_evaluation:en: Scientific Opinion on the re‐evaluation of ascorbic acid (E 300), sodium ascorbate (E 301) and calcium ascorbate (E 302) as food additives
 efsa_evaluation_adi_established:en: en:no
@@ -7220,7 +7148,6 @@ additives_classes:en: en:antioxidant
 e_number:en: 304
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of ascorbyl palmitate (E 304(i)) and ascorbyl stearate (E 304(ii)) as food additives
 efsa_evaluation_date:en: 2015-11-18
-# ingredient/fr:esters-d’acides-gras-de-l’acide-ascorbique has 62 products in 6 languages @2019-03-11
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2015.4289
 from_palm_oil:en: maybe
 # could be made from animal fat
@@ -7265,8 +7192,6 @@ description:en: ASCORBYL PALMITATE is an ester formed from ascorbic acid and pal
 e_number:en: 304
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of ascorbyl palmitate (E 304(i)) and ascorbyl stearate (E 304(ii)) as food additives
 efsa_evaluation_date:en: 2015-11-18
-# ingredient/fr:e304i has 17 products in french @2018-11-27
-# additive/e304i-ascorbyl-palmitate has 433 products in 12 languages @2018-11-27
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2015.4289
 vegan:en: yes
 vegetarian:en: yes
@@ -7340,7 +7265,6 @@ sv: E306, Tokoferolrika extrakt, Tocopherol-extrakt
 e_number:en: 306
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of tocopherol-rich extract (E 306), alpha-tocopherol (E 307), gamma-tocopherol (E 308) and delta-tocopherol (E 309) as food additives
 efsa_evaluation_date:en: 2015-09-30
-# additive/e306-tocopherol-rich-extract has 1268 products in 16 languages @2018-11-25
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2015.4247
 organic_eu:en: authorized
 vegan:en: yes
@@ -7834,8 +7758,6 @@ efsa_evaluation_adi:en: 6
 efsa_evaluation_date:en: 2016/01/20
 efsa_evaluation_overexposure_risk:en: en:no
 efsa_evaluation_url:en: https://efsa.onlinelibrary.wiley.com/doi/epdf/10.2903/j.efsa.2016.4360
-# ingredient/fr:isoascorbate-de-sodium has 250 products in 4 languages @2019-05-17
-# additive/e316-sodium-erythorbate has 7338 products in 28 languages @2019-05-17
 # usage:fr:antioxydants :lactate de portassium, isoascorbate de sodium
 vegan:en: yes
 vegetarian:en: yes
@@ -8275,8 +8197,6 @@ description:en: SODIUM LACTATE is the sodium salt of lactic acid, and has a mild
 # zh-sg:E325, 乳酸钠
 # zh-tw:E325, 乳酸鈉
 e_number:en: 325
-# ingredient/fr:lactate-de-sodium has 426 products in 4 languages @2019-05-18
-# additive/e325-sodium-lactate has 1960 products in 14 languages @2019-05-18
 # usage:sv:surhetsreglerande medel (natriumlaktat, natriumacetater)
 organic_eu:en: authorized
 vegan:en: yes
@@ -8323,8 +8243,6 @@ additives_classes:en: en:antioxidant, en:emulsifier, en:humectant
 description:en: POTASSIUM LACTATE is a compound with formula KC3H5O3. It is produced by neutralizing lactic acid which is fermented from a sugar source. Potassium lactate is commonly used in meat and poultry products to extend shelf life and increase food safety as it has a broad antimicrobial action. lactic acid and lactates can be consumed by all religious groups, vegans and vegetarians. Although the name refers to milk, it is not made from milk and thus suitable for people with milk allergy or lactose intolerance.
 # sr-el:E326, Kalijum laktat
 e_number:en: 326
-# ingredient/fr:lactate-de-potassium has 630 products in 5 languages @2019-05-18
-# additive/e326-potassium-lactate has 2488 products in 12 languages @2019-05-18
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q411342
@@ -8371,8 +8289,6 @@ additives_classes:en: en:thickener
 # zh-hans:E327, 乳酸钙
 # zh-hant:E327, 乳酸钙
 e_number:en: 327
-# ingredient/calcium-lactate has 1120 products @2019-05-17
-# additive/e327-calcium-lactate has 1257 products in 21 languages @2019-05-17
 # usage:en:acidity regulators (lactic acid, calcium lactate)
 vegan:en: yes
 vegetarian:en: yes
@@ -8501,8 +8417,6 @@ vi: E330, Axít citric
 wa: E330, Seur di citron
 zh: E330, 檸檬酸
 additives_classes:en: en:antioxidant, en:sequestrant
-# additive/e330-citric-acid has 63123 products in 39 languages @2018-11-17
-# ingredient/fr:citrique has 113 products in 5 languages @2019-03-16 (seems a recognition error)
 e_number:en: 330
 efsa_evaluation:en: Scientific Opinion on the safety evaluation of the active substances citric acid (E330) and sodium hydrogen carbonate (E500ii), used as carbon dioxide generators, together with liquid absorbers cellulose and polyacrylic acid sodium salt crosslinked, in active food contact materials.
 efsa_evaluation_date:en: 2013-04-09
@@ -8543,7 +8457,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Citric_acid
 #de:Säureregulator Citronensäure
 #fr:correcteur d'acidité acide citrique, correcteur d'acidité e330
 #it:correttore di acidità E330 - acido citrico
-# fr:correcteur-d’acidité-acide-citrique has 83 products in 3 languages @2018-11-17
 
 #comment:en:E331 should be in plural, the specific form can be entered under i, ii or iii. In some languages the singular can refer to any of the three variants. Sodium citrate may refer to any of the sodium salts of citric acid (though most commonly the third), but we make no assumptions.
 # plural here after
@@ -8603,8 +8516,6 @@ ro: E331(i), Citrat monosodic
 sl: E331(i), Mononatrijev citrat
 sv: E331(i), Mononatriumcitrat
 additives_classes:en: en:emulsifier, en:sequestrant, en:stabiliser
-# additive/e331i-monosodium-citrate has 112 products in 7 languages @2019-04-24
-# ingredient/fr:citrate-monosodique has 79 products in 5 languages @2019-04-24
 description:en: MONOSODIUM CITRATE, more correctly, sodium dihydrogen citrate, is an acid salt of citric acid.
 e_number:en: 331
 organic_eu:en: authorized
@@ -8638,7 +8549,6 @@ sk: E331(ii), Citran disodný
 sl: E331(ii), Dinatrijev citrat
 sv: E331(ii), Dinatriumcitrat
 additives_classes:en: en:emulsifier, en:sequestrant, en:stabiliser
-# additive/e331ii-disodium-citrate has 21 products in 2 languages @2019-04-24
 description:en: DISODIUM CITRATE, more properly, disodium hydrogen citrate, is an acid salt of citric acid with the chemical formula Na2C6H6O7. It is used as an antioxidant in food and to improve the effects of other antioxidants. It is also used as an acidity regulator and sequestrant. Typical products include gelatin, jam, sweets, ice cream, carbonated beverages, milk powder, wine, and processed cheeses.
 e_number:en: 331
 organic_eu:en: authorized
@@ -8729,7 +8639,6 @@ sv: E332(i), Monokaliumcitrat
 additives_classes:en: en:sequestrant, en:stabiliser
 e_number:en: 332
 mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser
-# additive/e332i-monopotassium-citrate has 3 products in french @2019-04-22
 
 #comment:en:(TRI-)POTASSIUM CITRATE is entered both under the minerals and the additives for the moment.
 #comment:en:Not sure which word is preferred on packages, either the more chemical tripotassium or just potassium citrate in singular form. We use the tripotassium version here in order to better distinguish from E332.
@@ -8774,7 +8683,6 @@ vi: E332(ii), Kali xitrat
 zh: E332(ii), 檸檬酸鉀
 # last wikidatasynchronisation 4-sep-2020
 additives_classes:en: en:sequestrant, en:stabiliser
-# additive/e332ii-tripotassium-citrate has 23 products in 2 languages @2019-04-22
 description:en: POTASSIUM CITRATE (also known as tripotassium citrate) is a potassium salt of citric acid with the molecular formula K3C6H5O7. As a food additive, potassium citrate is used to regulate acidity. It is also used in many soft drinks as a buffering agent.
 #azb:E332(ii), پوتاسیوم سیترات
 #zh-cn:E332(ii), 柠檬酸钾
@@ -8966,8 +8874,6 @@ zh: E334, 酒石酸
 additives_classes:en: en:antioxidant, en:sequestrant
 anses_additives_of_interest:en: yes
 description:en: TARTARIC ACID is a white, crystalline organic acid that occurs naturally in many fruits, most notably in grapes, but also in bananas, tamarinds, and citrus
-# en:tartric acid has 360 products in 8 languages @2018-11-18
-# additive/e334-l-tartaric-acid has 1559 products in 21 languages @2018-11-18
 e_number:en: 334
 organic_eu:en: authorized
 vegan:en: yes
@@ -9102,7 +9008,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q65770886
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium_tartrate
-# ingredient/fr:tartrates-de-potassium has 199 products in 6 languages @2019-03-22
 
 < en: E336
 en: E336(i), Monopotassium tartrate, monopotassic tartrate, Potassium bitartrate, potassium hydrogen tartrate, cream of tartar
@@ -9131,7 +9036,6 @@ sl: E336(i), Monokalijev tartrat
 sv: E336(i), Monokaliumtartrat
 anses_additives_of_interest:en: yes
 #Potassium bitartrate, also known as potassium hydrogen tartrate, with formula K C4 H5 O6
-# additive/e336i-monopotassium-tartrate has 127 products in 5 languages @2019-03-22
 description:en: POTASSIUM BITARTRATE, also known as potassium hydrogen tartrate, with formula KC4H5O6, is a byproduct of winemaking.
 e_number:en: 336
 organic_eu:en: authorized
@@ -9171,7 +9075,6 @@ e_number:en: 336
 organic_eu:en: authorized
 wikidata:en: Q418064
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium_tartrate
-# additive/e336ii-dipotassium-tartrate/ has 9 products in 3 languages @2019-03-22
 # Potassium tartrate, dipotassium tartrate or argol has formula K2C4H4O6.
 
 
@@ -9333,7 +9236,6 @@ vi: E339, Natri phosphat
 zh: E339, 磷酸钠
 additives_classes:en: en:emulsifier, en:humectant, en:preservative, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
-# fr:phosphate-de-sodium has 337 products @2018-11-05
 description:en: SODIUM PHOSPHATES is a generic term for a variety of salts of sodium (Na+) and phosphate (PO43−).
 e_number:en: 339
 efsa_evaluation:en: Re‐evaluation of phosphoric acid–phosphates – di‐, tri‐ and polyphosphates (E 338–341, E 343, E 450–452) as food additives and the safety of proposed extension of use
@@ -9383,7 +9285,6 @@ vi: E339(i), Natri đihiđrophotphat
 zh: E339(i), 磷酸二氢钠
 additives_classes:en: en:emulsifier, en:humectant, en:preservative, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
-# additive/e339i-monosodium-phosphate has 36 products in 6 languages @2018-11-05
 description:en: MONOSODIUM PHOSPHATE, also known as monobasic sodium phosphate and sodium dihydrogen phosphate, is an inorganic compound of sodium with a dihydrogen phosphate (H2PO4−) anion.
 # azb:E339(i), مونوسودیوم فوسفات
 e_number:en: 339
@@ -9424,8 +9325,6 @@ vi: E339(ii), Natri hiđrophotphat
 zh: E339(ii), 磷酸一氢钠
 additives_classes:en: en:emulsifier, en:humectant, en:preservative, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
-# fr:phosphate disodique has 54 products in 3 languages @2018-11-04
-# additive/e339ii-disodium-phosphate has 1940 products in 9 languages @2018-11-06
 description:en: DISODIUM PHOSPHATE, or sodium hydrogen phosphate, or sodium phosphate dibasic, is the inorganic compound with the formula Na2HPO4.
 # azb:E339(ii), دیسودیوم فوسفات
 # zh-cn:E339(ii), 磷酸一氢钠
@@ -9469,8 +9368,6 @@ sr: E339(iii), Trinatrijum fosfat
 sv: E339(iii), Trinatriumfosfat, Trinatriummonofosfat
 additives_classes:en: en:emulsifier, en:humectant, en:preservative, en:sequestrant, en:stabiliser, en:thickener
 anses_additives_of_interest:en: yes
-# fr:phosphate-trisodique has 45 products @2018-11-04
-# additive/e339iii-trisodium-phosphate has 398 products in 8 languages @2018-11-06
 description:en: TRISODIUM PHOSPHATE is the inorganic compound with the chemical formula Na3PO4.
 # azb:E339(iii), تریسودیوم فوسفات
 e_number:en: 339
@@ -9553,7 +9450,6 @@ anses_additives_of_interest:en: yes
 e_number:en: 340
 wikidata:en: Q415049
 wikipedia:en: https://en.wikipedia.org/wiki/Monopotassium_phosphate
-# additive/e340i-monopotassium-phosphate has 241 products in 10 languages @2018-11-7
 
 
 # description:en:Dipotassium phosphate (K2HPO4) (also dipotassium hydrogen orthophosphate; potassium phosphate dibasic) is a highly water-soluble salt
@@ -9938,8 +9834,6 @@ e_number:en: 343
 # wikipedia:en:https://en.wikipedia.org/wiki/Magnesium_phosphate
 wikidata:en: Q4161317
 wikipedia:en: https://en.wikipedia.org/wiki/Monomagnesium_phosphate
-# fr:phosphate-de-magnésium has 26 products in 5 languages @2018-11-07
-# mineral/magnesium-phosphate has 78 products in 4 languages @2018-11-07
 
 # description:en:Dimagnesium phosphate is a compound with formula MgHPO4.
 
@@ -10156,8 +10050,6 @@ additives_classes:en: en:humectant
 e_number:en: 350
 wikidata:en: Q836788
 wikipedia:en: https://en.wikipedia.org/wiki/Sodium_malate
-# ingredient/fr:malate-de-sodium has 18 products @2019-02-25
-# additive/e350i-sodium-malate has 38 products in 3 languages @2019-02-25
 # usage:fr:correcteur d'acidité:malate de sodium
 
 < en: E350
@@ -10187,7 +10079,6 @@ sv: E350(ii), Natriumvätemalat
 additives_classes:en: en:humectant
 e_number:en: 350
 wikidata:en: Q42807545
-# ingredient/fr:malate-acide-de-sodium has 125 products in 5 languages @2019-05-06
 
 en: E351, Potassium malate
 xx: E351
@@ -10825,7 +10716,6 @@ sv: E383, kalciumglycerolfosfat
 comment:en: CALCIUM GLYCEROPHOSPHATE is for the moment listed in both the additves and ingredients taxonomy.
 description:en: CALCIUM GLYCERYLPHOSPHATE (or calcium glycerophosphate) is a mineral supplement for Calcium.
 e_number:en: 383
-# ingredient/calcium-glycerophosphate has 1 product in french @2018-12-11
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q4119838
@@ -11140,8 +11030,6 @@ efsa_evaluation:en: Re‐evaluation of alginic acid and its sodium, potassium, a
 efsa_evaluation_adi_established:en: en:no
 efsa_evaluation_date:en: 2017/11/10
 efsa_evaluation_url:en: https://efsa.onlinelibrary.wiley.com/doi/10.2903/j.efsa.2017.5049
-# additive/e401-sodium-alginate has 2842 products in 16 languages @2019-05-19
-# ingredient/fr:alginate-de-sodium has 879 products in 7 languages @2019-05-19
 # usage:pl:substancja zagęszczająca:alginian sodu
 organic_eu:en: authorized
 vegan:en: yes
@@ -11385,7 +11273,6 @@ vegetarian:en: yes
 wikidata:en: Q177998
 # description:en:Agar or agar-agar is a jelly-like substance, obtained from red algae.
 wikipedia:en: https://en.wikipedia.org/wiki/Agar
-# ingredient/fr:agar has 213 products in 5 languages @2018-12-4
 
 en: E407, Carrageenan, e407 stabilizer
 xx: E407
@@ -11453,7 +11340,6 @@ vegetarian:en: yes
 wikidata:en: Q421991
 wikipedia:en: https://en.wikipedia.org/wiki/Carrageenan
 #description:en:CARRAGEENAN or carrageenins are a family of linear sulfated polysaccharides that are extracted from red edible seaweeds.
-# fr:carraghénane has 4521 products in 9 languages @2108-11-03
 
 
 en: E407a, Processed eucheuma seaweed
@@ -11493,7 +11379,6 @@ organic_eu:en: authorized
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q421991
-# fr:e407a has 325 products in 4 languages @2018-11-03
 
 en: E408, Bakers yeast glycan
 xx: E408
@@ -11654,8 +11539,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q423901
 #description:en:TRAGACANTH is a natural gum obtained from the dried sap of several species of Middle Eastern legumes of the genus Astragalus
-# ingredient/fr:gomme-adragante has 62 products in 4 languages @2019-03-23
-# additive/e413-tragacanth has 286 products in 6 languages @2019-03-24
 
 #< en:tree gum
 en: E414, Acacia gum, gum arabic, gum acacia, arabic gum, Gum arabic, E-414, E 414, INS414, INS 414
@@ -11857,7 +11740,6 @@ vegetarian:en: yes
 wikidata:en: Q15089452
 wikipedia:en: https://en.wikipedia.org/wiki/Tara_spinosa#Uses
 #description:en:TARA GUM is produced by separating and grinding the endosperm of T. spinosa seeds. Tara gum is used as a thickening agent and stabilizer in a number of food applications.
-# ingredient/fr:gomme-tara has 254 products in 6 languages -@2019-05-12
 
 #< en:tree gum
 en: E418, Gellan gum, gellan, E-418, E 418, INS418, INS-418, INS 418
@@ -12102,7 +11984,6 @@ vegetarian:en: yes
 wikidata:en: Q407646
 # description:en:MANNITOL is a type of sugar alcohol. It is often used as a sweetener in diabetic food, as it is poorly absorbed from the intestines. The pleasant taste and mouthfeel of mannitol also makes it a popular excipient for chewable tablets.
 wikipedia:en: https://en.wikipedia.org/wiki/Mannitol
-# ingredient/fr:mannitol has 177 products in 5 languages @2019-05-12
 
 #  description:en:GLYCEROL is a simple polyol compound. In food and beverages, glycerol serves as a humectant, solvent, and sweetener, and may help preserve foods. It is also used as filler in commercially prepared low-fat foods (e.g., cookies), and as a thickening agent in liqueurs.
 
@@ -12191,7 +12072,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q132501
 wikipedia:en: https://en.wikipedia.org/wiki/Glycerol
-# additive/e422-glycerol has 7288 products in 19 languages @2109-03-11
 
 en: E424, Curdlan
 xx: E424
@@ -12906,7 +12786,6 @@ vegetarian:en: yes
 wikidata:en: Q188154
 # description:en:PECTIN is a structural heteropolysaccharide contained in the primary cell walls of terrestrial plants.
 wikipedia:en: https://en.wikipedia.org/wiki/Pectin
-# en:pectin has 9364 products in 20 languages @2018-11-03
 
 < en: E440
 en: E440(i), non-amidated pectines
@@ -12919,7 +12798,6 @@ additives_classes:en: en:emulsifier, en:stabiliser, en:thickener
 e_number:en: 440
 organic_eu:en: authorized
 wikidata:en: Q188154
-# fr:e440i has 18 products in 5 languages @2018-11-03
 
 < en: E440
 en: E440(ii), Amidated pectin
@@ -12949,7 +12827,6 @@ sv: E440(ii), Amiderat pektin
 additives_classes:en: en:emulsifier, en:stabiliser, en:thickener
 e_number:en: 440
 wikidata:en: Q42807519
-# fr:pectine-amidée has 74 products in 1 language @2018-11-03
 
 
 # E441 is not officially listed as "animal gelatin"
@@ -13002,8 +12879,6 @@ wikidata:en: Q695975
 # comment:en:E442 is generally produced with rapeseed oil and can thus be consumed by all religious groups. However, the use of animal fat (incl. pork) can not be completed excluded.
 # origin:en:pork:maybe
 wikipedia:en: https://en.wikipedia.org/wiki/Mixed_ammonium_salts_of_phosphorylated_glycerides
-# fr:phosphatides-d’ammonium has 56 products in 6 languages @2018-11-06
-# additive/e442-ammonium-phosphatides has 246 products @2018-11-06
 
 en: E443, Brominated vegetable oil
 xx: E443
@@ -13120,7 +12995,6 @@ vegetarian:en: yes
 wikidata:en: Q836765
 #description:en:GLYCEROL ESTER OF WOOD ROSIN,  also known as glyceryl abietate or ester gum, is an oil-soluble food additive (E number E445).
 wikipedia:en: https://en.wikipedia.org/wiki/Glycerol_ester_of_wood_rosin
-# additive/e445-glycerol-esters-of-wood-rosin has 1622 products @2019-03-23
 
 
 en: E446, Succistearin
@@ -14477,7 +14351,6 @@ description:en: CELLULOSE is an organic compound with the formula (C6H10O5)n, a 
 # sr-el:E460, Celuloza
 # xmf:E460, ცელულოზა
 e_number:en: 460
-# ingredient/fr:cellulose has 364 products in 5 languages @2019-05-17
 # usage:fr:boyau collagénique (collagène, glycérine, cellulose)
 # usage:it:stabilizzanti:cellulosa
 vegan:en: yes
@@ -14517,7 +14390,6 @@ anses_additives_of_interest:en: yes
 e_number:en: 460
 wikidata:en: Q80294
 wikipedia:en: https://en.wikipedia.org/wiki/Microcrystalline_cellulose
-# ingredient/fr:cellulose-microcristalline has 72 products in 5 languages @2019-03-19# additive/e460i-microcrystalline-cellulose has 342 products in 7 languages @2019-03-19
 
 < en: E460
 en: E460(ii), Powdered cellulose, Purified cellulose
@@ -14589,8 +14461,6 @@ description:en: METHYL CELLULOSE is a chemical compound derived from cellulose. 
 # zh-hans:E461, 甲基纤维素
 # zh-hant:E461, 甲基纖維素
 e_number:en: 461
-# additive/e461-methyl-cellulose has 960 products in 14 languages @2019-05-17
-# ingredient/fr:e461 has 180 products in 13 languages @2019-03-25
 # usage:fr:épaississant (E461)
 # usage:fr:agents de charge:E461
 vegan:en: yes
@@ -14788,8 +14658,6 @@ vegetarian:en: yes
 wikidata:en: Q411030
 # description:en:CARBOXYMETHYL CELLULOSE   (CMC) or cellulose gum or tylose powder is a cellulose derivative with carboxymethyl groups (-CH2-COOH) bound to some of the hydroxyl groups of the glucopyranose monomers that make up the cellulose backbone.
 wikipedia:en: https://en.wikipedia.org/wiki/Carboxymethyl_cellulose
-# ingredient/fr:gomme-cellulosique has 81 products in 5 languages @2019-03-13
-# ingredient/carboxymethyl-cellulose has 729 products in 11 languages @2019-04-21
 
 en: E467, Ethulose
 xx: E467
@@ -15154,8 +15022,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q416711
 wikipedia:en: https://en.wikipedia.org/wiki/Mono-_and_diglycerides_of_fatty_acids
-# mono—and-diglycerides-of-fatty-acids has 2139 products in 19 languages @2018-11-12
-# fr:diglycérides-d’acide-gras has 2301 products in 11 languages @2018-11-12
 
 < en: E471
 en: mono- and diglycerides of vegetable fatty acids
@@ -15241,7 +15107,6 @@ from_palm_oil:en: maybe
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q26806065
-# additive/e472a-acetic-acid-esters-of-mono-and-diglycerides-of-fatty-acids has 205 products in 14 languages 2018-11-13
 
 en: E472b, Lactic acid esters of mono- and diglycerides of fatty acids
 xx: E472b
@@ -15280,8 +15145,6 @@ from_palm_oil:en: maybe
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q18967238
-# fr:esters-lactiques-des-mono—et-diglycérides-d’acides-gras has 79 products in 2 languages @2018-11-12
-# additive/e472b-lactic-acid-esters-of-mono-and-diglycerides-of-fatty-acids has 724 products in 16 languages @2018-11-12
 
 
 
@@ -15323,7 +15186,6 @@ from_palm_oil:en: maybe
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q18967202
-# additive/e472c-citric-acid-esters-of-mono-and-diglycerides-of-fatty-acids has 292 products in 11 languages @2018-11-14
 
 
 en: E472d, Tartaric acid esters of mono- and diglycerides of fatty acids
@@ -15361,7 +15223,6 @@ e_number:en: 472d
 from_palm_oil:en: maybe
 vegan:en: maybe
 vegetarian:en: maybe
-# additive/e472d-tartaric-acid-esters-of-mono-and-diglycerides-of-fatty-acids has 24 products in 2 languages @2018-11-14
 
 
 en: E472e, Mono- and diacetyltartaric acid esters of mono- and diglycerides of fatty acids, Mono- and diacetyl tartaric acid esters of mono- and diglycerides of fatty acids, DATEM, Mono- and diacetyltartaric esters of mono- and diglycerides of fatty acids, emulsifier E472e
@@ -15406,7 +15267,6 @@ from_palm_oil:en: maybe
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q409406
-# additive/e472e-mono-and-diacetyltartaric-acid-esters-of-mono-and-diglycerides-of-fatty-acids has 2464 products in 22 languages @2018-11-14
 
 en: E472f, Mixed acetic and tartaric acid esters of mono- and diglycerides of fatty acids
 xx: E472f
@@ -15444,7 +15304,6 @@ from_palm_oil:en: maybe
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q18967248
-# additive/e472f-mixed-acetic-and-tartaric-acid-esters-of-mono-and-diglycerides-of-fatty-acids has 7 products in 3 languages @2018-11-13
 
 en: E472g, Succinylated monoglycerides
 xx: E472g
@@ -15522,8 +15381,6 @@ vegetarian:en: maybe
 #description:en:SUCROSE ESTERS OR SUCROSE FATTY ACID ESTERS   are a group of surfactants chemically synthesized from esterification of sucrose and fatty acids (or glycerides).
 wikidata:en: Q55648666
 wikipedia:en: https://en.wikipedia.org/wiki/Sucrose_esters
-# ingredient/fr:sucroesters-d’acide-gras has 39 products in french @2019-02-26
-# additive/e473-sucrose-esters-of-fatty-acids has 438 products in 11 languages @2019-02-26
 
 en: E473a, Oligoesters of sucrose type I, Oligoesters of sucrose type II, Oligoesters of sucrose, Oligoesters of sucrose
 xx: E473a
@@ -15629,7 +15486,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 # comment:en:Although mainly vegetable oils are used, the use of animal fat (incl. pork) can not be excluded. Several groups, such as vegans, Muslims and Jews thus avoid these products.
 wikidata:en: Q4037764
-# ingredient/fr:esters-polyglycériques-d’acides-gras has 75 products in french @2019-04-04
 # additive/e475-polyglycerol-esters-of-fatty-acids has in 16 languages @2019-04-04
 # usage:pt:emulsionantes (lecitina de soja, E472b, E475)
 
@@ -15673,7 +15529,6 @@ vegetarian:en: yes
 wikidata:en: Q168686
 # description:en:POLYGLYCEROL POLYRICINOLEATE (PGPR), is an emulsifier made from glycerol and fatty acids (usually from castor bean, but also from soybean oil). In chocolate, compound chocolate and similar coatings, PGPR is mainly used with another substance like lecithin to reduce viscosity.
 wikipedia:en: https://en.wikipedia.org/wiki/Polyglycerol_polyricinoleate
-# ingredient/fr:polyricinoléate-de-polyglycérol has 191 products in 6 languages @2019-05-06
 # usage:fr:émulsifiants (mono - et diglycérides d'acides gras, lécithine de soja, polyricinoléate de polyglycérol)
 
 
@@ -15823,8 +15678,6 @@ wikidata:en: Q416058
 # comment:en:Although mainly vegetable oils are used, the use of animal fat (incl. pork) can not be excluded. Several groups, such as vegans, Muslims and Jews thus avoid these products.
 # description:en:SODIUM STEAROYL-2-LACTYLATE is a versatile food additive used to improve the mix tolerance and volume of processed foods. It finds widespread application in baked goods, pancakes, waffles, cereals, pastas, instant rice, desserts, icings, fillings, puddings, toppings, sugar confectionaries, powdered beverage mixes, creamers, cream liqueurs, dehydrated potatoes, snack dips, sauces, gravies, chewing gum, dietetic foods, minced and diced canned meats, mostarda di frutta, and pet food.
 wikipedia:en: https://en.wikipedia.org/wiki/Sodium_stearoyl_lactylate
-# ingredient/fr:stéaroyl-2-lactylate-de-sodium has 301 products in 6 languages @2019-05-15
-# additive/e481-sodium-stearoyl-2-lactylate has 2620 products in 18 languages @2019-05-15
 # usage:fr:emulsionante (mono- et diglycérides d'acides gras, stéaroyl-2-lactylate de sodium)
 
 
@@ -16204,7 +16057,6 @@ wikidata:en: Q907898
 # comment:en:Although mainly vegetable oils are used, the use of animal fat (incl. pork) can not be excluded. Several groups, such as vegans, Muslims and Jews thus avoid these products.
 # description:en:Sorbitan monostearate is an ester of sorbitan (a sorbitol derivative) and stearic acid and is sometimes referred to as a synthetic wax.
 wikipedia:en: https://en.wikipedia.org/wiki/Sorbitan_monostearate
-# ingredient/fr:monostéarate-de-sorbitane has 27 products in 4 languages @2019-01-29
 
 
 en: E492, Sorbitan tristearate
@@ -16597,8 +16449,6 @@ vi: E500(ii), natri bicacbonat
 zh: E500(ii), 碳酸氢钠
 additives_classes:en: en:stabiliser, en:thickener
 description:en: SODIUM BICARBONATE (sodium hydrogen carbonate), commonly known as baking soda, is a chemical compound with the formula NaHCO3.
-# fr:carbonate-acide-de-sodium has 2313 products  in 13 languages @210-11-03
-# fr:500ii has 403 products @2018-11-03
 e_number:en: 500
 efsa_evaluation:en: Scientific Opinion on the safety evaluation of the active substances citric acid (E330) and sodium hydrogen carbonate (E500ii), used as carbon dioxide generators, together with liquid absorbers cellulose and polyacrylic acid sodium salt crosslinked, in active food contact materials.
 efsa_evaluation_date:en: 2013-04-09
@@ -16664,7 +16514,6 @@ efsa_evaluation_date:en: 2013-04-09
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2013.3152
 organic_eu:en: authorized
 wikidata:en: Q2234978
-# additive/e500iii-sodium-sesquicarbonate has 6 products in french @2018-12-10
 
 # the E501 family contains
 #   E501(i): Potassium carbonate,
@@ -16780,8 +16629,6 @@ wikidata:en: Q379885
 # description:en:POTASSIUM CARBONATE is the inorganic compound with the formula K2CO3. It is an ingredient in the production of grass jelly, a food consumed in Chinese and Southeast Asian cuisines, as well as Chinese noodles and moon cake. It is used to tenderize tripe. German gingerbread recipes often use potassium carbonate as a baking agent, although in combination with hartshorn.
 # comment:en:Not convinced about all the translations. Sometimes the description is to short.
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium_carbonate
-# ingredient/fr:carbonate-de-potassium has 116 products @2019-04-21
-# additive/e501i-potassium-carbonate has 434 products in 8 languages @2019-04-21
 
 < en: E501
 en: E501(ii), Potassium hydrogen carbonate, Potassium bicarbonate
@@ -16833,7 +16680,6 @@ organic_eu:en: authorized
 # description:en:POTASSIUM BICARBONATE (also known as potassium hydrogen carbonate or potassium acid carbonate) is the inorganic compound with the chemical formula KHCO3. This compound is a source of carbon dioxide for leavening in baking. As an inexpensive, nontoxic base, it is widely used in diverse application to regulate pH or as a reagent. Examples include as buffering agent in medications, an additive in winemaking. Potassium bicarbonate is often found added to club soda to improve taste, to soften the effect of effervescence.
 wikidata:en: Q410529
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium_bicarbonate
-# ingredient/fr:carbonate-acide-de-potassium has 47 products in 12 languages @2019-04-13
 # usage:en:poudre à lever (carbonate acide de potassium, carbonate acide d'ammonium, carbonate acide de sodium)
 
 en: E502, Carbonates
@@ -16946,8 +16792,6 @@ uz: E503(i), Ammoniy karbonat
 vi: E503(i), Amoni cacbonat
 zh: E503(i), 碳酸铵
 description:en: AMMONIUM CARBONATE is a salt with the chemical formula (NH4)2CO3. Since it readily degrades to gaseous ammonia and carbon dioxide upon heating, it is used as a leavening agent. It is also known as baker's ammonia and was a predecessor to the more modern leavening agents baking soda and baking powder.
-# ingredient/fr:carbonate-d'ammonium has 1983 products in 19 languages @2019-04-05
-# additive/e503i-ammonium-carbonate has 584 products in 21 languages @2019-04-05
 e_number:en: 503
 organic_eu:en: authorized
 # azb:E503(i), آمونیوم کربونات
@@ -17001,7 +16845,6 @@ te: E503(ii), అమ్మోనియం బైకార్బొనేట్
 th: E503(ii), แอมโมเนียมไบคาร์บอเนต
 zh: E503(ii), 碳酸氢铵
 description:en: AMMONIUM BICARBONATE is an inorganic compound with formula (NH4)HCO3, simplified to NH5CO3. Ammonium bicarbonate is used in the food industry as a raising agent for flat baked goods, such as cookies and crackers, and in China in steamed buns and Chinese almond cookies. It was commonly used in the home before modern day baking powder was made available.
-# additive/e503ii-ammonium-hydrogen-carbonate has 1665 products in 23 languages @2019-04-05
 e_number:en: 503
 organic_eu:en: authorized
 # azb:E503(ii), بیکربونات آمونیوم
@@ -17092,7 +16935,6 @@ uk: E504(i), Карбонат магнію
 vi: E504(i), magie cacbonat
 zh: E504(i), 碳酸鎂
 additives_classes:en: en:carrier
-# ingredient/fr:carbonates-de-magnésium has 61 products in 4 languages @2019-03-20
 description:en: MAGNESIUM CARBONATE, MgCO3 (archaic name magnesia alba), is an inorganic salt that is a white solid.
 # azb:E504(i), منیزیوم کربونات
 # sr-ec:E504(i), магнезијум карбонат
@@ -17320,7 +17162,6 @@ vegetarian:en: yes
 wikidata:en: Q208451
 # description:en:Calcium chloride is an inorganic compound, a salt with the chemical formula CaCl2.
 wikipedia:en: https://en.wikipedia.org/wiki/Calcium_chloride
-# ingredient/calcium-chloride has 5542 products in 8 languages @2018-12-10
 
 
 
@@ -17406,8 +17247,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q188543
 wikipedia:en: https://en.wikipedia.org/wiki/Ammonium_chloride
-# ingredient/fr:chlorure-d’ammonium has 34 products in 3 languages @2019-02-10
-# additive/e510-ammonium-chloride has 133 products @2019-02-10
 
 en: E511, Magnesium chloride
 xx: E511
@@ -17782,8 +17621,6 @@ wikidata:en: Q407258
 # description:en:CALCIUM SULPHATE is the inorganic compound with the formula CaSO4 and related hydrates. The calcium sulfate hydrates are used as a coagulant in products such as tofu.
 # comment:en:I can not find a product where this is used as mineral.
 wikipedia:en: https://en.wikipedia.org/wiki/Calcium_sulfate
-# ingredient/calcium-sulphate has 311 products in 6 languages @2019-05-10
-# mineral/calcium-sulphate has 2466 products in 6 languages @2019-05-11
 # usage:it:coagulo:cloruro di magnesio, solfato di calcio
 
 en: E517, Ammonium sulphate, ammonium sulfate
@@ -18084,7 +17921,6 @@ wikidata:en: Q102769
 # description:en:SODIUM HYDROXIDE is an inorganic compound with the formula NaOH. uses of sodium hydroxide include washing or chemical peeling of fruits and vegetables, chocolate and cocoa processing, caramel coloring production, poultry scalding, soft drink processing, and thickening ice cream. Olives are often soaked in sodium hydroxide for softening; Pretzels and German lye rolls are glazed with a sodium hydroxide solution before baking to make them crisp.
 # comment:en:the chemical name is preferred
 wikipedia:en: https://en.wikipedia.org/wiki/Sodium_hydroxide
-# ingredient/fr:hydroxyde-de-sodium has 268 products in 13 languages @2019-05-14
 # usage:fr:correcteur d'acidité (hydroxyde de sodium)
 
 en: E525, Potassium hydroxide
@@ -18156,8 +17992,6 @@ vegetarian:en: yes
 wikidata:en: Q132298
 # description:en:POTASSIUM HYDROXIDE is an inorganic compound with the formula KOH. In food products, potassium hydroxide acts as a food thickener, pH control agent and food stabilizer. The FDA considers it (as a direct human food ingredient) as generally safe when combined with "good" manufacturing practice conditions of use.
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium_hydroxide
-# mineral/potassium-hydroxide has 133 products in 5 languages @2019-04-24
-# ingredient/fr:hydroxyde-de-potassium has 12 products in 4 languages @2019-04-24
 
 en: E526, Calcium hydroxide, Slaked lime
 xx: E526
@@ -18333,7 +18167,6 @@ wikidata:en: Q185006
 # description:en:CALCIUM OXIDE (CaO), commonly known as quicklime or burnt lime. It is known as a food additive to the FAO as an acidity regulator, a flour treatment agent and as a leavener.
 # comment:en:The wikipedia translations often use a very popular name (caustic lime) and not the chemical description. Unlikely that that is used on a product.
 wikipedia:en: https://en.wikipedia.org/wiki/Calcium_oxide
-# ingredient/calcium-oxide has 8 products @2019-02-17
 
 en: E530, Magnesium oxide, magnesia
 xx: E530
@@ -18399,7 +18232,6 @@ wikidata:en: Q214769
 # description:en:MAGNESIUM OXIDE (MgO), is a white hygroscopic solid mineral that occurs naturally as periclase and is a source of magnesium. Magnesium oxide has poor solubility in water and is poorly absorbed from the gut. For this reason, magnesium oxide is relatively ineffective for correcting magnesium deficiency.  As a food additive, it is used as an anti-caking agent. It is known to the FDA for cacao products; canned peas; and frozen dessert.
 # comment:en:Magnesium oxide is not listed a magnesium mineral due to the bad absorption in the gut.
 wikipedia:en: https://en.wikipedia.org/wiki/Magnesium_oxide
-# ingredient/fr:oxyde-de-magnésium has 150 products in 5 languages @2019-04-24
 
 en: E535, Sodium ferrocyanide, Yellow prussiate of soda
 xx: E535
@@ -18623,8 +18455,6 @@ vegetarian:en: yes
 wikidata:en: Q116269
 # description:en:SILICON DIOXIDE, also known as silica, silicic acid or silicic acid anydride is an oxide of silicon with the chemical formula SiO2, most commonly found in nature as quartz and in various living organisms.Silica is a common additive in food production, where it is used primarily as a flow agent in powdered foods, or to adsorb water in hygroscopic applications. It is used as an anti-caking agent in powdered foods such as spices and non-dairy coffee creamer.
 wikipedia:en: https://en.wikipedia.org/wiki/Silicon_dioxide
-# ingredient/fr:e551 has 279 products @2019-03-24
-# additive/e551-silicon-dioxide has 764 products in 20 languages @2019-03-24
 # antiagglomérant (E551)
 
 en: E552, Calcium silicate
@@ -18685,8 +18515,6 @@ organic_eu:en: authorized
 vegan:en: yes
 vegetarian:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Talc
-# ingredient/fr:talc has 121 products in 4 languages @2019-04-16
-# additive/e553b-talc has 219 products in 9 languages @2019-04-16
 
 #comment:en:E553a is a synthetic form of magnesium silicates (plural)
 # the E553a family contains E553a(i): Synthetic magnesium silicate and E553a(ii): Magnesium trisilicate
@@ -19354,7 +19182,6 @@ vegetarian:en: yes
 wikidata:en: Q114174
 # description:en:GLUCONO DELTA-LACTONE (GDL), also known as gluconolactone, is a food additive with the E number E575 used as a sequestrant, an acidifier, or a curing, pickling, or leavening agent.
 wikipedia:en: https://en.wikipedia.org/wiki/Glucono_delta-lactone
-# ingredient/fr:glucono-delta-lactone has 71 products in 9 languages @2019-04-12
 # usage:fr:poudres à lever (glucono-delta-lactone, carbonate acide de sodium)
 
 en: E576, Sodium gluconate
@@ -19473,7 +19300,6 @@ vegetarian:en: yes
 wikidata:en: Q413739
 # description:en:CALCIUM GLUCONATE is a mineral supplement and medication.
 wikipedia:en: https://en.wikipedia.org/wiki/Calcium_gluconate
-# ingredient/calcium-gluconate has 44 products in 2 languages @2018-12-11
 
 #WARNING:IRON(II) GLUCONATE is for the moment listed in both the additves and ingredients taxonomy.
 #<en:iron
@@ -19508,7 +19334,6 @@ sl: E579, Železov glukonat
 sr: E579, Gvožđe glukonat
 sv: E579, Järnglukonat
 tr: E579, ferrous gluconate
-# ingredient/fr:gluconate-de-fer has 37 products in 6 languages @2019-02-22
 description:en: IRON(II) GLUCONATE, or ferrous gluconate,[1] is a black compound often used as an iron supplement. It is the iron(II) salt of gluconic acid.
 # azb:E579, قلوکونات دمیر
 e_number:en: 579
@@ -19599,7 +19424,6 @@ vegetarian:en: yes
 wikidata:en: Q836793
 # description:en:FERROUS LACTATE, or iron(II) lactate, is a chemical compound consisting of one atom of iron (Fe2+) and two lactate anions.
 wikipedia:en: https://en.wikipedia.org/wiki/Iron(II)_lactate
-# fr:lactate-de-fer has 23 products in 3 languages @2019-01-27
 
 en: E586, 4-hexylresorcinol, 4-Hexyl-1\,3-benzenediol
 xx: E586
@@ -19755,9 +19579,6 @@ wikipedia_title:en: Monosodium glutamate
 wikipedia_title:fr: Glutamate monosodique
 wikipedia_url:en: https://en.wikipedia.org/wiki/Monosodium_glutamate
 wikipedia_url:fr: https://fr.wikipedia.org/wiki/Glutamate_monosodique
-# ingredient/fr:monoglutamate-de-sodium has 78 products in french @2019-01-25
-# additive/e621-monosodium-glutamate has 8428 products in 31 languages @2019-01-25
-# ingredient/fr:monosodium-glutamate has 62 products @2019-01-25
 
 
 en: E622, Monopotassium glutamate, Potassium glutamate
@@ -19978,8 +19799,6 @@ vegetarian:en: maybe
 wikidata:en: Q905776
 # description:en:Disodium guanylate, also known as sodium 5'-guanylate and disodium 5'-guanylate, is a natural sodium salt of the flavor enhancing nucleotide guanosine monophosphate (GMP)
 wikipedia:en: https://en.wikipedia.org/wiki/Disodium_guanylate
-# ingredient/fr:guanylate-de-sodium has 27 products in french @2019-03-09
-# ingredient/fr:guanylate-disodique has 248 products in 7 languages @2019-03-09
 
 
 # comment:en:Guanlyic acic and guanylates are generally produced from yeasts, but partly also from fish. They may thus not suitable for vegans and vegetarians.
@@ -20117,8 +19936,6 @@ vegetarian:en: maybe
 wikidata:en: Q905782
 #description:en:DISODIUM INOSINATE (E631) is the disodium salt of inosinic acid with the chemical formula C10H11N4Na2O8P.
 wikipedia:en: https://en.wikipedia.org/wiki/Disodium_inosinate
-# ingredient/fr:inosinate-de-sodium has 25 products in french @2019-03-09
-# additive/e631-disodium-inosinate has 2638 products in 20 languages @2019-03–09
 
 en: E632, Dipotassium inosinate, Potassium inosinate
 xx: E632
@@ -20240,7 +20057,6 @@ vegetarian:en: maybe
 wikidata:en: Q18967210
 # description:en:DISODIUM 5'-RIBONUCLEOTIDES, E number E635, is a flavor enhancer which is synergistic with glutamates in creating the taste of umami.
 wikipedia:en: https://en.wikipedia.org/wiki/Disodium_ribonucleotides
-# additive/e635-disodium-5-ribonucleotide has 454 products in 21 languages @2019-01-05
 
 en: E636, Maltol
 xx: E636
@@ -20566,7 +20382,6 @@ vegetarian:en: yes
 # description:en:Leucine (symbol Leu or L)[2] is an essential amino acid that is used in the biosynthesis of proteins.
 wikidata:en: Q483745
 wikipedia:en: https://en.wikipedia.org/wiki/Leucine
-# ingredient/fr:l-leucine has 104 products in 4 languages @2019-02-16
 
 en: E642
 xx: E642
@@ -20945,7 +20760,6 @@ vegetarian:en: yes
 wikidata:en: Q143739
 # description:en:BEESWAX (cera alba) is a natural wax produced by honey bees of the genus Apis. The three main types of beeswax products are yellow, white, and beeswax absolute. Beeswax may be used in small quantities acting as a glazing agent, which serves to prevent water loss, or used to provide surface protection for some fruits, soft gelatin capsules and tablet coatings. Beeswax is also a common ingredient of natural chewing gum.
 wikipedia:en: https://en.wikipedia.org/wiki/Beeswax
-# ingredient/beewax has 260 products in 7 languages @2019-05-13
 # usage:fr:agent antiadhérant:cire d'abeilles
 
 en: E902, Candelilla wax
@@ -21030,7 +20844,6 @@ vegetarian:en: yes
 wikidata:en: Q839494
 # description:en:CARNAUBA WAX, also called Brazil wax and palm wax, is a wax of the leaves of the palm Copernicia prunifera (Synonym:Copernicia cerifera), a plant native to and grown only in the northeastern Brazil.
 wikipedia:en: https://en.wikipedia.org/wiki/Carnauba_wax
-# additive/e903-carnauba-wax has 4590 products @2019-03-08
 
 en: E904, Shellac, Bleached shellac
 xx: E904
@@ -21089,7 +20902,6 @@ vegetarian:en: no
 wikidata:en: Q429659
 # description:en:SHELLAC is a resin secreted by the female lac bug, on trees in the forests of India and Thailand. It is processed and sold as dry flakes (pictured) and dissolved in alcohol to make liquid shellac, which is used as a brush-on colorant, food glaze and wood finish.
 wikipedia:en: https://en.wikipedia.org/wiki/Shellac
-# ingredient/fr:gomme-laque has 48 products in 4 languages @2019-02-17
 
 en: E905, Synthetic wax, Hydrocarbon wax, Fischer-Tropsch wax
 xx: E905
@@ -22144,9 +21956,6 @@ wikidata:en: Q186474
 # description:en:CYSTEINE is a semiessential proteinogenic amino acid with the formula HO2CCH(NH2)CH2SH. One of the largest applications is the production of flavors. For example, the reaction of cysteine with sugars in a Maillard reaction yields meat flavors. L-Cysteine is also used as a processing aid for baking. The animal-originating sources of L-cysteine as a food additive are a point of contention for people following dietary restrictions such as kosher, halal, vegan or vegetarian.
 # comment:en:The wikidata translation only translates the cystein part, not the chirality L. I tried to repair the wikidata-entry based on wikipedia as much as possible.
 wikipedia:en: https://en.wikipedia.org/wiki/Cysteine
-# ingredient/fr:l-cystéine has 58 products in 6 languages @2019-04-09
-# ingredient/fr:cystéine has 207 products in 6 languages @2019-04-10
-# additive/e920-l-cysteine-hydrochloride has 393 products @2019-04-09
 # usage:en:Flour treatment agent (l - cysteine)
 # en:source-material:en:animal or synthetic
 
@@ -23126,8 +22935,6 @@ vegetarian:en: yes
 wikidata:en: Q627
 # description:en:NITROGEN is a chemical element with symbol N and atomic number 7. Nitrogen can be used as a replacement, or in combination with, carbon dioxide to pressurise kegs of some beers, particularly stouts and British ales, due to the smaller bubbles it produces, which makes the dispensed beer smoother and headier.
 wikipedia:en: https://en.wikipedia.org/wiki/Nitrogen
-# ingredient/fr:azote has 19 products in 4 languages @2019-04-20
-# additive/e941-nitrogen has 63 products in 9 languages @2019-04-20
 # usage:es:agente de carga (E941)
 
 
@@ -23200,8 +23007,6 @@ vegetarian:en: yes
 wikidata:en: Q905750
 # description:en:NITROUS OXIDE, commonly known as laughing gas or nitrous, is a chemical compound, an oxide of nitrogen with the formula N2O.
 wikipedia:en: https://en.wikipedia.org/wiki/Nitrous_oxide
-# ingredient/fr:protoxyde-d’azote has 21 products in 3 languages @2019-02-20
-# additive/e942-nitrous-oxide has 120 products in 7 languages @2019-04-20
 
 en: E943a, Butane
 xx: E943a
@@ -23484,7 +23289,6 @@ e_number:en: 950
 efsa_evaluation:en: Safety of the proposed extension of use of acesulfame K (E 950) in foods for special medical purposes in young children
 efsa_evaluation_date:en: 2016-04-05
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2016.4437
-# ingredient/fr:acésulfame-k has 1285 products in 11 languages @2019-03-24
 non_nutritive_sweetener:en: yes
 sweetener:en: yes
 vegan:en: yes
@@ -23560,8 +23364,6 @@ efsa_evaluation_adi:en: 40
 efsa_evaluation_date:en: 2013-12-10
 efsa_evaluation_overexposure_risk:en: en:no
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2013.3496
-# ingredient/fr:e951 has 59 products @2019-03-24
-# additive/e951-aspartame has 3046 products in 23 languages @2019-03-24
 non_nutritive_sweetener:en: yes
 sweetener:en: yes
 vegan:en: yes
@@ -23613,7 +23415,6 @@ additives_classes:en: en:sweetener
 # zh-sg:E952, 甜蜜素
 # zh-tw:E952, 甜蜜素
 e_number:en: 952
-# ingredient/fr:cyclamate has 48 products in 4 languages @2019-03-03
 non_nutritive_sweetener:en: yes
 sweetener:en: yes
 vegan:en: yes
@@ -23664,7 +23465,6 @@ description:en: ISOMALT is a sugar substitute, a type of sugar alcohol used prim
 # sr-ec:E953, изомалт
 # sr-el:E953, Izomalt
 e_number:en: 953
-# ingredient/fr:isomalt has 399 products in 7 languages @2019-05-18
 # usage:fr:édulcorants (maltitol, isomalt)
 sweetener:en: yes
 vegan:en: yes
@@ -23964,7 +23764,6 @@ sl: E959, Neohesperidin dc, Neohesperidin dihidroalkon, Neohesperidin
 sr: E959, neohesperidin DC
 sv: E959, Neohesperidin dc, Neohesperidindihydrochalkon, NHDC
 zh: E959, 新橙皮苷二氢查耳酮
-# ingredient/fr:néohespéridine-dc has 26 products in 3 languages @2019-02-13
 additives_classes:en: en:sweetener
 # zh-cn:E959, 新橙皮苷二氢查耳酮
 # zh-hans:E959, 新橙皮苷二氢查耳酮
@@ -24016,8 +23815,6 @@ efsa_evaluation_exposure_95th_greater_than_adi:en: en:toddlers
 efsa_evaluation_exposure_mean_greater_than_adi:en: en:no-group
 efsa_evaluation_overexposure_risk:en: en:moderate
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2015.4146
-# additive/e960-steviol-glycosides has 1413 products in 17 languages @2019-04-20
-# ingredient/fr:extrait-de-stevia-rebaudiana has 77 products in 8 languages @2019-04-20
 # usage:fr:édulcorant :glycosides de stéviol (extrait de stevia rebaudiana)
 non_nutritive_sweetener:en: yes
 sweetener:en: yes
@@ -24202,8 +23999,6 @@ sr: E962, Aspartam-acesulfamska so
 sv: E962, Salt av aspartam och acesulfam, Aspartam och acesulfam, Aspartam-acesulfamsalt, E 962
 additives_classes:en: en:sweetener
 e_number:en: 962
-# ingredient/fr:sel-d'aspartame-acésulfame has 15 products in french @2019-04-20
-# additive/e962-salt-of-aspartame-acesulfame has 51 products in 4 languages @2019-04-20
 non_nutritive_sweetener:en: yes
 sweetener:en: yes
 vegan:en: yes
@@ -24353,7 +24148,6 @@ e_number:en: 965
 efsa_evaluation:en: Opinion of the Scientific Panel on Food Additives, Flavourings, Processing Aids and Materials in Contact with Food on a request from the Commission related to Maltitol Syrup E 965(ii) new production process. Change of specification
 efsa_evaluation_date:en: 2006-05-18
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2006.354
-# ingredient/fr:maltitol has 656 products in 11 languages @2019-05-18
 # usage:de:Süssungsmittel (Maltit)
 sweetener:en: yes
 vegan:en: yes
@@ -24534,8 +24328,6 @@ vegetarian:en: yes
 wikidata:en: Q212093
 # description:en:XYLITOL is a sugar alcohol used as a sugar substitute. Xylitol is naturally occurring in small amounts in plums, strawberries, cauliflower, and pumpkin. Xylitol is used as a sugar substitute in manufactured products, such as drugs or dietary supplements, confections, toothpaste, and chewing gum, but is not a common household sweetener.
 wikipedia:en: https://en.wikipedia.org/wiki/Xylitol
-# ingredient/xylitol has 539 products in 8 languages @2019-05-10
-# additive/e967-xylitol has 653 products in 12 languages @2019-05-10
 # usage:sv:sötningsmedel (sorbital, maltitol, xylitol 2%, aspartam, acesulfam K)
 
 en: E968, Erythritol, Meso-erythritol, Tetrahydroxybutane, E-968, E 968
@@ -24595,8 +24387,6 @@ vegetarian:en: yes
 wikidata:en: Q421873
 # description:en:  ERYTHRITOL is a sugar alcohol (or polyol) that is considered safe (GRAS) as a food additive in the United States and throughout much of the world. It occurs naturally in some fruit and fermented foods. At the industrial level, it is produced from glucose by fermentation with a yeast, Moniliella pollinis. Erythritol is 60–70% as sweet as sucrose (table sugar) yet it is almost noncaloric, does not affect blood sugar, does not cause tooth decay, and is partially absorbed by the body, excreted in urine and feces.
 wikipedia:en: https://en.wikipedia.org/wiki/Erythritol
-# ingredient/fr:érythritol has 88 products in 4 languages @2019-04-5
-# additive/e968-erythritol has 662 products in 7 languages @2019-04-05
 
 en: E969, Advantame
 xx: E969
@@ -24762,13 +24552,11 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q17153
 wikipedia:en: https://en.wikipedia.org/wiki/Amylase
-# ingredient/fr:amylase has 438 products in french @2019-07-09
 # usage:fr: enzymes (amylase, cellulase)
 # description:en:AMYLASE are enzymes that catalyse the hydrolysis of starch into sugars.
 # comment:en:when indicated, probably alpha-amylase is meant
 # alpha-amylase, (α-amylase) is a protein enzyme EC 3.2.1.1 that hydrolyses alpha bonds of large, alpha-linked polysaccharides, such as starch and glycogen, yielding glucose and maltose.
 # wikipedia:en:https://en.wikipedia.org/wiki/Alpha-amylase
-# additive/e1100-alpha-amylase has 518 products @2019-02-01
 
 en: E1101, Protease, peptidase, proteinase, EC 3.4, E-1101, E 1101
 xx: E1101
@@ -24829,7 +24617,6 @@ wikidata:en: Q212410
 # wikidata:en:Q212410
 #comment:en:the preferred name on products is protease. Not possible to copy 1:1
 wikipedia:en: https://en.wikipedia.org/wiki/Protease
-# ingredient/fr:protéase has 111 products in 5 languages @2019-02-01
 
 en: E1102, Glucose oxidase
 xx: E1102
@@ -24908,7 +24695,6 @@ vegetarian:en: yes
 wikidata:en: Q419189
 # description:en:INVERTASE is an enzyme that catalyzes the hydrolysis (breakdown) of sucrose (table sugar) into fructose and glucose. For industrial use, invertase is usually derived from yeast. It is also synthesized by bees, which use it to make honey from nectar. Chocolate-covered cherries, other cordials, and fondant candies include invertase, which liquefies the sugar.
 wikipedia:en: https://en.wikipedia.org/wiki/Invertase
-# ingredient/fr:invertase has 245 products in 7 languages @2019-05-10
 # usage:fr:stabilisant (invertase)
 
 
@@ -24962,7 +24748,6 @@ uk: E1104, Ліпаза
 uz: E1104, Lipaza
 vi: E1104, Lipase
 zh: E1104, 脂酶
-# ingredient/fr:lipase has 155 products in 3 languages @2019-07-09
 description:en: A LIPASE is any enzyme that catalyzes the hydrolysis of fats (lipids). Lipases serve important roles in human practices as ancient as yogurt and cheese fermentation. Lipases are generally animal sourced, but can also be sourced microbially.
 # kk-arab:E1104, لىيپازالار
 # kk-cn:E1104, لىيپازالار
@@ -26230,7 +26015,6 @@ vegetarian:en: yes
 wikidata:en: Q418057
 # description:en:TRIETHYL CITRATE is an ester of citric acid.
 wikipedia:en: https://en.wikipedia.org/wiki/Triethyl_citrate
-# ingredient/triethyl-citrate has 119 products in 4 languages @2019-02-26
 # stabilizzante:E1505
 
 en: E1510, Ethanol, ethyl alcohol, Methylcarbinol, Ethyl hydroxide, Ethyl hydrate
@@ -26602,15 +26386,12 @@ ru: дифосфаты и карбонаты натрия
 sk: difosforečnany a uhličitany sodné
 sl: difosfati in natrijevi karbonati
 sv: difosfater och natriumkarbonater
-# fr:e450-et-e500 has 64 products in 4 languages @2018-11-04
-# ingredient/fr:diphosphate-et-carbonate-de-calcium has 678 products @2019-05-18
 
 < en: E450(i)
 < en: E500(ii)
 ca: carbonat àcid de sodi i difosfat de disodi
 fr: diphosphate disodique et carbonate acide de sodium
 ru: сода, сода пищевая, гидрокарбонат натрия, разрыхлитель гидрокарбонат натрия
-# fr:diphosphate-disodique-et-carbonate-acide-de-sodium has 72 products in 2 languages @2018-11-04
 
 < en: E450
 < en: E451
@@ -26665,5 +26446,4 @@ ru: карбонаты аммония и натрия
 sk: uhličitany amónne a sodné
 sl: amonijevi in natrijevi karbonati
 sv: ammonium- och natriumkarbonater
-# ingredient/fr:carbonates-d’ammonium-et-de-sodium has 110 products in 7 languages @2019-04-06
 

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -614,7 +614,6 @@ it: coloranti naturali, colorante naturale
 nl: Natuurlijke kleurstoffen, natuurlijk kleurstof
 pl: barwnik naturalny, barwniki naturalne, naturalny barwnik, naturalne barwniki, naturalny preparat barwiący
 ru: краситель натуральный, натуральный краситель, натуральные красители
-# ingredient/fr:colorant-naturel has 283 products in 5 languages @2019-04-20
 
 < en: colour
 fr: denrée alimentaire colorante, denrées alimentaires colorantes
@@ -624,7 +623,6 @@ es: colorante alimenticio, colorantes alimenticios
 hu: élelmiszer színezék
 it: sostanze alimentari coloranti
 pl: żywność barwiąca, środek spożywczy o właściwościach barwiących, środek spożywczy barwiący, środki spożywcze barwiące
-# ingredient/fr:denrée-alimentaire-colorante has 202 products in 3 languages @2019-03-27
 # denrées alimentaires colorantes: concentrés de spriruline et de carthame
 
 < en: colour
@@ -663,7 +661,6 @@ th: สารให้สีเปลือก
 tr: kabuk renklendirici
 uk: барвник для скоринки
 zh: 外壳着色剂
-# ingredient/fr:colorant-de-la-croûte has 73 products in 2 languages @2019-03-27
 
 # http://www.fao.org/gsfaonline/additives/results.html?techFunction=10&searchBy=tf
 en: colour retention agent, colour adjunct, colour fixative, colour stabilizer, maintain color, color retention
@@ -931,7 +928,6 @@ sk: Stimulátor, zvýrazňovač chuti
 sl: Ojačevalec arome
 sv: Smakförstärkare
 zh: 增味劑
-# ingredient/fr:exhausteur-de-saveur has 32 products in 4 languages @2019-03-01
 description:en: Flavour enhancers are substances which enhance the existing taste and/or odour of a foodstuff.
 description:bg: Подобрители на вкуса са вещества, които подобряват вкуса и/или аромата на хранителни продукти.
 description:ca: Potenciadors del gust: substàncies que milloren el gust i/o l'olor d'un aliment.
@@ -1094,7 +1090,6 @@ ru: загустители, агент желирующий, желирующи�
 sk: Želírujúca látka
 sl: Želirno sredstvo
 sv: Geleringsmedel, Geleringmedel
-# fr:Gélifiant has 8019 products in 18 languages @2018-11-03
 description:en: Gelling agents are substances which give a foodstuff texture through formation of a gel.
 description:ar: وكلاء التجميد هي المواد التي تعطي للمواد الغذائية قوامًا من خلال تكوين هلام.
 description:cs: Želírujícími látkami se rozumějí látky, které udělují potravině texturu tím, že vytvářejí gel.
@@ -1378,7 +1373,6 @@ tr: meyve koruyucu
 uk: консервант для фруктів
 vi: chất bảo quản trái cây
 zh: 水果防腐剂
-# ingredient/fr:conservateur-de-fruit has 43 products in french@2019-02-10
 # ingredient/fr:conservateur-du-fruit has 124 produits in french @2019-05-02
 # usage:fr: Conservateur du fruit : Sorbate de potassium
 
@@ -1602,7 +1596,6 @@ sk: Stabilizátor
 sl: Stabilizator, Vezivo
 sv: Stabiliseringsmedel, Stabiliseringsämne, Stabilisator, Stabilisatorer, Stabilisering, Konsistensgivare, bindningsämnen
 #latest wikidata merge 2020-08-18 @aleene
-# ingredient/fr:liant has 52 products in 5 languages @2019-02-05
 # liant (amidon modifié de pomme de terre)
 # legante (gomma di guar, xantano)
 description:en: Stabilisers are substances which make it possible to maintain the physico-chemical state of a foodstuff; stabilisers include substances which enable the maintenance of a homogenous dispersion of two or more immiscible substances in a foodstuff, substances which stabilise, retain or intensify an existing colour of a foodstuff and substances which increase the binding capacity of the food, including the formation of cross-links between proteins enabling the binding of food pieces into re-constituted food.
@@ -1879,7 +1872,6 @@ fr: agent de coagulation, coagulant
 hu: koagulálószer, koaguláló, koaguláns
 it: agente coagulante, coagulante, agenti coagulanti, coagulanti
 ja: 凝固剤
-# ingredient/fr:agents-de-coagulation has 37 products in 5 languages @2019-02-08
 
 en: salt substitute
 ar: بديل الملح
@@ -1923,7 +1915,6 @@ tr: tuz ikamesi
 uk: замінник солі
 vi: chất thay thế muối
 zh: 盐替代品
-# ingredient/fr:substitut-du-sel has 23 products in 3 languages @2019-02-21
 # substitut du sel (chlorure de potassium)
 
 # also in ingredients.txt
@@ -1932,11 +1923,9 @@ en: creaming agent
 es: agente cremoso
 fr: agent de crémage, agent crémeux
 it: agente cremoso
-# ingredient/fr:agent-cremeux has 16 products in french @2018-02-17
 
 # also in ingredients.txt
 fr: conservateur de surface
-# ingredient/fr:conservateur-de-surface has 43 products in french @2019-03-02
 
 
 # also in ingredients.txt
@@ -1950,7 +1939,6 @@ hu: javító
 it: miglioranti, migliorante, agente migliorante, agenti miglioranti
 lv: uzlabotājs
 nl: verbeteraar
-# ingredient/fr:améliorant has 95 products in 5 languages @2019-03-06
 # améliorants (émulsifiant: E 472e, correcteurs d'acidité: E 516 et acide ascorbique, farine de soja, farine de blé)
 
 # also in ingredients.txt
@@ -1974,12 +1962,10 @@ ko: 요리 향상제
 pt: intensificador de cozimento
 ru: усилитель кулинарии
 zh: 烹饪增强剂
-# ingredient/fr:améliorant-de-cuisson has 51 products in 4 languages @2019-04-16
 # usage:en: acerola powder with cassava starch (cooking enhancer)
 
 fr: additifs alimentaires
 hr: aditiv, funkcionalno svojstvo
-# ingredient/fr:additifs-alimentaires has 52 products @2019-04-20
 # usage:fr: additif alimentaire (acide citrique)
 
 # roughly translates to "complex food supplement"

--- a/taxonomies/amino_acids.txt
+++ b/taxonomies/amino_acids.txt
@@ -543,8 +543,6 @@ zh: 色氨酸
 # zh-tw:色胺酸
 wikidata:en: Q181003
 wikipedia:en: https://en.wikipedia.org/wiki/L-tryptophan—pyruvate_aminotransferase
-# amino-acid/l-tryptophan has 79 products @2019-03-16
-# ingredient/fr:l-tryptophane has 61 products in 4 languages @2019-03-16
 
 < en: Amino acids
 en: L-tyrosine

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -34855,7 +34855,6 @@ ur: بسکٹ
 vi: Bích quy
 wa: Biscûte
 zh: 面饼
-# ingredient/fr:biscuit has 391 products in 8 languages @2019-02-23
 # Biscuit (egg, wheat flour, sugar, emulsifier:mono - and diglycerides of fatty acids, leavening agents:diphosphates and sodium carbonate)
 agribalyse_proxy_food_code:en: 24000
 carbon_footprint_fr_foodges_ingredient:fr: Biscuit au beurre
@@ -35636,8 +35635,6 @@ nl: Petit Beurre
 sr: Пти-бер
 tr: Petibör
 zh: 不的波
-# ingredient/fr:petit-beurre has 20 products in french @2018-02-08
-# category/petit-beurre has 263 products @2018-05-19
 agribalyse_food_code:en: 24015
 ciqual_food_code:en: 24015
 ciqual_food_name:en: Butter biscuit (cookie)
@@ -37784,8 +37781,6 @@ sv: krutong
 tr: kruton
 uk: грінки
 zh: 麵包丁
-# ingredient/fr:croûtons has 107 products in 5 languages @2019-04-21
-# category/croutons has 166 products @2019-05-19
 # usage:en:croutons (wheat flour, vegetable fat, edible salt, maltodextrin, grape sugar, onions, herbs, yeast extract, dehydrated garlic, flavoring, yeast, spice extract)
 agribalyse_food_code:en: 7430
 ciqual_food_code:en: 7430
@@ -38484,8 +38479,6 @@ zh: 蛋糕
 ciqual_food_code:en: 23000
 ciqual_food_name:en: Cake (average)
 ciqual_food_name:fr: Gâteau (aliment moyen)
-# category/cakes has 6408 products @2019-05-20
-# ingredient/fr:gâteau has 59 products in french @2019-02-06
 description:en: Cake is a form of sweet food that is usually baked. The most commonly used cake ingredients include flour, sugar, eggs, butter or oil or margarine, a liquid, and leavening agents, such as baking soda or baking powder. Common additional ingredients and flavourings include dried, candied, or fresh fruit, nuts, cocoa, and extracts such as vanilla, with numerous substitutions for the primary ingredients. Cakes can also be filled with fruit preserves, nuts or dessert sauces (like pastry cream), iced with buttercream or other icings, and decorated with marzipan, piped borders, or candied fruit.
 gpc_category_code:en: 10000172
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a sweet prepared food, usually made from flour, sugar, shortening/fat and eggs mixed with other ingredients and baked or fried. These products have been treated or packaged in such a way as to extend their consumable life. Definition Excludes: Excludes products such as Perishable and Frozen Cakes, Cake Mixes, all Bread Products.
@@ -42144,8 +42137,6 @@ tr: Nuga
 uk: Нуга
 vi: Kẹo Hạnh Phúc
 zh: 牛轧糖
-# category/nougats has 421 products @2019-05-18
-# ingredient/nougat has 52 products in 5 languages @2019-02-08
 # nougat (cane sugar , hazelnuts 33%, cocoa mass, cocoa butter)
 agribalyse_food_code:en: 31033
 ciqual_food_code:en: 31033
@@ -42676,7 +42667,6 @@ sv: Marsipan
 tr: Badem ezmesi
 uk: Марципан
 zh: 杏仁膏
-# ingredient/fr:massepain has 27 products in 4 languages @2019-02-12
 description:en: Marzipan is a confection consisting primarily of sugar or honey and almond meal (ground almonds), sometimes augmented with almond oil or extract.
 # ast:Mazapán
 # lfn:Masapan
@@ -49696,8 +49686,6 @@ ru: сыр из овечьего молока
 sr: овчији сир
 sv: Fårost
 zh: 羊奶酪
-# ingredient/fr:fromage-de-brebis has 42 products @2018-10-27
-# category/Sheep-Cheeses has 868 products @2019-05-24
 agribalyse_food_code:en: 12824
 ciqual_food_code:en: 12824
 ciqual_food_name:en: Soft ripened cheese with bloomy rind, from ewe's milk, Camembert-type cheese
@@ -52959,8 +52947,6 @@ zh: 奶渣
 ciqual_food_code:en: 19501
 ciqual_food_name:en: Quark, plain or fruit (average)
 ciqual_food_name:fr: Fromage blanc nature ou aux fruits (aliment moyen)
-# ingredient/nl:kwark has 2 products @2019-05-24
-# category/quark has 221 products @2019-05-24
 description:en: Quark is a type of fresh dairy product made by warming soured milk until the desired amount of curdling is met, and then straining it.
 google_product_taxonomy_id:en: 1855
 # bar:Tschottn
@@ -60871,7 +60857,6 @@ zh: 鹌鹑蛋
 ciqual_food_code:en: 22050
 ciqual_food_name:en: Quail egg, raw
 ciqual_food_name:fr: Oeuf de caille, cru
-# ingredient/fr:oeufs-de-cailles has 25 products @2019-05-23
 description:en: Quail eggs are the eggs layed by a quail. They can be prepared the same as chicken eggs.
 # tg-latn:Tuxmi bedona
 wikidata:en: Q1572135
@@ -65416,7 +65401,6 @@ agribalyse_proxy_food_name:fr: Muesli floconneux ou de type traditionnel
 ciqual_food_code:en: 32004
 ciqual_food_name:en: Muesli (average)
 ciqual_food_name:fr: Muesli (aliment moyen)
-# ingredient/fr:muesli has 46 products in 4 languages @2019-02-07
 description:en: Muesli is a breakfast dish based on raw rolled oats and other ingredients like grains, fresh or dried fruits, seeds and nuts, that may be mixed with milk, soy milk, almond milk, other plant milks, yogurt, or fruit juice.
 # be-tarask:Мюсьлі
 # ceb:Müesli
@@ -68540,7 +68524,6 @@ description:en: Ice cream is a sweetened frozen food typically eaten as a snack 
 # zh-my:冰淇淋
 # zh-sg:冰淇淋
 # zh-tw:冰淇淋
-# ingredient/ice-cream has 264 products in english @2019-04-29
 # usage:en:Ice cream:organic cream, organic milk, organic cane sugar, organic egg yolks, organic vanilla extract, organic locust bean gum, organic guar gum
 # usage:fr:glace (sucre, kirsch de Bâle-Campagne)
 nova:en: 3
@@ -75065,8 +75048,6 @@ google_product_taxonomy_id:en: 6812
 sales_format:en: weight, package
 wikidata:en: Q1652093
 wikipedia:en: https://en.wikipedia.org/wiki/Date_palm#Fruits
-# ingredient/dates has 827 products in 11 languages @2018-09-29
-# category/dates has 311 products @2019-05-24
 
 < en: Dates
 < en: Fruit pastes
@@ -87014,7 +86995,6 @@ uz: sho'rva
 vi: canh
 yi: יויך
 zh: 清汤
-# category/broths has 527 products @2019-05-19
 description:en: Broth is a savory liquid made of water in which bones, meat, fish, or vegetables have been simmered.
 gpc_category_code:en: 10000578
 gpc_category_description:en: Definition: Includes any products that can be described/observed as an extract resulting from boiling meat or fish and/or vegetables.  The extract is added to season or give a defined flavour to a particular food or recipe. These products have been treated or packaged in such a way as to extend their consumable life. Definition Excludes: Excludes products such as Perishable and Frozen Stock/Bones; Shelf Stable Extracts; Perishable or Shelf Stable Herbs and Spices; Gravy Browning; Soup Mixes.
@@ -93999,8 +93979,6 @@ xh: Inkuku
 yi: האן
 za: Gaeq
 zh: 鸡, 鸡肉
-# ingredient/chicken has 872 products @2019-05-18
-# category/chickens has 3369 products in 18 languages @2019-05-18
 agribalyse_food_code:en: 36016
 ciqual_food_code:en: 36016
 ciqual_food_name:en: Chicken, meat and skin, raw
@@ -96870,8 +96848,6 @@ tl: Longganisa
 uk: Чорісос
 vi: Chorizo
 zh: 乔利佐
-# ingredient/fr:chorizo has 210 products in 6 languages @2019-04-24
-# category/fr:chorizos has 267 products @2019-05-19
 # usage:fr:chorizo (maigre et gras de porc, sel, épices et extraits d'épices, dextrose de blé, ferments lactiques, conservateurs :E301, E250)
 agribalyse_food_code:en: 30315
 ciqual_food_code:en: 30315
@@ -99680,7 +99656,6 @@ wa: påsses itålyinnes
 wo: makaróni
 zh: 意式面食
 carbon_footprint_fr_foodges_ingredient:fr: Pâtes sèches
-# ingredient/fr:pâtes-alimentaires has 115 products 2019-05-20
 description:en: Pasta is type of noodle typically made from an unleavened dough of durum wheat flour mixed with water or eggs, and formed into sheets or various shapes, then cooked by boiling or baking. Rice flour, or legumes such as beans or lentils, are sometimes used in place of wheat flour to yield a different taste and texture, or as a gluten-free alternative. Pasta is a staple food of Italian cuisine.
 # ast:pastia
 # be-tarask:паста
@@ -100896,7 +100871,6 @@ zh: 意大利餃
 ciqual_food_code:en: 25216
 ciqual_food_name:en: Pasta (e.g. ravioli), filled, cooked
 ciqual_food_name:fr: Pâtes fraîches farcies (ex : raviolis), cuites (aliment moyen)
-# ingredient/ravioli has 92 products in 6 languages @2019-02-17
 # ravioli (water, durum wheat, 24% cream cheese, egg [open-air] 7%, mascarpone cheese, bread crumbs, coconut cream, 1% lemon juice, broth of vegetables, sugar, whey powder, juice of limes 0.3%, iodized cooking salt, lemon zest 0.2%, lemon extract 0.1%, syrup of limes, spices)
 description:en: Ravioli are a type of dumpling comprising a filling enveloped in thin pasta dough.
 # en-ca:Ravioli
@@ -113838,8 +113812,6 @@ ur: شاخ گوبھی
 vi: Bông cải xanh
 zh: 西蘭花
 # carbon_footprint_fr_foodges_ingredient:fr:Brocoli (France)
-# ingredient/broccoli has 1167 products in 10 languages @2018-10-16
-# category/broccoli has 150 products @2019-05-24
 agribalyse_food_code:en: 20057
 ciqual_food_code:en: 20057
 ciqual_food_name:en: Broccoli, raw
@@ -114446,8 +114418,6 @@ sv: Mangold
 tr: Pazı
 uk: Мангольд
 zh: 莙薘菜
-# ingredient/fr:blette/languages has 88 products in 8 languages @2019-03-22
-# category/chards has 16 products @2019-05-22
 agribalyse_proxy_food_code:en: 20004
 agribalyse_proxy_food_name:en: Swiss chard, raw
 agribalyse_proxy_food_name:fr: Bette ou blette, crue
@@ -114574,8 +114544,6 @@ uk: цикорій салатний
 vi: Rau cúc đắng
 zh: 苦苣
 # wikidata:en:Q28604477 what is this?
-# category/endives has 8 products @2019-05-22
-# ingredient/endive has 125 products @2019-05-22
 agribalyse_food_code:en: 20090
 ciqual_food_code:en: 20090
 ciqual_food_name:en: Escaroles
@@ -114728,7 +114696,6 @@ tr: Rezene
 uk: фенхель
 ur: سونف
 zh: 茴香
-# fr:fenouil has 634 products in 6 languages @2018-10-21
 agribalyse_food_code:en: 20028
 ciqual_food_code:en: 20028
 ciqual_food_name:en: Fennel, raw
@@ -115013,8 +114980,6 @@ vi: Tỏi tây
 wa: Porea
 yi: פארע-ציבעלע
 zh: 韭葱
-# ingredient/leek has 3620 products in 19 languages @2019-05-22
-# category/leeks has 34 products @2019-05-22
 agribalyse_food_code:en: 20039
 carbon_footprint_fr_foodges_ingredient:fr: Poireau
 ciqual_food_code:en: 20039
@@ -115161,8 +115126,6 @@ vi: Chi Rau diếp, Xà lách
 wa: Salåde
 za: byaekaengjgwx
 zh: 莴苣属, 萵苣
-# ingredient/fr:laitue has 157 products in 5 languages @2019-04-04
-# category/lettuces has 84 products @2019-5-22
 agribalyse_food_code:en: 20031
 ciqual_food_code:en: 20031
 ciqual_food_name:en: Lettuce, raw
@@ -115297,8 +115260,6 @@ tr: soğan
 vi: hành tây
 zh: 洋葱
 agribalyse_food_code:en: 20034
-# ingredient/onion has 12754 products in 18 languages @2018-12-06
-# category/onions has 233 products @2019-05-22
 carbon_footprint_fr_foodges_ingredient:fr: Oignons
 ciqual_food_code:en: 20034
 ciqual_food_name:en: Onion, raw
@@ -116434,8 +116395,6 @@ wa: Rådisse
 yi: רעטעך
 za: lauxbaeg
 zh: 萝卜
-# ingredient/fr:Radis has 393 products in 4 languages @2019-05-16
-# category/radish has 2 products @2019-05-22
 # usage:en:fruit and vegetable concentrates (safflower, radish, black carrot, lemon, hibiscus)
 # aeb-arab:فجل
 # azb:قیرمیزی تورپ
@@ -116609,8 +116568,6 @@ agribalyse_proxy_food_code:en: 13047
 agribalyse_proxy_food_name:en: Rhubarb, stalk, raw
 agribalyse_proxy_food_name:fr: Rhubarbe, tige, crue
 description:en: Rhubarb is a cultivated plant in the genus Rheum in the family Polygonaceae. Rhubarb is stewed with sugar or used in pies and desserts, but it can also be put into savoury dishes or pickled. Rhubarb can be dehydrated and infused with fruit juice.
-# ingredient/fr:rhubarbe has 191 products in 4 languages @2019-05-08
-# category/rhubarbs has 4 products 22019-05-22
 expected_ingredients:en: en:rhubarb
 sales_format:en: package, weight
 season_in_country_fr:en: 4,5,6
@@ -116716,9 +116673,6 @@ tr: Yeşil soğan
 vi: Hành lá
 zh: 青蔥
 comment:en: do not mix green onion with welsh onion
-# ingredient/fr:oignon-vert has 45 products in 6 languages @2018-12-06
-# ingredient/fr:oignons-de-printemps has 47 products @2018-12-06
-# category/scallions has 7 products @2019-05-22
 description:en: Scallions (green onions) are vegetables of various Allium onion species. Spring onions may be cooked or used raw as a part of salads, salsas or Asian recipes. Diced scallions are used in soup, noodle and seafood dishes, sandwiches, curries and as part of a stir fry. In many Eastern sauces, the bottom half-centimetre (quarter-inch) of the root is commonly removed before use.
 # sco:Sybae
 sales_format:en: weight, package
@@ -117525,8 +117479,6 @@ sr: Матовилац
 sv: Vårklynne
 wa: Doûcete
 zh: 萵苣纈草
-# ingredient/fr:mâche has 133 products in french @2019-05-08
-# category/corn-salad has 73 products @2019-05-22
 agribalyse_food_code:en: 20099
 ciqual_food_code:en: 20099
 ciqual_food_name:en: Lamb's lettuce, raw
@@ -117929,8 +117881,6 @@ ciqual_proxy_food_code:en: 20180
 ciqual_proxy_food_name:en: Onion, dried
 ciqual_proxy_food_name:fr: Oignon, séché
 wikidata:en: Q7093931
-# ingredient/fr:oignon-en-poudre has 1131 products in 15 languages @2018-11-06
-# category/onion-powder has 11 products @2019-05-12
 
 < en: Freeze-dried plant-based foods
 < en: Vegetables based foods
@@ -122593,7 +122543,6 @@ tl: Ubod
 agribalyse_proxy_food_code:en: 20018
 agribalyse_proxy_food_name:en: Palm heart, canned, drained
 agribalyse_proxy_food_name:fr: Coeur de palmier, appertisé, égoutté
-# fr:coeurs-de-palmier has 16 products in 3 languages @2018-10-19
 description:en: Heath of palm is a vegetable harvested from the inner core and growing bud of certain palm trees. Heart of palm may be eaten on its own, and often it is eaten in a salad. Hearts of palm are rich in fiber, potassium, iron, zinc, phosphorus, copper, vitamins B2, B6, and C.
 wikidata:en: Q743144
 wikipedia:en: https://en.wikipedia.org/wiki/Heart_of_palm
@@ -123314,8 +123263,6 @@ carbon_footprint_fr_foodges_ingredient:fr: Viennoiseries Brioche industrielle pr
 ciqual_food_code:en: 7741
 ciqual_food_name:en: Brioche
 ciqual_food_name:fr: Brioche, sans précision
-# ingredient/fr:brioche has 35 products @2019-01-28
-# category/brioches has 1483 products @2019-05-20
 description:en: Brioche is a bread of French origin that is similar to a highly enriched pastry, and whose high egg and butter content (400 grams for each kilogram of flour) give it a rich and tender crumb.
 # be-tarask:Брыёш
 # sr-ec:Бриош
@@ -123555,8 +123502,6 @@ agribalyse_proxy_food_code:en: 23799
 agribalyse_proxy_food_name:en: Crepe, plain, prepacked, refrigerated
 agribalyse_proxy_food_name:fr: Crêpe, nature, préemballée, rayon frais
 comment:en: A separate category for the dutch category pannenkoek, might be needed. A french crêpe is seen as a special pannenkoek, een flensje
-# ingredient/fr:crepe has 142 products in 4 languages @2019-02-05
-# category/crepes has 582 products @2019-05-18
 description:en: A crêpe is a type of very thin pancake. Crêpes are usually of two types: sweet crêpes (crêpes sucrées) and savoury galettes (crêpes salées). Crêpes are served with a variety of fillings, from the simplest with only sugar to flambéed crêpes Suzette or elaborate savoury galettes.
 # atj:tekirep
 # bar:Palatschinken

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -186,7 +186,6 @@ description:en: Imazalil is a fungicide widely used in agriculture, particularly
 # azb:انیل‌کونازول
 wikidata:en: Q421576
 wikipedia:en: https://en.wikipedia.org/wiki/Enilconazole
-# ingredient/fr:imazalil has 23 products @2019-05-29
 
 en: frying
 fr: friture
@@ -219,7 +218,6 @@ pl: syrop karmelowy
 pt: xarope de caramelo
 ru: Карамельный сироп
 uk: карамельный сироп
-# ingredient/caramel-syrup has 248 products @2019-03-09
 
 < en: caramel syrup
 < en: sugar
@@ -241,7 +239,6 @@ nl: gekarameliseerde suikerstroop, gebrande suikerstroop, karamelsuikerstroop, k
 pl: karmelizowany syrop cukrowy, syrop cukru skarmelizowanego, syrop cukru karmelizowanego, syrop cukru palonego, syrop palonego cukru, syrop ze skarmelizowanego cukru
 pt: xarome de açúcar caramelizado
 sv: karamelliserad sockersirap, karamelliserat sockersirap, karamelliserad sirap, karamellsockersirap
-# ingredient/caramelised-sugar-syrup has 56 products @2019-03-09
 
 # <en:caramel
 fr: caramel au lait
@@ -261,7 +258,6 @@ fi: Suolainen kinuski
 fr: caramel au beurre salé
 hr: karamel od slanog maslaca
 hu: sós vajkaramella, vajkaramell
-# ingredient/fr:caramel-au-beurre-salé has 185 products in 5 languages @2019-03-09
 # salted butter caramel (glucose syrup, sugar, butter, water, fresh cream, Guérande salt)
 it: caramello di burro salato
 nl: gekarameliseerde gezouten boter, karamel en gezouten boter
@@ -271,11 +267,9 @@ fr: éclats de caramel
 de: Caramelstücke, Karamellstücke, Karamellsplitter
 fi: toffeepala
 sv: karamellbitar
-# ingredient/fr:éclats-de-caramel has 120 products in 3 languages @2019-03-09
 
 #< en: compound
 fr: éclats de caramel au beurre salé
-# ingredient/fr:éclats-de-caramel-au-beurre-salé has 53 products in 2 languages @2019-02-21
 # éclats de caramel au beurre salé (sucre, sirop de glucose, crème fraîche de Normandie, beurre salé , lait écrémé en poudre, fleur de sel de Guérande, caramel (sirop de glucose-fructose, eau))
 
 
@@ -342,7 +336,6 @@ comment:en: Translations mix carotene and carotenoids.
 description:en: Carotenoids are yellow, orange, and red organic pigments that are produced by plants and algae, as well as several bacteria and fungi. Carotenoids from the diet are stored in the fatty tissues of animals. There is insufficient evidence to state that carotenoids have an antioxidant function in humans or that carotenoid dietary supplements lower the risk of or prevent diseases.
 wikidata:en: Q191907
 wikipedia:en: https://en.wikipedia.org/wiki/Carotenoid
-# ingredient/fr:caroténoïde has 2195 products in 12 languages @2019-04-29
 
 < en: carotenoids
 en: carotene, carotin, mixed carotenes
@@ -419,8 +412,6 @@ pl: kapsaicyna, ekstrakt z papryki, ekstrakty z papryki, ekstrakt z papryk
 pt: extrato de pimentão, extrato de pimento, extracto de pimentão, extracto de pimento
 ro: extract de paprika
 sv: Paprikaextrakt
-# en:paprika-extract has 3381 products in 16 languages @2018-10-15
-# fr:e160c has 637 products @2018-10-15
 
 # Not sure whether the natural adds anything special, paprika extract seems always to be natural
 
@@ -461,7 +452,6 @@ de: Capsaicin-Extrakt
 es: extracto de capsicum
 fr: extrait de capsicum
 hr: ekstrakt paprike
-# en:capsicum-extract has 16 products in 2 languages @2018-10-15
 it: estratto di capsaicina, estratto di capsicina, estratto di capseicina
 nl: capsicum-extract
 wikidata:en: Q53792073
@@ -525,7 +515,6 @@ usda_ndb_code:en: 4531
 usda_ndb_name:en: Oil, soybean lecithin
 vegan:en: yes
 vegetarian:en: yes
-# en:soya-lecithin has 27949 products in 29 languages @2018-11-10
 
 < en: soya lecithin
 en: GMO-free soy lecithin, non-gmo soy lecithin
@@ -537,7 +526,6 @@ hr: sojin lecitin bez GMO-a
 hu: GMO-mentes szójalecitin
 it: Lecitina di soia Ogm free, lecitine di soia Ogm free
 nl: GMO-vrije sojalecithine
-# gmo-free-soy-lecithin has 73 products in 2 languages @2018-11-10
 
 < en: E322(i)
 en: sunflower lecithin
@@ -566,7 +554,6 @@ ru: лецитин подсолнечный
 sk: slnečnicový lecitín
 sl: sončnični lecitin
 sv: solroslecitin, solroslecithin, solroslecitiner, solros lecitin
-# fr:lécithine-de-tournesol has 5218 products in 20 languages @2018-11-10
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q57271747
@@ -588,7 +575,6 @@ hr: sojin i suncokretov lecitin
 hu: szója- és napraforgólecitin
 it: lecitina di soia e di girasole, lecitine di soia e di girasole
 lt: sojų ir saulėgrąžų lecitinai
-# fr:lécithine-de-soja-et-de-tournesol has 50 products in 4 languages @2018-11-10
 vegan:en: yes
 vegetarian:en: yes
 
@@ -612,7 +598,6 @@ pt: lecitina de colza
 ro: lecitină din rapiță, lecitina din rapita
 sr: lecitin uljane repice
 sv: rapslecitin, rapslecithin
-# fr:lécithines-de-colza has 609 products in 6 languages @2018-11-10
 vegan:en: yes
 vegetarian:en: yes
 
@@ -644,7 +629,6 @@ zh: 单硬脂酸甘油酯
 # en-ca:Glycerol monostearate
 # en-gb:Glycerol monostearate
 description:en: GLYCEROL MONOSTEARATE, commonly known as GMS, is a monoglyceride commonly used as an emulsifier in foods. GMS is a food additive used as a thickening, emulsifying, anticaking, and preservative agent; an emulsifying agent for oils, waxes, and solvents; a protective coating for hygroscopic powders; a solidifier and control release agent in pharmaceuticals; and a resin lubricant.
-# ingredient/fr:monostéarate-de-glycérol has 54 products in french @2019-03-28
 from_palm_oil:en: maybe
 wikipedia:en: https://en.wikipedia.org/wiki/Glycerol_monostearate
 
@@ -659,7 +643,6 @@ it: gelatina
 ja: ゼラチン
 lt: želatina, želatinos
 pl: żelatyna, żelatyna spożywcza
-# ingredient/fr:gélatine has 1575 products in 12 languages @2019-02-10
 description:en: GELATIN or GELATINE is a translucent, colorless, brittle (when dry), flavorless food ingredient that is derived from collagen obtained from various animal body parts.
 vegan:en: no
 vegetarian:en: no
@@ -679,7 +662,6 @@ it: gelatina di manzo
 lt: jautienos želatina
 nl: rundergelatine
 pl: żelatyna wołowa
-# ingredient/fr:gélatine-de-bœuf has 216 products in 4 languages @2019-02-10
 vegan:en: no
 vegetarian:en: no
 
@@ -699,14 +681,12 @@ nl: visgelatine
 allergens:en: en:fish
 vegan:en: no
 vegetarian:en: no
-# ingredient/fr:gélatine-de-poisson has 71 products in 4 languages @2019-02-10
 
 < en: gelatin
 fr: gélatine non porcine
 de: schweinefreie Gelatine
 es: gelatina no porcina
 it: gelatina non suina
-# ingredient/fr:gélatine-non-porcine has 1 product in french @2019-02-10
 
 < en: gelatin
 < en: poultry
@@ -726,7 +706,6 @@ pl: żelatyna drobiowa
 pt: gelatina de aves
 sr: želatin od peradi
 zh: 家禽明胶
-# ingredient/fr:gélatine-de-volaille has 17 products in french @2019-02-10
 
 < en: gelatin
 < en: pork
@@ -745,7 +724,6 @@ lt: kiaulienos želatina
 nl: varkensgelatine
 pl: żelatyna wieprzowa, żelatynę wieprzową, żelatyna spożywcza wieprzowa
 pt: Gelatina de porco
-# ingredient/fr:gélatine-de-porc has 891 products in 8 languages @2019-02-10
 vegan:en: no
 vegetarian:en: no
 
@@ -778,7 +756,6 @@ it: pectina di frutta
 lt: vaisių pektinas
 nl: vruchtenpectine, fruitpectine
 pl: pektyna owocowa, pektyna z owoców
-# fr:pectine-de-fruit has 1579 products in 6 languages @2018-11-03
 
 < en: fruit pectin
 en: apple pectin
@@ -802,7 +779,6 @@ es: pectina de citricos, pectina cítrica, pectina extraída de cítricos
 fi: sitruspektiini
 fr: pectine d'agrumes
 hr: citrusni pektin
-# ingredient/en:citrus-pectin has 328 products in 3 languages @2020-05-21
 it: pectina di agrumi
 lt: citrusinių vaisių pektinas
 nl: citruspectine
@@ -827,7 +803,6 @@ de: Mono- und Diglyzeride von Speisefettsäuren
 es: monoglicéridos y diglicéridos de ácidos grasos de origen vegetal, monoglicéridos de acidos grasos de origen vegetal, diglicéridos de ácidos grasos de origen vegetal
 fr: mono- et diglycérides d'acides gras d'origine végétale, mono et diglycérides d'acides gras d'origine végétale
 hr: mono i digliceridi masnih kiselina biljnog podrijetla
-# fr:mono- et diglycérides d'acides gras d'origine végétale has 53 products @2018-11-12
 it: mono- e digliceridi degli acidi grassi di origini vegetali
 nl: mono- en diglyceriden van plantaardige vetzuren, mono- en diglyceriden van plantaardige oorsprong
 pt: mono e diglicéridos de ácidos gordos de origem vegetal
@@ -874,7 +849,6 @@ zh: 卤水
 # zh-hans:卤水
 # zh-hant:鹵水
 wikipedia:en: https://en.wikipedia.org/wiki/Bittern_(salt)
-# ingredient/fr:nigari has 231 products in 5 languages @2019-04-29
 # usafe:en:nigari (magnesium chloride)
 # usage:nl:stremmiddelen:nigari
 
@@ -906,7 +880,6 @@ ro: ceară de albine albă și galbenă
 sk: biely a žltý včelí vosk
 sl: čebelji vosek beli in rumeni
 sv: bivax vitt och gult
-# ingredient/fr:cire-d’abeille-blanche-et-jaune has 200 products in 9 languages  @2019-05-13
 
 < en: E941
 < en: E942
@@ -968,7 +941,6 @@ sv: lysozym från ägg, lysozym av ägg
 allergens:en: en:eggs
 vegan:en: no
 vegetarian:en: yes
-# ingredient/fr:lysozyme-d’oeuf has 289 products in 10 languages @2018-12-18
 
 
 < en: E1400
@@ -979,7 +951,6 @@ fr: dextrine de tapioca, dextrine de manioc
 hr: tapioka dekstrin
 it: destrina di tapioca
 pl: dekstryny z tapioki, dekstryna z tapioki
-# ingredient/fr:dextrine-de-tapioca has 49 products in 4 languages @2019-01-26
 
 < en: E1400
 en: potato dextrin
@@ -999,7 +970,6 @@ fi: vehnädekstriini
 fr: dextrine de blé
 it: destrina di grano
 nl: tarwedextrine
-# ingredient/fr:dextrine-de-blé has 63 products in french @2019-01-26
 
 < en: E1400
 en: corn dextrin
@@ -1012,7 +982,6 @@ hr: kukuruzni dekstrin
 hu: kukoricadextrin, dextrin kukoricából
 it: Destrina di mais
 nl: maïsdextrine
-# ingredient/fr:dextrine-de-maïs has 39 products in 3 languages @2019-01-26
 
 
 # <en:potato
@@ -1040,9 +1009,6 @@ ro: amidon modificat din cartofi
 ru: модифицированный картофельный крахмал
 sl: modificiran krompirjev škrob
 sv: modifierad potatisstärkelse
-# fr:fécule-de-pomme-de-terre-modifiée has 40 products in 3 languages @2018-10-15
-# fr:e1404 has 19 products in 4 languages @2018-10-15
-# en:modified-potato-starch has 1862 products in 7 languages @2018-10-15
 
 
 
@@ -1066,7 +1032,6 @@ fi: hapate, hapatteet, käyte, käyteaine
 fr: ferment, ferments, cultures
 hr: ferment
 hu: fermentált, erjesztett, kovászolt
-# ingredient/ferment has 33576 products in 28 languages @2019-07-08
 it: fermenti
 kk: Ферменттер
 ky: Фермент
@@ -1115,7 +1080,6 @@ ru: молокосвертывающий фермент
 sv: koagulerande enzym, mjölkkoagulerande enzym, mjölkkoagulerande ystenzym
 vegan:en: maybe
 vegetarian:en: maybe
-# ingredient/coagulating-enzyme has 8697 products in 33 languages @2019-07-09
 
 < en: coagulating enzyme
 en: microbial coagulating enzyme, microbial enzyme, microbial
@@ -1128,7 +1092,6 @@ hr: mikrobni koagulacijski enzim
 it: enzima microbico, enzima coagulante microbiotico
 nl: microbiële stremmingsenzymen
 ru: ферментный препарат микробного происхождения
-# ingredient/microbial-coagulating-enzyme has 453 products in 7 languages @2019-07-09
 vegan:en: yes
 vegetarian:en: yes
 
@@ -1155,7 +1118,6 @@ pl: Kultury bakterii, żywe kultury bakterii, kultury starterowe, kultury starto
 pt: Cultura microbial
 ro: Culturi microbiene
 sv: mikrobiell kultur, kultur, aktiva kulturer, levande kulturer, bakteriekultur
-# ingredient/culture has 683 products in 3 languages @2018-12-27
 # note: microbial culture is not a NOVA 3 marker, it is contained in plain yoghurts that are NOVA 1
 vegan:en: maybe
 vegetarian:en: maybe
@@ -1190,7 +1152,6 @@ pt: fermentos lácteos, culturas lácteas, leveduras lacteas, fermentos láticos
 ro: culturi lactice, culturi lactice selecționate, culturi lactice selectionate, fermenți de iaurt, fermenti de iaurt, fermenți lactici, fermenti lactici
 ru: Молочные ферменты, пробиотические микроорганизм
 sv: syrningskultur, syrakultur, syrakulturer, mjölksyrakultur, yoghurtkultur, startkultur, filkultur, filmjölkskultur, starterkultur, levande mjölksyrakultur, mjölksyrakulturer
-# fr:ferments-lactique has 10437 products in 23 languages @2019-07-09
 vegan:en: maybe
 vegetarian:en: yes
 wikidata:en: Q43017
@@ -1239,7 +1200,6 @@ fi: skyrhapatteet
 fr: cultures de skyr
 hr: skyr kulture
 is: skyrgerlar
-# ingredient/fr:cultures-de-skyr has 8 products in 3 languages @2020-06-08
 it: coltura di skyr
 nl: skyr-culturen
 
@@ -1252,7 +1212,6 @@ fr: Starters pour levain
 hr: predjelo od kiselog tijesta
 it: lievito madre
 wikidata:en: Q96694045
-# ingredient/en:sourdough-culture has 43 products in 2 languages @2020-06-08
 
 < en: lactic ferments
 en: vegan lactic ferments
@@ -1277,7 +1236,6 @@ hr: mliječni i fermenti starenja
 it: fermenti lattici e d'affinatura, fermenti lattici e invecchianti
 nl: melk- en rijpingsfermenten
 pt: fermentos lácticos e de maturação
-# ingredient/lactic-and-aging-ferments has 500 products in 10 languages @2019-05-18
 
 < en: lactic ferments
 en: selected lactic ferments
@@ -1285,7 +1243,6 @@ de: ausgewählte Milchsäurekulturen
 es: fermentos lácticos seleccionados
 fr: ferments lactiques sélectionnés
 hr: odabrani mliječni fermenti
-# fr:ferments-lactiques-sélectionnés has 140 products in 2 languages @2019-07-09
 it: fermenti lattici selezionati
 nl: geselecteerde melkzuurfermenten
 
@@ -1328,7 +1285,6 @@ zh: 雙歧桿菌屬
 # zh-cn:双歧杆菌
 wikidata:en: Q132656
 wikipedia:en: https://en.wikipedia.org/wiki/Bifidobacterium
-# ingredient/bifidus has 942 products in 10 languages @2019-07-08
 
 # description:en:BIFIDOBACTERIUM BIFIDUM is a bacterial species of the genus Bifidobacterium. B. bifidum is one of the most common probiotic bacteria that can be found in the body of mammals, including humans.
 
@@ -1377,7 +1333,6 @@ de: Bifidus ActiRegularis, Bifidus Kultur ActiRegularis
 fr: active probiotic culture, bifidobacterium lactis cncm I-2494
 hr: bifidus Actiregularis® kultura, Bifidus Actiregularis® kultura, CNCM I-2494 min 4x109/125g
 ru: бифидобактерии-actiregularis, бифидобактерии actiregularis
-# ingredient/bifidus-actiregularis has 142 products in 5 languages @2019-07-08
 
 < en: bifidus
 < en: lactic acid bacteria
@@ -1477,7 +1432,6 @@ xx: Lactobacillus bulgaricus, L. bulgaricus, Lactobacillus delbrueckii ssp. bulg
 bg: Лактобацилус булгарикус, Lactobacillus bulgaricus, Lactobacillus delbrueckii subsp. bulgaricus, L. delbrueckii subsp. bulgaricus, Lactobacillus delbrueskii subsp. bulgaricus
 es: lactobacilus delbrueckii sp Bulgaricus, Lactobacillus delbrueckii subspecies bulgaricus
 fr: L bulgaricus, bulgaricus
-# ingredient/Lactobacillus-bulgaricus has 157 products in 13 languages @2019-07-08
 it: Lactobacillus bulgaricus, L. bulgaricus
 sv: Lactobacillus bulgaricus, L. bulgaricus
 wikidata:en: Q47455075
@@ -1491,7 +1445,6 @@ en: lactobacillus casei, L. casei
 xx: lactobacillus casei, L. casei
 ar: ملبنة مجبنة
 hr: kultura lactobacillus casei
-# ingredient/lactobacillus-casei has 77 products in 6 languages @2019-07-08
 it: lactobacillus casei, L. casei
 ko: 락토바실러스 카제이
 zh: 乾酪乳酸桿菌
@@ -1547,7 +1500,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Lactobacillus_rhamnosus
 en: Lactobacillus rhamnosus GG
 xx: Lactobacillus rhamnosus GG, LGG
 hr: kultura Lactobacillus rhamnosus LGG, Lactobacillus rhamnosus Gorbach & Goldin ATCC 53103, Lactobacillus rhamnosus gorbach i goldin ATCC 53103
-# ingredient/fi:Lactobacillus-rhamnosus-GG has 1 product in 2 languages @2020-06-08
 
 # description:en:LACTIPLANTIBACILLUS is a genus of lactic acid bacteria
 
@@ -1589,7 +1541,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Bacillus_coagulans
 < en: lactic ferments
 < en: lactobacillus casei
 fr: ferments lactiques dont lactobacillus casei
-# fr:ferments-lactiques-dont-lactobacillus-casei has 28 products in 1 language @2018-11-02
 
 < en: lactic ferments
 en: Lacticaseibacillus paracasei, Lc. paracasei, L. paracasei
@@ -1617,7 +1568,6 @@ zh: 嗜热链球菌
 # zh-tw:嗜熱性鏈球菌
 wikidata:en: Q1041276
 wikipedia:en: https://en.wikipedia.org/wiki/Streptococcus_thermophilus
-# ingredient/Streptococcus-thermophilus has 173 products in 11 languages @2019-07-08
 
 < en: lactic ferments
 ru: закваска на кефирных грибках
@@ -1625,14 +1575,12 @@ ru: закваска на кефирных грибках
 < en: ferment
 fr: ferments de maturation
 hr: kulture za zrenje
-# ingredient/fr:ferments-de-maturation has 88 products in french @2019-07-08
 
 < en: ferment
 en: maturing ferments
 de: Reifungskulturen, Reifekulturen
 fr: ferments d'affinage
 it: fermenti di stagionatura
-# ingredient/fr:ferments-d’affinage has 34 products in french @2019-07-08
 
 < en: ferment
 en: selected ferments
@@ -1643,7 +1591,6 @@ hr: odabrani fermenti
 it: fermenti selezionati
 nl: geselecteerde fermenten
 pt: fermentos selecionados
-# ingredient/fr:ferments-sélectionnés has 134 products in 7 languages @2019-07-08
 
 
 
@@ -1761,7 +1708,6 @@ vegetarian:en: maybe
 # yue:酵素
 wikidata:en: Q8047
 wikipedia:en: https://en.wikipedia.org/wiki/Enzyme
-# ingredient/enzyme has 20643 products in 23 languages @2019-07-08
 
 # description:en:RENNET is a complex set of enzymes produced in the stomachs of ruminant mammals. Chymosin, its key component, is a protease enzyme that curdles the casein in milk
 
@@ -1809,7 +1755,6 @@ sr: сириште
 sv: löpe, ostlöpe, ostenzym
 tr: lab
 zh: 凝乳酶
-# ingredient/rennet has 5568 products in 19 languages @2019-07-08
 vegan:en: maybe
 vegetarian:en: maybe
 # gsw:Lab
@@ -1845,7 +1790,6 @@ pl: podpuszczka zwierzęca
 pt: coalho animal
 vegan:en: no
 vegetarian:en: no
-# ingredient/animal-based-rennet has 664 products in 5 languages @2019-07-08
 
 # description:en:CALF RENNET is extracted from the inner mucosa of the fourth stomach chamber (the abomasum) of young, unweaned calves as part of livestock butchering.
 
@@ -1859,7 +1803,6 @@ hr: teleće sirilo
 it: Caglio di vitello
 nl: kalfsstremsel
 pl: podpuszczka cielęca
-# fr:présure-de-veau has 40 products in 2 languages @2019-07-08
 
 < en: rennet
 en: vegetarian rennet, vegetable rennet, non animal rennet
@@ -1895,7 +1838,6 @@ pl: podpuszczka mikrobiologiczna
 pt: coalho microbiano
 ro: cheag microbian
 sv: mikrobiell ostlöpe, ystenzym, mikrobiellt ystenzym, mikrobiellt löpe, mikrobiellt
-# ingredient/microbial-rennet has 537 products in 12 languages @2019-07-08
 vegan:en: yes
 vegetarian:en: yes
 
@@ -1951,7 +1893,6 @@ zh: 纤维素酶
 # zh-tw:纖維素酶
 wikidata:en: Q410324
 wikipedia:en: https://en.wikipedia.org/wiki/Cellulase
-# ingredient/fr:cellulase has 173 products in 6 languages @2019–07-09
 
 < en: cellulase
 en: hemicellulase
@@ -1959,7 +1900,6 @@ de: Hemicellulase, Hemicellulasen
 fi: hemisellulaasi, hemisellulaasit
 fr: hémicellulase
 hr: hemicelulaza
-# ingredient/fr:hémicellulase has 27 products in french @2019-02-01
 it: emicellulasi
 
 
@@ -2012,7 +1952,6 @@ zh: 乳糖酶
 # yue:乳糖水解酶
 wikidata:en: Q379764
 wikipedia:en: https://en.wikipedia.org/wiki/Lactase
-# ingredient/lactase has 346 products in 8 languages @2019-07-09
 
 # description:en:Β-GALACTOSIDASE is a glycoside hydrolase enzyme that catalyzes the hydrolysis of β-galactosides into monosaccharides through the breaking of a glycosidic bond. β-galactosidase is important for the lactose intolerant community as it is responsible for making lactose-free milk and other dairy products. Many adult humans lack the lactase enzyme, which has the same function of beta-gal, so they are not able to properly digest dairy products. Beta-galactose is used in such dairy products as yogurt, sour cream, and some cheeses which are treated with the enzyme to break down any lactose before human consumption.
 
@@ -2036,7 +1975,6 @@ sh: Beta-galaktozidaza
 sr: Beta-galaktozidaza
 uk: Бета-галактозидаза
 zh: Β-半乳糖苷酶
-# ingredient/beta-galactosidase has 19 products @2019-07-09
 wikidata:en: Q286379
 wikipedia:en: https://en.wikipedia.org/wiki/Beta-galactosidase
 
@@ -2106,7 +2044,6 @@ zh: 木聚糖酶
 description:en: Xylanase is any of a class of enzymes that degrade the linear polysaccharide xylan into xylose,[1] thus breaking down hemicellulose, one of the major components of plant cell walls.
 wikidata:en: Q419510
 wikipedia:en: https://en.wikipedia.org/wiki/Xylanase
-# ingredient/fr:xylanase has 96 products in 6 languages @2019-07-09
 # usage:fr:xylanase (contient blé)
 # usage:fr:enzymes (xylanases)
 
@@ -2369,7 +2306,6 @@ vegetarian:en: yes
 # yue:牛油
 wikidata:en: Q34172
 wikipedia:en: https://en.wikipedia.org/wiki/Butter
-# ingredient/butter has 19735 products @2019-07-10
 
 # description:en:All categories of butter are sold in both salted and unsalted forms. Either granular salt or a strong brine are added to salted butter during processing. In addition to enhanced flavor, the addition of salt acts as a preservative.
 # description:fr:Beurre avec une salinité moins de 0,5 %
@@ -2395,7 +2331,6 @@ usda_ndb_code:en: 1145
 usda_ndb_name:en: Butter, without salt
 wikidata:en: Q57312618
 wikipedia:fr: https://fr.wikipedia.org/wiki/Beurre_doux
-# ingredient/unsalted-butter has 755 products in 5 languages @2019-07-10
 
 < en: unsalted butter
 en: 82% fat unsalted butter
@@ -2419,7 +2354,6 @@ fi: vähäsuolainen voi
 fr: beurre demi-sel
 hr: lagano posoljeni maslac
 hu: félig sózott vaj, félsós vaj
-# ingredient/fr:beurre-demi-sel has 115 products in french @2019-07-10
 it: burro leggermente salato
 nl: halfgezouten boter
 ciqual_food_code:en: 16402
@@ -2461,7 +2395,6 @@ ciqual_food_name:fr: Beurre à 80% MG, salé
 usda_ndb_code:en: 1001
 usda_ndb_name:en: Butter, salted
 wikipedia:fr: https://fr.wikipedia.org/wiki/Beurre_salé
-# ingredient/salted-butter has 633 products in 8 languages @2019-07-10
 
 < en: salted butter
 en: 80% fat salted butter
@@ -2490,7 +2423,6 @@ it: burro sbattuto
 nl: gekarnde boter
 comment:en: Is this traditional butter?
 description:en: CHURNED BUTTER is butter churned in a butter churn to convert cream into butter.
-# ingredient/churned-butter has 71 products in 3 languages @2019-07-10
 
 < en: churned butter
 fr: beurre de baratte demi-sel
@@ -2521,7 +2453,6 @@ hr: pasterizirani maslac
 hu: pasztőrözött vaj, pasztörizált vaj, hőkezelt vaj
 it: burro pastorizzato
 nl: gepasteuriseerde boter
-# ingredient/pasteurized-butter has 64 products in 4 languages @2019-07-10
 
 < en: pasteurized butter
 en: organic pasteurized butter
@@ -2547,7 +2478,6 @@ de: Deutsche Markenbutter mildgesäuert
 
 < en: butter
 fr: beurre d'isigny AOP
-# ingredient/fr:beurre-d'isigny-AOP has 60 products in 4 languages @2019-07-10
 
 < en: butter
 fr: beurre d'isigny
@@ -2570,7 +2500,6 @@ fr: Beurre Charentes-Poitou
 
 < en: butter
 fr: beurre de cuisine, beurre cuisinier
-# ingredient/fr:beurre-de-cuisine has 127 products in french @2019-07-10
 
 # description:en:FRESH BUTTER
 # comment:en:Not sure what the definition is. It is normally homemade butter. Maybe products use it to indicated not reconstituted butter.
@@ -2587,14 +2516,12 @@ hu: friss vaj
 it: burro fresco
 nl: verse boter
 pt: manteiga fresca
-# ingredient/fresh-butter has 424 products in 7 languages @2019-07-10
 
 # description:en:BEURRE LAITIER - is a French term used to describe butter made in a creamery or small dairy, as opposed to on a farm or in a factory
 
 < en: butter
 fr: beurre laitier
 nl: melkerijboter
-# ingredient/fr:beurre-laitier has 9 products in 3 languages @2019-07-10
 
 # description:en:RECONSTITUTED BUTTER - When combined with the correct ratio of water to restore a normal water / butterfat balance for butter, Concentrated Butter is called “reconstituted butter.”
 
@@ -2607,7 +2534,6 @@ es: mantequilla deshidratada reconstituida
 fi: ennastettu voi, rekombinoitu voi
 fr: beurre concentré reconstitué, beurre déshydraté reconstitué
 hr: rekonstituirani maslac
-# ingredient/reconstituted-butter has 92 products in 2 languages @2019-07-10
 it: burro ricostituito
 lt: sviesto milteliai
 nl: gereconstitueerde boter
@@ -2622,7 +2548,6 @@ fr: Beurre de crème pasteurisée
 hr: maslac od slatkog vrhnja
 it: Burro di panna dolce
 wikidata:en: Q26882140
-# ingredient/sweet-cream-butter has 16 products in english @2019-07-10
 
 #< en: compound
 < en: butter
@@ -2631,7 +2556,6 @@ ca: mantega en pols
 es: mantequilla en polvo
 fi: voijauho
 nl: boterpoeder
-# ingredient/fr:poudre-au-beurre has 66 products in 2 languages @2019-07-10
 # poudre au beurre (BEURRE, maltodextrines, protéines de LAIT, émulsifiant : E471)
 
 < en: butter
@@ -2862,7 +2786,6 @@ fi: vieroitusvalmiste
 fr: lait de suite
 hr: naknadno mlijeko
 it: latte di proseguimento
-# ingredient/fr:lait-de-suite has 54 products in 4 languages @2019-04-05
 
 < en: milk
 en: milk from France
@@ -2964,7 +2887,6 @@ sv: pastöriserad skummjölk
 ciqual_food_code:en: 19051
 ciqual_food_name:en: Milk, skimmed, pasteurised
 ciqual_food_name:fr: Lait écrémé, pasteurisé
-# 1253 in 14 @2021-09-14
 
 #kept due to ciqual
 < en: skimmed milk
@@ -2975,7 +2897,6 @@ es: leche descremada esterilizada UHT, leche desnatada esterilizada UHT, leche U
 fr: Lait écrémé stérilisé UHT, lait écrémé stérilisé u h t, lait stérilisé uht écrémé
 hr: uht sterilizirano obrano mlijeko
 hu: sovány UHT tej
-# 49 in 3 @2021-09-14
 it: latte scremato UHT sterilizzato
 nl: UHT-gesteriliseerde magere melk
 ciqual_food_code:en: 19050
@@ -3209,7 +3130,6 @@ nl: volle geitemelk
 ciqual_food_code:en: 19202
 ciqual_food_name:en: Goat milk, whole, raw
 ciqual_food_name:fr: Lait de chèvre, entier, cru
-# 97 in 3 @2021-08-25
 
 < en: yogurt
 en: goat's milk yogurt
@@ -3447,7 +3367,6 @@ fi: vuohen ja lampaan maito, lampaan ja vuohen maito
 fr: lait de brebis et de chèvre
 hr: ovčje i kozje mlijeko
 it: latte di pecora e capra
-# ingredient/en:sheep-and-goat-milk has 7 products in 1 language @2020-05-21
 
 ################################# BUFFALO MILKS ################################
 
@@ -3470,7 +3389,6 @@ uk: буйволине молоко
 usda_ndb_proxy_code:en: 1108
 usda_ndb_proxy_name:en: Milk, indian buffalo, fluid
 wikidata:en: Q16571278
-# ingredient/buffalo-milk has 8 products @2019-02-16
 
 en: fluid indian buffalo milk
 usda_ndb_code:en: 1108
@@ -3522,7 +3440,6 @@ zh: 淡奶
 # yue:淡奶
 wikidata:en: Q13417087
 wikipedia:en: https://en.wikipedia.org/wiki/Evaporated_milk
-# ingredient/evaporated-milk has 218 products in english @2019-04-16
 
 < en: evaporated milk
 en: coffee cream
@@ -3561,7 +3478,6 @@ ro: lapte condensat indulcit
 ru: молоко цельное сгущенное с сахаром
 sv: sockrad kondenserad mjölk, söt kondenserad mjölk, sötad kondenserad mjölk
 wikidata:en: Q57271749
-# 2985 in 25 @2021-09-05
 
 < en: sweetened condensed milk
 en: sweetened condensed skimmed milk
@@ -3575,7 +3491,6 @@ lt: saldintas sutirštintas nugriebtas pienas
 lv: saldināts iebiezināts vājpiens
 nl: gesuikerde gecondenseerde halfvolle melk
 sv: sockrad kondenserad skummjölk, söt kondenserad skummjölk
-# ingredient/fr:lait-ecreme-concentre-sucre has 398 products in 8 languages @2020-05-21
 
 < en: sweetened condensed milk
 en: sweetened condensed semi-skimmed milk
@@ -3593,7 +3508,6 @@ nl: gesuikerde gecondenseerde magere melk
 pt: leite magro condensado açucarado
 ro: lapte degresat condensat indulcit
 sl: sladkano kondenzirano posneto mleko
-# ingredient/fr:lait-écrémé-condensé-sucré has 42 products in 4 languages @2019-04-18
 # usage:de: gezuckerte Kondensmagermilch (Milch, Zucker)
 
 < en: sweetened condensed milk
@@ -3611,7 +3525,6 @@ nl: gecondenseerde volle melk met suiker
 ciqual_food_code:en: 19027
 ciqual_food_name:en: Condensed milk, with sugar, whole
 ciqual_food_name:fr: Lait concentré sucré, entier
-# ingredient/fr:lait-entier-condensé-sucré has 37 products in 4 languages @2019-04-16
 
 #< en: compound
 # category:en: en:Milk jams
@@ -3662,7 +3575,6 @@ nl: gecondenseerde volle melk
 ciqual_food_code:en: 19026
 ciqual_food_name:en: Condensed milk, without sugar, whole
 ciqual_food_name:fr: Lait concentré non sucré, entier
-# ingredient/condensed-whole-milk has 52 products in 5 languages @2019-04-16
 
 < en: lactose
 < en: milk proteins
@@ -3681,7 +3593,6 @@ pl: Białka mleczne i laktoza, białka mleka łącznie z laktozą
 pt: lactose e proteínas do leite, lactose e proteínas lácteas
 vegan:en: no
 vegetarian:en: yes
-# ingredient/lactose-and-milk-proteins has 1395 products in 10 languages @2019-05-06
 
 ################################ MILK POWDERS ##################################
 
@@ -3739,7 +3650,6 @@ fr: lait en poudre demi-écrémé, lait en poudre partiellement écrémé, poudr
 hr: poluobrano mlijeko u prahu
 nl: halfvolle poedermelk
 pt: leite meio gordo em pó
-# ingredient/fr:lait-en-poudre-demi-ecreme has 8 products @2019-05-31
 ciqual_food_code:en: 19044
 ciqual_food_name:en: Milk, powder, semi-skimmed
 ciqual_food_name:fr: Lait en poudre, demi-écrémé
@@ -3840,7 +3750,6 @@ it: latte e panna pastorizzati
 nl: Gepasteuriseerde melk en room
 pt: Leite e natas pateurizados
 sv: pastöriserad mjölk och grädde
-# ingredient/fr:lait-et-crème-pasteurisé has 177 products in 7 languages @2019-02-03
 
 ###################### LACTOSE and MINERALS related stuff ######################
 
@@ -3890,7 +3799,6 @@ zh: 异麦芽酮糖
 # zh-hamt:異麥芽酮糖
 wikidata:en: Q420281
 wikipedia:en: https://en.wikipedia.org/wiki/Isomaltulose
-# ingredient/fr:isomaltulose has 59 products in 4 languages @2019-03-01
 
 # nova:en:lactose
 # <en:Disaccharide
@@ -3994,7 +3902,6 @@ ro: minerale din lapte
 vegan:en: no
 vegetarian:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Milk#Salts,_minerals,_and_vitamins
-# ingredient/fr:minéraux-du-lait has 107 products in 5 languages @2019-04-16
 
 < en: milk minerals
 en: milk mineral concentrate
@@ -4005,7 +3912,6 @@ fr: concentré des minéraux du lait, concentré de minéraux du lait
 hr: mineralni koncentrat mlijeka
 it: concentrato minerale di latte
 nl: melkmineralenconcentraat
-# ingredient/fr:concentré-des-minéraux-du-lait has 226 products in 6 languages @2019-05-12
 
 < en: lactose
 < en: milk minerals
@@ -4013,7 +3919,6 @@ fr: lactose et minéraux du lait
 ca: lactosa i minerals de la llet
 es: lactosa y minerales de la leche
 nl: lactose en melkmineralen
-# ingredient/fr:lactose-et-minéraux-du-lait has 139 products in 5 languages @2019-04-16
 
 
 ###################################################################################################
@@ -4123,8 +4028,6 @@ nl: magere yoghurt
 comment:en: should this be split in multiple ones?
 usda_ndb_code:en: 1117
 usda_ndb_name:en: Yogurt, plain, low fat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:rasvaton-jogurtti
-# 2 entries @ 2019-11-02
 
 < en: yogurt
 en: skim milk plain yogurt
@@ -4203,7 +4106,6 @@ fr: yaourt doux
 hr: blagi jogurt
 it: yogurt delicato
 nl: milde yogurt
-# ingredient/nl:milde-yoghurt has 1 product @2019-05-24
 
 < en: mild yogurt
 en: skimmed mild yogurt
@@ -4255,7 +4157,6 @@ it: yogurt greco
 nl: Griekse yoghurt
 pl: jogurt grecki, jogurt typu greckiego
 sk: Grécky jogurt
-# 395 in 5 @2021-08-25
 
 < en: greek yogurt
 en: Plain Greek-style Yogurt
@@ -4602,7 +4503,6 @@ nl: Gedemineraliseerde wei
 
 < en: Demineralised whey
 fr: lactosérum partiellement déminéralisé, petit lait partiellement déminéralisé
-# ingredient/fr:lactosérum-partiellement-déminéralisé has 20 products in 4 languages @2019-02-12
 
 < en: whey
 en: concentrated whey
@@ -4645,8 +4545,6 @@ ro: produs din zer
 sk: srvatkový výrobok
 sv: vassleprodukt
 nova:en: 4
-# ingredient/fr:produit-de-lactosérum has 22 products in 4 languages @2019-02-07
-# ingredient/fr:préparation-à-base-de-lactosérum has 34 products @2019-03-18
 
 < en: whey
 en: whey permeate, milk permeate
@@ -4661,7 +4559,6 @@ it: permeato di siero di latte
 nl: weipermeaat, melkweipermeaat, melkpermeaat
 pl: permeat serwatkowy
 sv: vasslepermeat
-# ingredient/fr:perméat-de-petit-lait has 126 products in 5 languages @2019-04-21
 
 < en: whey permeate
 en: reconstituted whey permeate
@@ -4694,7 +4591,6 @@ de: kondensierte Molke
 fi: kondensoitu hera
 hr: kondenzirana sirutka
 it: siero di latte condensato
-# ingredient/en:condensed-whey has 55 products in 7 languages @2020-05-24
 
 ###################################################################################################
 #
@@ -4798,7 +4694,6 @@ vegetarian:en: yes
 # yue:忌廉
 wikidata:en: Q13228
 wikipedia:en: https://en.wikipedia.org/wiki/Cream
-# ingredient/cream has 27881 products in 29 languages @2019-07-12
 
 < en: Cream
 fr: Crème fleurette, Crèmes fleurettes
@@ -4891,7 +4786,6 @@ ciqual_food_name:fr: Crème de lait, 30% MG, semi-épaisse, UHT
 #pt:nata pasteurizada
 #ru:пастеризованные сливки, сливки пастеризованные
 #sv:pastöriserad grädde
-# ingredient/pasteurized-cream has 1877 products in 9 languages @2019-07-12
 
 #processing:en: en:powdered # see ingredients_processing.txt
 < en: cream
@@ -4911,7 +4805,6 @@ sv: gräddpulver
 #nl:roompoeder, poederroom
 #ro:praf de frișcă
 #ru:сливки сухие
-# ingredient/cream-powder has 910 products in 6 languages @2019-07-12
 
 #processing:en: en:rehydrated # see ingredients_processing.txt
 #processing:en: en:powdered
@@ -4921,7 +4814,6 @@ sv: gräddpulver
 #de:Rehydriertes Sahnepulver
 #es:crema de leche en polvo rehidratada, crema de leche en polvo reconstituida, nata en pols rehidratada, nata en pols reconstituida
 #fr:crème en poudre réhydratée
-# ingredient/rehydrated-cream-powder has 2 products @2019-07-12
 
 < en: cream
 en: british cream
@@ -4940,7 +4832,6 @@ hr: krema iz normandije
 it: panna di Normandia
 ja: ノルマンディー産生クリーム
 nl: room uit Normandië
-# ingredient/Cream-from-Normandy has 50 products in 5 languages @2019-07-12
 
 < en: cream
 en: raw cream
@@ -4961,7 +4852,6 @@ fr: crème stérilisée
 hr: sterilizirana krema
 hu: hőkezelt tejszín
 it: panna sterilizzata
-# ingredient/fr:crème-stérilisée has 56 products in french @2019-07-12
 
 < en: cream
 en: UHT cream
@@ -4974,7 +4864,6 @@ hr: uht krema
 hu: UHT tejszín
 it: panna UHT
 nl: UHT room
-# ingredient/fr:crème-uht has 114 products in french @2019-07-12
 
 < en: UHT cream
 < en: sterilized cream
@@ -4986,7 +4875,6 @@ fi: sterilisoitu UHT kerma, sterilisoitu iskukuumennettu kerma, sterilisoitu UHT
 fr: crème stérilisée uht
 hr: sterilizirana uht krema
 it: panna UHT sterilizzata
-# ingredient/fr:crème-stérilisée-uht has 10 products in french @2019-07-12
 
 < en: cream
 fr: Crème fraîche liquide
@@ -5004,13 +4892,11 @@ hr: svijetla krema
 hu: főzőtejszín
 it: crema leggera
 nl: Lichte room
-# ingredient/light-cream has 579 products in 8 languages @2019-07-12
 
 < en: light cream
 fr: crème fraîche légère epaisse
 ca: crema de llet lleugera espessa, nata lleugera espessa
 es: crema de leche ligera espesa, nata ligera espesa
-# ingredient/fr:crème-fraîche-légère-epaisse has 13 products in french @2019-07-12
 
 # Recipes calling for 'single cream' are referring to pure or thickened cream with about 35% fat.
 
@@ -5026,7 +4912,6 @@ hu: habtejszín
 it: panna liquida
 nl: vloeibare room
 sv: flytande grädde, matgrädde
-# ingredient/single-cream has 608 products in 8 languages @2019-07-12
 
 # comment:en:Seems to have a 35% fat percentage
 
@@ -5049,7 +4934,6 @@ hr: cijela krema
 hu: teljes tejszín
 it: panna intera
 nl: volle room
-# ingredient/whole-cream has 66 products in 4 languages @2019-07-12
 
 # cream with a high percentage of fat. similar/synonym to whipping cream
 < en: cream
@@ -5066,7 +4950,6 @@ fr: crème à fouetter
 hr: vrhnje za šlag
 it: panna da montare
 sv: vispgrädde
-# ingredient/fr:creme-a-fouetter has 21 products in 5 languages @2020-05-21
 
 < en: whipping cream
 en: pasteurized whipping cream
@@ -5075,7 +4958,6 @@ fi: pastöroitu kuohukerma
 hr: pasterizirano vrhnje za šlag
 it: panna da montare pastorizzata
 sv: pastöriserad vispgrädde
-# ingredient/sv:pastöriserad-vispgrädde has 2 products in 2 languages @2020-05-25
 
 < en: cream
 en: whipped cream
@@ -5101,7 +4983,6 @@ fi: rasvaton maito ja pastöroitu kerma
 fr: lait écrémé et crème pasteurisés
 hr: obrano mlijeko i pasterizirano vrhnje
 it: latte scremato e panna pastorizzata
-# ingredient/fr:lait-écrémé-et-crème-pasteurisés has 64 products in 4 languages @2019-02-03
 
 < en: cream
 en: fresh cream
@@ -5162,7 +5043,6 @@ zh: 酸忌廉
 usda_ndb_proxy_code:en: 1179
 usda_ndb_proxy_name:en: Sour cream, light
 wikipedia:en: https://en.wikipedia.org/wiki/Sour_cream
-# ingredient/Sour-cream has 773 products in 7 languages @2019-07-12
 
 < en: sour cream
 en: fat free sour cream
@@ -5223,7 +5103,6 @@ zh: 斯美塔那酸奶油
 # vep:Kandatez
 wikidata:en: Q326061
 wikipedia:en: https://en.wikipedia.org/wiki/Smetana_(dairy_product)
-# ingredient/smetana has 18 products @2019-07-12
 
 #<en:Sour cream
 #en:sour cream powder
@@ -5262,7 +5141,6 @@ vi: Kem fraîche
 zh: 法式酸奶油
 wikidata:en: Q1142459
 wikipedia:en: https://en.wikipedia.org/wiki/Crème_fraîche
-# ingredient/Crème-fraîche has 4440 products in 15 languages @2019-07-12
 
 # comment:en:Is creme fraiche really different from creme. Not according to the translations.
 
@@ -5275,7 +5153,6 @@ fi: pastöroitu crème fraîche
 fr: creme fraiche pasteurisée
 hr: pasterizirana crème fraîche
 it: panna fresca pastorizzata
-# ingredient/fr:creme-fraiche-pasteurisee has 164 products in 5 languages @2019-07-12
 # usage:fr:Crème fraîche pasteurisée 99.99%, ferments lactiques
 
 ###################################################################################################
@@ -5335,7 +5212,6 @@ nn: filmjølk
 sv: filmjölk, fil
 wikidata:en: Q14732227
 wikipedia:en: https://en.wikipedia.org/wiki/Filmj%C3%B6lk
-# ingredient/sv:filmjölk has 1 product in 1 language @2020-12-22
 
 ###################################################################################################
 #
@@ -5449,7 +5325,6 @@ pt: leitelho em pó
 sv: kärnmjölkspulver
 usda_ndb_code:en: 1094
 usda_ndb_name:en: Milk, buttermilk, dried
-# ingredient/fr:babeurre-en-poudre has 116 products in 12 languages @2018-12-15
 
 #processing:en: en:solids
 < en: buttermilk
@@ -5606,7 +5481,6 @@ yi: קעז
 yo: wàràkàsì
 zh: 乾酪
 zu: Ushizi
-# en:cheese has 579 products in 10 languages @2018-10-28
 ciqual_proxy_food_code:en: 12999
 ciqual_proxy_food_name:en: Cheese (average)
 nova:en: 3
@@ -5778,13 +5652,11 @@ es: queso de leche de vaca ecológica
 fr: fromage au lait de vache pasteurisé
 ca: formatge de llet de vaca pasteuritzada
 es: queso de leche de vaca pasteurizada
-# fr:fromage-au-lait-de-vache pasteurisé has 39 products in 3 languages @2018-10-27
 
 < en: cow cheese
 fr: Fromage au lait cru de vache
 ca: formatge de llet de vaca crua
 es: queso de leche de vaca cruda
-# ingredient/fr:fromage-au-lait-cru-de-vache has 15 products in french @2019-05-24
 
 < en: cow cheese
 en: cow's cheese with chives
@@ -5844,7 +5716,6 @@ carbon_footprint_fr_foodges_value:fr: 3.6
 # sr-el:kozji sir
 wikidata:en: Q198815
 wikipedia:en: https://en.wikipedia.org/wiki/Goat_cheese
-# fr:fromage de chèvre has 391 products in 6 languages @2018-10-27
 
 < en: goat cheese
 fr: fromage de chèvre frais
@@ -5857,7 +5728,6 @@ es: queso fresco de cabra
 fr: fromage de chèvre au lait pasteurisé, fromage au lait de chèvre pasteurisé
 ca: formatge de llet de cabra pasteuritzada
 es: queso de leche de cabra pasteurizada
-# fr:fromage-de-chèvre-au-lait-pasteurisé has 44 products in 1 language @2018-10-27
 
 < en: goat cheese
 en: Crottin cheese, Crottin cheese from goat's milk
@@ -5979,14 +5849,11 @@ zh: 羊奶酪
 # de-ch:Schafskäse
 wikidata:en: Q1411808
 wikipedia:en: https://en.wikipedia.org/wiki/Sheep_milk_cheese
-# ingredient/fr:fromage-de-brebis has 42 products @2018-10-27
-# category/Sheep-Cheeses has 868 products @2019-05-24
 
 < en: sheep's-milk cheese
 fr: fromage de brebis au lait pasteurisé
 ca: formatge de llet d'ovella pasteuritzada
 es: queso de leche de oveja pasteurizada
-# ingredient/fr:fromage-de-brebis-au-lait-pasteurise has 14 products in french @2019-05-24
 
 < en: cheese
 en: soft white cheese
@@ -6004,7 +5871,6 @@ nl: Zachte witte kaas
 sv: färskost
 carbon_footprint_fr_foodges_ingredient:fr: Fromage frais 58% MG
 carbon_footprint_fr_foodges_value:fr: 3.5
-# fr:fromage-frais has 474 products @2018-10-28
 
 < en: soft white cheese
 fr: fromage frais au lait demi-écrémé
@@ -6049,7 +5915,6 @@ hu: ömlesztett sajt
 it: formaggio fuso
 nl: smeltkaas
 sv: smältost
-# fr:fromage-fondu has 420 products in 5 languages @2018-10-28
 
 < en: melted cheese
 #en:process:en:powder
@@ -6064,7 +5929,6 @@ it: formaggio in polvere fuso
 #hu:ömlesztett porított sajt
 #it:formaggio fuso in polvere
 #nl:poeder van gesmolten kazen
-# fr:fromage-fondu-en-poudre has 98 products in 6 languages @2018-10-28
 
 < en: melted cheese
 en: melted grated cheese
@@ -6083,17 +5947,14 @@ fr: fromage maigre
 hr: nemasni sir
 it: formaggio magro
 nl: vetarme kaas
-# fr:fromage maigre has 33 products in 3 languages @2018-10-28
 
 < en: cheese
 fr: fromage à pâte pressée cuite
-# fr:fromage-à-pâte-pressée-cuite has 54 products in 1 language @2018-10-28
 
 < en: cheese
 fr: fromage au lait cru
 ca: formatge de llet crua
 es: queso de leche cruda
-# ingredient/fr:fromage-au-lait-cru has 14 products in french @2019-05-27
 
 # comment:en:sometimes this is the description of the products
 
@@ -6101,7 +5962,6 @@ es: queso de leche cruda
 fr: fromage au lait pasteurisé
 ca: formatge de llet pasteuritzada
 es: queso de leche pasteurizada
-# fr:fromage-au-lait-pasteurisé has 55 products in 1 language @2018-10-28
 
 < en: cheese
 en: cheese powder
@@ -6126,7 +5986,6 @@ sv: ostpulver
 #pt:queijo em pó
 #ru:Сырный порошок
 #sk:sirotka v prahu
-# fr:fromage en poudre has 200 products in 14 languages @2018-10-28
 
 < en: cheese powder
 < en: melted cheese
@@ -6153,7 +6012,6 @@ nl: harde kaas
 pl: ser twardy
 pt: queijo de pasta dura, queijo duro
 sv: Hårdost
-# fr:fromage-à-pâte-dure has 133 products in 5 languages @2018-10-28
 
 < en: hard cheese
 < en: semi-hard cheeses
@@ -6208,7 +6066,6 @@ it: formaggio svizzero, formaggi svizzeri
 nl: Zwitserse kaas
 usda_ndb_code:en: 1040
 usda_ndb_name:en: Cheese, swiss
-# fr:fromage-suisse has 21 products in 3 languages @2018-10-27
 
 < en: cheese
 en: paneer
@@ -6233,7 +6090,6 @@ sv: ostsås
 usda_ndb_code:en: 1164
 usda_ndb_name:en: Cheese sauce, prepared from recipe
 wikidata:en: Q27972032
-# ingredient/en:cheese-sauce has 425 products in 2 languages @2020-06-07
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -6285,7 +6141,6 @@ description:it: Il formaggio Asiago è un prodotto caseario di latte vaccino a p
 description:nl: Asiago is een Italiaanse kaassoort, geproduceerd met koemelk, afkomstig uit het gebied rond de gelijknamige gemeente in de provincie Vicenza.
 wikidata:en: Q727210
 wikipedia:en: https://en.wikipedia.org/wiki/Asiago_cheese
-# ingredient/asiago has 1014 products in 5 languages @2021-08-14
 
 < en: asiago
 en: asiago medium cheese
@@ -6322,7 +6177,6 @@ origins:en: en:france
 protected_name_type:en: en:pdo
 wikidata:en: Q781150
 wikipedia:en: https://en.wikipedia.org/wiki/Beaufort_cheese
-# ingredient/en:beaufort has 50 products in 2 languages @2021-08-14
 
 
 #category/bries
@@ -6468,7 +6322,6 @@ usda_ndb_code:en: 1007
 usda_ndb_name:en: Cheese, camembert
 wikidata:en: Q131480
 wikipedia:en: https://en.wikipedia.org/wiki/Camembert
-# 113 in 8 @2020-08-29
 
 < en: camembert
 en: camembert from pasteurised milk
@@ -6477,7 +6330,6 @@ es: camembert de leche pasteurizada
 fr: camembert au lait pasteurisé
 hr: camembert od pasteriziranog mlijeka
 it: camembert da latte pastorizzato
-# ingredient/fr:camembert-au-lait-pasteurisé has 15 products in 4 languages @2019-02-17
 
 #category:en: en:cantal
 < en: cow cheese
@@ -6610,7 +6462,6 @@ usda_ndb_code:en: 1009
 usda_ndb_name:en: Cheese, cheddar (Includes foods for USDA's Food Distribution Program)
 wikidata:en: Q217525
 wikipedia:en: https://en.wikipedia.org/wiki/Cheddar_cheese
-# en:cheddar has 10196 products @2021-08-14
 
 < en: cheddar
 en: mild cheddar, mild cheddar cheese
@@ -6670,7 +6521,6 @@ en: red cheddar
 fr: cheddar orange, cheddar rouge
 hr: crveni cheddar
 it: cheddar rosso
-# ingredient/fr:cheddar-orange has 52 products in 2 languages @2021-08-14
 
 < en: cheddar
 en: melted cheddar
@@ -6679,7 +6529,6 @@ es: queso cheddar fundido
 fr: cheddar fondu
 hr: rastopljeni cheddar
 it: cheddar fuso
-# fr:cheddar-fondu has 97 products in 3 languages @2021-08-14
 
 < en: melted cheddar
 < fr: cheddar orange
@@ -6719,7 +6568,6 @@ ciqual_food_code:en: 12110
 ciqual_food_name:en: Comté cheese, from cow's milk
 ciqual_food_name:fr: Comté
 description:en: COMTÉ (or Gruyère de Comté) is a French cheese made from unpasteurized cow's milk in the Franche-Comté region of eastern France.
-# ingredient/comte-cheese has 356 products in 6 languages @2021-08-14
 description:de: Comté ist ein Hart-Rohmilchkäse aus der französischen Region Franche-Comté.
 description:es: El comté es un queso francés con denominación de origen.
 description:fr: Comté est l'appellation d'origine d'un fromage français transformé principalement en Franche-Comté et bénéficiant d'une AOC.
@@ -6739,7 +6587,6 @@ es: comté DOP
 nl: Comté AOC
 origins:en: en:france
 protected_name_type:en: en:pdo
-# fr:comté-aop has 40 products in 1 language @2018-10-27
 
 < en: cheese
 en: Cotija cheese, Cotija
@@ -6827,7 +6674,6 @@ usda_ndb_code:en: 1018
 usda_ndb_name:en: Cheese, edam
 wikidata:en: Q597473
 wikipedia:en: https://en.wikipedia.org/wiki/Edam_cheese
-# fr:edam has 206 products in 11 languages @2018-10-28
 
 
 < en: cheese
@@ -6893,7 +6739,6 @@ wikidata:en: Q932214
 wikipedia:en: https://en.wikipedia.org/wiki/Emmental_cheese
 
 
-# fr:emmental has 3349 products in 20 languages @2021-08-14
 
 < en: emmental
 en: Emmental from France
@@ -6906,7 +6751,6 @@ hr: emental iz Francuske
 it: Emmental francese
 nl: Emmental uit Frankrijk
 # origins:en: en:France
-# fr:emmental-français has 47 products in 3 languages @2018-10-27
 
 < en: Emmental from France
 fr: emmental de Savoie IGP
@@ -6924,7 +6768,6 @@ hr: otopljeni sir ementaler
 hu: ömlesztett ementáli
 it: formaggio Emmental fuso
 nl: gesmolten Emmental
-# fr:emmental-fondu has 92 products in 3 languages @2018-10-27
 
 < en: emmental
 en: grated emmental cheese, Emmental cheese grated from cow's milk
@@ -6942,13 +6785,11 @@ sv: riven emmentalerost
 ciqual_food_code:en: 12118
 ciqual_food_name:en: Emmental cheese, grated, from cow's milk
 ciqual_food_name:fr: Emmental ou emmenthal râpé
-# ingredient/grated-emmental-cheese has 589 products in 7 languages @2021-08-14
 
 < en: grated emmental cheese
 fr: emmental français râpé
 ca: emmental francès ratllat, formatge emmental ratllat
 es: queso emmental francés rallado, queso emmenthal francés rallado
-# fr:emmental-français-râpé has 43 products in 1 language @2018-10-27
 
 
 # en:description:FROMAGE BLANC is a fresh cheese originating from the north of France and the south of Belgium.
@@ -6977,13 +6818,11 @@ ciqual_food_name:en: Quark, plain or fruit (average)
 # en-gb:Fromage blanc
 wikidata:en: Q3323634
 wikipedia:en: https://en.wikipedia.org/wiki/Fromage_blanc
-# fr:fromage-blanc has 631 products in 7 languages @2018-10-27
 
 < en: fromage blanc
 fr: fromage blanc frais
 ca: formatge blanc fresc
 es: queso blanco fresco
-# fr:fromage blanc frais has 60 products in 1 language @2018-10-28
 
 # description:en:QUARK is a type of fresh dairy product made by warming soured milk until the desired amount of curdling is met, and then straining it.
 
@@ -7072,8 +6911,6 @@ zh: 奶渣
 # pt-br:Quark
 wikidata:en: Q259642
 wikipedia:en: https://en.wikipedia.org/wiki/Quark_(dairy_product)
-# ingredient/nl:kwark has 2 products @2019-05-24
-# category/quark has 221 products @2019-05-24
 
 < en: quark
 en: lactose-free quark
@@ -7093,12 +6930,9 @@ hr: mršava krma
 it: quark magro
 nl: magere kwark
 pl: twaróg odtłuszczony, ser twarogowy odtłuszczony, twarożek odtłuszczony, twaróg chudy, ser twarogowy chudy
-# ingredient/fr:séré-maigre has 33 products in 4 languages @2019-03-01
 
 < en: Quark
 fi: rasvaton rahka
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:rasvaton-rahka
-# 1 entry @ 2019-11-02
 
 < en: Quark
 de: Sauermilchquark
@@ -7189,7 +7023,6 @@ usda_ndb_code:en: 1019
 usda_ndb_name:en: Cheese, feta
 wikidata:en: Q182760
 wikipedia:en: https://en.wikipedia.org/wiki/Feta
-# 775 in 7 @2021-08-30
 
 < en: feta
 en: Feta cheese from ewe's milk
@@ -7295,7 +7128,6 @@ description:nl: Gorgonzola is blauwschimmelkaas van volle koemelk uit het noorde
 # zh-tw:古岡左拉起司
 wikidata:en: Q209044
 wikipedia:en: https://en.wikipedia.org/wiki/Gorgonzola
-# 354 in 10 @2021-09-01
 
 
 < en: cheese
@@ -7350,7 +7182,6 @@ usda_ndb_code:en: 1022
 usda_ndb_name:en: Cheese, gouda
 wikidata:en: Q593675
 wikipedia:en: https://en.wikipedia.org/wiki/Gouda_cheese
-# fr:gouda has 92 products @2018-10-28
 
 
 
@@ -7375,7 +7206,6 @@ ru: Грана падано
 sl: ribani trdi sir Grana Padano
 uk: Грана Падано
 zh: 格拉娜·帕達諾芝士
-# fr:grana-padano has 753 products in 4 languages @2021-08-14
 ciqual_food_code:en: 12123
 ciqual_food_name:en: Grana Padano cheese, from cow's milk
 ciqual_food_name:fr: Grana Padano
@@ -7410,7 +7240,6 @@ pt: queijo Grana Padano DOP
 sv: Grana Padano-ost D O P
 origins:en: en:italy
 protected_name_type:en: en:pdo
-# fr:fromage-grana-padano-aop has 36 products in 5 languages @2018-10-27
 
 
 
@@ -7446,7 +7275,6 @@ description:en: Gruyere is a hard cheese mad from cow milk. It originates either
 description:nl: Gruyere is een harde kaas van koemelk, hetzij uit Zwitserland, hetzij uit Frankrijk.
 usda_ndb_code:en: 1023
 usda_ndb_name:en: Cheese, gruyere
-# fr:gruyere has 104 products in 7 languages @2021-08-14
 
 < en: gruyère
 en: gruyère AOP
@@ -7462,7 +7290,6 @@ description:nl: Gruyère is een kaas die genoemd is naar de Zwitserse stad Gruy�
 description:pt: O Gruyère é um queijo duro suíço, originário da cidade de Gruyères e produzido nos cantões de Fribourg, Vaud, Neuchâtel, Jura e Berna.
 wikidata:en: Q2376488
 wikipedia:en: https://en.wikipedia.org/wiki/Gruyère_cheese
-# ingredient/fr:gruyere-aop has 5 products in 4 languages @2021-08-14
 
 < en: gruyère
 en: gruyere pgi, Gruyere cheese France Protected Geographical Indication from cow's milk
@@ -7598,7 +7425,6 @@ description:nl: Maasdam kaas, ook maasdammer genoemd, is een Nederlandse kaas di
 description:pt: O Maasdam é um queijo oriundo da cidade holandesa de mesmo nome, caracterizado pela presença de grandes buracos. É firme, porém macio, maturação demora cerca de quatro semanas. De sabor suave, adocicado, lembra nozes.
 wikidata:en: Q3273732
 wikipedia:en: https://en.wikipedia.org/wiki/Maasdam_cheese
-# fr:Maasdam has 71 products in 6 languages @2021-08-14
 
 < en: maasdam
 en: reduced fat Maasdam-type firm cheese with around 14% fat
@@ -7718,7 +7544,6 @@ tr: mascarpone
 uk: Маскарпоне
 vi: Mascarpone
 zh: 马斯卡邦尼奶酪
-# fr:mascarpone has 254 products @2018-10-27
 ciqual_food_code:en: 19584
 ciqual_food_name:en: Mascarpone cheese, from cow's milk
 ciqual_food_name:fr: Mascarpone
@@ -7817,8 +7642,6 @@ zh: 傑克芝士
 description:en: MONTEREY JACK, sometimes shortened to Jack, is an American white, semi-hard cheese made using cow's milk. It is noted for its mild flavor and slight sweetness.
 wikidata:en: Q1056415
 wikipedia:en: https://en.wikipedia.org/wiki/Monterey_Jack
-# Montenerey jack has 31 products @2019-05-31
-# ingredient/en:monterey-jack has 55 products in 1 language @2020-06-08
 
 < en: monterey jack
 en: pepper jack, pepper jack cheese
@@ -7826,7 +7649,6 @@ de: Pepper Jack, Pepper-Jack-Käse
 fr: Fromage Peppers Jack /Fromage aux poivres
 hr: pepper jack
 it: pepper jack
-# ingredient/en:pepper-jack has 5 products in 1 language @2020-06-08
 
 #category/morbier
 < en: cheese
@@ -8175,13 +7997,11 @@ description:pt: O parmesão é um tipo de queijo italiano, com denominação de 
 # zh-tw:帕馬森乾酪
 wikidata:en: Q155922
 wikipedia:en: https://en.wikipedia.org/wiki/Parmigiano-Reggiano
-# ingredient/parmesan has 6922 products in 15 languages @2021-08-15
 
 < en: parmigiano reggiano
 fr: Parmigiano Reggiano AOP
 origins:en: en:italy
 protected_name_type:en: en:pdo
-# fr:Parmigiano-Reggiano-AOP has 35 products @2018-10-27
 
 
 # description:en:PECORINO is a family of hard Italian cheeses made from sheep's milk.
@@ -8211,7 +8031,6 @@ usda_ndb_code:en: 1038
 usda_ndb_name:en: Cheese, romano
 wikidata:en: Q677640
 wikipedia:en: https://en.wikipedia.org/wiki/Pecorino
-# fr:pecorino has 45 products in 3 languages @2018-10-27
 
 < en: pecorino
 en: pecorino romano, pecorino romano cheese, Peccorino Romano PDO cheese
@@ -8226,9 +8045,6 @@ it: Pecorino romano
 nl: pecorino romano, pecorino romano kaas
 origins:en: en:italy
 protected_name_type:en: en:pdo
-# en:romano has 65 products in 1 language @2018-10-28
-# fr:pecorino-romano has 30 products in 1 language @2018-10-27
-# fr:pecorino-romano-aop has 10 product in 1 language @2018-10-27
 
 #category/pont-l-eveque
 < en: cheese
@@ -8299,7 +8115,6 @@ usda_ndb_code:en: 1035
 usda_ndb_name:en: Cheese, provolone
 wikidata:en: Q1900114
 wikipedia:en: https://en.wikipedia.org/wiki/Provolone
-# fr:provolone has 28 products in 4 languages @2018-10-28
 
 
 
@@ -8334,7 +8149,6 @@ description:fr: Le raclette est un fromage à base de lait cru de vache, à pât
 # zh-hant:拉可雷特芝士
 wikidata:en: Q57827645
 wikipedia:en: https://en.wikipedia.org/wiki/Raclette
-# 84 in 4 @2021-08-31
 
 < en: cheese
 #category/reblochon
@@ -8361,7 +8175,6 @@ reblochon:nl: De reblochon is een Franse gewassenkorstkaas, geproduceerd in Haut
 # yue:雷布洛芝士
 wikidata:en: Q543805
 wikipedia:en: https://en.wikipedia.org/wiki/Reblochon
-# ingredient/fr:reblochon has 64 products @2018-12-27
 
 < en: reblochon
 fr: Reblochon AOP, Reblochon de Savoie AOP
@@ -8436,7 +8249,6 @@ sv: ricotta, ricottaost
 tr: Ricotta
 uk: Рікота
 zh: 里考塔
-# fr:ricotta has 532 products in 6 languages @2018-10-27
 ciqual_food_code:en: 19585
 ciqual_food_name:en: Ricotta cheese
 ciqual_food_name:fr: Ricotta
@@ -8504,7 +8316,6 @@ usda_ndb_code:en: 1039
 usda_ndb_name:en: Cheese, roquefort
 wikidata:en: Q189221
 wikipedia:en: https://en.wikipedia.org/wiki/Roquefort
-# ingredient/fr:roquefort has 74 products in 4 languages @2019-04-03
 
 #category/saint-nectaire
 < en: cheese
@@ -8624,7 +8435,6 @@ ru: таледжо
 uk: таледжіо
 wikidata:en: Q775835
 wikipedia:en: https://en.wikipedia.org/wiki/Taleggio_cheese
-# fr:fromage Taleggio AOP has 1 product @2018-10-28
 
 
 # description:en:TILSIT cheese or Tilsiter cheese is a light yellow semihard smear-ripened cheese, created in the mid-19th century by Prussian-Swiss settlers, the Westphal family, from the Emmental valley.
@@ -8656,7 +8466,6 @@ uk: Тільзитер
 # gsw:Tilsiter
 wikidata:en: Q2433798
 wikipedia:en: https://en.wikipedia.org/wiki/Tilsit_cheese
-# fr:tilsit has 1 product in 3 languages @2018-10-27
 
 
 < en: cheese
@@ -8676,7 +8485,6 @@ description:fr: La tomme ou tome est un fromage de montagne, existant en de mult
 description:it: La tomme es un queso francés de montaña.
 wikidata:en: Q2164539
 wikipedia:en: https://en.wikipedia.org/wiki/Tomme
-# 34 in 4 @2020-08-29
 
 < en: tomme
 en: tomme de Savoie, tomme de Savoie IGP
@@ -8702,7 +8510,6 @@ ja: ヴァシュラン・フリブール
 ko: 바슈랭 프리부르주아
 wikidata:en: Q677647
 wikipedia:fr: https://fr.wikipedia.org/wiki/Vacherin_fribourgeois
-# fr:Vacherin-fribourgeois-AOP has 2 products in 3 languages @2018-10-27
 
 #category/blue-veined-cheeses
 < en: cheese
@@ -8768,7 +8575,6 @@ hr: plavi sir od kravljeg mlijeka
 ciqual_food_code:en: 12520
 ciqual_food_name:en: Blue cheese, from cow's milk
 ciqual_food_name:fr: Fromage bleu au lait de vache
-# ingredient/fr:bleu has 84 products in french @2021-08-28
 # bleu (lait de vache entier pasteurisé, présure végétale, ferments lactiques, sel)
 # TODO: can we put it up to blue cheese ?
 
@@ -8884,7 +8690,6 @@ fr: base aromatisante fromage
 ca: base aromatitzant de formatge
 es: base aromatizante de queso
 nl: kaassmaak
-# fr:base-aromatisante-fromage has 28 products @2018-10-27
 
 #< en: compound
 < en: cheese
@@ -8892,7 +8697,6 @@ fr: préparation fromagère
 ca: preparació de formatges
 de: käsezubereitung
 es: preparación de quesos
-# fr:préparation-fromagère has 40 products in 1 language @2018-10-28
 
 # description:en:HALLOUMI or haloumi is a semi-hard, unripened, brined cheese made from a mixture of goat's and sheep's milk, and sometimes also cow's milk.
 
@@ -8931,7 +8735,6 @@ ur: حلومی
 zh: 哈羅米芝士
 wikidata:en: Q549793
 wikipedia:en: https://en.wikipedia.org/wiki/Halloumi
-# ingredient/fr:halloumi has 1 product in 1 language @2020-06-08
 
 # description:en:VÄSTERBOTTEN CHEESE is a cheese from the Västerbotten region of Sweden.
 
@@ -8952,7 +8755,6 @@ sv: västerbottensost
 # bar:västerbotten kaas
 wikidata:en: Q2096655
 wikipedia:en: https://en.wikipedia.org/wiki/V%C3%A4sterbotten_cheese
-# ingredient/sv:västerbottensost has 2 products in 1 language @2020-06-08
 
 
 # description:en:Wensleydale is a style of cheese originally produced in Wensleydale, North Yorkshire, England
@@ -9207,7 +9009,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Smoked_salt
 
 < en: salt
 fr: concentré salin liquide
-# ingredient/fr:concentré-salin-liquide has 44 products in french @2019-03-30
 
 < en: salt
 en: black salt
@@ -9487,7 +9288,6 @@ ciqual_food_name:en: Sea salt, grey, no enrichment
 ciqual_food_name:fr: Sel marin gris, non iodé, non fluoré
 wikidata:en: Q5493196
 wikipedia:en: https://en.wikipedia.org/wiki/Sel_gris
-# ingredient/fr:sel-gris-marin has 32 products in french @2020-04-03
 
 < en: Salt from Guérande
 < en: sel gris
@@ -9498,7 +9298,6 @@ es: sal gris de Guérande
 fr: sel gris de Guérande
 hr: siva sol iz guérande
 it: sale grigio di Guérande
-# ingredient/fr:sel-gris-de-guerande has 16 products in french @2020-04-03
 
 < en: sea salt
 en: Fleur de sel
@@ -9537,7 +9336,6 @@ fr: Flocons de sel marin
 hr: pahuljice morske soli
 it: fiocchi di sale marino
 sv: havssaltflingor
-# ingredient/en:sea-salt-flakes has 4 products in 2 languages @2020-06-08
 
 < en: salt
 en: sodium iodide
@@ -9588,7 +9386,6 @@ zh: 碘化钠
 description:en: Sodium iodide (chemical formula NaI) is an ionic compound formed from the chemical reaction of sodium metal and iodine.
 wikidata:en: Q390305
 wikipedia:en: https://en.wikipedia.org/wiki/Sodium_iodide
-# ingredient/fr:iodure-de-sodium has 35 products in french @2019-03-13
 
 < en: salt
 en: potassium iodide
@@ -9665,7 +9462,6 @@ description:en: CURING SALT is used in meat processing to generate a pinkish sha
 wikidata:en: Q5194756
 wikipedia:en: https://en.wikipedia.org/wiki/Curing_salt
 # usage:en:Curing Salt (Salt, Preservative: Sodium Nitrite)
-# ingredient/en:curing-salt has 20 products in 4 languages @2020-06-08
 
 #< en: compound
 < en: curing salt
@@ -9681,7 +9477,6 @@ nl: nitrietpekelzout
 pl: sól peklowa azotynowa, sól peklująca azotynowa
 sv: nitritsalt
 # usage:en:nitrite curing salt (salt, preservative: sodium nitrite)
-# ingredient/en:nitrite-curing-salt has 2 products in 3 languages @2020-06-08
 
 < en: nitrite curing salt
 de: jodiertes Nitritpökelsalz
@@ -9702,8 +9497,6 @@ it: sale marino iodato
 pl: sól morska jodowana, jodowana sól morska
 sl: jodirana morska sol
 sv: joderat havssalt, joderad havssalt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:jodioitu-merisuola
-# 1 entry @ 2019-11-02
 
 # mixes?
 
@@ -9867,13 +9660,11 @@ nova:en: 4
 #< en:compound
 fi: kokolihavalmiste
 sv: helköttsprodukt
-# ingredient/sv:helköttsprodukt has 1 product in 2 languages @2020-05-21
 
 < en: chicken meat
 < fi: kokolihavalmiste
 fi: kanakokolihatuote
 sv: kycklinghelköttsprodukt
-# ingredient/sv:kycklinghelköttsprodukt has 1 product in 1 language @2020-12-22
 
 #comment:en:'ham preparation' or 'ham cut' is used for a meat preparation containing ham and in addition meat protein or other protein preparations or other binders (fiber preparations and modified starches), and which differs from sliced sausage in terms of degree of mincing and  the method of preparation.
 #comment:en:usually 65 - 80 % meat
@@ -9930,7 +9721,6 @@ zh: 肉丸
 # zh_yue:肉丸
 wikidata:en: Q4831844
 wikipedia:en: https://en.wikipedia.org/wiki/Meatball
-# ingredient/en:meatball has 22 products in 1 language @2020-06-13
 
 < en: meatball
 en: chicken meatball
@@ -9942,7 +9732,6 @@ hr: pileća polpeta
 it: polpette di pollo
 # usage:en:chicken meatballs (organic chicken, water, organic almond flour, organic garlic, organic crushed red pepper, organic oregano)
 # mainIngredient:en:chicken meat
-# ingredient/en:chicken-meatballs has 4 products in 1 language @2020-12-21
 
 < en: meatball
 en: beef meatball
@@ -10067,7 +9856,6 @@ ro: vită
 ru: Говядина
 sv: nötkött
 zh: 牛
-# ingredient/fr:bœuf has 257 products in 7 languages @2019-04-19
 # usage:fr:gélatine (bœuf)
 nutriscore_red_meat:en: yes
 vegan:en: no
@@ -10132,7 +9920,6 @@ hu: marhahúskivont
 it: estratto di manzo
 ja: ビーフエキス
 nl: rundvleesextrakt
-# ingredient/fr:extrait-de-bœuf has 110 products in 4 languages @2019-04-14
 
 < en: beef
 en: roasted beef including beef juices
@@ -10197,7 +9984,6 @@ hu: főtt marhahús
 it: manzo cotto, carne di manzo cotta
 nl: gekookt rundvlees
 pl: mięso wołowe gotowane
-# ingredient/fr:bœuf-cuit has 58 products in 4 languages @2019-04-02
 
 < en: beef meat
 fr: Viande bovine fraîche protégée sous vide
@@ -10338,9 +10124,6 @@ hr: goveđe srce
 hu: marhaszív
 it: cuore di manzo
 pl: serca wołowe, serce wołowe
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:naudan-syd%C3%A4n
-# 1 entry @ 2019-11-02
-# ingredient/fr:cœur-de-bœuf has 17 products in french @2019–02-12
 ciqual_food_code:en: 40053
 ciqual_food_name:en: Heart, beef, cooked
 ciqual_food_name:fr: Coeur, boeuf, cuit
@@ -10396,7 +10179,6 @@ pl: wątroba wołowa, wątroby wołowe, wątroby wołowej
 sv: nötlever
 ifct_food_code:en: O032
 ifct_food_name:en: Beef, liver
-# ingredient/fr:foie-de-boeuf has 13 products in french @2019-05-24
 
 < en: beef liver
 en: calf liver, calf's liver, Raw young cow liver
@@ -10529,7 +10311,6 @@ sv: högrev, högrev av nötkött
 # zh_yue:牛肩扒
 wikidata:en: Q1365996
 wikipedia:en: https://en.wikipedia.org/wiki/Chuck_steak
-# ingredient/sv:högrev-av-nötkött has 1 product in 1 language @2020-06-27
 
 
 # description:en:In general a sheep in its first year is called a LAMB, and its meat is also called lamb.
@@ -10601,7 +10382,6 @@ ecobalyse_labels_en_organic:en: e07f7703-c4f7-479e-a8ac-bb73d3f08c78
 usda_ndb_proxy_code:en: 17224
 usda_ndb_proxy_name:en: Lamb, ground, raw
 wikidata:en: Q643419
-# ingredient/fr:viande-d’agneau has 71 products in 5 languages @2019-04-16
 
 < en: lamb-meat
 en: raw ground lamb
@@ -11080,7 +10860,6 @@ ru: крольчатина
 uk: Кролятина
 vi: Thịt thỏ
 zh: 兔肉
-# ingredient/rabbit-meat has 109 products in french @2019-04-19
 carbon_footprint_fr_foodges_ingredient:fr: Lapin
 carbon_footprint_fr_foodges_value:fr: 8.1
 ciqual_food_code:en: 34001
@@ -11261,7 +11040,6 @@ yi: שאף
 yo: Àgùtàn
 zh: 羊
 zu: imvu
-# ingredient/fr:mouton has 12 products @2019-04-19
 # usage:fr: mouton (graisse et viande)
 nutriscore_red_meat:en: yes
 # ace:Bubiri
@@ -11337,7 +11115,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sheep
 < en: sheeps fat
 < en: sheeps meat
 fr: viande et gras de mouton
-# ingredient/fr:viande-et-gras-de-mouton has 19 products in french @2019-04-16
 
 < en: meat
 < en: sheep
@@ -11365,7 +11142,6 @@ tr: Koyun eti
 uk: баранина
 wikidata:en: Q14566073
 wikipedia:en: https://en.wikipedia.org/wiki/Lamb_and_mutton
-# ingredient/fr:viande-de-mouton has 91 products in 2 languages @2019-04-19
 
 < en: casing
 en: sheeps casing, Sheep gut, mutton casing
@@ -11377,7 +11153,6 @@ hr: ovčje crijevo
 hu: juhbél, birkabél
 it: budello di pecore, budello di sale
 pl: jelito baranie
-# ingredient/fr:boyau-de-mouton has 80 products in 4 languages @2019-02-12
 
 < en: sheeps casing
 en: natural sheep casing
@@ -11386,7 +11161,6 @@ fr: boyau naturel de mouton
 hr: prirodno ovčje crijevo
 it: budello di pecora naturale
 pl: naturalne jelito baranie
-# ingredient/fr:boyau-naturel-de-mouton has 285 products in 3 languages @2019-02-12
 
 < en: meat
 < en: sheep
@@ -11471,7 +11245,6 @@ usda_ndb_proxy_code:en: 17164
 usda_ndb_proxy_name:en: Game meat, deer, raw
 wikidata:en: Q2296872
 wikipedia:en: https://en.wikipedia.org/wiki/Venison
-# ingredient/fr:viande-de-cerf has 26 products in 4 languages @2019-04-16
 
 < en: venison
 en: raw venison
@@ -11501,7 +11274,6 @@ description:en: "Reindeer" is used in Europe and Asia, and also refers to the do
 nutriscore_red_meat:en: yes
 wikidata:en: Q5410921
 wikipedia:en: https://en.wikipedia.org/wiki/Reindeer
-# ingredient/fr:renne has 1 product in 1 language @2020-06-08
 
 < en: reindeer
 < en: venison
@@ -11514,7 +11286,6 @@ it: carne di renna
 sv: renkött
 wikidata:en: Q10650944
 # <category:en:Reindeer meat
-# ingredient/fi:poronliha has 3 products in 2 languages @2020-05-21
 
 < en: reindeer meat
 en: reindeer shoulder
@@ -11524,7 +11295,6 @@ fr: épaule de renne
 hr: plećka sobova
 it: spalla di renna
 sv: renbog
-# ingredient/fi:poron-lapa has 1 product in 2 languages @2020-06-08
 
 ###################################################################################################
 #
@@ -11710,7 +11480,6 @@ yi: פערד
 yo: ẹṣin
 za: max
 zh: 马
-# ingredient/fr:cheval has 4 products in 1 language @2020-05-21
 nutriscore_red_meat:en: yes
 # ace:guda
 # als:hauspferd
@@ -11841,7 +11610,6 @@ usda_ndb_proxy_code:en: 17170
 usda_ndb_proxy_name:en: Game meat, horse, raw
 wikidata:en: Q1124327
 wikipedia:en: https://en.wikipedia.org/wiki/Horse_meat
-# ingredient/fr:viande-de-cheval has 21 products in 4 languages @2020-05-21
 
 < en: horse meat
 en: raw horse meat
@@ -11877,7 +11645,6 @@ it: polpetta di carne
 ko: 패티
 nl: runderhamburger
 # lmo:svizzera
-# ingredient/fr:steak-haché has 18 products in french @2019-02-07
 
 < en: meat patty
 fr: Steak haché pur boeuf, pure viande de boeuf hachée, viande hachée pur bœuf
@@ -11999,7 +11766,6 @@ usda_ndb_proxy_code:en: 17168
 usda_ndb_proxy_name:en: Game meat, goat, raw
 wikidata:en: Q449506
 wikipedia:en: https://en.wikipedia.org/wiki/Goat_meat
-# ingredient/fr:viande-de-chèvre has 1 product @2019-04-02
 
 < en: goat meat
 en: raw goat meat
@@ -12358,7 +12124,6 @@ zu: Couenne
 # vls:Couenne
 # yue:豬皮
 wikidata:en: Q3695900
-# ingredient/fr:couenne has 282 products in 4 languages @2019-05-08
 
 
 # description:en: Bacon is a type of salt-cured pork. Bacon is prepared from several different cuts of meat, typically from the pork belly or from back cuts, which have less fat than the belly. It is eaten on its own, as a side dish (particularly in breakfasts), or used as a minor ingredient to flavour dishes
@@ -12439,7 +12204,6 @@ vegan:en: no
 vegetarian:en: no
 wikidata:en: Q11106
 wikipedia:en: https://en.wikipedia.org/wiki/Bacon
-# ingredient/bacon has 807 products in 16 languages @2019-05-10
 
 < en: bacon
 en: unprepared canadian bacon
@@ -12512,7 +12276,6 @@ hu: füstölt bacon, füstölt bacon szalonna
 it: pancetta affumicata
 nl: gerookte spek, gerookt spek
 sv: rökt bacon
-# ingredient/fr:lard-fumé has 66 products in 4 languages @2019-05-10
 
 # description:fr:La BARDE est une fine tranche de lard gras frais, de lard salé ou de lard fumé avec laquelle on enveloppe divers morceaux de viandes, fruits ou légumes pour garder leur texture moelleuse et éviter le dessèchement.
 
@@ -12575,7 +12338,6 @@ fr: lardons cuits fumés, lardons cuits fumés rissolés
 hr: dimljeni kuhani lardoons
 it: lardo cotto affumicato
 pt: toucinho cozido fumado
-# ingredient/fr:lardons-cuits-fumés has 168 products in 8 languages @2019-05-10
 # usage:de:Speckwürfel gekocht und geräuchert (Schweinebrust, Wasser, Glukosesirup, Salz, natürliche Aromen, Gemüsebrühe, Fermente)
 
 < en: pork meat
@@ -12644,7 +12406,6 @@ fr: Côtes de porc
 hr: svinjski odresci
 it: costolette di maiale
 sv: sida av gris
-# ingredient/fr:cotes-de-porc has 8 products @2019-05-29
 ciqual_food_code:en: 28100
 ciqual_food_name:en: Pork, chop, raw
 ciqual_food_name:fr: Porc, côte, crue
@@ -12684,7 +12445,6 @@ ru: шея
 sk: krkovička
 sv: karré, fläskkarré
 zh: 上肩肉
-# ingredient/fr:carre-de-porc has 79 products in 2 languages @2020-12-22
 ciqual_food_code:en: 28104
 ciqual_food_name:en: Pork, rack, raw
 ciqual_food_name:fr: Porc, carré, cru
@@ -13250,7 +13010,6 @@ pl: Polędwiczka
 sv: ytterfilé av gris, fläskfilé
 vi: Nạc thăn
 zh: 豬柳
-# ingredient/fr:filet-de-porc has 248 products in 6 languages @2021-08-17
 ciqual_food_code:en: 28201
 ciqual_food_name:en: Pork tenderloin, lean, raw
 ciqual_food_name:fr: Porc, filet, maigre, cru
@@ -13279,7 +13038,6 @@ it: costoletta di maiale
 ko: 포크 커틀릿
 ru: свиная вырезка
 sv: grisschnitzel
-# ingredient/fr:escalope-de-porc has 5 products in 1 language @2020-12-22
 ciqual_food_code:en: 28460
 ciqual_food_name:en: Pork, ham escalope, raw
 ciqual_food_name:fr: Porc, escalope de jambon, crue
@@ -13400,7 +13158,6 @@ ciqual_food_name:fr: Saindoux
 # yue:豬油
 wikidata:en: Q72827
 wikipedia:en: https://en.wikipedia.org/wiki/Lard
-# ingredient/lard has 2818 products in 10 languages @2019-07-10
 
 ###################################################################################################
 #
@@ -13583,7 +13340,6 @@ tr: Kollajen
 uk: Колаген
 vi: Collagen
 zh: 膠原蛋白
-# ingredient/fr:collagène has 128 products in 4 languages @2019-04-21
 vegan:en: no
 vegetarian:en: no
 # sco:collagen
@@ -13605,7 +13361,6 @@ pl: hydrolizat kolagenu
 sv: kollagenpeptider
 vi: collagen peptide
 wikidata:en: Q1779264
-# ingredient/en:hydrolyzed-collagen has 106 products in 3 languages @2020-06-13
 
 < en: casing
 < en: collagen
@@ -13620,12 +13375,10 @@ nl: natuurlijk omhulsel, eetbare natuurdarm
 pl: osłonka naturalna
 ro: Membrana naturala comestibila
 sv: naturtarm
-# ingredient/fr:boyau-naturel has 176 products in 2 languages @2019-02-12
 
 < en: collagen
 fr: boyau collagénique
 nl: collageendarm
-# ingredient/fr:boyau-collagénique has 41 products @2019-02-12
 # boyau collagénique (collagène, glycérine, cellulose)
 
 < en: beef
@@ -13638,7 +13391,6 @@ hu: marhabél
 it: budello di manzo
 nl: rundercollageen
 pl: jelito wołowe
-# ingredient/fr:boyau-de-boeuf has 24 products in 4 languages @2019-01-30
 # enveloppe:boyau de boeuf
 
 < en: beef
@@ -13663,7 +13415,6 @@ hu: sertésbél, disznóbél
 it: budello di maiale
 nl: varkenscollageen, varkencollageen, varkensdarm
 pl: jelito wieprzowe, jelita wieprzowe, kolagen wieprzowy
-# ingredient/fr:boyau-de-porc has 1085 products in 5 languages @2019-02-12
 
 < en: pork collagen
 fr: boyau naturel de porc
@@ -13676,7 +13427,6 @@ fr: jus de cuisson de viande de bœuf, jus de cuisson de viande de boeuf, jus de
 
 < fr: jus de cuisson de viande de bœuf
 fr: jus concentré d'os et de viande de bœuf, jus concentré d'os et de viande de boeuf
-# ingredient/fr:jus-concentré-d’os-et-de-viande-de-bœuf has 14 products in 2 languages @2019-02-12
 
 
 # SAUSAGES
@@ -13706,7 +13456,6 @@ ciqual_food_code:en: 30150
 ciqual_food_name:en: Merguez sausage, raw
 ciqual_food_name:fr: Merguez, crue
 wikipedia:en: https://en.wikipedia.org/wiki/Merguez
-# ingredient/fr:merguez has 63 products in french @2019-03–22
 
 < en: merguez
 en: raw Merguez sausage
@@ -13800,7 +13549,6 @@ description:nl: Salami is de benaming voor gedroogde worst van Italiaanse oorspr
 description:pt: O salame é um enchido de origem italiana.
 wikidata:en: Q188655
 wikipedia:en: https://en.wikipedia.org/wiki/Salami
-# ingredient/salami has 1158 products @2021-08-17
 
 # description:en:PEPPERONI is an American variety of salami, made from a cured mixture of pork and beef seasoned with paprika or other chili pepper.
 
@@ -13934,7 +13682,6 @@ carbon_footprint_fr_foodges_value:fr: 5.1
 fr: saucisse de strasbourg
 
 fr: plasma déshydraté
-# ingredient/fr:plasma-déshydraté has 46 products in french @2019-02-10
 
 
 # <en:context
@@ -13949,7 +13696,6 @@ it: fegato
 pl: wątroba
 wikidata:en: Q1470283
 wikipedia:en: https://en.wikipedia.org/wiki/Liver_(food)
-# ingredient/fr:foie has 57 products in french @2019-03-01
 # Porc 91% (gorge, foie, épaule)
 
 < en: animal
@@ -14061,7 +13807,6 @@ vegetarian:en: yes
 wikidata:en: Q41534
 wikipedia:en: https://en.wikipedia.org/wiki/Starch
 
-# ingredient/fr:fécules has 612 products in 5 languages @2019-01-25
 # usage:fr:fécules (dont blé)
 
 < en: starch
@@ -14461,8 +14206,6 @@ pt: Amido de ervilha
 ru: Гороховый крахмал
 sl: Škrob graha
 sv: ärtstärkelse
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:hernet%C3%A4rkkelys
-# 1 entry @ 2019-11-02
 
 < en: barley
 < en: starch
@@ -14475,7 +14218,6 @@ hr: ječmeni škrob
 it: amido d'orzo, amido (orzo), amido orzo
 sv: kornstärkelse
 allergens:en: en:gluten
-# ingredient/fr:amidon-d'orge has 1 product in 1 language @2020-06-08
 
 < en: starch
 en: Sago
@@ -14603,7 +14345,6 @@ carbon_footprint_fr_foodges_value:fr: 2.6
 from_palm_oil:en: maybe
 vegan:en: yes
 vegetarian:en: yes
-# ingredient/vegetable-oil-and-fat has 120986 products @2019-07-10
 
 < en: oil and fat
 en: refined vegetable oil
@@ -14751,7 +14492,6 @@ nb: hydrogenert olje
 nl: Gehydrogeneerde olie
 wikidata:en: Q57656844
 wikipedia:en: https://en.wikipedia.org/wiki/Hydrogenation#Food_industry
-# ingredient/hydrogenated-oil has 283 products in 9 languages @2019-07-10
 
 < en: oil
 en: frying oil
@@ -14768,7 +14508,6 @@ nl: bakvet
 ciqual_food_code:en: 16128
 ciqual_food_name:en: Frying oil
 ciqual_food_name:fr: Huile pour friture, sans précision
-# 69 in 4 @2021-08-22
 
 # description:en:FAT is one of the three main macronutrients, along with the other two:carbohydrate and protein. Fats molecules consist of primarily carbon and hydrogen atoms, thus they are all hydrocarbon molecules.
 
@@ -14846,7 +14585,6 @@ ur: شحم
 vi: chất béo
 zh: 脂肪
 from_palm_oil:en: maybe
-# ingredient/fat has 7494 products in 29 languages @2019-07-10
 vegan:en: maybe
 vegetarian:en: maybe
 # ast:grasa
@@ -14885,7 +14623,6 @@ it: grassi idrogenati
 nb: hydrogenert fett
 nl: gehydrogeneerd vet
 pl: tłuszcz uwodorniony, tłuszcze uwodornione
-# ingredient/hydrogenated-fat has 277 products in 8 languages @2019-07-10
 vegan:en: maybe
 vegetarian:en: maybe
 
@@ -14960,7 +14697,6 @@ vegan:en: no
 vegetarian:en: no
 wikidata:en: Q1423543
 wikipedia:en: https://en.wikipedia.org/wiki/Animal_fat
-# ingredient/animal-fat has 3013 products in 11 languages @2019-07-10
 
 < en: animal fat
 en: suet
@@ -14981,7 +14717,6 @@ hr: ovčja mast
 hu: juhzsír, birkazsír
 it: grasso di pecora
 nl: schaapsvet
-# ingredient/sheeps-fat has 79 products in 3 languages @2019-07-10
 
 
 < en: animal fat
@@ -14994,7 +14729,6 @@ hr: teleća mast
 hu: borjúzsír
 it: grasso di vitello
 nl: kalfsvet
-# ingredient/fr:gras-de-bovin has 90 products in french @2019-07-10
 
 < en: animal fat
 en: beef fat
@@ -15011,7 +14745,6 @@ nl: rundvet, rundervet
 pl: tłuszcz wołowy, tłuszcze wołowe
 usda_ndb_proxy_code:en: 4001
 usda_ndb_proxy_name:en: Fat, beef tallow
-# ingredient/fr:gras-de-bœuf has 365 products in 5 languages @2019-07-10
 
 < en: beef fat
 en: beef tallow fat
@@ -15124,7 +14857,6 @@ vegan:en: no
 vegetarian:en: yes
 wikidata:en: Q909729
 wikipedia:en: https://en.wikipedia.org/wiki/Butterfat
-# ingredient/butterfat has 9828 products in 35 languages @2019-07-10
 
 # description:en:CLARIFIED BUTTER is milk fat rendered from butter to separate the milk solids and water from the butterfat
 # comment:en:Not sure if this is really different from butterfat. Maybe the clarification is a special process.
@@ -15227,7 +14959,6 @@ ciqual_food_name:fr: Huile de beurre ou Beurre concentré
 usda_ndb_code:en: 1323
 usda_ndb_name:en: Butter, Clarified butter (ghee)
 wikidata:en: Q323225
-# ingredient/ghee has 24 products in 3 languages @2019-07-10
 
 
 ################################# vegetable oil ####################
@@ -15291,7 +15022,6 @@ zh: 植物油
 # roa-rup:Untulemnu
 # sco:Vegetable ile
 wikipedia:en: https://en.wikipedia.org/wiki/Vegetable_oil
-# ingredient/vegetable oil has 103341 products @2019-07-10
 
 < en: vegetable oil
 fr: huile végétale raffinée
@@ -15416,7 +15146,6 @@ hr: djelomično očvrsnuta biljna mast, djelomično hidrogenirana biljna mast
 it: grasso vegetale parzialmente idrogenato
 ro: grăsime vegetală parțial hidrogenată
 sv: delvis härdade vegetabiliska fetter
-# ingredient/fr:graisse-vegetale-partiellement-hydrogenee has 34 products in 1 language @2020-06-10
 
 < en: vegetable fat
 en: non-hydrogenated vegetable fats, non-hydrogenated vegetable fat
@@ -15467,7 +15196,6 @@ it: oli vegetali completamente idrogenati
 nb: fullherdet vegetabilske oljer
 ru: дезодорированные растительные масла
 sv: fullhärdade vegetabiliska oljor
-# ingredient/en:fully-hydrogenated-vegetable-oils has 130 products in 2 languages @2020-06-08
 
 ###################### specific oils in alphabetical order
 
@@ -15562,7 +15290,6 @@ hu: camelina olaj, sárgarepce olaj
 it: cammello
 pl: olej rydzowy, oleje rydzowe, oleju rydzowego
 description:en: CAMELINA sativa is a flowering plant in the family Brassicaceae and is usually known in English as camelina. The crop is being researched due to its exceptionally high level (up to 45%) of omega-3 fatty acids, which is uncommon in vegetable sources.
-# ingredient/fr:huile-de-cameline has 10 products @2019-06-03
 from_palm_oil:en: no
 wikipedia:en: https://en.wikipedia.org/wiki/Camelina_sativa
 
@@ -15635,7 +15362,6 @@ usda_ndb_code:en: 4501
 usda_ndb_name:en: Oil, cocoa butter
 wikidata:en: Q251106
 wikipedia:en: https://en.wikipedia.org/wiki/Cocoa_butter
-# ingredient/cocoa-butter has 26027 products in 39 languages @2019-05-25
 
 < en: cocoa butter
 en: raw cacao butter
@@ -15653,7 +15379,6 @@ fr: pur beurre de cacao
 hr: čisti kakao maslac
 it: Burro cocco puro
 nl: puur cacaoboter
-# ingredient/fr:pur-beurre-de-cacao has 74 products @2019-05-25
 
 < en: vegetable oil
 en: corn oil, maize oil
@@ -15890,7 +15615,6 @@ hr: organsko laneno ulje
 hu: bio lenmagolaj
 it: olio di lino biologico
 nl: olie van biologisch geteelde zaden van de vlasplant
-# ingredient/nl:olie-van-biologisch-geteelde-zaden-van-de-vlasplant has 2 products @2019-05-24
 
 # <en:mango
 < en: vegetable oil
@@ -15902,7 +15626,6 @@ fr: huile de noyaux de mangue, huile végétale de noyau de mangue, graisses vé
 hr: mangove koštice
 hu: mangómagolaj, mangóolaj
 it: Burro di mango
-# ingredient/fr:noyaux-de-mangue has 31 products in french @2019-03-01
 # matières grasses végétales (palme, karité, sal, noyaux de mangue, illipé, kokum gurgi dans des proportions variables)
 from_palm_oil:en: no
 
@@ -16095,7 +15818,6 @@ hu: bio pálmaolaj
 it: olio di palma biologico
 nl: biologische palmolie
 ru: Органическое пальмовое масло
-# ingredient/nl:biologische-palmolie has 1 product @2019-05-24
 
 < en: palm oil
 en: sustainable palm oil, sustainable palm fruit oil, sustainable palm
@@ -16180,7 +15902,6 @@ th: น้ำมันปาล์มโอเลอิน
 description:en: The olein (liquid) fraction of palm oil.
 #wiktionary:en:palmolein
 wikidata:en: Q57312740
-# 328 in 9 @2021-09-09
 
 < en: palm olein
 en: refined palmolein oil
@@ -16209,7 +15930,6 @@ sv: palmstearin
 description:en: Palm stearin is the solid fraction of palm oil.
 wikidata:en: Q7128109
 wikipedia:en: https://en.wikipedia.org/wiki/Palm_stearin
-# 135 in 5 @2021-09-09
 
 #comment:en:Not all languages use palm fat, but use palm oil instead
 
@@ -16245,7 +15965,6 @@ sv: palmfett
 description:en: the solid state of the vegetable oil, obtained from the fruit of oil palms.
 usda_ndb_code:en: 4055
 usda_ndb_name:en: Oil, palm
-# 9007 in 34 @2021-09-09
 
 #processing:en en:non-hydrogenated
 #<en:palm fat
@@ -16274,7 +15993,6 @@ nb: hydrogenert palmefett
 nl: Gehydrogeneerd palmvet
 pl: utwardzony tłuszcz palmowy, tłuszcz palmowy utwardzony, tłuszcze roślinne palmowy utwardzony
 sv: hydrerad palmfett
-# ingredient/en:hydrogenated-palm-fat has 43 products in 4 languages @2020-06-08
 
 < en: palm fat
 en: totally hydrogenated palm fat
@@ -16418,7 +16136,6 @@ hr: hidrogenirano ulje palminih koštica
 it: olio di palmisti idrogenato
 nl: Gehydrogeneerde palmpitolie
 sv: härdat palmkärnolja, härdat palmkärna
-# ingredient/en:hydrogenated-palm-kernel-oil has 1820 products in 2 languages @2020-06-08
 
 < en: palm kernel oil
 fr: palmiste totalement hydrogénée, huile de palmiste entièrement hydrogénée
@@ -16506,7 +16223,6 @@ hu: bio tökmagolaj
 it: olio di semi di zucca biologico
 nl: olie van biologische pompoenpitten
 sv: ekologisk pumpafröolja
-# ingredient/nl:olie-van-biologische-pompoenpitten has 1 product @2019-05-24
 
 # description:en:COCONUT OIL, or copra oil, is an edible oil extracted from the kernel or meat of mature coconuts harvested from the coconut palm (Cocos nucifera).
 
@@ -16579,7 +16295,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Coconut_oil
 #fr:huile de coco biologique
 #hu:bio kókuszolaj
 #nl:Biologische kokosolie
-# ingredient/nl:biologische-kokosolie has 1 product @2019-05-24
 
 < en: coconut oil
 en: virgin coconut oil, raw coconut oil
@@ -16589,7 +16304,6 @@ fr: huile vierge de noix de coco, huile de coco vierge, Huile vierge de coco
 hr: djevičansko kokosovo ulje
 it: olio di cocco vergine
 pl: olej kokosowy virgin
-# ingredient/fr:huile-de-coco-vierge has 10 products @2019-06-02
 
 #<en:organic coconut oil
 < en: virgin coconut oil
@@ -16635,7 +16349,6 @@ fr: huile de coco fractionnée
 hr: frakcioniranog kokosovog ulja
 it: olio di cocco frazionato
 sv: fraktionerad kokosolja
-# ingredient/en:fractionated-coconut-oil has 153 products in 1 language @2020-06-08
 
 < en: coconut oil
 en: refined coconut oil
@@ -16679,8 +16392,6 @@ agribalyse_food_code:en: 16040
 ciqual_food_code:en: 16040
 ciqual_food_name:en: Coconut fat or oil
 from_palm_oil:en: no
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:matière-grasse-de-noix-de-coco
-# 36 products in 4 languages @2018-10-03
 
 # creamed coconut differs from coconut cream: https://en.wikipedia.org/wiki/Creamed_coconut
 < en: coconut fat
@@ -16706,7 +16417,6 @@ nb: fullhydrogenert kokosfett, fullherdet kokosfett
 nl: geheel gehard kokosvet
 pl: całkowicie utwardzony tłuszcz kokosowy, tłuszcz kokosowy całkowicie utwardzony
 sv: fullhärdat kokosfett
-# ingredient/fr:graisse-de-coco-totalement-hydrogenee has 21 products in 4 languages @2020-06-08
 
 
 < en: unhydrogenated coconut oil
@@ -16924,7 +16634,6 @@ nl: olie van biologische olijven
 pl: organiczna oliwa z oliwek
 pt: azeite biológico, azeite de oliva biológico
 sv: ekologisk olivolja
-# ingredient/nl:olie-van-biologische-olijven has 2 products @2019-05-24
 
 < en: virgin olive oil
 en: refined olive oil
@@ -16961,8 +16670,6 @@ it: Olio di oliva extra vergine biologico
 nl: biologische extra olijfolie van de eerste persing
 pt: azeite extra virgem biológico, azeite virgem extra biológico, azeite de oliva extra virgem biológico, azeite de oliva virgem extra biológico
 sv: ekologisk extra jungfruolivolja
-# ingredient/fr:huile-d'olive-vierge-extra-biologique has 25 products in 2 languages @2019-05-23
-# ingredient/fr:huile-d-olive-vierge-extra-issue-de-l-agriculture-biologique has 12 products in 2 languages @2019-05-25
 
 < en: organic olive oil
 en: Spanish organic olive oil
@@ -16975,7 +16682,6 @@ it: olio d'oliva biologico spagnolo
 nl: olie van biologische Spaanse olijven
 pt: azeite biológico espanhol, azeite biológico de Espanha, azeite de oliva biológico espanhol, azeite de oliva biológico de Espanha
 sv: spansk ekologisk olivolja, ekologisk spansk olivolja
-# nl:olie-van-biologische-spaanse-olijven has 2 products @2019-05-24
 
 < en: olive oil
 en: olive pomace oil
@@ -17132,7 +16838,6 @@ fi: kokonaan kovetettu rypsiöljy
 hr: potpuno hidrogenirano ulje repice
 it: olio di canola completamente idrogenato
 sv: fullhärdad rypsolja
-# ingredient/fi:kokonaan-kovetettu-rypsiöljy has 4 products in 1 language @2020-06-08
 
 < en: rapeseed oil
 en: low erucic acid rapeseed oil
@@ -17156,7 +16861,6 @@ it: preparazione di olio di canola
 sv: rypsoljeberedning
 # usage:fi:rypsiöljyvalmiste (rypsiöljy, voiaromi)
 # mainIngredient:en:canola oil
-# ingredient/fi:rypsiöljyvalmiste has 2 products in 1 language @2020-06-08
 
 < en: rapeseed oil
 en: colza oil
@@ -17202,7 +16906,6 @@ es: aceite hidrogenado de colza
 #hr:potpuno hidrogenirano repičino ulje
 #nb:fullherdet rapsolje
 #sv:fullhärdad rapsolja
-# ingredient/fr:huile-de-colza-totalement-hydrogenee has 41 products in 4 languages @2020-06-10
 
 #processing:en: en:non-hydrogenated
 #<en:colza oil
@@ -17220,7 +16923,6 @@ fr: huile de colza vierge
 fr: monodiglycérides de colza
 de: Mono- und Diglyceride von Raps
 hu: repce mono- és digliceridjei
-# ingredient/fr:monodiglycérides-de-colza has 16 products in 2 languages @2019-02-18
 
 #process:en: en:non-hydrogenated
 #<en:rapeseed oil
@@ -17228,7 +16930,6 @@ hu: repce mono- és digliceridjei
 #de:ungehärtetes Rapsöl
 #fi:kovettamaton rapsiöljy
 #sv:ohärdad rapsolja
-# ingredient/en:non-hydrogenated-rapeseed-oil has 4 products in 4 languages @2020-06-08
 
 < en: palm oil and fat
 en: palm and rapeseed
@@ -17239,7 +16940,6 @@ hr: palma i repica
 hu: pálma- és repcemag
 it: palma e colza
 nl: Palm en koolzaad
-# ingredient/fr:palme-et-colza has 100 products in 4 languages @2019-04-09
 # usage:fr: huiles et graisses végétales (palme colza)
 
 < en: rapeseed oil
@@ -17284,7 +16984,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Walnut_oil
 
 < en: walnut oil
 fr: huile vierge de noix
-# ingredient/fr:huile-vierge-de-noix has 21 products in french @2019-04-24
 
 < en: vegetable oil
 en: mustard oil
@@ -17341,7 +17040,6 @@ ciqual_food_name:en: Peanut oil
 ciqual_food_name:fr: Huile d'arachide
 description:en: PEANUT OIL, also known as groundnut oil or arachis oil, is a mild-tasting vegetable oil derived from peanuts.
 ecobalyse:en: c704400c-9108-49a8-a79a-b830eccb6b5e
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/peanut-oil/
 from_palm_oil:en: no
 usda_ndb_proxy_code:en: 4042
 usda_ndb_proxy_name:en: Oil, peanut, salad or cooking
@@ -17447,7 +17145,6 @@ hr: organsko sezamovo ulje
 hu: bio szezámolaj, bio szezámmagolaj
 it: olio di sesamo biologico
 nl: olie van biologische sesamzaadjes
-# ingredient/nl:olie-van-biologische-sesamzaadjes has 1 product @2019-05-24
 
 < en: sesame oil
 en: Virgin sesame oil, sesame oil virgin
@@ -17498,7 +17195,6 @@ tr: soğuk sıkım susam yağı, doğal susam yağı
 uk: нерафінована кунжутна олія, натуральна олія з кунжуту
 vi: dầu mè nguyên chất, dầu mè tự nhiên
 zh: 纯正芝麻油, 天然芝麻油
-# ingredient/fr:huile-vierge-de-sesame has 12 products in french @2019-05-29
 
 < en: vegetable oil
 en: soya oil, Soybean oil, soy oil, soyabean oil
@@ -17553,7 +17249,6 @@ usda_ndb_proxy_code:en: 4044
 usda_ndb_proxy_name:en: Oil, soybean, salad or cooking
 wikidata:en: Q926892
 wikipedia:en: https://en.wikipedia.org/wiki/Soybean_oil
-# ingredient/soya-oil has 41836 products 1in 28 languages @2021-08-16
 
 < en: soya oil
 en: salad or cooking soybean oil
@@ -17694,7 +17389,6 @@ usda_ndb_proxy_code:en: 4536
 usda_ndb_proxy_name:en: Oil, sheanut
 wikidata:en: Q495857
 wikipedia:en: https://en.wikipedia.org/wiki/Shea_butter
-# ingredient/fr:beurre-de-karité has 93 products in 6 languages @2019-04-16
 
 # < en:shea why is this here?
 < en: vegetable oil
@@ -17719,7 +17413,6 @@ hr: suncokretova mast
 hu: napraforgózsír
 it: olio idrogenato di semi di girasole
 pl: tłuszcz słonecznikowy, tłuszcz roślinny słonecznikowy, tłuszcze roślinne słonecznikowy
-# ingredient/sunflower-fat has 2 products in english @2019-04-16
 from_palm_oil:en: no
 
 #<en:sunflower fat
@@ -17832,7 +17525,6 @@ description:en: SAL OIL (Shorea robusta seed oil) is an edible oil extracted fro
 from_palm_oil:en: no
 wikidata:en: Q15087371
 wikipedia:en: https://en.wikipedia.org/wiki/Shorea_robusta_seed_oil
-# ingredient/en:sal-oil has 10 products in 2 languages @2020-06-08
 
 < en: vegetable fat
 en: sal fat
@@ -17887,7 +17579,6 @@ de: Natives Haselnussöl
 fr: huile vierge de noisette
 hr: djevičansko ulje lješnjaka
 it: olio vergine di nocciole
-# ingredient/fr:huile-vierge-de-noisette has 9 products @2019-06-02
 ecobalyse:en: 1e3d325d-b369-4f03-b3a3-f4261924fca4
 from_palm_oil:en: no
 
@@ -17994,7 +17685,6 @@ hr: organsko suncokretovo ulje
 hu: bio napraforgóolaj
 it: olio di girasole biologico
 nl: olie van biologische zonnebloempitten, olie van biologisch zonnebloempitten, biozonnebloemolie, bio zonnebloemolie
-# ingredient/nl:olie-van-biologische-zonnebloempitten has 2 products @2019-05-24
 
 # description:en:Hydrogenation is a chemical process by adding hydrogen to liquid vegetable oils, so it would remain solid at room temperature
 
@@ -18070,7 +17760,6 @@ pl: wysoko oleinowy olej słonecznikowy
 comment:en: has a higher oleic oil fraction
 usda_ndb_proxy_code:en: 4584
 usda_ndb_proxy_name:en: Oil, sunflower, high oleic (70% and over)
-# ingredient/fr:tournesol-oléique has 55 products in french @2019-02-22
 # huiles végétales (tournesol oléique, colza, tournesol)
 
 < en: sunflower oil
@@ -18122,7 +17811,6 @@ fr: huile de tournesol oléique désodorisée
 
 < en: sunflower oil
 fr: oléisol®
-# ingredient/fr:oléisol® has 21 products in french @2019-02-06
 
 # In current edible oil refining, deodorization is also the process in which free (nonesterifed) fatty acids (in the case of physical refining) and volatile contaminants are stripped and unwanted color pigments are degraded (heat bleaching).
 
@@ -18377,7 +18065,6 @@ pl: olejek anyżowy
 sv: anisolja
 wikidata:en: Q549313
 # derivedFrom:en:aniseed
-# ingredient/en:aniseed-oil has 27 products in 3 languages @2020-06-08
 
 < en: essential oil
 en: lime oil
@@ -18389,7 +18076,6 @@ hr: ulje limete
 it: olio di lime
 nl: Limoen olie
 sv: limeolja
-# ingredient/en:lime-oil has 484 products in 1 language @2020-06-08
 
 # description:en:EUCALYPTUS OIL is the generic name for distilled oil from the leaf of Eucalyptus, a genus of the plant family Myrtaceae native to Australia and cultivated worldwide. Eucalyptus oil has a history of wide application, as a pharmaceutical, antiseptic, repellent, flavouring, fragrance and industrial uses.
 
@@ -18419,7 +18105,6 @@ vi: dầu khuynh diệp
 wikidata:en: Q511687
 wikipedia:en: https://en.wikipedia.org/wiki/Eucalyptus_oil
 # derivedFrom:en:eucalyptus
-# ingredient/fr:huile-essentielle-d'eucalyptus has 20 products in 2 languages @2020-06-08
 
 < en: essential oil
 en: thyme oil
@@ -18527,7 +18212,6 @@ hu: baromfizsír
 it: Grasso di pollame
 nl: Vet van gevogelte
 pl: Tłuszcz drobiowy
-# ingredient/fr:graisse-de-volaille has 76 products in 5 languages @2019-03-01
 vegan:en: no
 vegetarian:en: no
 
@@ -18551,7 +18235,6 @@ ciqual_food_code:en: 16550
 ciqual_food_name:en: Duck fat
 ciqual_food_name:fr: Graisse de canard
 wikidata:en: Q47472133
-# 1229 in 11 @2021-09-12
 
 
 < en: poultry fat
@@ -18585,7 +18268,6 @@ usda_ndb_code:en: 4542
 usda_ndb_name:en: Fat, chicken
 wikidata:en: Q5096296
 wikipedia:en: https://en.wikipedia.org/wiki/Chicken_fat
-# 4183 in 20 @2021-09-12
 # kippenvet (kippenvet, antioxidant:rozemarijnextract)
 
 # from:en:goose
@@ -18607,7 +18289,6 @@ ciqual_food_name:fr: Graisse d'oie
 usda_ndb_code:en: 4576
 usda_ndb_name:en: Fat, goose
 wikidata:en: Q68187377
-# 146 in 5 @2021-09-12
 
 # from:en:turkey
 < en: poultry fat
@@ -19004,7 +18685,6 @@ en: condiment with white balsamic
 fr: condiment balsamique blanc
 hr: začiniti bijelim balzamikom
 it: Condimento con balsamico bianco
-# ingredient/fr:condiment-balsamique-blanc has 56 products @2019-03-29
 # usage:fr:condiment balsamique blanc (vinaigre de vin, moût de raisin)
 
 < en: vinegar
@@ -19162,7 +18842,6 @@ fr: vinaigre à l'estragon
 hr: estragon ocat
 it: aceto di dragoncello
 sv: dragonvinäger
-# ingredient/en:tarragon-vinegar has 4 products in 1 language @2020-06-08
 
 < en: vinegar
 nl: natuurazijn
@@ -19334,7 +19013,6 @@ ciqual_food_code:en: 1014
 ciqual_food_name:en: Pure alcohol
 wikidata:en: Q153
 wikipedia:en: https://en.wikipedia.org/wiki/Ethanol
-# fr:alcool-éthylique has 237 products in 5 languages @2018-10-29
 
 #<en:compound
 < en: alcohol
@@ -19413,7 +19091,6 @@ uz: Likyor
 vi: rượu mùi
 yi: ליקער
 zh: 力娇酒
-# ingredient/fr:liqueur has 30 products in 5 languages @2019-02-15
 # Likör (Glucosesirup, Wasser, Alkohol, Zucker, Aromen)
 ciqual_food_code:en: 1003
 ciqual_food_name:en: Liqueur
@@ -19455,7 +19132,6 @@ hr: čokoladni liker
 hu: csokoládélikőr
 it: liquore al cioccolato
 nl: chocoladelikeur
-# ingredient/chocolate-liqueur has 46 products @2019-02-15
 
 < en: liqueur
 en: advocaat
@@ -19691,7 +19367,6 @@ tt: Шампан
 uk: Шампанське
 vi: Sâm panh
 zh: 香槟酒
-# ingredient/champagne has 74 products in 2 languages @2018-12-14
 ciqual_food_code:en: 5207
 ciqual_food_name:en: Champagne
 ciqual_food_name:fr: Champagne
@@ -19719,7 +19394,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Champagne
 
 < en: champagne
 fr: champagne brut
-# ingredient/fr:champagne-brut has 18 products @2019-05-29
 
 < en: alcohol
 en: cava
@@ -19754,7 +19428,6 @@ de: Marc de Bourgogne
 fr: marc de bourgogne
 hr: marc de bourgogne
 it: Marc de Bourgogne
-# ingredient/fr:marc-de-bourgogne has 43 products in 4 languages @2019-03-29
 
 
 < en: brandy
@@ -19767,7 +19440,6 @@ hr: marc de champagne
 it: Marc de Champagne
 sv: marc de champagne
 wikidata:en: Q1892862
-# ingredient/fr:marc-de-champagne has 30 products in 4 languages @2018-12-14
 
 
 
@@ -19791,7 +19463,6 @@ description:en: A kirschwasser or kirsch is a clear, colorless fruit brandy trad
 # nrm:Qùierche
 wikidata:en: Q279034
 wikipedia:en: https://en.wikipedia.org/wiki/Kirsch
-# ingredient/fr:kirsch has 184 products in 5 languages @2018-12-29
 
 < en: alcohol
 en: tequila
@@ -20052,14 +19723,12 @@ description:en: WINE is an alcoholic beverage made from fermented grapes.
 # zh-hant:葡萄酒
 wikidata:en: Q282
 wikipedia:en: https://en.wikipedia.org/wiki/Wine
-# en:wine has 4233 products in 6 languages @2018-10-29
 
 < en: wine
 en: pedro ximenez wine
 es: vino Pedro Ximenez
 hr: vino pedro ximenez
 it: vino Pedro Ximenez
-# en:pedro ximenez wine has 3 products in spanish @2021-08-14
 
 < en: wine
 en: natural sweet wine
@@ -20139,8 +19808,6 @@ zh: 气泡酒
 # zh-tw:氣泡酒
 wikidata:en: Q321263
 wikipedia:en: https://en.wikipedia.org/wiki/Sparkling_wine
-# ingredient/fr:vin-mousseux has 10 products in french @2019-05-29
-# category/sparkling-wines has 293 products 2019-05-29
 
 < en: sparkling wine
 fr: vin cremant de Loire aop
@@ -20193,7 +19860,6 @@ ciqual_proxy_food_name:fr: Vin blanc (sec)
 description:en: WHITE WINE is a wine whose colour can be straw-yellow, yellow-green, or yellow-gold.
 wikidata:en: Q10210
 wikipedia:en: https://en.wikipedia.org/wiki/White_wine
-# en:white-wine has 2793 products in 5 languages @2018-10-29
 
 < en: white wine
 en: dry white wine
@@ -20227,7 +19893,6 @@ it: vino bianco dalla Francia
 
 < en: white wine
 fr: vin blanc réduit
-# fr:vin-blanc-réduit has 33 products in 1 language @2018-10-29
 
 < en: white wine
 fr: vin blanc modifié
@@ -20244,7 +19909,6 @@ hu: fehérbor kivonat
 it: estratto di vino bianco
 nl: witte wijnextract
 sv: vitvinsextrakt
-# fr:extrait-de-vin-blanc has 221 products in 3 languages @2018-10-29
 
 < en: white wine
 en: white wine from cava
@@ -20268,7 +19932,6 @@ hr: muskadet
 ja: ミュスカデ
 ru: мюскаде
 wikipedia:en: https://en.wikipedia.org/wiki/Muscadet
-# fr:muscadet has 82 products in 1 language @2018-10-29
 
 # <category:en:Red wines
 < en: wine
@@ -20343,8 +20006,6 @@ description:en: RED WINE is a type of wine made from dark-colored (black) grape 
 ecobalyse:en: 6621c18e-85de-4683-82be-7b236e68bc48
 wikidata:en: Q1827
 wikipedia:en: https://en.wikipedia.org/wiki/Red_wine
-# ingredient/red-wine has 658 products @2019-05-29
-# category/red-wines has 920 products @2019-05-29
 
 < en: red wine
 en: organic red wine
@@ -20378,7 +20039,6 @@ fr: extrait de vin rouge
 hr: ekstrakt crnog vina
 hu: vörösbor kivonat
 it: estratto di vino rosso
-# fr:extrait-de-vin-rouge has 15 products in 3 languages @2018-10-29
 
 
 # description:en:Sauternes is a French sweet wine from the Sauternais region of the Graves section in Bordeaux.
@@ -20407,7 +20067,6 @@ zh: 索泰爾納
 # zh-hant:索泰爾納白葡萄酒
 wikidata:en: Q771636
 wikipedia:en: https://en.wikipedia.org/wiki/Sauternes_(wine)
-# ingredient/fr:sauternes has 74 products in 4 languages @2019-02-14
 
 < en: wine
 en: rosé wine, rosé
@@ -20458,11 +20117,9 @@ ciqual_food_name:fr: Vin rosé
 description:en: A ROSÉ is a type of wine that incorporates some of the color from the grape skins, but not enough to qualify it as a red wine.
 wikidata:en: Q12979
 wikipedia:en: https://en.wikipedia.org/wiki/Rosé
-# fr:vin-rosé has 33 products @2018-10-29
 
 < en: wine
 fr: vin aromatisé
-# fr:vin-aromatisé has 67 products in 2 languages @2018-10-29
 
 < en: wine
 en: stale wine
@@ -20520,7 +20177,6 @@ zh: 加强葡萄酒
 # zh-hk:加強葡萄酒
 wikidata:en: Q722338
 wikipedia:en: https://en.wikipedia.org/wiki/Fortified_wine
-# ingredient/fr:vin-de-liqueur has 18 products in 4 languages @2109-04-26
 
 
 # description:en:MADEIRA is a fortified wine made on the Portuguese Madeira Islands, off the coast of Africa. Madeira is produced in a variety of styles ranging from dry wines which can be consumed on their own as an aperitif to sweet wines usually consumed with dessert.
@@ -20572,7 +20228,6 @@ zh: 马德拉酒
 # yue:孖爹剌
 wikidata:en: Q27697
 wikipedia:en: https://en.wikipedia.org/wiki/Madeira_wine
-# ingredient/fr:madère has 120 products in 4 languages @2019-04-26
 # usage:en:liqueur wine (Madeira)
 
 
@@ -20693,7 +20348,6 @@ zh: 波特酒
 # zh-tw:波特酒
 wikidata:en: Q191034
 wikipedia:en: https://en.wikipedia.org/wiki/Port_wine
-# fr:porto has 411 products in 5 languages @2018-10-28
 
 < en: port
 en: red port
@@ -20705,7 +20359,6 @@ hu: kékoportó, vörös portói
 it: porto rosso
 nl: rode port
 wikidata:en: Q26879196
-# fr:port-rouge has 72 products in 2 languages @2018-10-29
 
 #< en: compound ingredient
 < en: red port
@@ -20772,7 +20425,6 @@ zh: 雪利酒
 # zh_yue:些厘酒
 wikidata:en: Q16398
 wikipedia:en: https://en.wikipedia.org/wiki/Sherry
-# ingredient/en:sherry has 78 products in 1 language @2020-05-24
 
 < en: sherry
 en: amontillado sherry
@@ -20863,7 +20515,6 @@ zh: 白兰地
 wikidata:en: Q146470
 wikipedia:en: https://en.wikipedia.org/wiki/Brandy
 # <category:en:brandys
-# ingredient/fr:brandy has 152 products in 4 languages @2020-06-08
 
 < en: brandy
 fr: brandy modifié
@@ -20936,7 +20587,6 @@ description:es: El vermú es un vino macerado en hierbas servido durante los ape
 description:fr: Vin blanc dans lequel on a fait infuser des plantes amères, toniques et aromatiques.
 description:nl: Vermout is een versterkte wijn, op smaak gebracht met aromatische planten en kruiden.
 description:pt: bebida alcoólica à base de vinho, com adição de flores ou ervas aromáticas.
-# 151 in 5 @2021-09-09
 wikidata:en: Q231088
 wiktionary:en: vermouth
 
@@ -20978,7 +20628,6 @@ es: cognac modificado
 fr: cognac modifié
 hr: modificirani konjak
 it: cognac modificato
-# fr:cognac-modifié has 41 products in 3 languages @2018-10-29
 
 < en: alcohol
 en: cointreau
@@ -21225,7 +20874,6 @@ pl: Absynt
 pt: absinto
 wikidata:en: Q170210
 wikipedia:en: https://en.wikipedia.org/wiki/Absinthe
-# en:absinth has 3 products in 7 languages @2018-10-29
 
 < en: alcohol
 en: Chartreuse liqueur
@@ -21357,7 +21005,6 @@ ru: вкусоароматические вещества и препараты
 sv: smakberedning
 # ingredient/fr:préparation-aromatisante has  50 products in 5 languages @2019-03-04
 # usage:de:Aromaextrakte (Pfefferminzextrakt)
-# ingredient/fr:préparation-aromatique has 64 products in 3 languages @2019-04-11
 # usage:fr: préparation aromatique (arôme naturel, colorants : caramel, curcumine, extrait de paprika, céleri)
 
 < en: flavouring
@@ -21428,7 +21075,6 @@ fr: base aromatisante barbecue
 hr: aroma za roštilj
 it: aroma barbecue
 pl: aromat barbecue
-# ingredient/fr:base-aromatisante-barbecue has 28 products in 2 languages @2019-03-01
 
 < en: flavouring
 en: biscuit flavouring
@@ -21481,7 +21127,6 @@ de: natürliches Dill-Aroma, natürliches Dillaroma
 fr: arôme naturel d'aneth
 hr: prirodna aroma kopra
 it: aroma naturale di aneto
-# ingredient/fr:arome-naturel-d'aneth has 34 products in 1 language @2020-05-21
 
 < en: flavouring
 en: chicken flavouring
@@ -22656,7 +22301,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q33495
 wikipedia:en: https://en.wikipedia.org/wiki/Vanillin
-# ingredient/fr:vanilline has 831 products in 10 languages @2018-12-12
 
 < en: vanillin
 en: ethylvanillin
@@ -22782,7 +22426,6 @@ fi: luontainen piparminttuaromi ja muita luontaisia aromeja
 hr: prirodne arome mente s drugim prirodnim aromama
 it: aroma naturale di menta piperita con altri aromi naturali
 sv: naturlig pepparmintsarom med andra naturliga aromer
-# ingredient/sv:naturlig-pepparmintsarom-med-andra-naturliga-aromer has 1 product in 1 language @2020-05-25
 
 
 < en: natural citrus flavouring
@@ -22919,7 +22562,6 @@ sk: aróma slaniny
 sl: okus slanine
 sv: baconarom
 tr: domuz pastırması aroması
-# ingredient/en:bacon-flavor has 55 products in 1 language @2020-12-20
 
 < en: natural flavouring
 en: natural garlic flavouring, natural garlic aroma
@@ -23448,7 +23090,6 @@ it: aroma di burro
 pl: aromat maślany, aromat masła
 ru: ароматизатор масла, ароматизатор идентичный натуральному сливки
 sv: smörarom
-# ingredient/fr:arome-de-beurre has 25 products in 5 languages @2020-06-08
 
 < en: flavouring
 en: garlic flavouring
@@ -23462,7 +23103,6 @@ hr: aroma češnjaka
 it: aroma di aglio
 pl: aromat czosnku, aromaty czosnku, aromat czosnkowy
 sv: vitlökarom, vitlöksarom
-# ingredient/fr:arome-d'ail has 21 products in 4 languages @2020-06-13
 
 < en: flavouring
 en: blackcurrant flavouring
@@ -23476,7 +23116,6 @@ it: aroma di ribes nero
 nb: solbær aroma
 pl: aromat czarnej porzeczki
 sv: svartvinbärsarom
-# ingredient/fr:arome-cassis has 17 products in 4 languages @2020-06-13
 
 < en: flavouring
 en: lime flavouring
@@ -23487,7 +23126,6 @@ fr: arôme de citron vert
 hr: aroma limete
 it: aroma di lime
 sv: limearom
-# ingredient/fr:arome-de-citron-vert has 6 products in 1 language @2020-06-08
 
 < en: flavouring
 en: blueberry flavouring
@@ -23498,7 +23136,6 @@ fr: arôme de myrtille
 hr: aroma borovnice
 it: aroma di mirtillo
 sv: blåbärsarom
-# ingredient/fr:arome-de-myrtille has 2 products in 2 languages @2020-06-08
 
 < en: flavouring
 en: dill flavouring
@@ -23510,7 +23147,6 @@ hr: aroma kopra
 hu: kapor aroma
 it: aroma di aneto
 sv: dillarom
-# ingredient/sv:dillarom has 7 products in 1 language @2020-05-21
 
 < en: natural flavouring
 en: natural sea-buckthorn flavouring
@@ -23519,7 +23155,6 @@ fi: luontainen tyrniaromi
 fr: arôme naturel de baie d'argousier
 hr: prirodna aroma krkavine
 sv: naturlig havtornsarom
-# ingredient/fr:arome-naturel-de-baie-d'argousier has 1 product in 1 language @2020-06-08
 
 < en: flavouring
 en: juniper berry flavouring
@@ -23528,7 +23163,6 @@ fi: katajanmarja-aromi
 hr: aroma bobica kleke
 it: aroma di bacche di ginepro
 sv: enbärsarom
-# ingredient/fi:katajanmarja-aromi has 1 product in 1 language @2020-06-08
 
 < en: flavouring
 en: horseradish flavouring
@@ -23540,7 +23174,6 @@ it: aroma di rafano
 pl: aromat chrzanu
 ru: аромат хрена
 sv: pepparrotsarom
-# ingredient/fi:piparjuuriaromi has 1 product in 1 language @2020-06-08
 
 < en: natural flavouring
 en: natural hops flavouring
@@ -23550,7 +23183,6 @@ fr: arôme naturel de houblon
 hr: prirodna aroma hmelja
 it: luppolo naturale
 sv: naturlig humlearom
-# ingredient/sv:naturlig-humlearom has 1 product in 1 language @2020-05-23
 
 < en: flavouring
 en: malt flavouring
@@ -23561,7 +23193,6 @@ fr: arôme de malt
 hr: aroma slada
 it: aroma di malto
 sv: maltarom
-# ingredient/fr:arome-de-malt has 4 products in 2 languages @2020-05-23
 
 < en: flavouring
 en: barley malt flavouring
@@ -23581,7 +23212,6 @@ fr: arôme naturel de malt
 hr: prirodna aroma slada
 it: aroma naturale di malto
 sv: naturlig maltarom
-# ingredient/fr:arome-naturel-de-malt has 1 product in 1 language @2020-05-24
 
 < en: flavouring
 en: cream flavouring
@@ -23593,7 +23223,6 @@ fr: arôme de crème
 hr: aroma vrhnja
 it: aroma di panna
 pl: aromat śmietankowy
-# ingredient/fr:arome-de-creme has 4 products in 4 languages @2020-05-27
 
 < en: flavouring
 en: shrimp flavouring
@@ -23604,7 +23233,6 @@ fr: arôme de crevette
 hr: aroma za škampe
 it: aroma di gamberetto
 sv: räkarom
-# ingredient/fr:arome-de-crevette has 3 products in 1 language @2020-05-28
 
 < en: natural flavouring
 en: natural asparagus flavouring
@@ -23613,7 +23241,6 @@ fi: luontainen parsa-aromi
 hr: prirodna aroma šparoga
 it: aroma naturale di asparagi
 sv: naturlig sparrisarom
-# ingredient/sv:naturlig-sparrisarom has 1 product in 1 language @2020-06-10
 
 < en: natural flavouring
 en: natural parsley flavouring
@@ -23623,7 +23250,6 @@ fr: arôme naturel de persil
 hr: prirodna aroma peršina
 it: aroma naturale di prezzemolo
 sv: naturlig persiljearom
-# ingredient/fr:arome-naturel-de-persil has 6 products in 2 languages @2020-06-11
 
 < en: flavouring
 en: mushroom flavouring
@@ -23637,7 +23263,6 @@ nl: paddenstoelaroma
 pl: aromat grzybowy
 ru: ароматизатор грибов
 sv: champinjonarom
-# ingredient/fr:arome-champignon has 9 products in 1 language @2020-06-12
 
 < en: natural flavouring
 en: natural clove flavoring
@@ -23768,7 +23393,6 @@ vegetarian:en: yes
 # zh-hk:煙
 wikidata:en: Q130768
 wikipedia:en: https://en.wikipedia.org/wiki/Smoking_(cooking)
-# ingredient/fr:fumée has 437 products in 12 languages @2019-04-14
 
 < en: smoke
 en: beech wood smoke, beechwood smoke
@@ -23784,7 +23408,6 @@ pl: dym z drewna bukowego
 ro: fum din lemn de fag
 sk: dym z bukového dreva
 sv: bokträrök
-# ingredient/fr:fumée-de-bois-de-hêtre has 211 products in 4 languages @2019-04-14
 
 < en: smoke
 en: fir wood smoke
@@ -23824,7 +23447,6 @@ zh: 煙熏液
 # zh-hk:煙熏液
 wikidata:en: Q909463
 wikipedia:en: https://en.wikipedia.org/wiki/Liquid_smoke
-# ingredient/liquid-smoke has 183 products in 2 languages @2019-03-14
 
 < en: flavouring
 en: vegetable flavouring
@@ -23849,7 +23471,6 @@ fr: son
 hr: mekinje
 hu: korpa
 pl: otręby
-# ingredient/fr:son has 38 products in 2 languages @2019-02-10
 
 < en: bran
 en: bran flour
@@ -23998,7 +23619,6 @@ hr: pahuljice od integralnih žitarica
 it: fiocchi di cereali integrali
 ro: fulgi de cereale integrale
 sv: fullkornsflingor
-# ingredient/fr:flocons-de-cereales-completes has 26 products in 6 languages @2020-06-08
 
 < en: cereal
 < en: seed
@@ -24332,7 +23952,6 @@ it: germogli di grano, grano in germogli
 pl: kiełki pszenicy
 usda_ndb_code:en: 20087
 usda_ndb_name:en: Wheat, sprouted
-# 69 in 3 @2021-10-22
 
 < en: wheat
 en: cooked wheat
@@ -24342,7 +23961,6 @@ fr: blé précuit à la vapeur
 hr: kuhana pšenica
 hu: előfőzőtt búza
 it: grano cotto
-# 20 in 4 @2021-10-22
 
 < en: wheat
 en: wheat grain
@@ -24353,7 +23971,6 @@ fi: vehjänjyvä, vehnänjyvät
 fr: grains de blé
 hr: zrno pšenice
 sv: vetekorn
-# 81 in 6 @2021-10-22
 
 < en: wheat
 en: wheat grit
@@ -24366,8 +23983,6 @@ de: Weizenpops
 fr: blé soufflé
 hr: nabujala pšenica
 it: frumento soffiato
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:blé-soufflé
-# 55 in 5 @2021-10-22
 
 < en: wheat
 #<en:whole grain
@@ -24458,8 +24073,6 @@ lt: pilno grūdo kviečių dribsniai, pilno grūdo kvietiniai dribsniai, pilno g
 nl: volkoren tarwevlokken
 pt: flocos de trigo integral, płatki pszenne pełnoziarniste
 sv: fullkornsveteflingor, fullkorn veteflingor, fullkorn veteflinga
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pétales-de-blé-complet
-# 22 products in 5 languages @2018-09-22
 
 < en: whole wheat
 en: whole wheat groats
@@ -24476,7 +24089,6 @@ it: cruschello di frumento integrale
 sl: pšenični polnozrnati drobljenec
 sr: integralna pšenična prekrupa
 sv: fullkornsvetekross
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:t%C3%A4ysjyv%C3%A4vehn%C3%A4rouhe
 # 1 product @ 2019-10-31
 
 < en: malt
@@ -24613,7 +24225,6 @@ hr: pšenična krupica
 it: semola di grano
 ru: крупа пшеничная
 sv: vetekross
-# ingredient/fr:gruau-de-ble has 3 products in 1 language @2020-12-19
 
 < en: wheat groats
 az: Manna yarması
@@ -24723,7 +24334,6 @@ fr: fins finots de blé dur
 hr: fino mljevena durum pšenica
 it: friscello di grano duro
 # https://world.openfoodfacts.org/ingredient/fr:fins-finots-de-blé-dur/
-# 35 in 4 @2021-10-07
 
 < en: durum wheat
 en: pre-cooked durum wheat, pre-cooked durum
@@ -24749,7 +24359,6 @@ bg: пълнозърнеста твърда пшеница
 de: Hartweizenvollkorn, Hartweizen-Vollkorn
 fi: täysjyvädurumvehnä
 fr: blé dur complet
-# ingredient/fr:ble-dur-complet has 6 products in 1 language @2020-06-08
 hr: durum pšenice
 it: grano duro integrale
 sv: fullkornsdurumvete, fullkorms durumvete
@@ -24823,12 +24432,10 @@ wikidata:en: Q95370124
 #hu:bio durumbúzadara, bio durum búzadara
 #it:semola di grano duro bio
 #nl:biologische harde tarwegries
-# ingredient/fr:semoule-de-ble-dur-bio has 9 products @2019-05-27
 
 #<en:durum wheat semolina
 #en:organic superior quality durum wheat semolina
 #fr:Semoule de blé dur biologique de qualité supérieure, semoule de blé dur de qualité supérieure #issue de l'agriculture biologique, semoule de blé dur de qualité supérieure issu de l'agriculture #biologique, semoule de blé dur de qualité supérieure biologique, Semoule de blé dur de qualité #supérieure issu de la Filière Alpina Savoie
-# ingredient/fr:semoule-de-ble-dur-de-qualite-superieure-issue-de-l-agriculture-biologique has 15 products in french @2019-05-23
 
 #processing:en: en:rehydrated
 #<en:durum wheat semolina
@@ -24852,7 +24459,6 @@ pt: sêmola de trigo rijo de qualidade superior
 
 < en: durum wheat semolina
 fr: semoule blanche de blé dur
-# ingredient/fr:semoule-blanche-de-ble-dur has 16 products @2019-06-02
 
 < fr: semoule blanche de blé dur
 fr: semoule de blé dur blanche biologique
@@ -24868,7 +24474,6 @@ en: semi-whole durum wheat semolina, semi-complete durum wheat semolina
 de: Halbvollkorn-Hartweizengrieß, Hartweizengrieß halbvollkorn
 fr: semoule de blé dur semi-complète, semoule semi-complète de blé dur
 hr: polucjelovita krupica od durum pšenice
-# 61 in 2 @2021-09-28
 it: semola di grano duro semi-integrale
 nl: halfvolkoren harde tarwegriesmeel
 
@@ -24891,7 +24496,6 @@ ru: Органичесая цельнозерновая мука из тверд
 sl: polnozrnati pšenični zdrob durum
 sr: integralna krupica durum pšenice
 sv: fullkornsdurumvetesemolina
-# 350 in 20 @2021-09-28
 
 < en: whole durum wheat semolina
 en: organic whole durum wheat semolina
@@ -24900,8 +24504,6 @@ it: semola di grano duro integrale bio, semola integrale di grano duro bio
 
 < en: durum wheat semolina
 fr: semoule de blé dur précuite
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:semoule-de-blé-dur-précuite/
-# 75 products in 1 language @20180922
 
 # description:en:Freekeh (sometimes spelled frikeh) or farik is a cereal food made from green durum wheat (Triticum turgidum var. durum) that is roasted and rubbed to create its flavour.
 < en: durum wheat
@@ -24979,7 +24581,6 @@ ciqual_food_name:en: Wheat germ
 usda_ndb_code:en: 20078
 usda_ndb_name:en: Wheat germ, crude
 wikipedia:en: https://en.wikipedia.org/wiki/Cereal_germ#Wheat_germ
-# ingredient/fr:germes-de-blé has 498 products in 8 languages @2019-05-12
 
 < en: cereal flour
 < en: wheat
@@ -25037,7 +24638,6 @@ ciqual_food_code:en: 25598
 ciqual_food_name:en: Seitan, prepacked
 wikidata:en: Q943935
 wikipedia:en: https://en.wikipedia.org/wiki/Wheat_gluten_(food)
-# ingredient/fr:seitan has 43 products @2019-02-09
 # seitan* (eau, protéine de blé)
 
 
@@ -25207,7 +24807,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q76605
 wikipedia:en: https://en.wikipedia.org/wiki/Couscous
-# ingredient/fr:couscous has 57 products @2019-02-21
 
 ##################################################################################
 #
@@ -25591,7 +25190,6 @@ hr: ječmene pahuljice od cijelog zrna
 it: fiocchi d'orzo integrale
 nl: volkoren gerstvlokken
 sv: fullkornskornflingor
-# ingredient/fr:flocons-d'orge-complete has 16 products in 4 languages @2020-06-08
 
 < en: barley
 en: barley groats
@@ -25775,8 +25373,6 @@ wikidata:en: Q152024
 # nds-nl:Malt
 # sco:Maut
 wikipedia:en: https://en.wikipedia.org/wiki/Malt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/malt/
-# 707 entries @ 2018-09-22
 
 < en: malt
 < en: vegetable extract
@@ -25798,8 +25394,6 @@ pt: extrato de malte, extracto de malte
 ro: extract de malț, extract de malt
 ru: Экстракт солода, солодовый экстракт, экстракт солодовый
 sv: maltextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/malt-extract/
-# 484 entries @ 2018-09-22
 
 < en: malt
 nl: moutmeel
@@ -25812,7 +25406,6 @@ fr: extrait de malt en poudre
 hr: osušeni ekstrakt slada
 hu: szárított malátakivonat
 it: estratto di malto in polvere
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/dried-malt-extract/
 
 < en: wort
 en: kvass wort
@@ -25836,7 +25429,6 @@ hr: karamel slad
 it: malto caramellato
 pt: malte de caramelo
 sv: karamellmalt
-# ingredient/en:caramel-malt has 11 products in 1 language @2020-06-08
 
 < en: malt
 en: munich malt
@@ -25937,7 +25529,6 @@ hr: sirup od ječmenog slada
 it: Sciroppo di malto d'orzo
 nl: gerstemoutstroop
 pl: syrop jęczmienny, syrop ze słodu jęczmiennego
-# ingredient/en:barley-malt-syrup has 370 products in 1 language @2020-05-21
 usda_ndb_proxy_code:en: 19352
 usda_ndb_proxy_name:en: Syrups, malt
 wikidata:en: Q3485291
@@ -26230,7 +25821,6 @@ zh: 卡莎
 # yue:卡莎
 wikidata:en: Q10379618
 wikipedia:en: https://en.wikipedia.org/wiki/Kasha
-# ingredient/fr:kasha has 13 products @2019-02-17
 
 < en: buckwheat kasha
 en: roasted buckwheat kasha
@@ -26340,7 +25930,6 @@ description:en: Millets are a group of highly variable small-seeded grasses, wid
 usda_ndb_proxy_code:en: 20031
 usda_ndb_proxy_name:en: Millet, raw
 wikidata:en: Q259438
-# 2479 in 16 @2021-10-13
 
 < en: millet
 en: millet groats
@@ -26369,8 +25958,6 @@ hu: kölespehely
 it: fiocchi di miglio
 nl: gierstvlokken
 pl: płatki jaglane
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-de-millet/
-# 46 products in 3 languages @2018-09-22
 
 < en: millet
 en: millet seed
@@ -26469,7 +26056,6 @@ usda_ndb_proxy_code:en: 20001
 usda_ndb_proxy_name:en: Amaranth grain, uncooked
 wikidata:en: Q10407363
 wikipedia:en: https://en.wikipedia.org/wiki/Amaranth_grain
-# 1227 in 15 @2021-10-05
 
 < en: amaranth
 en: uncooked amaranth grain
@@ -26494,7 +26080,6 @@ sv: amarantmel
 ciqual_proxy_food_code:en: 9345
 ciqual_proxy_food_name:en: Amaranth, raw
 ciqual_proxy_food_name:fr: Amarante, crue
-# 249 in 10 @2021-10-05
 
 < en: amaranth flour
 < en: wholemeal flour
@@ -26654,7 +26239,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Oat
 #fr:avoine biologique
 #hu:bio zab
 #ru:Органический овес
-# ingredient/fr:avoine-biologique has 12 products in french @2019-05-25
 
 < en: oat
 en: oat grain
@@ -26665,7 +26249,6 @@ fr: grains d'avoine
 hr: zobena prekrup
 it: avena in grani
 sv: havre korn
-# ingredient/en:oat-grain has 15 products in 1 language @2020-07-06
 
 < en: oat
 en: wholemeal oat, wholegrain oats, whole grain oats
@@ -26972,7 +26555,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 # usage:en:oat base (water, oats)
 # mainIngredient:en:water
-# ingredient/fr:jus-d'avoine has 5 products in 2 languages @2020-06-08
 
 < en: plant protein
 en: oat protein
@@ -27078,8 +26660,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q139925
 wikipedia:en: https://en.wikipedia.org/wiki/Quinoa
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/quinoa
-# 425 products in 6 languages @2018-09-22
 
 < en: quinoa
 en: raw quinoa, uncooked quinoa
@@ -27136,8 +26716,6 @@ hu: fehér kinoa
 it: quinoa bianca
 pl: komosa ryżowa biała
 pt: quinoa branco
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/white-quinoa
-# 63 products in 4 languages @2018-09-22
 
 < en: white quinoa
 en: oganic white quinoa
@@ -27296,7 +26874,6 @@ wikidata:en: Q12099
 # nan:thǹg-theh-be̍h
 # yue:黑麥
 wikipedia:en: https://en.wikipedia.org/wiki/Rye
-# 3649 in 27 @2021-10-28
 
 # see ingredients_processing.txt
 < en: rye
@@ -27405,8 +26982,6 @@ hu: teljes kiőrlésű rozs
 it: Segale integrale
 nl: volkorenrogge
 sv: fullkornsråg, fullkorn av råg
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:seigle-complet/
-# 37 entries @ 2018-09-22
 
 < en: rye flour
 en: medium rye flour
@@ -27462,7 +27037,6 @@ nl: roggemout
 pl: słód żytni
 ru: солод ржаной
 sv: rågmalt, malt av råg
-# 138 in 9 @2021-10-28
 
 < en: rye malt
 en: rye malt extract
@@ -27482,14 +27056,12 @@ fi: ruismallasrouhe, kaljamallas
 hr: raženi slad grist
 it: grist di malto di segale
 sv: rågmaltkross
-# ingredient/de:roggenmalzschrot has 2 products in 2 languages @2020-06-08
 
 < en: rye malt
 en: fermented rye malt
 hr: fermentirani raženi slad
 it: malto di segale fermentato
 ru: солод ржаной ферментированный
-# ingredient/ru:солод-ржаной-ферментированный has 8 product in 1 language bit.ly/3b9Rn1K @2021-03-03
 
 < en: rye malt
 en: ground rye malt
@@ -27506,7 +27078,6 @@ hr: vlakna raži
 it: fibra di segale
 nl: roggevezel
 sv: rågfiber
-# ingredient/fi:ruiskuitu has 1 product in 1 language @2020-12-20
 
 #processing:en: en:scalding
 en: scalding
@@ -27597,8 +27168,6 @@ usda_ndb_proxy_code:en: 20140
 usda_ndb_proxy_name:en: Spelt, uncooked
 wikidata:en: Q158767
 wikipedia:en: https://en.wikipedia.org/wiki/Spelt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:épeautre
-# 278 products in 6 languages @2018-09-22
 
 < en: spelt
 en: raw spelt, uncooked spelt
@@ -27628,7 +27197,6 @@ pl: kiełki orkiszu
 #fr:épeautre biologique
 #hu:bio tönkölybúza
 #nl:Biologische spelt
-# ingredient/nl:biologische-spelt has 1 product @2019-05-24
 
 < en: spelt
 fr: flocons d'épeautre, flocons blé d'épeautre
@@ -27639,8 +27207,6 @@ hu: tönkölybúzapehely
 it: fiocchi di quinoa
 nl: spelttarwevlokken
 pl: płatki orkiszowe
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-d'épeautre
-# 69 products in 3 languages @2018-09-22
 
 < en: spelt
 nl: speltschroot
@@ -27659,7 +27225,6 @@ hr: pahuljice od pira u cijelom zrnu
 it: fiocchi di farro integrale
 pl: płatki orkiszowe pełnoziarniste
 sv: fullkornsdinkelveteflingor
-# ingredient/fr:flocons-d'épeautre-complet has 23 products in 2 languages @2018-09-22
 
 < en: spelt
 en: spelt bran
@@ -28100,7 +27665,6 @@ hr: mješavina brašna
 it: Miscela di farina
 sv: mjölblanding, mjölmix, brödmix
 # usage:en:flour blend (wheat flour, rye flour)
-# ingredient/fr:melange-de-farine has 7 products in 1 language @2020-06-08
 
 < en: flour
 < en: flour blend
@@ -28265,8 +27829,6 @@ fr: blé malté torréfié concassé
 
 < en: malted wheat flour
 fr: farine de blé malté torréfié
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:farine-de-blé-malté-torréfié
-# 33 products in 3 languages @2018-09-22 (has translation issues)
 
 < en: malted wheat flour
 en: caramelized malted wheat flour
@@ -28288,7 +27850,6 @@ pl: mąka pszenna typ 450, mąka pszenna 450, mąka pszenna tortowa typ 450, mą
 < en: wheat flour
 fr: farine de blé type 55, farine de blé t55
 pl: mąka pszenna typ 550, mąka pszenna 550
-# ingredient/fr:farine-de-ble-type-55 has 12 products @2019-06-02
 
 < en: wheat flour
 en: Wheat flour type 55, Wheat flour T55, Wheat flour type 55 for bread
@@ -28588,7 +28149,6 @@ de: Weizenbrotmehl, dunkles Weizenmehl, Hefebrotweizenmehl, Hefebrotmehl
 fi: hiivaleipäjauho, tumma vehnäjauho, hiivaleipävehnäjauho, vehnähiivaleipäjauho
 hr: tamno pšenično brašno
 sv: jästbrödsvetemjöl, vetejästbrödmjöl
-# ingredient/fi:hiivaleipäjauho has 1 product in 1 language @2020-06-08
 
 < en: preparation
 < en: wheat flour
@@ -28695,8 +28255,6 @@ ro: făină de secară, faina de secara
 ru: Ржаная мука, мука ржаная
 sv: rågmjöl
 tr: çavdar unu
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/rye-flour
-# 1039 products in 11 languages @2018-09-22
 ciqual_proxy_food_code:en: 9532
 ciqual_proxy_food_name:en: Rye flour, type 85
 ciqual_proxy_food_name:fr: Farine de seigle T85
@@ -28787,7 +28345,6 @@ hr: raženo sladno brašno
 it: Farina di malto di segale
 nl: gemoute roggemeel
 sv: rågmaltmjöl
-# ingredient/fr:farine-de-seigle-maltée has 44 products in 2 languages @2018-09-22
 
 < en: rye flour
 en: sifted rye flour
@@ -28825,7 +28382,6 @@ ciqual_food_name:en: Millet flour
 ciqual_food_name:fr: Farine de millet
 usda_ndb_code:en: 20647
 usda_ndb_name:en: Millet flour
-# ingredient/fr:farine-de-millet has 40 products in 4 languages @2018-09-22
 
 < en: millet flour
 < en: wholemeal flour
@@ -28851,7 +28407,6 @@ ciqual_food_name:fr: Farine de châtaigne
 description:en: Chestnuts can be dried and milled into flour, which can then be used to prepare breads, cakes, pies, pancakes, pastas, polenta, or used as thickener for stews, soups, and sauces.
 description:de: Maronenmehl wird aus getrockneten und geschälten Kastanien hergestellt und meist mehrfach gemahlen.
 wikidata:en: Q3066928
-# 7 in 3 @2021-09-02
 
 
 
@@ -28883,7 +28438,6 @@ pl: mąka lniana, mąka z lnu
 ro: făină din seminte de in
 sv: linfrömjöl
 #openfoodfacts:https://fr.openfoodfacts.org/ingredient/farine-de-lin
-# 57 products (FR) @2020-04-23
 
 < en: flour
 < en: sunflower seed
@@ -28895,7 +28449,6 @@ fr: farine de graines de tournesol
 hr: brašno sjemenki suncokreta
 it: farina di semi di girasole
 sv: solrosfrömjöl
-# ingredient/en:sunflower-seed-flour has 14 products in 1 language @2020-05-24
 
 < en: sunflower seed flour
 en: reduced-fat sunflower seed flour
@@ -29020,8 +28573,6 @@ zh: 玉米淀粉
 ciqual_food_code:en: 9545
 ciqual_food_name:en: Maize/corn flour
 ciqual_food_name:fr: Farine de maïs
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:farine-de-mais
-# 1291 products in 19 languages @2018-09-23
 nutriscore_fruits_vegetables_nuts:en: no
 
 < en: corn flour
@@ -29058,7 +28609,6 @@ it: farina di mais giallo
 nb: gult maismel
 nl: geel maïsmeel
 sv: gult majsmjöl
-# ingredient/fr:farine-de-mais-jaune has 38 products @2019-06-02
 
 < en: corn flour
 en: white corn flour
@@ -29095,7 +28645,6 @@ it: farina di mais integrale
 sv: fullkornsmajsmjöl
 usda_ndb_proxy_code:en: 20016
 usda_ndb_proxy_name:en: Corn flour, whole-grain, yellow
-# ingredient/en:whole-grain-corn-flour has 176 products in 2 languages @2020-06-11
 
 < en: white corn flour
 < en: whole grain corn flour
@@ -29154,7 +28703,6 @@ description:it: La farina di riso è un tipo di farina ottenuta dal riso.
 description:nl: Rijstmeel is meel gemaakt van fijngemalen rijst.
 wikidata:en: Q1269205
 wiktionary:en: rice_flour
-# 21929 in 39 @2021-09-08
 
 < en: rice flour
 en: dextrinated rice flour
@@ -29217,8 +28765,6 @@ hu: quinoa liszt, quinoaliszt
 it: Farina di quinoa
 nl: quinoameel
 pl: mąka z komosy ryżowej
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/quinoa-flour
-# 173 products in 5 languages @2018-09-22
 
 < en: quinoa flour
 < en: wholemeal flour
@@ -29241,8 +28787,6 @@ it: farina di piselli
 nl: erwtenmeel
 pl: mąka grochowa, mąka z grochu
 ro: făină de mazăre
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:farine-de-pois
-# 36 products in 4 languages @2018-09-22
 
 < en: green split pea
 < en: pea flour
@@ -29274,7 +28818,6 @@ hr: kokosovo brašno, kokos brašno
 it: farina di cocco
 pl: mąka kokosowa, mąka z kokosa
 sv: kokosmjöl
-# ingredient/fr:farine-de-noix-de-coco has 24 products in 2 languages @2020-06-08
 
 ##################################################################################
 #
@@ -29407,7 +28950,6 @@ wa: dinrêye d'awousse
 yi: קוקורוזע
 za: haeuxyangz
 zh: 玉米
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/corn
 carbon_footprint_fr_foodges_ingredient:fr: Maïs
 carbon_footprint_fr_foodges_value:fr: 0.7
 ciqual_food_code:en: 9200
@@ -29473,7 +29015,6 @@ wikidata:en: Q11575
 # zh-min-nan:hoan-be̍h
 # yue:粟米
 wikipedia:en: https://en.wikipedia.org/wiki/Maize
-# 41540 in 66 @2021-12-19
 
 < en: corn
 en: canned corn
@@ -29493,7 +29034,6 @@ hr: organski kukuruz
 hu: bio kukorica
 nl: biologische mais
 pt: milho orgânico
-# ingredient/nl:biologische-mais has 1 product @2019-05-24
 
 < en: corn
 en: white corn
@@ -29524,7 +29064,6 @@ en: blue corn
 hr: plavi kukuruz
 it: mais blu
 pl: niebieska kukurydza, niebieskiej kukurydzy
-# ingredient/en:blue-corn has 95 product @2023-06-25
 
 < en: corn
 en: yellow corn
@@ -29579,7 +29118,6 @@ hr: mladi kukuruz
 it: baby corn
 pl: mini kolby kukurydzy, kukurydza baby, małe kolby kukurydzy
 sv: babymajs
-# ingredient/en:baby-corn has 117 products @2023-06-25
 
 < en: vegetable fiber
 en: corn fiber
@@ -29633,7 +29171,6 @@ hr: kukuruzna melasa
 it: melassa di mais
 nl: maïsmelasse
 pl: melasa kukurydziana
-# 31 in 6 @2021-0-05
 
 < en: corn
 < en: malt
@@ -29686,15 +29223,9 @@ ciqual_food_name:en: Polenta or maize semolina, dry
 #ciqual_food_name:en: Polenta or maize semolina, cooked, unsalted
 #ciqual_food_name:fr: Polenta ou semoule de maïs, cuite, non salée
 wikipedia:en: https://en.wikipedia.org/wiki/Cornmeal
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:semoule-de-mais
-# 597 products in 15 languages @2018-09-23
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/cornmeal
-# 281 products in 1 language @201809-23
 
 < en: cornmeal
 fr: semoule de maïs précuite
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:semoule-de-maïs-précuite
-# 27 products in 1 language @2018-09-24
 
 < en: cornmeal
 en: wholegrain maize semolina
@@ -29730,7 +29261,6 @@ hr: dekstrinirano kukuruzno brašno
 hu: dextrinált kukoricadara
 it: farina di mais destrinata
 nl: gedextrineerd maïsmeel
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/dextrinated-cornmeal
 # NO products @2018-09-23
 
 < en: corn
@@ -29749,12 +29279,6 @@ nl: maïsvlokken, cornflakes
 pl: płatki kukurydziane
 pt: flocos de milho
 sv: majsflingor, cornflakes
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/cornflakes
-# 11 products in 2 languages @2018-09-23
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/corn-flakes
-# 82 products in 5 languages @2018-09-23
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-de-maïs
-# 22 products in 5 languages @2018-09-23
 # ingredient/fr:pétales-de-maïs 180 products in 8 languages @2018-09-24
 
 < en: corn
@@ -29810,7 +29334,6 @@ fr: maïs moulu
 fi: maissirouhe
 nl: gemalen maïs
 pt: milho moído
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:maïs-moulu 28 products in 3 languages @2018-09-24
 
 < en: corn
 en: popcorn
@@ -30094,7 +29617,6 @@ vegetarian:en: maybe
 #it:riso bio
 #nl:biorijst
 #ru:Органический рис
-# ingredient/fr:riz-bio has 12 products in 4 languages @2019-05-25
 
 #<en:organic rice
 #en:superior quality organic rice
@@ -30118,7 +29640,6 @@ it: riso italiano
 nl: rijst uit Italië, italiaanse rijst
 pl: ryż włoski
 ro: orez italian
-# ingredient/italian-rice has 17 products in 12 languages @2018-12-19
 
 
 # comment:en:Parboiled rice is an independent aspect and can be present for all rice entries.
@@ -30138,7 +29659,6 @@ pt: arroz parboilizado. arroz estufado
 ciqual_food_code:en: 9101
 ciqual_food_name:en: Rice, parboiled, raw
 ciqual_food_name:fr: Riz blanc étuvé, cru
-# 1087 in 10 @2021-09-12
 
 < en: rice
 en: glutinous rice
@@ -30181,7 +29701,6 @@ uk: kлейкий рис
 vi: gạo nếp
 zh: 糯稻
 wikidata:en: Q115443
-# 174 in 11 @2021-09-13
 
 
 ########################### PROCESSING STAGES OF RICES #######################
@@ -30230,7 +29749,6 @@ ciqual_food_code:en: 9102
 ciqual_food_name:en: Rice, brown, raw
 ciqual_food_name:fr: Riz complet, cru
 wikidata:en: Q1066624
-# 3816 in 19 @2021-09-13
 
 < en: brown rice
 en: whole grain brown rice, wholegrain brown rice
@@ -30257,7 +29775,6 @@ nl: biozilvervliesrijst
 < en: brown rice
 < en: parboiled rice
 fr: riz complet étuvé, riz complet précuit
-# ingredient/fr:riz-complet-précuit has 26 products in french @2018-12-19
 
 < en: parboiled rice
 < en: whole grain brown rice
@@ -30298,7 +29815,6 @@ ciqual_food_code:en: 9100
 ciqual_food_name:en: Rice, raw
 ciqual_food_name:fr: Riz blanc, cru
 wikidata:en: Q2674257
-# 970 products in 6 @2021-09-12
 
 #<en:white rice
 #en:organic white rice
@@ -30336,9 +29852,6 @@ nl: Langkorrelige rijst
 pl: ryż długoziarnisty
 sv: långkornigt ris, långkorniga ris
 wikidata:en: Q67594028
-# ingredient/fr:riz-long-grain has 46 products in 4 languages @2018-12-19
-# ingredient/fr:riz-long-blanc has 9 products in french @2018-12-19
-# ingredient/fr:riz-long has 26 products in french @2018-12-19
 
 < en: long grain rice
 en: organic long grain rice
@@ -30357,7 +29870,6 @@ fr: riz long grain de qualité supérieure, riz long de qualité supérieure
 hr: riža dugog zrna vrhunske kvalitete
 it: riso a grani lunghi di qualità superiore
 nl: langkorrelige rijst van hoogwaardige kwaliteit
-# ingredient/fr:riz-long-grain-de-qualite-superieure has 10 products in french @2019-05-25
 
 < en: organic long grain rice
 < en: superior quality long grain rice
@@ -30377,7 +29889,6 @@ hu: hosszú szemű fehérrizs
 it: riso bianco a grani lunghi
 pl: ryż biały długoziarnisty
 sv: långkornigt vitt ris
-# ingredient/fr:riz-long-grain-blanc has 4 products @2019-05-30
 
 < en: long grain white rice
 < en: superior quality long grain rice
@@ -30415,7 +29926,6 @@ it: riso integrale a grani lunghi
 nl: langkorrelige zilvervliesrijst
 sv: långkornigt brunt ris
 wikidata:en: Q95733958
-# ingredient/fr:riz-long-complet has 13 products @2019-05-29
 
 < en: long grain brown rice
 < en: long grain parboiled rice
@@ -30434,7 +29944,6 @@ zh: 標香米
 
 < en: long grain rice
 fr: riz long grain naturellement parfumé
-# ingredient/fr:riz-long-grain-naturellement-parfume has 4 products @2019-05-29
 
 < en: long grain rice
 < en: parboiled rice
@@ -30448,8 +29957,6 @@ hu: forrázott hosszú szemű rizs
 it: riso parboiled a grani lunghi
 nl: voorgekookte langkorrelrijst
 sv: långkornigt parboil ris
-# ingredient/fr:riz-long-étuvé has 40 products in french @2018-12-19
-# ingredient/parboiled-long-grain-rice has 26 products in 3 languages @2018-12-19
 
 < en: parboiled long grain rice
 fr: riz long italien étuvé
@@ -30473,7 +29980,6 @@ es: arroz grano largo vaporizado de calidad superior
 fr: riz long grain étuvé de qualité supérieure, riz long étuvé de qualité supérieure
 hr: prokuhana riža dugog zrna vrhunske kvalitete
 it: riso parboiled a grani lunghi di qualità superiore
-# ingredient/fr:riz-long-grain-étuvé-de-qualité-supérieure has 39 products in 2 languages @2018-12-19
 
 < en: parboiled long grain brown rice
 < en: superior quality long grain parboiled rice
@@ -30483,7 +29989,6 @@ es: arroz grano largo vaporizado integral de calidad superior
 fr: riz long grain complet étuvé de qualité supérieure, riz long complet etuve de qualite superieure
 hr: vrhunska kvaliteta parboiled smeđe riže dugog zrna
 it: riso integrale parboiled a grani lunghi di qualità superiore
-# ingredient/fr:riz-long-grain-complet-étuvé-de-qualite-superieure has 4 products @2019-05-29
 
 ########################### MEDIUM GRAIN RICES #######################
 
@@ -30513,7 +30018,6 @@ hu: kerek rizs
 it: riso tondo
 sv: rundkornigt ris
 wikidata:en: Q67593960
-# ingredient/fr:riz-rond has 27 products in french @2019-05-28
 
 < en: round rice
 #<en:organic rice
@@ -30530,8 +30034,6 @@ it: riso tondo biologico
 en: white round rice
 fr: riz rond blanc, Riz rond blanchi
 nl: witte ronde rijst, ronde rijst wit
-# ingredient/fr:riz-rond-blanchi has 4 products @2019-05-29
-# ingredient/fr:riz-rond-blanc has 15 products @2019-05-29
 
 < en: organic round rice
 < en: white round rice
@@ -30552,12 +30054,10 @@ fr: riz rond complet
 hr: cijela okrugla riža
 it: riso tondo integrale
 nl: volkoren ronde rijst
-# ingredient/fr:riz-rond-complet has 19 products @2019-05-29
 
 < en: round rice
 en: superior quality round rice
 fr: riz rond de qualité supérieure
-# ingredient/fr:riz-rond-de-qualite-superieure has 11 products @2019-05-29
 
 < en: organic round rice
 < en: superior quality round rice
@@ -30576,7 +30076,6 @@ hu: rizottó rizs
 it: riso per risotto
 pt: arroz risotto
 wikidata:en: Q67438406
-# ingredient/fr:riz-pour-risotto has 8 products @2019-05-30
 
 < en: long grain rice
 < en: risotto rice
@@ -30651,7 +30150,6 @@ ciqual_food_name:en: Rice, red, raw
 ciqual_food_name:fr: Riz rouge, cru
 wikidata:en: Q7305375
 wikipedia:en: https://en.wikipedia.org/wiki/Red_rice
-# 239 in 11 @2021-09-14
 
 # comment:en:cargo seems to mean whole/brown. I doubt the translations on the packages, seem more taken from Google
 < en: red rice
@@ -30672,7 +30170,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Red_Cargo_rice
 
 < en: red rice
 fr: riz rouge long complet
-# ingredient/fr:riz-rouge-long-complet has 5 products @2019-05-29
 
 < en: rice
 en: black rice
@@ -30743,7 +30240,6 @@ ecobalyse:en: cce078cf-3d3e-4153-a0a1-35555b2da639
 ecobalyse_labels_en_organic:en: dcdcb4d1-1793-4f1b-bd1f-7578d02e4fb1
 wikidata:en: Q1649635
 wikipedia:en: https://en.wikipedia.org/wiki/Basmati
-# 1035 in 8 @2021-09-14
 
 < en: basmati rice
 < en: white rice
@@ -30757,8 +30253,6 @@ hu: fehér basmati rizs, fehér baszmati rizs
 it: riso basmati bianco
 nl: witte basmatirijst
 sv: vitt basmatiris
-# ingredient/fr:riz-basmati-blanc has 11 products @2019-0529
-# ingredient/fr:riz-basmati-blanc has 11 products @2019-0529
 
 < en: basmati rice
 < en: brown rice
@@ -30772,7 +30266,6 @@ hu: barna basmati rizs, barna baszmati rizs
 it: riso basmati integrale
 nl: volkoren basmati rijst
 sv: brunt basmatiris
-# ingredient/fr:riz-basmati-complet has 11 products @2019-05-29
 
 #<en:brown basmati rice
 #en:Organic Brown Basmati Rice, Certified Organic Brown Basmati Rice
@@ -30789,12 +30282,10 @@ hr: basmati riža dugog zrna
 hu: hosszú szemű basmati rizs, hosszú szemű baszmati rizs
 it: Riso basmati di grano lungo
 nl: langkorrelige basmatirijst
-# fr:riz-long-basmati has 14 products in french @2019-05-25
 
 < en: long grain basmati rice
 < fr: riz long grain naturellement parfumé
 fr: Riz basmati long grain naturellement parfumé
-# ingredient/fr:riz-basmati-long-grain-naturellement-parfume has 6 products 22019-05-29
 
 < en: long grain basmati rice
 < en: superior quality long grain rice
@@ -30804,7 +30295,6 @@ fr: riz basmati long grain de qualité supérieure, riz long grain Basmati de qu
 hr: visokokvalitetna basmati riža dugog zrna
 it: riso basmati a grani lunghi di alta qualità
 nl: langkorrelige basmatirijst van hoogwaardige kwaliteit
-# ingredient/fr:riz-basmati-long-grain-de-qualite-superieure has 16 products in 3 languages @2019-05-23
 
 #< en:high quality long grain Basmati rice
 #< en:organic long grain rice
@@ -30816,7 +30306,6 @@ nl: langkorrelige basmatirijst van hoogwaardige kwaliteit
 fr: riz basmati précuit
 de: basmati Reis gegart
 fi: parboil-käsitelty basmatiriisi
-# ingredient/fr:riz-basmati-précuit has 33 products in french @2018-12-19
 
 < en: basmati rice
 < en: cooked rice
@@ -30826,7 +30315,6 @@ fi: keitetty basmatiriisi, kypsennetty basmatiriisi
 fr: riz basmati cuit
 it: riso Basmati cotto
 nl: gekookte basmatirijst
-# ingredient/fr:riz-basmati-cuit has 93 products @2018-12-19
 
 # <category:en:Jasmine rice
 < en: long grain rice
@@ -30844,10 +30332,6 @@ sv: Jasminris
 description:en: JASMINE RICE is a long-grain variety of fragrant rice (also known as aromatic rice). Its fragrance, reminiscent of jasmine and popcorn, results from the rice plant's natural production of aromatic compounds
 wikidata:en: Q2733021
 wikipedia:en: https://en.wikipedia.org/wiki/Jasmine_rice
-# ingredient/fr:riz-thai has 23 products @2019-05-29
-# ingredient/fr:riz-jasmin has 22 products in 4 languages @2019-05-25
-# ingredient/fr:riz-parfume has 17 products @2019-05-29
-# category/jasmine-rice has 106 products @2019-05-30
 
 < en: Thai rice
 < en: white rice
@@ -30874,7 +30358,6 @@ hu: hosszú szemű jázminrizs, hosszú szemű jázmin rizs
 it: riso tailandese a grani lunghi
 nl: Langkorrelige Thaise rijst
 sv: långkornigt jasminris
-# ingredient/fr:riz-long-grain-thai has 4 products @2019-05-29
 
 < en: Thai long grain rice
 en: Hom Mali rice, thai hom mali rice
@@ -30908,7 +30391,6 @@ fi: tumma jasmiiniriisi
 fr: Riz thaï complet, riz complet thaï
 hr: tajlandska smeđa riža
 it: riso integrale tailandese
-# ingredient/fr:riz-thai-complet has 7 products @2019-05-29
 
 < en: Thaï brown rice
 < en: Thaï rice
@@ -30919,7 +30401,6 @@ fr: Riz Thaï complet étuvé, riz thaï noir complet de Thailande
 fr: Riz thaï long grain de qualité supérieure
 de: qualitativ hochwertiger thailändischer Langkornreis
 nl: Thaise langkorrelrijst van hoge kwaliteit
-# ingredient/fr:riz-thai-long-grain-de-qualite-superieure has 16 products @2019-05-23
 
 < en: Thai rice
 fr: riz rouge complet thaï au jasmin
@@ -30948,7 +30429,6 @@ de: Camargue Premiumqualität Langkornreis
 fr: Riz de Camargue long grain de qualité supérieure
 hr: riža dugog zrna camargue vrhunske kvalitete
 it: riso Camargue a grani lunghi di qualità superiore
-# ingredient/fr:riz-de-camargue-long-grain-de-qualite-superieure has 3 products @2019-05-29
 
 < en: Camargue rice
 en: Camargue long grain white rice
@@ -30957,7 +30437,6 @@ fi: pitkäjyväinen valkoinen camargue-riisi
 fr: riz de Camargue long blanc
 hr: camargue bijela riža dugog zrna
 it: riso bianco a grani lunghi Camargue
-# ingredient/fr:riz-de-camargue-long-blanc has 4 products @2019-05-29
 
 < en: Camargue long grain white rice
 fr: Riz de Camargue long blanc biologique
@@ -30987,12 +30466,10 @@ fr: riz arborio
 hr: arborio riža
 hu: Arborio rizs
 it: Riso Arborio
-# ingredient/fr:riz-arborio has 14 products @2019-05-29
 
 < en: Arborio rice
 < en: long grain rice
 fr: Riz Arborio long grain de qualité supérieure, riz long grain Arborio de qualité supérieure, riz long arborio de qualite superieure
-# ingredient/fr:riz-arborio-long-grain-de-qualite-superieure has 3 products @2019-05-29
 
 # description:en:CARNAROLI is a medium-grained rice grown in the Pavia, Novara and Vercelli provinces of northern Italy. Carnaroli is used for making risotto, differing from the more common arborio rice due to its higher starch content and firmer texture, as well as having a longer grain.
 
@@ -31014,8 +30491,6 @@ ru: Карнароли
 # en-gb:Carnaroli
 wikidata:en: Q1043890
 wikipedia:en: https://en.wikipedia.org/wiki/Carnaroli
-# ingredient/fr:riz-carnaroli has 33 products @2019-05-29
-# category/carnaroli-rices has 7 products @2019-05-29
 
 
 ################################    processed rices
@@ -31035,7 +30510,6 @@ pt: creme de arroz
 #hu:őrölt rizs
 #it:riso macinato
 #nl:rijst gemalen
-# ingredient/fr:riz-moulu has 20 products in 4 languages @2018-12-19
 
 # This can be found under the flours
 #<en:rice
@@ -31078,8 +30552,6 @@ hr: rižin griz
 hu: rizsdara
 it: semolino di riso
 pt: sêmola de arroz
-# ingredient/fr:semoule-de-riz has 287 products in 5 languages @2018-12-19
-# ingredient/fr:son-de-riz has 31 products @2018-12-19
 
 # see ingredients_processing.txt
 < en: rice
@@ -31095,7 +30567,6 @@ pl: płatki ryżowe
 pt: flocos de arroz
 ifct_food_code:en: A011
 ifct_food_name:en: Rice, flakes
-# ingredient/fr:flocons-de-riz has 47 products in 6 languages @2018-12-19
 
 # see ingredients_processing.txt
 < en: rice
@@ -31113,7 +30584,6 @@ pl: ekstrudat ryżowy
 pt: arroz extrudido
 sr: pirinač ekstrudat
 # sr-el:pirinač ekstrudat
-# ingredient/fr:riz-extrudé has 36 products in 4 languages @2018-12-19
 # comment:en::riz extrudé is a compound ingredient
 
 < en: rice
@@ -31133,11 +30603,7 @@ pt: arroz tufado
 sv: riskrisp, puffat ris
 ciqual_proxy_food_code:en: 32006
 ciqual_proxy_food_name:en: Puffed rice, plain, fortified with vitamins and minerals
-# ingredient/fr:riz-soufflé has 180 products in 10 languages @2018-12-19
-# ingredient/fr:riz-croustillant has 44 products in 2 languages @2018-12-19
 # usage:en:crisped rice (Rice, Sugar, Salt, Barley Malt Extract)
-# ingredient/fr:riz-soufflé has 180 products in 10 languages @2018-12-19
-# ingredient/fr:riz-croustillant has 44 products in 2 languages @2018-12-19
 # usage:en:crisped rice (Rice, Sugar, Salt, Barley Malt Extract)
 
 < en: corn
@@ -31150,7 +30616,6 @@ fr: galette de riz
 de: Reiswaffeln
 it: gallette di riso
 nl: rijstwafel, rijstwafels
-# ingredient/fr:galette-de-riz has 132 products @2018-12-19
 # fr:extrait de riz is a compound ingredient, eg:(eau, riz, huile de tournesol)
 
 < en: rice
@@ -31166,7 +30631,6 @@ hu: rizskivonat
 it: estratto di riso
 nl: rijstextract
 sv: risextrakt
-# ingredient/fr:extrait-de-riz has 36 products in 3 languages @2018-12-19
 
 < en: rice
 en: fermented rice
@@ -31175,7 +30639,6 @@ ru: рис ферментированный
 
 < en: rice
 fr: riz précuit
-# ingredient/fr:riz-précuit has 143 products in 4 languages @2018-12-19
 
 
 # fr:riz cuisiné is a compound product, eg:(eau, riz, sel)
@@ -31194,7 +30657,6 @@ nl: gekookte rijst
 pl: ryż gotowany, gotowany ryż
 ro: orez fiert, orez gătit
 sv: kokt ris
-# ingredient/fr:riz-cuisiné has 47 products in french @2018-12-19
 
 < en: cooked rice
 en: cooked white rice
@@ -31207,12 +30669,10 @@ hr: kuhana bijela riža
 hu: főtt fehér rizs
 it: riso bianco cotto
 nl: gekookte witte rijst
-# ingredient/cooked-white-rice has 75 products in 2 languages @2018-12-19
 
 < en: rice
 fr: crème de riz
 nl: rijst crème
-# ingredient/fr:crème-de-riz has 148 products in 10 languages @2018-12-19
 
 < en: rice
 en: germinated rice, sprouted rice
@@ -31757,7 +31217,6 @@ usda_ndb_code:en: 19334
 usda_ndb_name:en: Sugars, brown
 wikidata:en: Q11190742
 wikipedia:en: https://en.wikipedia.org/wiki/Brown_sugar
-# ingredient/fr:vergeoise has 61 products in 4 languages @2019-03-22
 
 
 < en: sugar
@@ -31935,7 +31394,6 @@ fr: sucre roux bio
 hr: organski smeđi šećer
 it: zucchero di canna biologico
 nl: biologische bruine suiker
-# ingredient/fr:sucre-roux-bio has 15 products in french @2019-05-23
 
 < en: sugar
 en: liquid sugar
@@ -31997,7 +31455,6 @@ uk: ванільний цукор
 # usage:en:vanilla sugar (sugar, vanillin)
 # mainIngredient:en:sugar
 # <category:en:Vanilla sugars
-# ingredient/fr:sucre-vanille has 77 products in 2 languages @2020-06-08
 ciqual_food_code:en: 31044
 ciqual_food_name:en: Sugar, vanilla flavoured
 ciqual_food_name:fr: Sucre vanillé
@@ -32037,7 +31494,6 @@ comment:en: "granulated sugar" is generally white sugar, but other sugars can be
 description:en: Granulated, familiar as table sugar, with a grain size about 0.5-0.6 mm across.
 usda_ndb_code:en: 19335
 usda_ndb_name:en: Sugars, granulated
-# ingredient/fr:sucre-cristal has 77 products @2019-06-08
 
 # see ingredients_processing.txt
 < en: sugar
@@ -32205,7 +31661,6 @@ nl: suikerrietsap
 
 < en: sugar
 nl: Arenga bossuiker
-# ingredient/nl:arenga-bossuiker has 1 product @2019-05-24
 
 < en: sugar
 en: cane sugar, pure cane sugar, natural cane sugar
@@ -32245,7 +31700,6 @@ comment:en: Cane sugar inherits vegan:maybe from sugar because some cane sugar i
 description:en: Since the 6th century BC, cane sugar producers have crushed the harvested vegetable material from sugarcane in order to collect and filter the juice. They then treat the liquid (often with lime (calcium oxide)) to remove impurities and then neutralize it. Boiling the juice then allows the sediment to settle to the bottom for dredging out, while the scum rises to the surface for skimming off.
 wikidata:en: Q165267
 wikipedia:en: https://en.wikipedia.org/wiki/Sucrose#Cane
-# ingredient/cane-sugar has 17093 products in 23 languages @2019-05-31
 
 < en: sugarcane juice
 en: evaporated cane juice
@@ -32291,8 +31745,6 @@ it: zucchero di cana bio
 nb: økologisk rørsukker
 nl: biologische rietsuiker, biologisch rietsuiker
 sv: ekologisk rörsocker
-# ingredient/fr:sucre-de-canne-bio has 104 products in 6 languages @2019-03-23
-# ingredient/fr:sucre-de-canne-biologique has 22 products @2019-05-30
 
 < en: brown sugar
 < en: cane sugar
@@ -32428,7 +31880,6 @@ it: zucchero Demerara
 pl: cukier demerara, demerara
 sv: demerarasocker
 wikidata:en: Q837194
-# ingredient/fr:sucre-demerara has 36 products in 3 languages @2020-06-08
 
 < en: unrefined cane sugar
 < en: whole cane sugar
@@ -32514,11 +31965,9 @@ vegetarian:en: yes
 wikidata:en: Q5139861
 wikipedia:en: https://en.wikipedia.org/wiki/Coconut_sugar
 # 50in3@2019-06-09
-# ingredient/fr:sucre-de-fleur-de-coco has 49 products @2019-05-27
 
 < en: coconut sugar
 nl: biologische kokosbloesem siroop
-# ingredient/nl:biologische-kokosbloesem-siroop has 1 product @2019-05-24
 
 < en: coconut sugar
 es: nectar del brote de la flor del coco
@@ -32629,7 +32078,6 @@ zh: 麥芽糖
 # zh-tw:麥芽糖
 description:en: MALTOSE, also known as maltobiose or malt sugar, is a disaccharide formed from two units of glucose joined. Maltose is a component of malt, a substance which is obtained in the process of allowing grain to soften in water and germinate. It is also present in highly variable quantities in partially hydrolysed starch products like maltodextrin, corn syrup and acid-thinned starch. In humans, maltose is broken down by various maltase enzymes, providing two glucose molecules which can be further processed: either broken down to provide energy, or stored as glycogen. The lack of the sucrase-isomaltase enzyme in humans causes sucrose intolerance.
 wikidata:en: Q170002
-# ingredient/fr:maltose has 144 products in 4 languages @2019-04-13
 
 < en: maltose
 < en: syrup
@@ -32641,8 +32089,6 @@ hr: maltozni sirup
 it: sciroppo di maltosio
 pl: syrop maltozowy
 pt: xarope de maltose
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:maltoosisiirappi
-# 1 entry @ 2019-10-31
 
 < en: maltose syrup
 en: organic maltose syrup
@@ -32655,7 +32101,6 @@ hu: bio maltóz szirup
 it: sciroppo di maltosio bio
 nl: biologische maltosestroop
 pt: xarope de maltose orgânica
-# ingredient/nl:biologisch-maltosestroop has 1 product @2019-05-24
 
 # description:en:SUCROSE is common table sugar. It is a disaccharide, a molecule composed of two monosaccharides:glucose and fructose.
 
@@ -32742,7 +32187,6 @@ zh: 蔗糖
 # yue:蔗醣
 wikidata:en: Q4027534
 wikipedia:en: https://en.wikipedia.org/wiki/Sucrose
-# ingredient/fr:sucrose has 73 products @2019-02-22
 
 < en: sugar
 en: molasses, black treacle
@@ -32824,7 +32268,6 @@ usda_ndb_code:en: 19304
 usda_ndb_name:en: Molasses
 wikidata:en: Q154389
 wikipedia:en: https://en.wikipedia.org/wiki/Molasses
-# ingredient/molasses has 4917 products in 10 languages @2019-02-08
 
 < en: molasses
 en: cane sugar molasses, cane molasses, molasses of cane sugar
@@ -32844,7 +32287,6 @@ sv: rörsockermelass
 ciqual_food_code:en: 31067
 ciqual_food_name:en: Cane molasses
 ciqual_food_name:fr: Mélasse de canne
-# 505 in 12 @2021-09-06
 
 # description:en: TREHALOSE is a sugar consisting of two molecules of glucose. It is also known as mycose or tremalose. Trehalose has about 45% the sweetness of sucrose at concentrations above 22%, but when the concentration is reduced, its sweetness decreases more quickly than that of sucrose, so that a 2.3% solution tastes 6.5 times less sweet as the equivalent sugar solution. It is commonly used in prepared frozen foods, like ice cream, because it lowers the freezing point of foods.
 
@@ -32900,7 +32342,6 @@ zh: 海藻糖
 # zh-tw:海藻糖
 wikidata:en: Q421773
 wikipedia:en: https://en.wikipedia.org/wiki/Trehalose
-# ingredient/fr:tréhalose has 66 products in 4 languages @2019-04-02
 # usage:en:trehalose (source of glucose)
 
 < en: molasses
@@ -32980,8 +32421,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q6584340
 wikipedia:en: https://en.wikipedia.org/wiki/Syrup
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/syrup
-# 9746 products in 24 languages @2018-09-24
 
 # description:en:GLUCOSE (synonymous Dextrose) is a simple sugar with the molecular formula C6H12O6.
 
@@ -33070,8 +32509,6 @@ ur: گلوکوز
 uz: Glukoza
 vi: Glucose
 zh: 葡萄糖
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose
-# 24682 products in 24 languages @2018-09-24
 # probably not a very good CIQUAL proxy
 ciqual_proxy_food_code:en: 31016
 ciqual_proxy_food_name:en: Sugar, white
@@ -33137,8 +32574,6 @@ ciqual_proxy_food_code:en: 31016
 ciqual_proxy_food_name:en: Sugar, white
 ciqual_proxy_food_name:fr: Sucre blanc
 # ast:Almíbar
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-syrup
-# 32467 products in 29 languages @2018-09-24
 # not always a UPF marker (Nova 4)
 wikidata:en: Q14770547
 wikipedia:en: https://en.wikipedia.org/wiki/Glucose_syrup
@@ -33165,10 +32600,6 @@ it: sciroppo di glucosio disidratato
 nl: gedroogde glucosestroop
 pl: suszony syrop glukozowy
 sv: torkad glukossirap
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/powdered-glucose-syrup
-# 60 products in 4 languages @2018-09-24
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/dehydrated-glucose-syrup
-# 350 products in 8 languages
 
 < en: glucose syrup
 en: powdered glucose syrup
@@ -33200,14 +32631,10 @@ fr: sirop de glucose de maïs, glucose de maïs
 it: sciroppo di glucosio di mais
 pl: syrop glukozowy z kukurydzy, syrop glukozowy kukurydziany
 sv: majsglukossirap
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-de-glucose-de-maïs
-# 148 products in 1 language @2018-09-24
 
 #<en:wheat
 < en: glucose
 fr: glucose de blé
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:glucose-de-blé
-# 30 products in 1 language @2018-09-24
 allergens:en: en:gluten
 
 < en: glucose syrup
@@ -33226,8 +32653,6 @@ pl: syrop glukozowy z pszenicy
 pt: xarope de glucose de trigo
 sv: glukossirap från vetemjöl
 allergens:en: en:gluten
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/wheat-glucose-syrup
-# 661 products in 7 languages @2018-09-24
 
 #<en:syrup
 #<en:rye
@@ -33327,15 +32752,11 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q122043
 wikipedia:en: https://en.wikipedia.org/wiki/Fructose
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fructose
-# 44556 in 41 @2021-09-15
 
 < en: fructose
 #<en:wheat
 fr: fructose de blé
 allergens:en: en:gluten
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fructose-de-blé
-# 39 products in 4 languages @2018-09-24
 
 < en: fructose
 en: fructose syrup
@@ -33353,8 +32774,6 @@ sl: fruktozni sirup
 sv: fruktossirap
 vegan:en: yes
 vegetarian:en: yes
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fructose-syrup
-# 11561 products in 5 languages @2018-09-24
 
 < en: fructose syrup
 de: Fruktosepulver
@@ -33386,7 +32805,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q418945
 wikipedia:en: https://en.wikipedia.org/wiki/Fructooligosaccharide
-# ingredient/fr:oligofructose has 245 products in 5 languages @2019-05-12
 # usage:en: dietary fibres (oligofructose, polydextrose)
 
 < en: oligofructose
@@ -33402,8 +32820,6 @@ fr: sirop d'oligofructose
 hr: oligofruktozni sirup
 it: sciroppo di oligofruttosio
 nl: oligofructosestroop
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-d'oligofructose
-# 29 products in 3 languages @2018-09-24
 
 < en: oligofructose
 en: oligofructose fibre
@@ -33425,8 +32841,6 @@ hr: glukoza-fruktoza
 it: Glucosio-fruttosio
 nl: glucose-fructose
 sv: Glukos-Fruktos
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-fructose
-# 19 products in 3 languages @2018-09-24
 
 < en: fructose
 < en: glucose
@@ -33460,7 +32874,6 @@ sl: izoglukozni sirup
 sr: glukozno-fruktozni sirup
 sv: glukos-fruktossirap, glukosfruktossirap
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/glucose-and-fructose-syrup
-# 5775 products in 21 languages @2018-09-24
 
 #<en:wheat
 < en: glucose-fructose syrup
@@ -33474,7 +32887,6 @@ pl: syrop glukozowo-fruktozowy z pszenicy, syrop fruktozowo-glukozowy z pszenicy
 allergens:en: en:gluten
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/glucose-and-fructose-syrup
 openfoodfacts:fr: https://world.openfoodfacts.org/ingredient/fr:sirop-de-glucose-fructose-de-blé
-# 271 products in 4 languages @2018-09-24
 
 #< en:corn syrup
 < en: glucose-fructose syrup
@@ -33504,8 +32916,6 @@ usda_ndb_code:en: 19351
 usda_ndb_name:en: Syrups, corn, high-fructose
 wikidata:en: Q11422173
 wikipedia:en: https://en.wikipedia.org/wiki/High-fructose_corn_syrup
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-de-glucose-fructose-de-maïs
-# 28 products in 2 languages @2018-09-24
 
 < en: invert sugar
 < en: sugar syrup
@@ -33630,7 +33040,6 @@ uk: Кукурудзяний сироп
 uz: makkajo'xori siropi
 vi: siro ngô
 zh: 玉米糖漿
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/corn-syrup 19402 products in 7 languages @2018-09-24
 # probably not a very good proxy, but the closest one in Ciqual
 ciqual_proxy_food_code:en: 31089
 ciqual_proxy_food_name:en: Syrup, agave
@@ -33741,7 +33150,6 @@ hr: čisti javorov sirup
 it: sciroppo d'acero puro
 ciqual_proxy_food_code:en: 31034
 ciqual_proxy_food_name:en: maple syrup
-# ingredient/fr:sirop-d-erable-pur has 20 products in french @2019-05-23
 
 # handled by ingredients processing
 #< en:maple syrup
@@ -33787,8 +33195,6 @@ vegetarian:en: yes
 
 < en: sugar syrup
 fr: sirop de sucres issus de fruits
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-de-sucres-issus-de-fruits
-# 22 products @2019-05-30
 
 < en: sugar syrup
 en: coconut blossom syrup
@@ -33811,7 +33217,6 @@ hr: pšenični sirup
 it: Sciroppo di grano
 nl: tarwestroop
 allergens:en: en:gluten
-# ingredient/fr:sirop-de-ble has 381 products in 4 languages @2020-06-08
 
 < en: disaccharide
 < en: syrup
@@ -33837,7 +33242,6 @@ fr: sirop de sucre partiellement inverti
 hr: djelomično invertirani šećerni sirup
 it: sciroppo di zucchero parzialmente invertito
 sv: delvis inverterad sockersirap
-# ingredient/en:partially-inverted-sugar-syrup has 101 products in 2 languages @2020-06-08
 
 < en: maltitol
 < en: syrup
@@ -33921,7 +33325,6 @@ hr: sirup od šećerne repe
 it: sciroppo di barbabietola da zucchero
 nl: suikerbietstroop, suikerbietsiroop
 sv: sockerbetssirap
-# ingredient/fr:sirop-de-betterave has 11 products in 4 languages @2020-06-08
 
 < en: sugar syrup
 en: brown sugar syrup
@@ -33932,7 +33335,6 @@ fr: Sirop de sucre brun, sirop de sucre mélassé
 hr: sirup od smeđeg šećera
 it: sciroppo di zucchero di canna
 nl: bruine suikerstroop, bruine suiker siroop
-# ingredient/en:brown-sugar-syrup has 386 products in 3 languages @2020-06-08
 
 # description:en:Glucose (synonymous Dextrose) is a simple sugar with the molecular formula C6H12O6
 
@@ -33970,8 +33372,6 @@ sk: dextróza
 sl: dekstroza
 sr: dekstroza
 sv: dextros
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/dextrose
-# 29818 products in 30 languages @2018-09-24
 ciqual_proxy_food_code:en: 31016
 ciqual_proxy_food_name:en: Sugar, white
 ciqual_proxy_food_name:fr: Sucre blanc
@@ -33986,7 +33386,6 @@ hr: organska dekstroza
 hu: bio dextróz
 it: destrosio biologico
 nl: biologische dextrose
-# ingredient/nl:biologische-dextrose has 1 product @2019-05-24
 
 < en: dextrose
 en: corn dextrose, dextrose from corn
@@ -34010,7 +33409,6 @@ ro: dextroza din porumb
 sl: dekstroza iz koruze
 sv: majssocker, druvsocker från majs
 tr: misir dekstrozu
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/corn-dextrose 868 products in 18 languages @2018-09-24
 
 < en: dextrose
 en: wheat dextrose, dextrose from wheat
@@ -34028,8 +33426,6 @@ pl: dekstroza pszenna
 pt: dextrose de trigo
 sv: vetedextros
 allergens:en: en:gluten
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/wheat-dextrose
-# 992 products in 9 languages @2018-09-25
 
 < en: corn dextrose
 < en: wheat dextrose
@@ -34042,8 +33438,6 @@ hr: pšenična ili kukuruzna dekstroza
 hu: dextróz kukoricából vagy búzából
 it: destrosio di grano o mais
 nl: dextrose van tarwe of maïs
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/wheat-or-corn-dextrose
-# 64 products in 3 languages @2018-09-25
 
 < en: dextrose
 en: dextrose monohydrate
@@ -34075,8 +33469,6 @@ nl: Polydextrose
 pt: Polidextrose
 wikidata:en: Q424616
 wikipedia:en: https://en.wikipedia.org/wiki/Polydextrose
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:polydextrose
-# 265 products in 4 languages @2018-09-25
 
 < en: wheat dextrose
 < fr: dextrose de tapioca
@@ -34088,7 +33480,6 @@ sv: dextros av vete eller tapioka
 fr: dextrose de tapioca
 fi: tapiokadekstroosi
 nl: tapiocadextrose
-# ingredient/fr:dextrose-de-tapioca has 26 products @2018-09-25
 
 
 # description:en:Agave nectar (more accurately, agave syrup) is a sweetener commercially produced from several species of agave, including Agave tequilana (blue agave) and Agave salmiana. The carbohydrate composition in agave syrup depends on the species from which the syrup was made
@@ -34138,7 +33529,6 @@ hr: organski agavin sirup
 hu: bio agaveszirup
 it: sciroppo d'agave biologico
 nl: biologische agave
-# ingredient/nl:biologische-agave has 2 products @2019-05-24
 
 < en: agave syrup
 en: concentrated agave syrup
@@ -34148,7 +33538,6 @@ fr: jus d'agave concentré
 hr: koncentriranog agavinog sirupa
 it: succo di agave concentrato
 pl: koncentrat syropu z agawy
-# ingredient/fr:jus-d’agave-concentré has 16 products in 3 languages @2018-12-17
 
 < en: concentrated agave syrup
 en: organic concentrated agave syrup
@@ -34188,7 +33577,6 @@ sv: isomalto-oligosackarider
 zh: 低聚异麦芽糖
 wikidata:en: Q6086060
 wikipedia:en: https://en.wikipedia.org/wiki/Isomaltooligosaccharide
-# ingredient/en:isomalto-oligosaccharides has 155 products in 3 languages @2020-12-22
 
 # description:en:FRUCTOOLIGOSACCHARIDES (FOS) also sometimes called oligofructose or oligofructan, are oligosaccharide fructans, used as an alternative sweetener. FOS is extracted from the blue Agave plant as well as fruits and vegetables such as bananas, onions, chicory root, garlic, asparagus, jícama, and leeks.
 
@@ -34227,7 +33615,6 @@ zh: 果寡糖
 # zh-tw:果寡糖
 wikidata:en: Q418945
 wikipedia:en: https://en.wikipedia.org/wiki/Fructooligosaccharide
-# ingredient/fructooligosaccharide has 139 products in 7 languages @2019-05-06
 
 < en: prebiotics
 < en: sweetener
@@ -34445,7 +33832,6 @@ vegetarian:en: yes
 fr: protéines végétales réhydratées
 hu: rehidratált növényi fehérjék
 nl: gehydrolyseerde plantaardige eiwitten, plantaardig eiwithydrolysaat
-# ingredient/fr:protéines-végétales-réhydratées has 32 products in french @2019-03-11
 
 < en: plant protein
 en: textured plant protein
@@ -34516,7 +33902,6 @@ fi: vedellä turvotettu herneproteiini
 hr: rehidrirani protein graška
 it: proteine di piselli reidratate
 sv: rehydrerat ärtprotein
-# ingredient/fi:vedellä-turvotettu-herneproteiini has 1 product in 1 language @2020-05-25
 
 < en: plant protein
 en: broad bean protein
@@ -34529,7 +33914,6 @@ nl: tuinbooneiwit
 pl: białko bobu, białka bobu
 ro: proteină de bob
 sv: bondbönsprotein, protein från bondböna
-# ingredient/en:broad-bean-protein has 6 products in 1 language @2020-05-25
 
 < en: plant protein
 en: chickpea protein
@@ -34567,7 +33951,6 @@ pl: białko ziemniaczane
 pt: Proteína de batata
 ro: proteină de cartofi
 sv: potatisprotein
-# ingredient/fr:proteine-de-pomme-de-terre has 44 products in 4 languages @2020-05-25
 
 # description:en:HYDROLYZED VEGETABLE PROTEIN -  products are foodstuffs obtained by protein hydrolysis
 
@@ -34813,7 +34196,6 @@ hr: rehidrirani pšenični protein
 it: proteine del grano reidratate
 nl: gerehydrateerd tarwe-eiwit
 sv: rehydrerat veteprotein
-# ingredient/fr:proteines-de-ble-rehydratees has 3 products in 1 language @2020-06-08
 
 < en: wheat protein
 en: textured wheat protein, textured wheat gluten
@@ -34825,7 +34207,6 @@ hr: teksturirani pšenični protein
 it: proteine del grano testurizzate
 nl: getextuurd tarwe-eiwit, getextureerd tarwe-eiwit
 pl: teksturat białek pszenicy, teksturowane białko pszenne, teksturowane białko pszenicy, teksturowany gluten pszenny
-# ingredient/en:textured-wheat-protein has 75 products in 3 languages @2020-06-11
 
 < en: hydrolysed vegetable protein
 < en: wheat protein
@@ -34900,7 +34281,6 @@ hr: proteini krvi
 hu: vérfehérjék
 it: proteine del sangue
 vegetarian:en: no
-# ingredient/blood-proteins has 80 products in french @2018-12-28
 
 < en: animal protein
 en: pork protein
@@ -34918,8 +34298,6 @@ pl: białko wieprzowe, białka zwierzęce wieprzowe
 ro: proteină de porc, proteina de porc
 sv: grisköttprotein, animaliskt protein av gris
 vegetarian:en: no
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:sianlihaproteiini
-# 1 entry @ 2019-10-31
 
 < en: pork protein
 en: pork collagen protein
@@ -34938,8 +34316,6 @@ hu: marhafehérje
 it: proteine del manzo, proteine di manzo
 pl: białko wołowe
 vegetarian:en: no
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:naudan-proteiini
-# 1 entry @ 2019-10-31
 
 < en: beef protein
 en: beef collagen protein
@@ -35002,7 +34378,6 @@ sv: mjölkprotein, mjölkproteiner
 allergens:en: en:milk
 nova:en: 4
 vegetarian:en: yes
-# ingredient/fr:lactoprotéines has 40 products in french @2019-02-03
 
 < en: milk proteins
 en: milk protein isolate
@@ -35021,7 +34396,6 @@ nl: biologisch melkeiwit
 
 < en: milk proteins
 fr: protéines solubles de lait
-# ingredient/fr:protéines-solubles-de-lait has 33 products in french @2019-02-22
 
 # see ingredients_processing.txt
 < en: hydrolysed protein
@@ -35058,8 +34432,6 @@ it: Proteine del latte concentrate
 nl: melkeiwitconcentraat
 pl: koncentrat białek mleka
 wikidata:en: Q6858051
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:maitoproteiinitiiviste
-# 1 entry @ 2019-10-31
 
 
 # nova:en:whey-proteins
@@ -35124,8 +34496,6 @@ it: Isolato proteico di siero
 nl: wei-eiwitisolaat
 pl: izolat serwatki
 wikidata:en: Q7993541
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:heraproteiini-isolaatti
-# 1 entry @ 2019-10-31
 
 < en: milk proteins
 en: Casein
@@ -35200,7 +34570,6 @@ nl: Calciumcaseïnaat
 vegan:en: no
 vegetarian:en: yes
 wiktionary:en: https://en.wiktionary.org/wiki/caseinate
-# ingredient/fr:caséinate has 44 products in 4 languages @2019-03-06
 
 
 # description:en:Casein has a wide variety of uses, from being a major component of cheese, to use as a food additive. The most common form of casein is SODIUM CASEINATE. Several foods, creamers, and toppings all contain a variety of caseinates. Sodium caseinate acts as a greater food additive for stabilizing processed foods
@@ -35222,7 +34591,6 @@ nl: natriumcaseïnaat
 pl: kazeinian sodu
 pt: caseinato de sódio
 wikidata:en: Q63120038
-# ingredient/fr:caséinate-de-sodium has 130 products in 4 languages @2019-04-13
 # usage:fr: caséinate de sodium (de lait)
 
 < en: caseinate
@@ -35430,7 +34798,6 @@ ciqual_proxy_food_code:en: 16030
 ciqual_proxy_food_name:en: Cocoa butter
 ciqual_proxy_food_name:fr: Beurre de cacao
 wikidata:en: Q1721876
-# ingredient/cocoa-paste has 14530 products in 32 languages @2019-05-25
 
 < en: cocoa paste
 en: cocoa paste processed with alkali, alkalized cocoa paste
@@ -35483,7 +34850,6 @@ ciqual_food_code:en: 18100
 ciqual_food_name:en: Cocoa powder, without sugar, powder, instant
 ciqual_food_name:fr: Cacao, non sucré, poudre soluble
 wikidata:en: Q1062396
-# ingredient/cocoa-powder has 4521 products in 23 languages @2019-05-25
 
 < en: cocoa powder
 en: raw cacao powder, Instant cocoa powder without sugar
@@ -35518,8 +34884,6 @@ ro: cacao pudra degresata, pudră de cacao cu conţinut redus de grăsime
 ru: какао порошок с пониженным содержанием жира
 sk: kakaový prášok so zníženým množstvom tuku
 sv: fettreducerat kakaopulver, fettreducerad kakaopulver, fettreduserat kakaopulver, avfettat kakaopulver, fettfattigt kakaopulver, fettfattig kakaopulver, lågfett kakaopulver
-# ingredient/fr:poudre-de-cacao-maigre has 843 products in 8 languages @2019-05-25
-# ingredient/fr:cacao-en-poudre-fortement-dégraissé has 76 products @2019-05-25
 
 < en: fat reduced cocoa powder
 en: 3% fat reduced cocoa powder
@@ -35564,7 +34928,6 @@ fi: kaakaomassa ja -voi
 fr: pâte et beurre de cacao, pâte de cacao et beurre de cacao
 hr: kakao masu i kakao maslac
 it: massa di cacao e burro di cacao
-# ingredient/fr:pâte-et-beurre-de-cacao has 92 products in 2 languages @2019-05-25
 
 < en: cocoa mass and cocoa butter
 en: organic cocoa mass and organic cocoa butter
@@ -35581,7 +34944,6 @@ fi: kaakaouute
 fr: extrait de cacao
 it: estratto di cacao
 nl: cacao-extract
-# ingredient/fr:extrait-de-cacao has 67 products in 4 languages @2019-05-25
 
 < en: cocoa
 en: cocoa bean, cocoa beans, cacao bean
@@ -35618,7 +34980,6 @@ zh: 可可豆
 #zh-sg: 可可豆
 #zh-tw: 可可豆
 wikidata:en: Q208008
-# ingredient/fr:fèves-de-cacao has 341 products in 6 languages @2019-05-26
 
 < en: cocoa bean
 en: cocoa nibs, cocoa bean chips
@@ -35630,14 +34991,12 @@ fr: éclats de fèves de cacao
 hr: kakao zrnca
 it: granella di semi di cacao, scaglie di cacao, granella di fave di cacao, granella di cacao
 ja: カカオニブ
-# ingredient/fr:éclats-de-fèves-de-cacao has 122 products in 6 languages @2019-05-26
 
 < en: cocoa nibs
 fr: éclats de fèves de cacao torréfiés
 es: trozos de habas de cacao tostados, trocitos de pepitas de cacao tostadas
 it: granella di fave di cacao tostate
 nl: geroosterde schilfers van cacaobonen
-# ingredient/fr:éclats-de-fèves-de-cacao-torréfiés has 34 products in 4 languages @2019-05-25
 # usage:es:trozos de habas de cacao caramelizados (trozos de habas de cacao tostados, azúcar)
 
 < en: cocoa nibs
@@ -35645,7 +35004,6 @@ es: trocitos de pepitas de cacao caramelizadas, pepitas de cacao caramelizadas, 
 fr: éclats de fèves de cacao caramélisés
 it: granella caramellata di semi di cacao
 nl: gekaramelliseerde schilfers van cacaobonen
-# ingredient/fr:éclats-de-fèves-de-cacao-caramélisés has 35 products @2019-05-25
 # usage:es:pepitas de cacao caramelizadas (cacao, azúcar)
 
 < en: cocoa
@@ -35797,8 +35155,6 @@ wo: sokolaa
 yi: שאקאלאד
 zh: 巧克力
 zu: shokoledi
-# ingredient/chocolate has 4595 products in 18 languages @2019-05-26
-# category/chocolates has 7757 products @2019-05-26
 # usage:en:chocolate (cocoa mass, sugar, cocoa butter, emulsifiers:lecithins (soy), natural vanilla flavouring)
 carbon_footprint_fr_foodges_ingredient:fr: Chocolat en morceau (noir)
 carbon_footprint_fr_foodges_value:fr: 4.9
@@ -35895,7 +35251,6 @@ sv: Chokladpulver
 zh: 巧克力粉
 carbon_footprint_fr_foodges_ingredient:fr: Chocolat en poudre non sucré
 carbon_footprint_fr_foodges_value:fr: 4.7
-# ingredient/fr:chocolat-en-poudre has 1051 products in 9 languages @2019-05-25
 # usage:en:chocolate powder (sugar, cocoa powder)
 ciqual_food_code:en: 18101
 ciqual_food_name:en: Cocoa or chocolate powder, for beverages, with sugar
@@ -35917,7 +35272,6 @@ nl: Chocostukjes
 pl: Kawałki czekolady
 pt: raspas de chocolate
 sv: Choklad bitar, chokladbitar
-# ingredient/fr:morceaux-de-chocolat has 63 products in 4 languages @2019-03-11
 # usage:de:Schokoladenstücke 18% (Kakaomasse, Zucker, Emulgator: Sojalecithin, Vanillepulver)
 ciqual_proxy_food_code:en: 31005
 ciqual_proxy_food_name:en: Dark chocolate bar, less than 70% cocoa
@@ -35966,7 +35320,6 @@ fr: fourrage au chocolat, fourrage chocolat
 hr: keks s kakaom, punilo okusa čokolade, punjenje okusa čokolade
 it: ripieno al cioccolato
 pl: nadzienie czekoladowe
-# ingredient/fr:fourrage-au-chocolat has 40 products in 4 languages @2019-05-25
 
 < en: chocolate filling
 < en: coconut chips
@@ -35982,7 +35335,6 @@ fr: chocolat pur beurre de cacao
 hr: čokolada s čistim kakao maslacem
 it: cioccolato puro burro di cacao
 nl: chocolade met pure cacaoboter
-# ingredient/fr:chocolat-pur-beurre-de-cacao has 45 products in 6 languages @2019-05-25
 
 < en: chocolate
 en: chocolate cream
@@ -36054,8 +35406,6 @@ description:en: DARK BLACK CHOCOLATE is a form of chocolate containing cocoa sol
 ecobalyse:en: 6f3939f7-408c-45d5-8653-61f3336bf305
 wikidata:en: Q277628
 wikipedia:en: https://en.wikipedia.org/wiki/Dark_chocolate
-# ingredient/dark-chocolate has 3653 products in 12 languages @2019-05-25
-# category/dark-chocolates has 3311 products @2019-05-25
 
 < en: dark chocolate
 en: belgian dark chocolate, dark belgian chocolate
@@ -36067,7 +35417,6 @@ nl: Belgische pure chocolade
 
 < en: dark chocolate
 fr: chocolat noir à 70 de cacao
-# ingredient/fr:chocolat-noir-a-70-de-cacao-minimum has 31 products in french @2019-05-25
 
 < en: dark chocolate
 # <en:chocolate chips
@@ -36081,7 +35430,6 @@ hr: kapljice tamne čokolade
 it: pezzetti di cioccolato fondente
 nl: stukjes pure chocolade
 pl: kawalki czekolady deserowej
-# ingredient/fr:morceaux-de-chocolat-noir has 66 products in 5 languages @2019-03-29
 # usage:it: pezzetti di cioccolato fondente (zucchero, pasta di cacao, burro di cacao, emulsionante: lecitina di soia: aroma naturale di vaniglia)
 
 < en: dark chocolate chunks
@@ -36164,8 +35512,6 @@ ciqual_food_code:en: 31004
 ciqual_food_name:en: Milk chocolate bar
 ciqual_food_name:fr: Chocolat au lait, tablette
 description:en: MILK CHOCOLATE is solid chocolate made with milk added in the form of powdered milk, liquid milk, or condensed milk.
-# ingredient/milk-chocolate has 4843 products in 20 languages @2019-05-25
-# category/milk-chocolates has 2071 products @2019-05-25
 # usage:fr:Chocolat au lait [sucre, beurre de cacao, pâte de cacao, poudre de lait écrémé, lactose, matière grasse de lait anhydre, émulsifiant:lécithines (tournesol), arôme]
 vegan:en: no
 vegetarian:en: yes
@@ -36190,20 +35536,17 @@ nl: stukjes melkchocolade
 pl: kawalki czekolady mlecznej
 pt: pepitas de chocolate de leite
 sv: bitar av mjölkchoklad
-# ingredient/fr:pépites-de-chocolat-au-lait has 108 products in 7 languages @2019-05-25
 # usage:nl:stukjes melkchocolade (suiker, volle melkpoeder, cacaomassa, cacaoboter, emulgator (zonnebloemlecithine))
 
 < en: milk chocolate
 de: Feine Milchschokolade, Vollmilchschokolade, Edel-Vollmilchschokolade
 fr: chocolat supérieur au lait
 it: Cioccolato superiore al latte
-# ingredient/fr:chocolat-supérieur-au-lait has 207 products in 12 languages @2019-05-25
 # usage:fr:Chocolat supérieur au lait (sucre, lait en poudre, beurre de cacao, pâte de cacao, émulsifiants:lécithine [soja], vanilline)
 
 < en: milk chocolate
 fr: chocolat au lait du pays alpin
 comment:en: Milka marketing
-# ingredient/fr:chocolat-au-lait-du-pays-alpin has 22 products @2019-05-25
 
 < en: milk chocolate
 fr: chocolat au lait en poudre
@@ -36288,8 +35631,6 @@ description:en: WHITE CHOCOLATE is made of sugar, milk, and cocoa butter, withou
 # zh-hant:白朱古力
 # zh-hk:白朱古力
 wikidata:en: Q742385
-# ingredient/white-chocolate has 1212 products in 8 languages @2019-05-25
-# category/white-chocolates has 444 products @2018-05-25
 # usage:fr:Chocolat blanc (beurre de cacao, sucre, lait écrémé en poudre, beurre concentré, émulsifiants:lécithines [soja], arômes)
 
 < en: white chocolate
@@ -36698,7 +36039,6 @@ hr: planinska izvorska voda
 it: acqua di sorgente di montagna
 nl: bergbronwater
 pl: górska woda źródlana
-# ingredient/fr:eau-de-source-de-montagne has 13 products in french @2019-05-23
 
 < en: carbonated water
 < en: spring water
@@ -36890,7 +36230,6 @@ fr: eau minérale gazeuse
 hr: gazirana mineralna voda
 it: acqua minerale gassata
 nl: Bruisend mineraalwater, gashoudendmineraalwater
-# ingredient/fr:eau-minerale-gazeuse has 9 products @2019-06-02
 
 # comment:en:eau minérale naturelle gazéifiée implies that gas is present
 
@@ -36914,7 +36253,6 @@ it: acqua minerale naturale con aggiunta di anidride carbonica
 < fr: eau minérale naturelle gazéifiée
 fr: Eau minérale naturelle de Spa gazéifiée
 nl: Koolzuurhoudend Spa natuurlijk mineraalwater
-# ingredient/nl:koolzuurhoudend-spa-natuurlijk-mineraalwater has 1 product @2019-05-24
 
 < en: carbonated natural mineral water
 en: naturally carbonated natural mineral water
@@ -36927,7 +36265,6 @@ nl: natuurlijk gashoudend natuurlijk mineraalwater
 
 < en: carbonated natural mineral water
 fr: Eau minérale naturelle renforcée au gaz de la source
-# ingredient/fr:eau-minerale-naturelle-renforcee-au-gaz-de-la-source has 11 products in french @2019-05-24
 
 < en: water
 en: filtered water, purified water
@@ -36944,10 +36281,6 @@ pl: Woda filtrowana
 pt: Água filtrada
 ru: Фильтрованная вода
 sv: filtrerat vatten
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:eau-filtrée
-# 134 products in 2 languages @2018-09-29
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:eau-purifiée
-# 43 products in 1 language @2018-09-29
 
 < en: water
 en: cooking water
@@ -36957,8 +36290,6 @@ fr: eau de cuisson
 hr: voda za kuhanje
 it: acqua di cottura
 nl: kookwater
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:eau-de-cuisson
-# 410 products in 2 languages @2018-09-29
 
 
 # description:en:Ice is water frozen into a solid state.
@@ -37106,7 +36437,6 @@ zu: Iqhwa
 # zh-tw:冰
 wikidata:en: Q23392
 wikipedia:en: https://en.wikipedia.org/wiki/Ice
-# ingredient/fr:glace has 145 products in 6 languages @2019-04-27
 
 
 en: soya, soy, soja, soia
@@ -37176,8 +36506,6 @@ description:en: SOYA is used as a generic word to indicate it is made from soybe
 # war:Soya
 vegan:en: yes
 vegetarian:en: yes
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/soy
-# 39698 products in 23 languages @2018-09-25
 
 < en: soya
 en: soya flower
@@ -37263,7 +36591,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Soybean
 #nl:biologische sojabonen
 #pl:soja bio
 #sv:ekologiska sojabönor
-# ingredient/nl:biologische-sojabonen has 1 product @2019-05-24
 
 < en: soya bean
 en: sprouted soybeans
@@ -37273,8 +36600,6 @@ hr: proklijala soja
 it: germogli di soia
 nl: sojaspruiten
 pl: kiełki soi
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pousses-de-soja
-# 24 products in 1 language @2018-09-25
 
 #process:en en:toasted
 #<en:soya bean
@@ -37294,13 +36619,10 @@ it: fagioli di soia decorticati
 #it:semi di soia decorticati
 #nl:gepelde sojabonen
 #sv:skalade sojabönor
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:soja-dépelliculé
-# 95 products in 4 languages @2018-09-25
 
 < en: hulled soya bean
 en: GMO-free hulled soya bean
 fr: fèves de soja sans ogm décortiquées
-# fr:fèves-de-soja-sans-ogm-décortiquées has 31 products in 5 languages @2018-09-25
 
 < en: soya bean
 en: black soy bean
@@ -37336,8 +36658,6 @@ pl: pasta sojowa
 #fr:flocons de soja
 #it:fiocchi di soia
 #nl:Sojavlokken
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-de-soja
-# 77 products in 4 languages @2018-09-25
 
 #process:en: en:grits
 #<en:soya bean
@@ -37384,8 +36704,6 @@ nl: sojabasis
 pl: baza sojowa
 sv: sojabas
 # it:salsa di soia translation error
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-soja
-# 253 products in 7 languages @2018-09-25
 vegan:en: maybe
 vegetarian:en: yes
 
@@ -37759,7 +37077,6 @@ fr: levure enrichie en vitamine D
 hr: kvasac s vitaminom d
 it: lievito di vitamina D
 nl: vitamine D-gist
-# ingredient/fr:levure-enrichie-en-vitamine-d has 52 products in 4 languages @2020-12-20
 
 # description:en:NUTRITIONAL YEAST is a deactivated yeast, often a strain of Saccharomyces cerevisiae, which is sold commercially as a food product.
 
@@ -37780,7 +37097,6 @@ pl: drożdże odżywcze
 ru: пищевые дрожжи
 sv: näringsjäst, bjäst
 uk: харчові дріжджі
-# ingredient/fr:levure-alimentaire has 71 products in 4 languages @2020-06-08
 ciqual_food_code:en: 11009
 ciqual_food_name:en: Nutritional yeast
 ciqual_food_name:fr: Levure alimentaire
@@ -37797,7 +37113,6 @@ fr: flocons de levure alimentaire
 hr: prehrambene pahuljice kvasca
 it: lievito alimentare in scaglie
 pl: płatki drożdżowe
-# ingredient/en:nutritional-yeast-flakes has 3 products in 1 language @2020-12-20
 
 # see ingredients_processing.txt
 #en:comment: fr:poudre-a-lever is an additive class.
@@ -37938,7 +37253,6 @@ sv: bryggerijäst
 description:en: SACCHAROMYCES CEREVISIAE is a species of yeast. It has been instrumental to winemaking, baking, and brewing since ancient times. S. cerevisiae is used in baking; the carbon dioxide generated by the fermentation is used as a leavening agent in bread and other baked goods. Historically, this use was closely linked to the brewing industry's use of yeast, as bakers took or bought the barm or yeast-filled foam from brewing ale from the brewers (producing the barm cake); today, brewing and baking yeast strains are somewhat different.
 wikidata:en: Q719725
 wikipedia:en: https://en.wikipedia.org/wiki/Saccharomyces_cerevisiae
-# ingredient/fr:saccharomyces-cerevisiae has 58 products @2019-03-29
 # usage:en:bakery yeast (saccharomyces cerevisae)
 # usage:fr:Levure Boulangère (Saccharomyces Cerevisiae)
 
@@ -38167,7 +37481,6 @@ pl: zakwas żytni
 sv: rågsurdeg, surdeg av råg
 allergens:en: en:gluten
 wikidata:en: Q107263089
-# ingredient/en:rye-sourdough has 47 products in 3 languages @2020-06-12
 
 < en: natural sourdough
 < en: rye sourdough
@@ -38347,8 +37660,6 @@ zh: 水果
 carbon_footprint_fr_foodges_ingredient:fr: Fruit ou légume moyen importé par bateau et camion
 carbon_footprint_fr_foodges_value:fr: 1.3
 eurocode_2_group_1:en: 9
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fruit
-# 963 products in 9 languages @2018-09-26
 nutriscore_fruits_vegetables_nuts:en: yes
 #carbon_footprint_fr_foodges_ingredient:fr:Fruit ou légume moyen, hors saison produit sous serre chauffée
 #carbon_footprint_fr_foodges_value:fr:2.3
@@ -38504,7 +37815,6 @@ hr: mješavina bobičastog voća
 it: miscela di bacche
 sv: bärblandning
 # usage:en:berry blend (strawberries, blueberries, blackberries, black currants, raspberries)
-# ingredient/fr:melange-de-fruits-rouges has 8 products in 2 languages @2020-06-08
 
 #< en: compound
 en: seed and berry mix
@@ -38546,7 +37856,6 @@ hr: priprema bobičastog voća
 it: preparazione di bacche
 sv: bärsprodukt
 # usage:fr:préparation de fruits rouges 11 % (sirop de glucose-fructose, fruits 4,4 %* (fraise, mûre, myrtille, framboise)
-# ingredient/fr:preparation-de-fruits-rouges has 5 products in 2 languages @2020-06-08
 
 # <compound:en:This is a compound ingredient
 fr: fruits confits
@@ -38554,8 +37863,6 @@ de: Früchte kandiert
 es: frutas confitadas
 fi: kandeeratut hedelmät
 it: frutta candita
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruits-confits
-# 75 products in 3 languages @2018-10-02
 
 < en: fruit
 en: exotic fruit
@@ -38563,8 +37870,6 @@ da: eksotisk frugt
 fi: eksoottiset hedelmät
 fr: fruit exotique, fruits exotiques
 wikidata:en: Q3089309
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruits-exotiques
-# 24 products in 1 language @2018-10-02
 
 # <en:fruit and vegetable
 < en: fruit concentrate
@@ -38580,8 +37885,6 @@ it: concentrati di frutta e verdura
 nl: groente- en fruitconcentraten
 pt: Concentrado de frutas e vegetais
 sv: frukt- och grönsakskoncentrat, frukt och grönsaks koncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruits-et-légumes-concentrés
-# 18 products in 1 language @2018-10-02
 
 < en: fruit
 en: dried fruit, dried fruits
@@ -38596,8 +37899,6 @@ it: frutta secca
 ja: ドライフルーツ
 nl: gedroogd fruit
 pl: owoce suszone, suszone owoce, owoców suszonych
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruits-séchés
-# 33 products @2018-10-02
 
 # description:en:Juice is a drink made from the extraction or pressing of the natural liquid contained in fruit and vegetables.
 
@@ -38614,7 +37915,6 @@ nl: sap
 pl: sok, soki, soku, soków
 pt: suco, sumo
 ru: Сок
-# ingredient/fr:jus has 156 products in 4 languages @2019-02-02
 vegan:en: maybe
 vegetarian:en: maybe
 
@@ -38631,7 +37931,6 @@ lt: sulčių koncentratas, koncentruotos sultys
 nl: sap uit vruchtensapconcentraat, geconcentreerd sap
 pl: zagęszczony sok, sok zagęszczony, koncentrat soku, koncentrat soku z, zagęszczone soki
 ru: концентрированные соки
-# ingredient/fr:jus-concentré has 184 products in 5 languages @2019-02-02
 # concentrated juice:lemon and orange
 
 < en: fruit
@@ -38662,8 +37961,6 @@ uk: Фруктовий сік
 vegan:en: yes
 vegetarian:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Juice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruits
-# 1687 products in 6 languages @2018-10-04
 
 < en: fruit juice
 en: berry juice
@@ -38706,8 +38003,6 @@ it: succhi di frutta a base di concentrato, succhi di frutta a base di concentra
 nl: vruchtsap van concentraat, vruchtensap uit concentraat
 pl: sok owocowy z koncentratu, soki owocowe z koncentratu, sok owocowy z koncentratu z, soki z soków zagęszczonych, soki z zagęszczonych soków, soki owocowe z zagęszczonych soków owocowych
 sv: fruktjuice från koncentrat, juicer framställd av koncentrat, juice från koncentrat, frukt juice från koncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruits-à-base-de-concentré
-# 650 products in 7 languages @2018-10-04
 
 < en: fruit juice from concentrate
 fr: jus de fruits rouges à base de concentrés
@@ -38721,7 +38016,6 @@ fi: hedelmäpyree
 it: popa di frutti
 pl: przecier owocowy, przecier z owoców
 pt: puré de fruta, puré de frutas, puré de fruto, puré de frutos
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-fruits
 # Is and Compound, i.e. ingredient:jus et purées de fruits à base de concentré :pomme, mangue, orange, ananas et fruits de la passion.
 
 < fr: purée de fruits
@@ -38735,18 +38029,13 @@ de: Fruchtsaft und Püree aus Konzentrat
 fr: jus et purées de fruits à base de concentrés
 hr: voćni sokovi i pirei od koncentrata
 it: succhi e puree di frutta da concentrato
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-et-purées-de-fruits-à-base-de-concentrés
-# 49 products in 1 language @2018-10-04
 
 < en: fruit
 fr: pulpe de fruits, pulpes de fruits
 fi: hedelmäliha
 hr: kaša voća, pulpa voća
 pt: polpa de fruta, polpa de frutas, polpa de fruto, polpa de frutos
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pulpe-de-fruits
 # 41 in 1 language products @2018-10-04
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pulpes-de-fruits
-# 63 products in 1 language @2018-10-04
 
 # Is an AGGREGATE ingredient, i.e.:fruit and plant concentrates:safflower, apple, spirulina, radish, lemon, sweet potato, carrot, blackcurrant, hibiscus;
 
@@ -38762,8 +38051,6 @@ it: concentrati di frutta e plante
 nl: vruchten- en plantenconcentraten
 pl: koncentraty owocowe i roślinne, koncentraty roślinne i owocowe, owocowo-roślinne koncentraty
 sv: frukt- och plantkoncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:concentré-de-fruits-et-de-plantes
-# 282 products in 5 languages @2018-10-04
 
 # Is an AGGREGATE ingredient, i.e.:concentrés de fruits (framboise, orange, citron)
 
@@ -38781,8 +38068,6 @@ hr: koncentrirani sokovi
 it: concentrati di frutta
 nl: fruitconcentraat, vruchtconcentraten
 pt: concentrados de fruta, concentrados de fruto, concentrados de frutas, concentrados de frutos
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:concentrés-de-fruits
-# 42 products in 3 languages @2018-10-04
 
 < en: concentrate
 < en: plant
@@ -38825,7 +38110,6 @@ it: preparazione di pere
 nl: perenbereiding
 pt: preparação de pera
 sv: päronberedning
-# ingredient/fr:preparation-de-poires has 2 products in 2 languages @2020-12-21
 # usage:fr:préparation de poires 13% (sucre, poires 41%, amidon de maïs, jus de citron concentré, arôme naturel)
 
 
@@ -38993,7 +38277,6 @@ wikidata:en: Q3733836
 # yue:杏桃
 # zh-cn:杏
 wikipedia:en: https://en.wikipedia.org/wiki/Apricot
-# 5160 in 25 @2021-09-12
 
 < en: apricot
 en: raw pitted apricot
@@ -39102,8 +38385,6 @@ fr: abricots secs, abricots séchés
 hr: suhe marelice
 it: albicocche secche
 nl: gedroogde abrikozen
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:abricots-secs
-# 138 products in 5 languages @2018-09-29
 
 #processing:en: en:dried
 #processing:en: en:pitted
@@ -39131,8 +38412,6 @@ it: Noccioli di albicocca, mandorle d'albicocca
 nb: aprikoskjerner
 nl: abrikozenpitten
 sv: aprikoskärnor
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/apricot-kernels
-# 97 products @2018-09-29
 
 #<en:apricot compound
 < en: jam
@@ -39267,7 +38546,6 @@ yi: באנאן
 yo: Ọ̀gẹ̀dẹ̀
 za: Gyoijhom
 zh: 香蕉
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/banana
 carbon_footprint_fr_foodges_ingredient:fr: Banane
 carbon_footprint_fr_foodges_value:fr: 1.2
 ciqual_proxy_food_code:en: 13005
@@ -39317,7 +38595,6 @@ usda_ndb_proxy_code:en: 9040
 usda_ndb_proxy_name:en: Bananas, raw
 wikidata:en: Q503
 wikipedia:en: https://en.wikipedia.org/wiki/Banana
-# 1538 products in 10 languages @2018-09-26
 
 < en: banana
 en: raw banana, raw bananas
@@ -39385,7 +38662,6 @@ it: piantaggine
 nl: weegbree
 pl: plantan, plantany, plantana
 comment:en: "plantain" is ambiguous, in ingredients lists it refers to plantain bananas, or the plantain plant used for fibers
-# ingredient/fr:plantain has 51 products @2019-02-25
 # fibres végétales (chicorée, pomme de terre, pois, riz, plantain, psyllium)
 
 
@@ -39411,7 +38687,6 @@ ciqual_food_name:en: Banana, pulp, dried
 ciqual_food_name:fr: Banane, pulpe, sèche
 usda_ndb_code:en: 9041
 usda_ndb_name:en: Bananas, dehydrated, or banana powder
-# 215 in 7 @2021-09-10
 
 #processing:en: en:flakes
 #<en:banana
@@ -39423,7 +38698,6 @@ usda_ndb_name:en: Bananas, dehydrated, or banana powder
 #it:fiocchi di banane
 #ja:バナナチップス
 #pt:flocos de banana, flocos de bananas
-# 198 in 9 @2021-09-10
 
 #processing:en: en:chips
 #<en:banana
@@ -39444,7 +38718,6 @@ usda_ndb_name:en: Bananas, dehydrated, or banana powder
 #it:purea di banana
 #nl:Bananenpuree
 #pt:Puré de banana
-# 2082 in 15 @2021-09-10
 
 #processing:en: en:powder
 < en: banana
@@ -39465,7 +38738,6 @@ usda_ndb_name:en: Bananas, dehydrated, or banana powder
 #fi:banaanimehu, banaanitäysmehu
 #fr:jus de banane
 #pt:Suco de banana, suco de bananas, sumo de banana, sumo de bananas
-# 61 in 6 @2021-09-10
 
 < en: fruit
 en: arctostaphylos uva-ursi
@@ -39530,7 +38802,6 @@ usda_ndb_name:en: Breadfruit, raw
 #plant:wikidata:en:Q14677
 wikidata:en: Q5869893
 wikipedia:en: https://en.wikipedia.org/wiki/Breadfruit
-# ingredient/breadfruit has 1 product in french @2019-04-29
 
 < en: fruit
 en: jackfruit
@@ -39602,8 +38873,6 @@ zh: 榴槤屬
 usda_ndb_code:en: 9422
 usda_ndb_name:en: Durian, raw or frozen
 wikipedia:en: https://en.wikipedia.org/wiki/Durian
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/durian
-# 3 products in 1 language @2018-09-27
 
 ###################################################################################################
 #
@@ -39688,8 +38957,6 @@ usda_ndb_code:en: 9078
 usda_ndb_name:en: Cranberries, raw
 wikidata:en: Q13181
 wikipedia:en: https://en.wikipedia.org/wiki/Cranberry
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cranberries
-# 7222 in 27 @2021-09-29
 
 #processing:en: en:dried
 #<en:cranberry
@@ -39705,7 +38972,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Cranberry
 #ru:клюква сушеная
 #sk:sušené kľukvy
 #sv:torkade tranbär
-# ingredient/fr:canneberges-séchées has 57 products in 4 languages @2018-12-29
 
 #processing:en: en:juice
 #<en:cranberry
@@ -39718,8 +38984,6 @@ cs: šťáva z klikvy velkoplodé z koncentrátu
 de: Cranberrysaft (Moosbeerensaft) aus Cranberrysaftkonzentrat
 fr: jus de cranberry à base de concentré
 it: succo di mirtillo rosso da concentrato
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-cranberry-à-base-de-concentré
-# 32 products in 3 languages @2018-10-02
 
 < en: cranberry
 en: sugared cranberries
@@ -39728,8 +38992,6 @@ fi: sokeroitu karpalo, sokeroidut karpalot
 hr: ušećerene brusnice
 it: mirtilli rossi zuccherati
 wikidata:en: Q26897677
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:sokeroitu-karpalo
-# 1 entry @ 2019-10-31
 
 # description:en:Vaccinium macrocarpon (also called large cranberry, American cranberry and bearberry) is a North American species of cranberry of the subgenus Oxycoccus and genus Vaccinium.
 < en: cranberry
@@ -39935,8 +39197,6 @@ usda_ndb_proxy_code:en: 9176
 usda_ndb_proxy_name:en: Mangos, raw
 wikidata:en: Q3919027
 wikipedia:en: https://en.wikipedia.org/wiki/Mango
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/mango
-# 1597 products in 10 languages @2018-09-27
 
 < en: mango
 fr: Mangue importée en avion
@@ -40008,9 +39268,6 @@ pt: Puré de manga, polpa de manga
 ru: манговое пюре, пюре манго
 sv: mangopuré
 # In process de:Mangopüree, Mangomark
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-mangue
-# 393 products @2018-09-27
-# ingredient/fr:pulpe-de-mangue has 49 products in 3 languages @2018-12-12
 ciqual_food_code:en: 13025
 ciqual_food_name:en: Mango, pulp, raw
 ciqual_food_name:fr: Mangue, pulpe, crue
@@ -40057,7 +39314,6 @@ hr: aroma manga
 it: aroma di mango
 pl: aromat mango
 sv: mangoarom
-# ingredient/fr:arome-de-mangue has 6 products in 4 languages @2020-05-25
 
 < en: natural flavouring
 en: natural mango flavouring
@@ -40251,7 +39507,6 @@ it: succo di pesca
 #ro:suc de piersici
 #ru:Персиковый сок
 #sv:persikojuice
-# ingredient/en:peach-juice has 736 products in 18 languages @2021-08-19
 
 #process:en:juice
 #process:en:from-concentrate
@@ -40286,7 +39541,6 @@ it: sciroppo di pesca
 nl: perzikensiroop
 vegan:en: yes
 vegetarian:en: yes
-# ingredient/en:peach-syrup has 7 product in 4 languages @2021-08-19
 
 #processing:en:dried
 < en: peach
@@ -40311,7 +39565,6 @@ fi: persikkatahna
 hr: pasta od breskve
 it: pasta di pesca
 sv: persikopasta
-# ingredient/en:peach-paste has 2 product in 2 language @2021-08-19
 
 #compound
 < en: peach
@@ -40455,8 +39708,6 @@ usda_ndb_proxy_code:en: 9252
 usda_ndb_proxy_name:en: Pears, raw
 wikidata:en: Q13099586
 wikipedia:en: https://en.wikipedia.org/wiki/Pear
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/pear
-# 130 products in 5 languages @2018-09-28
 
 < en: pear
 en: raw pear
@@ -40556,8 +39807,6 @@ agribalyse_proxy_food_code:en: 13188
 ciqual_proxy_food_code:en: 13188
 ciqual_proxy_food_name:en: Pear, var. Conférence, flesh without skin, raw
 wikidata:en: Q747247
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/conference-pear
-# 3 products in 1 language @2018-09-28
 
 < en: pear
 en: Williams' bon chrétien pear, Williams pear, Bartlett pear
@@ -40598,8 +39847,6 @@ hr: kruške u kockama
 it: pere a cubetti
 nl: perenblokjes
 #processing:en: en:cubes
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/pears-in-cubes
-# 38 products in 1 language @2018-09-28
 
 < en: pear
 < en: purée
@@ -40615,8 +39862,6 @@ nl: perenpuree
 pl: przecier gruszkowy
 pt: Puré de pêra
 ro: piure de pere
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-poires
-# 233 products in 5 langauges @2018-09-28
 
 < en: Williams' bon chrétien pear
 < en: pear puree
@@ -40658,8 +39903,6 @@ sv: päronjuice
 tr: armut suyu
 #yue: 梨汁
 wikidata:en: Q2461726
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/pear-juice
-# 132 products in 4 languages @2018-09-28
 
 < en: fruit juice concentrate
 < en: pear juice
@@ -40671,8 +39914,6 @@ fr: jus de poire concentré
 hr: koncentrat soka od kruške
 it: Succo di pere concentrato
 pl: koncentrat soku z gruszki
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-poire-concentré
-# 25 products in 3 languages @2018-09-28
 
 < en: fruit juice from concentrate
 < en: pear juice
@@ -40685,8 +39926,6 @@ hr: sok kruške od koncentriranog soka
 it: succo di pera da concentrato
 nl: perensap uit concentraat
 sv: päronjuice från koncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-poire-à-base-de-concentré
-# 23 products in 4 languages @2018-09-28
 
 < en: pear juice
 < en: pear puree
@@ -40800,7 +40039,6 @@ usda_ndb_proxy_code:en: 9279
 usda_ndb_proxy_name:en: Plums, raw
 wikidata:en: Q12372598
 wikipedia:en: https://en.wikipedia.org/wiki/Plum
-# 35 products in 1 language @2018-09-30
 
 < en: plum
 en: raw plum
@@ -40895,7 +40133,6 @@ usda_ndb_proxy_code:en: 9291
 usda_ndb_proxy_name:en: Plums, dried (prunes), uncooked
 wikidata:en: Q6766526
 wikipedia:en: https://en.wikipedia.org/wiki/Prune
-# 1092 in 13 @2021-09-15
 
 < en: prune
 en: uncooked prune
@@ -40940,8 +40177,6 @@ en: prune puree
 fr: purée de pruneaux
 usda_ndb_code:en: 9423
 usda_ndb_name:en: Prune puree
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-pruneaux
-# 39 products in 1 language @2018-09-30
 
 < en: prunus species fruit
 en: chickasaw plum
@@ -41011,7 +40246,6 @@ usda_ndb_proxy_code:en: 9296
 usda_ndb_proxy_name:en: Quinces, raw
 wikidata:en: Q2751465
 wikipedia:en: https://en.wikipedia.org/wiki/Quince
-# ingredient/fr:coings has 76 products @2019-02-16
 
 < en: quince
 en: raw quinces
@@ -41057,7 +40291,6 @@ sv: Grön Reine Claude
 ciqual_food_code:en: 13041
 ciqual_food_name:en: Greengage plum, raw
 ciqual_food_name:fr: Prune Reine-Claude, crue
-# ingredient/fr:reines-claudes has 37 products in 3 languages @2019-02-16
 eurocode_2_group_3:en: 9.20.36
 # bar:Ringlo
 # mzn:هلی
@@ -41104,7 +40337,6 @@ pl: Śliwa mirabelka
 ru: Мирабель
 sv: Mirabelle
 zh: 黃香李
-# ingredient/fr:mirabelles has 41 products in french @2018-12-28
 eurocode_2_group_3:en: 9.20.34
 # atj:Micta miko cowemin
 # dsb:Mirabela
@@ -41273,8 +40505,6 @@ zu: Ihhabhula
 #carbon_footprint_fr_foodges_value:fr:0.3
 carbon_footprint_fr_foodges_ingredient:fr: Pomme amérique du Sud
 carbon_footprint_fr_foodges_value:fr: 1.3
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/apple
-# 5809 products in 12 languages @2018-10-05
 ciqual_food_code:en: 13050
 ciqual_food_name:en: Apple, pulp, raw
 ciqual_food_name:fr: Pomme, pulpe, crue
@@ -41441,7 +40671,6 @@ hr: zlatna delišes jabuka
 it: mela Golden Delicious
 wikidata:en: Q201996
 wikipedia:en: https://en.wikipedia.org/wiki/Golden_Delicious
-# ingredient/fr:pommes-golden-delicious has 8 products in french @2019-05-25
 
 #US plant patent 3637, McKenzie, Oct 15 1974
 < en: apple
@@ -41522,7 +40751,6 @@ sv: Idared rött äpple, Idared röda äpplen
 
 < en: apple
 nl: appels van biologisch-dynamische teelt
-# ingredient/nl:appels-van-biologisch-dynamische-teelt has 1 product @2019-05-24
 
 < en: apple
 en: Organic apple
@@ -41534,7 +40762,6 @@ fr: pomme bio, Pommes bio
 hr: organska jabuka
 it: mele bio
 nl: biologische appel, Biologische appels
-# ingredient/fr:pommes-bio has 18 products in 4 languages @2019-05-23
 
 < en: apple
 en: cider apples
@@ -41566,7 +40793,6 @@ th: แอปเปิลอบแห้ง
 ciqual_food_code:en: 13111
 ciqual_food_name:en: Apple, dried
 ciqual_food_name:fr: Pomme, sèche
-# 1152 in 20 @2021-09-15
 
 < en: dried apple
 da: tørrede æbleskiver
@@ -41582,8 +40808,6 @@ fr: morceaux de pomme, morceaux de pommes
 hr: komadići jabuke
 it: pezzi di mela
 nl: stukjes appel
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:morceaux-de-pomme
-# 45 products in 4 languages @2018-10-04
 
 < en: apple pieces
 < en: dried apple
@@ -41597,16 +40821,12 @@ it: Pezzi di mela essiccati
 nl: stukjes gedroogde appel
 sl: sušeni koščki jabolk
 sv: torkade äppelbitar
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:kuivattu-omena-paloina
-# 1 entry @ 2019-10-31
 
 < en: apple
 fr: compote de pommes
 bg: компот от ябълки
 fi: omenasose
 nl: appelcompote
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:compote-de-pommes
-# 74 products in 4 languages @2018-10-04
 
 < fr: compote de pommes
 fr: compote de pommes allégée en sucres
@@ -41621,8 +40841,6 @@ hr: pulpa jabuke
 it: polpa di mele
 ja: りんごパルプ
 nl: appelpuree
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pulpe-de-pomme
-# 46 products @2018-10-04
 ciqual_food_code:en: 13050
 ciqual_food_name:en: Apple, pulp, raw
 ciqual_food_name:fr: Pomme, pulpe, crue
@@ -41651,8 +40869,6 @@ pt: puré de maçã, puré de maçãs
 ru: Яблочное пюре, пюре яблочное
 sv: äppelpuré
 # In process de:Apfelpüree
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-pomme
-# 1022 products @2018-10-04
 
 < en: apple purée
 en: bramley apple purée
@@ -41661,8 +40877,6 @@ it: purea di mela Bramley
 
 < en: apple purée
 fr: purée de pommes françaises
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-pommes-françaises
-# 28 products in 1 language @2018-10-04
 
 < en: apple purée
 fr: purée de pommes concentrée, purée de pomme concentrée, concentrés végétaux de pomme
@@ -41670,26 +40884,18 @@ de: Apfel-Püree konzentriert
 fi: omenapyreetiiviste
 nl: geconcentreerde appelpuree
 pl: skoncentrowane puree jabłkowe
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-pommes-concentrée
-# 65 products in 3 languages @2018-10-04
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-pomme-concentrée
-# 56 products in 4 languages @2018-10-04
 
 < en: apple
 fr: pommes en poudre
 de: Apfelpulver
 fi: omenajauhe
 it: mele in polvere
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pommes-en-poudre
-# 6 products in 3 languages @2018-10-04
 
 < en: apple
 fr: flocons de pomme
 de: Apfelflocken
 fi: omenahiutale
 it: fiocchi di mela
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-de-pomme
-# 46 products in 4 languages @2018-10-04
 
 < en: vegetable fiber
 en: apple fiber
@@ -41701,8 +40907,6 @@ hr: jabučna vlakna
 it: fibra di mela, fibre di mele
 nl: appelvezel
 pl: błonnik jabłkowy
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/apple-fiber
-# 106 products in 7 languages @2018-10-04
 
 #< en: compound
 fi: omenavalmiste
@@ -41761,8 +40965,6 @@ ciqual_food_name:fr: Jus de pomme, pur jus
 # chy:ma'xemené-mahpe
 # yue:蘋果汁
 wikidata:en: Q618355
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/apple-juice
-# 1508 products in 6 languages @2018-10-04
 
 < en: apple juice
 en: organic apple juice, juice from select organic apples
@@ -41785,8 +40987,6 @@ hr: cijeđeni sok od jabuke
 it: Succo mela puro
 pl: sok jabłkowy wyciskany bezpośrednio z owoców
 description:en: apple juice that does NOT come from concentrated apple juice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/pure-apple-juice
-# 51 products in 2 languages @2018-10-04
 
 < en: squeezed apple juice
 fr: pur jus de pommes à cidre de Bretagne
@@ -41817,8 +41017,6 @@ pl: zagęszczony sok jabłkowy, koncentrat soku jabłkowego
 pt: suco de maçã concentrado, sumo de maçã concentrado
 ru: Концентрированный яблочный сок
 sv: äppeljuicekoncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/concentrated-apple-juice
-# 423 products in 5 languages @2018-10-04
 
 < en: concentrated apple juice
 en: apple juice from concentrate
@@ -41838,7 +41036,6 @@ pl: sok jabłkowy z koncentratu, sok jabłkowy z zagęszczonego soku jabłkowego
 pt: Suco de maçã obtido a partir de um produto concentrado, sumo de maçã obtido a partir de um produto concentrado, suco de maçã reconstituído, sumo de maçã reconstituído, suco de maçã verde reconstituído, sumo de maçã verde reconstituído
 ro: suc de mere obţinut din suc concentrat
 sv: äppeljuice från koncentrat
-# ingredient/fr:jus-de-pomme-à-base-de-concentré has 240 products @2018-10-04
 
 < en: concentrated apple juice
 < en: concentrated grape juice
@@ -41849,7 +41046,6 @@ fi: omena- päärynä- ja rypäletäysmehu tiivisteestä
 en: cider apple juice
 fr: pur jus de pommes à cidre
 it: succo di mela da sidro
-# ingredient/fr:pur-jus-de-pommes-a-cidre has 10 products @2019-05-28
 
 < en: cider apple juice
 en: organic cider apple juice
@@ -42218,16 +41414,12 @@ usda_ndb_proxy_code:en: 9433
 usda_ndb_proxy_name:en: Clementines, raw
 wikidata:en: Q460517
 wikipedia:en: https://en.wikipedia.org/wiki/Clementine
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:clémentines
-# 81 products @2018-10-01
 
 < en: clementine
 < en: fruit juice
 fr: jus de clémentine
 de: Clementinensaft
 fi: klementiinimehu
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-clémentine
-# 75 products in 2 languages @2018-10-01
 
 < en: clementine
 en: clementine pulp
@@ -42393,7 +41585,6 @@ zh: 葡萄柚汁
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:jus-de-pamplemousse
 #yue:西柚汁
 wikidata:en: Q1138468
-# 491 in 11 @2021-1025
 
 < en: grapefruit juice
 en: concentrated grapefruit juice
@@ -42408,7 +41599,6 @@ hr: sok od grejpa na bazi koncentrata
 it: succo di pompelmo a base di concentrato
 pl: sok grejpfrutowy z zagęszczonego soku grejpfrutowego
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:jus-de-pamplemousse-à-base-de-concentré
-# 32 products in 5 @2021-10-25
 
 < en: grapefruit
 fr: écorces de pamplemousse
@@ -42452,7 +41642,6 @@ nl: roze pompelmoessap
 pl: sok z rózowego grejpfruta
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:jus-de-pamplemousse-rose
 wikidata:en: Q57271711
-# 53 products @2018-09-30
 
 < en: pink grapefruit juice
 en: pink grapefruit juice from concentrate
@@ -42463,8 +41652,6 @@ fr: jus de pamplemousse rose à base de concentré
 hr: sok od ružičastog grejpa iz koncentrata
 it: succo di pompelmo rosa ricavata di concentrato
 nl: roze pompelmoessap uit sapconcentraat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-pamplemousse-rose-à-base-de-concentré
-# 30 products @2018-09-30
 
 
 < en: syrup
@@ -42625,7 +41812,6 @@ zh: 箭叶橙
 # yue:泰國青檸
 wikidata:en: Q465934
 wikipedia:en: https://en.wikipedia.org/wiki/Kaffir_lime
-#  fr:combava has 42 products in 4 languages @2019-02-16
 
 < en: kaffir lime
 < en: spice
@@ -42636,7 +41822,6 @@ fr: feuilles de combava, feuilles de lime kaffir
 hr: list kafirske limete
 it: foglia di lime kaffir
 pl: liście kaffiru, liście limonki kaffir
-# kaffir-lime-leaf has 25 products in 2 languages @2018-10-25
 
 < en: kaffir lime
 en: kaffir lime peel
@@ -42950,7 +42135,6 @@ pt: polpa de limão
 ciqual_food_code:en: 13009
 ciqual_food_name:en: Lemon, pulp, raw
 ciqual_food_name:fr: Citron, pulpe, cru
-# 270 in 7 @2021-10-09
 
 < en: lemon
 en: raw peeled lemon
@@ -42974,8 +42158,6 @@ pt: puré de limão
 < en: lemon puree
 fr: purée de citron sucrée
 nl: gesuikerde citroenpuree
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-citron-sucrée
-# 41 products @2018-10-01
 
 < en: lemon
 en: lemon cells
@@ -42995,7 +42177,6 @@ it: fibra di limone, fibre di limone
 nl: citroenvezels
 ru: цитрусовые волокна
 sv: citronfiber
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/lemon-fibre
 # 59 in 1 language products @2018-10-01
 
 # lemons preserved in salt and water or oil
@@ -43003,8 +42184,6 @@ sv: citronfiber
 en: preserved lemon
 fr: citron confit, citrons confits
 it: limone conservato
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:citron-confit
-# 70 products in 1 language @2018-10-01
 
 # candied lemon zest in sugar
 < en: lemon
@@ -43031,8 +42210,6 @@ pl: olejek cytrynowy
 pt: Óleo de limão
 sv: citronolja
 from_palm_oil:en: no
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:essence-de-citron
-# 28 products @2018-10-01
 
 # <en:lemon
 < en: fruit juice
@@ -43066,8 +42243,6 @@ ciqual_food_name:fr: Jus de citron, pur jus
 ifct_food_code:en: E033
 ifct_food_name:en: Lemon, juice
 
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/lemon-juice
-# 9259 products in 16 languages @2018-10-01
 
 < en: lemon juice
 en: pasteurized lemon juice
@@ -43094,7 +42269,6 @@ hr: organski sok od limuna
 it: succo di limone biologico
 nl: biologisch citroensap
 sv: ekologisk citronjuice
-# ingredient/fr:jus-de-citron-bio has 12 products @2019-06-03
 
 < en: lemon juice
 en: lemon powder, dried lemon juice
@@ -43110,11 +42284,7 @@ nl: gedroogd citroensap, citroensappoeder
 nn: tørket sitronsaft, sitronjuivepulver
 pt: suco de limão desidratado, sumo de limão desidratado
 sv: torkad citronjuice, citronjuicepulver
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:citron-en-poudre
-# 25 products in 3 languages @2018-10-01
 wikidata:en: Q206496
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:sitruunajauhe
-# 1 entry @ 2019-10-31
 
 < en: citrus fruit extract
 en: lemon extract
@@ -43126,15 +42296,11 @@ fr: concentré de citron, extrait de citron
 # hr:ekstrakt limuna # see ingredients_processing.txt
 it: estratto di limone, concentrato di limone
 sv: citronextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/lemon-extract
-# 137 products @2018-10-01
 
 < en: lemon extract
 fr: extrait naturel de citron, extraits naturels de citron
 en: natural lemon extract
 it: estratto naturale di limone, estratto naturale di limoni
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-naturel-de-citron
-# 40 products in 1 language @2018-10-01
 
 < en: lemon juice
 en: concentrated lemon juice, Lemon juice concentrate
@@ -43159,8 +42325,6 @@ pt: Concentrado de suco de limão, concentrado de sumo de limão
 ru: Концентрированный лимонный сок
 sv: citronkoncentrat, citronsaftkoncentrat, citronjuicekoncentrat
 tr: limon suyu konsantresi
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:concentré-de-citron
-# 170 products @2018-10-01
 
 < en: lemon juice
 en: lemon juice from concentrate
@@ -43182,8 +42346,6 @@ usda_ndb_name:en: Lemon juice from concentrate, canned or bottled
 
 < en: lemon juice from concentrate
 fr: jus de citron bio concentré
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-citron-bio-concentré
-# 26 products in 1 lamguage @2018-10-02
 
 < en: lemon
 en: concentrated lemon extract
@@ -43321,8 +42483,6 @@ usda_ndb_proxy_code:en: 9159
 usda_ndb_proxy_name:en: Limes, raw
 wikidata:en: Q13195
 wikipedia:en: https://en.wikipedia.org/wiki/Lime_(fruit)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:citron-vert
-# 251 products @2018-10-01
 
 < en: lime
 en: lime pulp
@@ -43363,8 +42523,6 @@ ru: Лаймовый сок
 sv: limejuice, limesaft
 usda_ndb_proxy_code:en: 9160
 usda_ndb_proxy_name:en: Lime juice, raw
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-citron-vert
-# 342 products @2018-10-01
 
 < en: lime juice
 en: raw lime juice
@@ -43380,8 +42538,6 @@ fr: jus de citron vert concentré
 hr: koncentrirani sok od limete
 it: Succo di lime concentrato
 sv: limesaftkoncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-citron-vert-concentré
-# 43 products in 1 language @2018-10-01
 
 < en: lime juice
 en: reconstituted lime juice
@@ -43393,8 +42549,6 @@ hr: rekonstituirani sok od limete
 it: succo di lime ricostituito
 nl: limoensap uit concentraat
 pl: sok z limonki z zagęszczonego soku z limonki, sok z limonki z zagęszczonego soku z limonek, sok limonkowy z zagęszczonego soku limonkowego
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-citron-vert-à-base-de-concentré
-# 74 products in 3 languages @2018-10-01
 
 < en: lime
 de: Limettenschale
@@ -43412,7 +42566,6 @@ hr: list lipe
 it: foglia di lime
 nl: limoenblaadjes, limoenblad
 sv: limeblad
-# ingredient/en:lime-leaf has 8 products in 1 language @2020-05-23
 
 
 ###################################################################################################
@@ -43515,7 +42668,6 @@ nl: mandarijnsap
 pl: sok mandarynkowy
 usda_ndb_proxy_code:en: 9221
 usda_ndb_proxy_name:en: Tangerine juice, raw
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-mandarine
 # 168 in 3 languages @2021-10-07
 
 < en: tangerine juice
@@ -43531,8 +42683,6 @@ fr: Jus de mandarine concentré
 hr: koncentriranog soka od mandarine
 it: succo concentrato di mandarino
 ru: Концентрированный мандариновый сок
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:mandariinit%C3%A4ysmehutiiviste
-# 1 entry @ 2019-10-31
 
 < en: tangerine juice
 en: Mandarin juice from concentrate
@@ -43752,8 +42902,6 @@ usda_ndb_proxy_code:en: 9200
 usda_ndb_proxy_name:en: Oranges, raw, all commercial varieties
 wikidata:en: Q13191
 wikipedia:en: https://en.wikipedia.org/wiki/Orange_(fruit)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/orange
-# 2121 products in 8 languages @2018-09-28
 
 < en: orange
 en: eating orange
@@ -43868,7 +43016,6 @@ nl: bloedsinaasappel
 wikidata:en: https://www.wikidata.org/wiki/Q303669
 wikipedia:en: https://en.wikipedia.org/wiki/Blood_orange
 #openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:orange-sanguine
-# 23 products (FR), 8 products (EN), 4 products (ES) @2020-04-23
 
 < en: orange
 en: calamansi
@@ -43882,8 +43029,6 @@ sv: apelsinterpen, apelsin terpener
 < en: citrus fruit
 < en: orange juice
 fr: jus d'orange et autres agrumes à base de concentrés
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-d'orange-et-autres-agrumes-à-base-de-concentrés
-# 46 products in 1 language @2018-09-30
 
 # label:en: en:Pasteurized
 < en: orange juice
@@ -43902,7 +43047,6 @@ fr: jus d'orange biologique, Jus d'orange issu de l'agriculture biologique
 hr: organski sok od naranče
 it: succo d'arancia biologico
 nl: Biologisch sinaasappelsap
-# ingredient/fr:jus-d-orange-issu-de-l-agriculture-biologique has 11 products in french @2019-05-24
 
 < en: orange juice
 en: squeezed orange juice, squeezed oranges, freshly squeezed orange juice
@@ -43977,7 +43121,6 @@ nn: appelsinjus med fruktkjøt
 pl: sok pomarańczowy z miąższem
 ifct_food_code:en: E047
 ifct_food_name:en: Orange, pulp
-# ingredient/fr:jus-d'orange-avec-pulpe has 38 products in 2 languages @2018-09-28
 
 < en: orange juice with pulp
 < en: squeezed orange juice
@@ -44067,7 +43210,6 @@ pt: polpa de laranja
 ciqual_food_code:en: 13034
 ciqual_food_name:en: Orange, pulp, raw
 ciqual_food_name:fr: Orange, pulpe, crue
-# 571 in 13 @2021-10-01
 
 < en: orange
 en: orange cells
@@ -44099,8 +43241,6 @@ sv: apelsinskal
 tr: portakal kabuğu
 usda_ndb_proxy_code:en: 9216
 usda_ndb_proxy_name:en: Orange peel, raw
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:zeste-d'orange
-# 136 products in 4 languages @2018-09-28
 
 < en: orange zest
 en: raw orange peel
@@ -44117,8 +43257,6 @@ de: Orangeschalenextrakt
 fi: appelsiininkuoriuute
 fr: extrait de zeste d'orange
 # hr:ekstrakt kore naranče # see ingredients_processing.txt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-zeste-d'orange
-# 54 products in 2 languages @2018-09-28
 
 < en: orange extract
 en: concentrated orange extract
@@ -44135,7 +43273,6 @@ es: extracto natural de naranja dulce
 fi: luontainen appelsiiniuute
 it: estratto naturale d'arancia, estratto naturale di arancia
 #openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extraits-naturels-d'orange
-# 28 products in 3 languages @2018-09-28
 
 # CANDIED ORANGE PEEL is a compound ingredient
 en: candied orange peel, candied orange zest
@@ -44148,9 +43285,6 @@ fr: écorces d'orange confites, écorces d'oranges confites, orangeat
 # hr:kandirana narančina korica # see ingredients_processing.txt
 it: scorze d'arancia candite, cubetti di scorza di limone
 nl: gekonfijte sinaasappelschillen
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:écorces-d'orange-confites/
-# 303 products in 6 languages @2018-09-28openfoodfacts:https://world.openfoodfacts.org/ingredient/en:candied-orange-zest
-# 3 products in 1 language @2018-09-28
 
 #<en:compound
 # <en:orange
@@ -44246,7 +43380,6 @@ hr: okus esencijalnog ulja naranče
 it: aroma di olio essenziale di arancia
 nb: naturling smak fra eterisk appelsinolje
 sv: smak från eterisk apelsinolja
-# ingredient/fi:eteerinen-appelsiiniöljyaromi has 1 product in 1 language @2020-06-08
 
 < en: fruit
 en: sweet Valencia orange
@@ -44314,7 +43447,6 @@ vi: cam chua
 zh: 苦橙
 wikidata:en: Q147096
 wikipedia:en: https://en.wikipedia.org/wiki/Bitter_orange
-# ingredient/en:bitter-orange has 16 products in 3 languages @2020-06-13
 
 ##########################################
 #              Flavourings
@@ -44357,8 +43489,6 @@ hr: acai sok
 it: succo di acai
 nl: acaisap
 pl: sok z jagód acai
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/acai-juice
-# 9 products in 2 languages @2018-10-04
 
 ###################################################################################################
 #
@@ -44381,8 +43511,6 @@ eurocode_2_group_2:en: 9.25
 eurocode_2_group_3:en: 9.25.48
 usda_ndb_code:en: 9001
 usda_ndb_name:en: Acerola, (west indian cherry), raw
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/acerola
-# 133 products in 4 languages @2018-10-03
 
 #< en:acerola
 < en: fruit juice
@@ -44399,10 +43527,6 @@ pl: sok z aceroli
 ru: Сок ацеролы
 usda_ndb_proxy_code:en: 9002
 usda_ndb_proxy_name:en: Acerola juice, raw
-# ingredient/acerola-juice has 18 products in 2 languages @2018-10-03
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-concentré-d'acérola
-# 3 products in 1 language @2018-10-03
-# ingredient/fr:extrait-d'acérola has 215 products in 4 languages @2018-10-03
 
 < en: acerola juice
 en: raw acerola juice
@@ -44429,7 +43553,6 @@ hr: prah acerole
 it: acerola in polvere
 nl: acerolapoeder
 pl: acerola w proszku, susz z owoców aceroli
-# ingredient/fr:poudre-d'acérola has 37 products @2018-10-03
 
 < en: acerola powder
 en: acerola powder on manioc starch
@@ -44437,7 +43560,6 @@ de: Acerolapulver auf Maniokstärke
 fr: poudre d'acérola avec fécule de manioc, poudre d'acérola sur fécule de manioc
 hr: prah acerole na škrobu manioke
 it: acerola in polvere con fecola di manioca, acerola in polvere con amido di manioca
-# ingredient/fr:poudre-d'acérola-avec-fécule-de-manioc has 38 products @2018-10-03
 
 
 ###################################################################################################
@@ -44504,7 +43626,6 @@ zh: 黑莓
 ciqual_food_code:en: 13029
 ciqual_food_name:en: Blackberry, raw
 ciqual_food_name:fr: Mûre (de ronce), crue
-# 404 products in 7 languages @21018-10-01
 eurocode_2_group_3:en: 9.30.24
 # ang:blæcberige
 # bar:mur
@@ -44639,7 +43760,6 @@ usda_ndb_proxy_code:en: 9083
 usda_ndb_proxy_name:en: Currants, european black, raw
 wikidata:en: Q2941309
 wikipedia:en: https://en.wikipedia.org/wiki/Blackcurrant
-# 3581 in 22 @2021-09-12
 
 < en: blackcurrant
 en: raw european black currants
@@ -44693,8 +43813,6 @@ hr: sok brusnice u granulama
 it: succo di ribes nero da concentrato
 nl: zwarte bessensap op basis van concentraat
 sv: svartvinbärsjuice från koncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-cassis-à-base-de-concentré
-# 144 in 8 @2021-09-12
 
 #processing:en: en:pureed
 #<en:blackcurrant
@@ -44780,7 +43898,6 @@ eurocode_2_group_3:en: 9.30.46
 usda_ndb_proxy_code:en: 9050
 usda_ndb_proxy_name:en: Blueberries, raw
 wikidata:en: Q5812410
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/blueberry
 # 943 producten in 13 languages @2018-10-01
 
 < en: blueberry
@@ -44843,7 +43960,6 @@ hr: divlja borovnica, šumska borovnica
 it: mirtilli selvatici
 nl: wilde bosbes, wilde blauwe bosbessen, wilde bosbessen
 pl: borówka dzika, borówki dzikie
-# 336 in 6 @2021-09-19
 
 #<en:blueberry
 #en:organic blueberry
@@ -44884,7 +44000,6 @@ sv: blåbärssaft
 #it:succo di mirtillo
 #nl:bosbessensap
 #ru:Черничный сок
-# ingredient/fr:jus-de-myrtille has 32 products in 5 languages @2019-06-04
 
 < en: blueberry juice
 en: concentrated blueberry juice
@@ -44970,7 +44085,6 @@ usda_ndb_proxy_code:en: 9057
 usda_ndb_proxy_name:en: Boysenberries, frozen, unsweetened
 wikidata:en: Q896083
 wikipedia:en: https://en.wikipedia.org/wiki/Boysenberry
-# ingredient/en:boysenberry has 7 products in 1 language @2020-06-13
 
 < en: boysenberry
 < en: fruit juice
@@ -45134,7 +44248,6 @@ tt: морак
 uk: морошка
 vi: rubus chamaemorus
 zh: 雲莓
-# ingredient/sv:hjortron has 3 products in 2 languages @2020-06-13
 eurocode_2_group_3:en: 9.30.28
 # ast:rubus chamaemorus
 # atj:cikotai
@@ -45265,10 +44378,8 @@ vo: cel
 wa: Ceréjhe
 wo: sëriis
 zh: 樱
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/cherry
 carbon_footprint_fr_foodges_ingredient:fr: Cerise
 carbon_footprint_fr_foodges_value:fr: 1.3
-# 969 products in 7 languages @2018-09-29
 ciqual_food_code:en: 13008
 ciqual_food_name:en: Cherry, pitted, raw
 ciqual_food_name:fr: Cerise, dénoyautée, crue
@@ -45390,8 +44501,6 @@ fr: cerise noire, cerises noires
 hr: crna trešnja
 it: ciliegie nere
 nl: zwarte kers
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/black-cherry
-# 83 products in 4 languages @2018-09-29
 
 # description:fr:Le cerisier acide, cerisier aigre ou griottier (Prunus cerasus) est un arbre fruitier du genre Prunus, famille des Rosaceae. Il est cultivé pour ses fruits, les griottes.
 
@@ -45411,8 +44520,6 @@ pt: ginjas
 ciqual_food_code:en: 13110
 ciqual_food_name:en: Morello cherry, raw
 ciqual_food_name:fr: Griotte, crue
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:griottes
-# 182 products in 7 languages @2018-09-29
 eurocode_2_group_3:en: 9.20.45
 
 < en: cherry juice
@@ -45523,11 +44630,9 @@ eurocode_2_group_3:en: 9.20.40
 usda_ndb_code:en: 9070
 usda_ndb_name:en: Cherries, sweet, raw
 wikidata:en: Q165137
-# ingredient/fr:bigarreaux has 105 products in french @2019-02-22
 
 < en: sweet cherry
 fr: bigarreaux confits
-# ingredient/fr:bigarreaux-confits has 40 products in french @2019-02-22
 # bigarreaux confits  ( bigarreaux ; sucre ; conservateurs :E202, anhydride sulfureux; correcteur d'acidité :acide citrique ; colorant :E127)
 
 < en: cherry preparation
@@ -45543,8 +44648,6 @@ fi: kandeeratut kirsikat
 fr: cerises confites
 hr: glacé trešnja
 it: ciliegia candita
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cerises-confites
-# 42 products @2018-09-29
 
 < en: cherry
 < en: purée
@@ -45560,8 +44663,6 @@ nb: kirsebærpuré
 nn: kirsebærpuré
 pl: przecier z wiśni
 sv: körsbärspuré
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/en:cherry-purée
-# 35 products @2018-09-29
 
 < en: cherry
 en: cherry paste
@@ -45642,8 +44743,6 @@ zh: 野櫻莓
 # pt-br:aronia
 # sr-ec:Аронија
 # sr-el:Aronija
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:aronia
-# 163 products in 5 languages @2018-10-03
 
 < en: chokeberry
 < en: fruit juice
@@ -45656,8 +44755,6 @@ fr: jus d'aronia
 hr: sok od aronije
 it: succo d'aronia
 pl: sok z aronii, sok aroniowy
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-d'aronia
-# 20 products in 3 languages @2018-10-03
 
 < en: chokeberry juice
 en: concentrated chokeberry juice
@@ -45730,8 +44827,6 @@ wikipedia:fr: https://fr.wikipedia.org/wiki/Noix_de_coco
 # The term "coconut" can refer to the whole coconut palm, the seed, or the fruit, which botanically is a drupe, not a nut.
 # NOTE the oil and fat of a coconut can be found under the fats section
 # When coconut is listed as ingredient, probably the white stuff is meant. The watery stuff is probably never used? I.e. coco versus coconut
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noix-de-coco
-# 1209 products in 11 languages @2018-10-03
 
 < en: coconut
 en: raw coconut meat
@@ -45761,8 +44856,6 @@ ciqual_food_name:fr: Lait de coco ou Crème de coco
 nutriscore_fruits_vegetables_nuts:en: no
 usda_ndb_code:en: 12115
 usda_ndb_name:en: Nuts, coconut cream, raw (liquid expressed from grated meat)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:crème-de-noix-de-coco
-# 33 products @2018-10-03
 
 # Is this a compound product? coconut cream + water?
 
@@ -45788,8 +44881,6 @@ pt: Leite de cocô
 ru: Кокосовое молоко
 sv: kokosmjölk
 zh: 椰子奶
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:lait-de-noix-de-coco
-# 87 products @2018-10-03
 ciqual_food_code:en: 18041
 ciqual_food_name:en: Coconut milk or coconut cream
 ciqual_food_name:fr: Lait de coco ou Crème de coco
@@ -45911,8 +45002,6 @@ sv: kokosnötvatten tillverkat av koncentrat från kokosnötvatten
 #ja:ココナッツエキス
 #nl:Kokosextract
 #sv:kokosnötsextrakt, extrakt av kokosnöt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-noix-de-coco
-# 216 products in 6 languages @2018-10-03
 
 #processing:en: en:pulp
 < en: coconut
@@ -45926,8 +45015,6 @@ sv: kokosnötvatten tillverkat av koncentrat från kokosnötvatten
 #it:polpa di cocco
 nl: Kokospulp
 pt: Polpa de coco
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pulpe-de-noix-de-coco
-# 21 products in 18 @2021-09-06
 
 
 #<en:coconut
@@ -45939,8 +45026,6 @@ pt: Polpa de coco
 #fr:noix de coco en poudre
 #it:noce di cocco in polvere
 #nl:kokospoeder
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noix-de-coco-en-poudre
-# 86 products in 5 languages @2108-10-03
 
 < en: coconut
 en: desiccated coconut
@@ -45973,8 +45058,6 @@ ciqual_food_name:fr: Noix de coco, amande, sèche
 #it:noce di cocco in polvere
 #ja:ココナッツパウダー
 #nl:kokospoeder
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noix-de-coco-en-poudre
-# 86 products in 5 languages @2108-10-03
 
 ##processing:en: en:grated
 #<en:coconut
@@ -45989,8 +45072,6 @@ ciqual_food_name:fr: Noix de coco, amande, sèche
 #nl:Gemalen kokos
 #pt:coco ralado
 #sv:riven kokos
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noix-de-coco-râpée
-# 575 products in 7 languages @2018-10-03
 
 < en: coconut
 en: coconut flakes
@@ -46006,10 +45087,6 @@ pl: wiórki kokosowe, wiórki z kokosa
 pt: coco ralado
 ru: кокосовая-стружка
 sv: kokosflinga, kokosflingor
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-de-coco
-# 15 products in 4 languages @2018-10-03
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-de-noix-de-coco
-# 44 products @2018-10-03
 
 
 < en: coconut
@@ -46022,8 +45099,6 @@ fr: Chips de coco
 hr: kokos čips, kokosov čips
 it: Scaglie di cocco
 sv: kokoschips
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:kookoslastu
-# 1 entry @ 2019-10-31
 
 < en: coconut
 en: coconut paste
@@ -46124,7 +45199,6 @@ pt: tâmaras deglet nour
 ru: финики деглет нур
 usda_ndb_code:en: 9087
 usda_ndb_name:en: Dates, deglet noor
-# ingredient/fr:dattes-deglet-nour has 16 products in french @2019-05-23
 
 < en: date
 en: medjool dates
@@ -46236,8 +45310,6 @@ sv: fläder
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q22701
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sureau
-# 332 products @2018-09-29
 
 < en: berries
 < en: elder
@@ -46278,8 +45350,6 @@ nl: vlierbessap
 pl: sok z czarnego bzu
 pt: Suco de sabugo, sumo de sabugo
 sv: fläderbärsjuice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-sureau
-# 52 products @2018-09-29
 wikidata:en: Q109977301
 
 < en: concentrate
@@ -46293,8 +45363,6 @@ hr: koncentrat soka od bazge
 it: Sciroppo di sambuco concentrato
 pl: koncentrat soku z czarnego bzu, zagęszczony sok z czarnego bzu
 sv: koncentrerad fläderbärsjuice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-sureau-concentré
-# 40 products @2018-09-29
 
 < en: elderberry juice concentrate
 en: elderberry juice from concentrate
@@ -46304,8 +45372,6 @@ fi: seljanmarjamehu tiivisteestä, seljanmarjatäysmehu tiivisteestä
 fr: jus de sureau à base de concentré
 hr: sok od bazge iz koncentrata
 it: succo di sambuco a base di concentrato, succo concentrato di sambuco
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-sureau-à-base-de-concentré
-# 25 products @2018-09-29
 
 < en: elderberry
 en: elderberry extract
@@ -46318,10 +45384,6 @@ hr: ekstrakt bazge
 it: estratto di sambuco
 pl: ekstrakt z czarnego bzu, ekstrakt czarnego bzu
 sv: fläderbär extract
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-sureau
-# 29 products @2018-09-29
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-baie-de-sureau
-# 57 products in 1 language @2018-09-29
 
 < en: elderberry extract
 en: natural elderberry extract
@@ -46354,8 +45416,6 @@ fr: concentré de sureau
 de: Holunderbeerenkonzentrat
 es: concentrato di coccole di sambuco
 fi: seljanmarjatiiviste
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:concentré-de-sureau
-# 33 products @2018-09-29
 
 < en: elder
 en: elderflower, elderflowers
@@ -46374,8 +45434,6 @@ sl: bezgov cvet
 sv: fläderblom, blommor från fläderbusken
 zh: 接骨木花
 wikidata:en: Q67778134
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fleurs-de-sureau
-# 51 products @2018-09-29
 
 < en: elderflower
 de: Aufguss aus weißem Tee und Holunderblüte
@@ -46476,7 +45534,6 @@ openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fig
 usda_ndb_proxy_code:en: 9089
 usda_ndb_proxy_name:en: Figs, raw
 wikidata:en: Q2746643
-# 570 products @2018-09-29
 
 < en: fig
 en: raw fig
@@ -46525,7 +45582,6 @@ ciqual_food_name:en: Fig, dried
 ciqual_food_name:fr: Figue, sèche
 usda_ndb_proxy_code:en: 9094
 usda_ndb_proxy_name:en: Figs, dried, uncooked
-# 325 in 10 @2021-09-14
 
 < en: dried fig
 en: uncooked dried figs
@@ -46550,8 +45606,6 @@ fr: figue de Barbarie
 hr: kaktus smokva
 it: Fico d'India
 nl: cactusvijg
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/cactus-fig
-# 3 products in 1 language @2018-09-29
 
 ###################################################################################################
 #
@@ -46705,7 +45759,6 @@ ciqual_food_code:en: 13138
 ciqual_food_name:en: Goji berry, dried
 usda_ndb_code:en: 9110
 usda_ndb_name:en: Goji berries, dried
-# ingredient/fr:baies-de-goji-sechees has 52 products in 4 languages @2019-05-23
 
 ###################################################################################################
 #
@@ -46787,7 +45840,6 @@ usda_ndb_proxy_code:en: 9139
 usda_ndb_proxy_name:en: Guavas, common, raw
 wikidata:en: Q3181909
 wikipedia:en: https://en.wikipedia.org/wiki/Guava
-# 1058 in 12 @2021-09-29
 
 < en: guava
 en: raw common guavas
@@ -46808,7 +45860,6 @@ pl: przecier z gujawy, przecier z guawy
 ciqual_food_code:en: 13083
 ciqual_food_name:en: Guava, pulp, raw
 ciqual_food_name:fr: Goyave, pulpe, crue
-# 302 in 7 @2021-09-29
 
 < en: fruit
 en: horned melon, kiwano
@@ -47010,8 +46061,6 @@ nl: vossebes, rode bosbes
 pl: borówka brusznica, borówka czerwona
 ru: брусника
 sv: lingon
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/lingonberry
-# 7 products @2018-10-01
 eurocode_2_group_3:en: 9.30.44
 
 < en: lingonberry
@@ -47163,7 +46212,6 @@ usda_ndb_code:en: 9164
 usda_ndb_name:en: Litchis, raw
 # wikidata:en:Q13182 refers to the plant
 wikipedia:en: https://en.wikipedia.org/wiki/Lychee
-# ingredient/fr:litchi has 65 products in 6 languages @2019-03-01
 
 < en: lychee
 en: raw lychee
@@ -47265,8 +46313,6 @@ tl: Milon
 tr: kavun
 uk: баштанні культури
 zh: 瓜
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/melon 5 products @2018-09-29
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:melon 94 products in 5 languages @2018-09-29
 carbon_footprint_fr_foodges_ingredient:fr: Melon
 carbon_footprint_fr_foodges_value:fr: 0.5
 ecobalyse:en: 7b30c4ad-e851-4274-8062-4e14850108a9
@@ -47291,7 +46337,6 @@ fr: melons confits
 de: kandierte Melonen
 fi: kandeerattu meloni
 it: meloni canditi
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:melons-confits 59 products in 3 languages @2018-09-29
 
 
 < en: melon
@@ -47351,7 +46396,6 @@ description:en: Cantaloupe (muskmelon, mushmelon, rockmelon, sweet melon) or spa
 usda_ndb_proxy_code:en: 9181
 usda_ndb_proxy_name:en: Melons, cantaloupe, raw
 wikidata:en: Q477179
-# 125 in 2 @2021-10-10
 
 < en: cantaloupe
 en: raw cantaloupe
@@ -47383,7 +46427,6 @@ nl: galia meloen
 pl: Melon Galia
 sv: Galiamelon
 wikidata:en: Q356844
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/galia-melon
 # 1 product in 1 language @2018-09-29
 
 # description:en:Citrullus lanatus is a plant species in the family Cucurbitaceae, a vine-like (scrambler and trailer) flowering plant originally from Africa.
@@ -47531,7 +46574,6 @@ openfoodfacts:en: https://world.openfoodfacts.org/ingredient/watermelon
 usda_ndb_proxy_code:en: 9326
 usda_ndb_proxy_name:en: Watermelon, raw
 wikidata:en: Q38645
-# 172 products in 2 languages @ 2018-09-29
 
 < en: watermelon
 en: raw watermelon
@@ -47933,7 +46975,6 @@ usda_ndb_proxy_code:en: 9226
 usda_ndb_proxy_name:en: Papayas, raw
 wikidata:en: Q12330939
 wikipedia:en: https://en.wikipedia.org/wiki/Papaya
-# 1218 in 13 @2021-10-15
 
 < en: papaya
 en: raw papaya
@@ -48054,8 +47095,6 @@ pt: suco de maracujá, sumo de maracujá
 sv: passionsfruktjuice, passionsfrukts
 usda_ndb_proxy_code:en: 9232
 usda_ndb_proxy_name:en: Passion-fruit juice, purple, raw
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruit-de-la-passion
-# 262 products in 6 languages @2018-09-29
 
 < en: passion fruit juice
 en: raw purple passion-fruit juice
@@ -48079,8 +47118,6 @@ hr: sok od marakuje od koncentriranog soka škrob
 lt: pasiflorų sultys iš koncentrąto
 sk: marakujová štava z koncentrátu
 sv: passionsfruktsjuice från koncentrat
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fruit-de-la-passion-à-base-de-concentré
-# 82 products in 4 languages @2018-09-29
 
 #processing:en: en:juice
 #processing:en: en:concentrated
@@ -48106,7 +47143,6 @@ sv: passionsfruktsjuice från koncentrat
 #fr:purée de fruit de la passion
 #it:polpa del frutto della passione
 #nl:passievruchtenpuree
-# 131 in 6 @2021-10-12
 
 
 ###################################################################################################
@@ -48190,8 +47226,6 @@ usda_ndb_proxy_code:en: 9266
 usda_ndb_proxy_name:en: Pineapple, raw, all varieties
 wikidata:en: Q10817602
 wikipedia:en: https://en.wikipedia.org/wiki/Pineapple
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/pineapple
-# 2512 products in 11 languages @2018-09-30
 
 < en: pineapple
 en: raw pineapple
@@ -48220,8 +47254,6 @@ de: Ananasstücke, Ananaswürfel, Ananas-Scheiben
 fr: segments d'ananas
 hr: segmenti ananasa
 it: spicchi di ananas
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:segments-d'ananas
-# 36 products in 1 language @2018-09-30
 
 < en: vegetable fiber
 en: pineapple fibre, pineapple fibres
@@ -48235,7 +47267,6 @@ hu: ananászrost
 it: fibre d'ananas, fibre di ananas
 nl: ananasvezels
 sv: ananasfiber
-# ingredient/fr:fibres-d'ananas has 120 products in 6 languages @2018-09-30
 
 < en: pineapple
 #<en:purée
@@ -48247,7 +47278,6 @@ fr: purée d'ananas, pulpe d'ananas victoria
 hr: pire od ananasa
 it: purea di ananas
 nl: ananaspuree
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-d'ananas
 # 60 in 4 languages @2021-09-26
 
 < en: fruit juice
@@ -48273,8 +47303,6 @@ ru: Ананасовый сок
 sv: ananasjuice
 tr: ananas suyu
 zh: 菠萝汁
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-d'ananas
-# 287 products in 6 languages @2018-09-30
 ciqual_food_code:en: 2073
 ciqual_food_name:en: Pineapple juice, pure juice
 #ciqual_food_code:en: 13716
@@ -48293,7 +47321,6 @@ nl: geconcentreerd ananassap
 pl: koncentrat soku ananasowego
 ru: Концентрированный ананасовый сок
 sv: ananasjuice koncentrat
-# ingredient/fr:jus-d'ananas-concentré has 37 products in 3 languages @2018-09-30
 
 < en: pineapple juice
 en: Pure pineapple juice, Pineapple Juice not from Concentrate
@@ -48322,7 +47349,6 @@ nb: Eplejuice fra konsentrat og puré
 nl: Ananassap van concentraat
 pl: sok ananasowy z koncentratu
 pt: Suco de ananás obtido a partir de um produto concentrado, sumo de ananás obtido a partir de um produto concentrado
-# ingredient/fr:jus-d'ananas-à-base-de-concentré has 96 products in 3 languages @2018-09-30
 
 < en: pineapple
 en: pineapple syrup
@@ -48424,8 +47450,6 @@ usda_ndb_code:en: 9286
 usda_ndb_name:en: Pomegranates, raw
 wikidata:en: Q13222088
 wikipedia:en: https://fr.wikipedia.org/wiki/Grenade_(fruit)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:grenade
-# 53 products in 3 languages @2018-10-03
 
 < en: pomegranate
 en: raw pomegranate
@@ -48451,8 +47475,6 @@ hr: sjemenke nara
 it: semi di melograno
 nb: granateplekjerner
 sv: granatäppelkärnor
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:graines-de-grenade
-# 4 products in 3 languages @2018-10-03
 
 < en: fruit juice
 #< en:pomegranate
@@ -48467,8 +47489,6 @@ it: succo di melagrana
 pl: sok z granatu
 usda_ndb_proxy_code:en: 9442
 usda_ndb_proxy_name:en: Pomegranate juice, bottled
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-grenade
-# 61 products in 3 languages @2018-10-03
 
 < en: pomegranate juice
 en: bottled pomegranate juice
@@ -48756,7 +47776,6 @@ eurocode_2_group_3:en: 9.30.20
 usda_ndb_code:en: 9302
 usda_ndb_name:en: Raspberries, raw
 usda_ndb_process_2:en: en:pureed
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/raspberry
 # 2014 in 12 languages @2018-09-27
 
 < en: raspberry
@@ -48786,8 +47805,6 @@ nl: hele frambozen
 #hr: organska malina
 #it: lampone biologico
 #pl: maliny bio, malina bio, malinowy bio
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:luomuvadelma
-# 1 entry @ 2019-10-31
 
 #< en: fruit purée
 #< en: raspberry
@@ -48805,8 +47822,6 @@ en: raspberry puree
 #pl: mus malinowy
 #sv: hallonpuré
 #wikidata:en: Q57328284
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:puree-de-framboise
-# 461 products in 6 languages @2018-09-27
 
 < en: raspberry puree
 en: seedless raspberry puree
@@ -48825,8 +47840,6 @@ de: konzentriertes Himbeerpuree
 es: puré de frambuesa concentrado
 fi: vadelmapyreetiiviste
 pt: concentrado de polme de framboesa
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-framboise-concentrée
-# 51 products in 4 languages @2018-09-27
 
 < en: berry juice
 < en: raspberry
@@ -48843,8 +47856,6 @@ nl: Frambozensap
 pl: sok malinowy, sok z malin, sok z maliny
 ru: Малиновый сок
 sv: hallonjuice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-framboise
-# 72 products in 4 languages @2018-09-27
 
 < en: raspberry juice
 en: raspberry juice from concentrated juice
@@ -48856,7 +47867,6 @@ it: succo di lamponi a base di concentrato
 nl: frambozensap uit sapconcentraat
 pl: sok malinowy z zagęszczonego soku malinowego, sok malinowy z koncentratu
 sv: hallonjuice från koncentrat
-# ingredient/fr:jus-de-framboise-à-base-de-concentré has 73 products in 5 languages @2018-09-27
 
 < en: raspberry juice
 en: concentrated raspberry juice, raspberry juice concentrate
@@ -48870,8 +47880,6 @@ nl: frambozendiksap
 pl: zagęszczony sok malinowy, zagęszczony sok z maliny, skoncentrowany sok malinowy, skoncentrowany sok z owoców malin
 usda_ndb_code:en: 9554
 usda_ndb_name:en: Raspberry juice concentrate
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/concentrated-raspberry-juice
-# 44 products in 3 languages @2018-09-27
 
 < en: concentrated raspberry juice
 en: concentrated raspberry juice from concentrate
@@ -48882,8 +47890,6 @@ hr: koncentrirani sok od maline od koncentrata
 it: Succo di lampone concentrato da concentrato
 nl: frambozendiksap concentraat
 pl: zagęszczony sok malinowy z koncentratu, zagęszczony sok malinowy z zagęszczonego soku malinowego
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/concentrated-raspberry-juice-from-concentrate
-# 15 products in 1 language @2018-09-27
 
 < en: raspberry
 # <en:liqueur
@@ -48895,8 +47901,6 @@ fr: liqueur de framboises
 hr: liker od maline
 it: liquore di lamponi
 nl: frambozenlikeur
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/raspberry-liqueur
-# 3 products in 2 languages @2018-09-27
 
 < en: sauce
 en: raspberry sauce
@@ -48943,7 +47947,6 @@ ciqual_food_code:en: 13019
 ciqual_food_name:en: Red currant, raw
 ciqual_food_name:fr: Groseille, crue
 description:nl: rode bes of witte bes; vrucht van de aalbesstruik
-# 866 in 12 @2021-09-12
 eurocode_2_group_3:en: 9.30.34
 wikidata:en: Q14714085
 
@@ -49041,8 +48044,6 @@ openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:cynorrhodon
 # zh-tw:蔷薇果, 薔薇果
 wikidata:en: Q46740
 wikipedia:en: https://en.wikipedia.org/wiki/Rose_hip
-# 65 products @2018-10-02
-# ingredient/fr:églantier has 66 products in 5 languages @2019-04-03
 
 < en: plant
 en: dog rose
@@ -49222,8 +48223,6 @@ usda_ndb_proxy_code:en: 9316
 usda_ndb_proxy_name:en: Strawberries, raw
 wikidata:en: Q14458220
 wikipedia:en: https://en.wikipedia.org/wiki/Strawberry
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/strawberry
-# 2504 products in 15 languages @2018-10-01
 
 < en: strawberry
 en: raw strawberry
@@ -49302,8 +48301,6 @@ hr: sok od jagode iz koncentrata
 it: succo di fragola da concentrato
 nl: geconcentreerd aardbeiensap
 pl: sok truskawkowy z koncentratu, sok truskawkowy z zagęszczonego soku truskawkowego, sok truskawkowy z zagęszczonego soku, sok truskawkowy z soku zagęszczonego
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-fraise-à-base-de-concentré
-# 58 products @2018-10-01
 
 < en: purée
 < en: strawberry
@@ -49323,8 +48320,6 @@ pl: przecier truskawkowy, przecier z truskawek, puree truskawkowe
 pt: Puré de morango
 ru: Клубничное пюре, пюре клубничное
 sv: jordgubbspuré
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-fraise
-# 450 products in 6 languages @2018-10-01
 
 < en: strawberry puree
 en: concentrated strawberry puree
@@ -49372,7 +48367,6 @@ nn: markjordbær
 pl: poziomka, poziomki, poziomkowy
 wikidata:en: Q104219130
 wikipedia:en: https://en.wikipedia.org/wiki/Fragaria_vesca
-# ingredient/fr:fraises-des-bois has 23 products in 4 languages @2020-12-23
 
 ###################################################################################################
 #
@@ -49425,7 +48419,6 @@ sv: havtorn
 tg: ангат
 uk: обліпиха звичайна
 zh: 沙棘
-# ingredient/fr:argousier has 7 products in 4 languages @2020-06-13
 description:en: Hippophae rhamnoides, also known as SEA-BUCKTHORN is a species of flowering plant in the family Elaeagnaceae, native to the cold-temperate regions of Europe and Asia.
 eurocode_2_group_3:en: 9.30.70
 wikidata:en: Q165378
@@ -49702,7 +48695,6 @@ ciqual_food_name:en: Grape, white, raw
 ciqual_food_name:fr: Raisin blanc à gros grain (type Italia ou Dattier) cru
 eurocode_2_group_3:en: 9.30.10
 wikidata:en: Q128470835
-# 356 in 7 @2021-10-15
 
 < en: seedless grape
 < en: white grape
@@ -49742,8 +48734,6 @@ ciqual_proxy_food_code:en: 13045
 ciqual_proxy_food_name:en: Grape, red, raw
 ciqual_proxy_food_name:fr: Raisin noir, cru
 eurocode_2_group_3:en: 9.30.12
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:raisins-noirs
-# 51 products in 1 language @2018-10-02
 
 < en: black grape
 en: Concord grape, Concord black grape
@@ -49930,7 +48920,6 @@ fi: rusinatiiviste
 fr: concentré de raisin
 hr: koncentrat grožđica
 it: concentrato di uva passa
-# 1314 products in 6 languages @2018-10-02
 
 < en: white seedless grape
 en: sultana, sultanas, sultanina, Thompson Seedless, Lady de Coverly
@@ -49975,7 +48964,6 @@ description:en: SULTANA is a "white" (pale green), oval seedless grape variety a
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:raisins-secs-sultanines
 wikidata:en: Q1898118
 wikipedia:en: https://en.wikipedia.org/wiki/Sultana_(grape)
-# 46 products in 3 languages @2018-10-02
 
 < en: raisin
 en: golden raisin
@@ -50043,8 +49031,6 @@ usda_ndb_code:en: 9085
 usda_ndb_name:en: Currants, zante, dried
 wikidata:en: Q1382423
 wikipedia:en: https://en.wikipedia.org/wiki/Zante_currant
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:raisins-de-corinthe
-# 57 products in 3 languages @2018-10-02
 
 < en: fruit juice
 < en: grape
@@ -50106,8 +49092,6 @@ ciqual_food_name:en: Grape juice, pure juice
 description:en: Grape juice is obtained from crushing and blending grapes into a liquid.
 wikidata:en: Q1209756
 wikipedia:en: https://en.wikipedia.org/wiki/Grape_juice
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/grape-juice
-# 701 products in 6 languages @2018-10-02
 
 #<en:grape juice
 #pt:suco de uva integral, sumo de uva integral
@@ -50132,9 +49116,6 @@ nl: Geconcentreerd grapefruitsap
 pl: zagęszczony sok winogronowy, koncentrat soku winogronowego
 sv: druvsaftkoncentrat, druvjuicekoncentrat
 th: จากนำองุ่นเข้มข้น
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/concentrated-grape-juice
-# 139 products in 2 languages @2018-10-02
-# ingredient/fr:concentré-de-jus-de-raisin has 26 products in 3 languages @2018-10-02
 
 < en: fruit juice from concentrate
 < en: grape juice
@@ -50172,8 +49153,6 @@ it: succo d'uva bianca
 nl: Witte druivensap
 pl: sok z białych winogron
 wikidata:en: Q128305959
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-raisin-blanc
-# 71 products in 4 languages @2018-10-02
 
 < en: concentrated grape juice
 < en: white grape juice
@@ -50223,8 +49202,6 @@ nl: rode druivensap, blauw druivensap
 pl: sok z czerwonych winogron
 pt: suco de uva tinta, sumo de uva tinta, suco de uva vermelha, sumo de uva vermelha
 th: น้ำองุ่นแดง
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-de-raisin-rouge
-# 35 products in 4 languages @2018-10-02
 
 < en: grape juice from concentrate
 < en: red grape juice
@@ -50328,8 +49305,6 @@ ru: виноградное сусло
 sq: mushti i rrushit
 ta: நொதியேறாப் பழச்சாறு
 wikidata:en: Q140389101
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:moût-de-raisin
-# 273 products in 4 languages @2018-10-02
 
 < en: grape must
 en: concentrated grape must
@@ -50341,8 +49316,6 @@ hr: koncentrirani grožiani mošt, koncentrirani grožđani mošt
 it: mosto d'uva concentrato
 nl: geconcentreerde druivenmost
 pl: skoncentrowany moszcz winogronowy, skoncentrowany moszcz z winogron
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:moût-de-raisin-concentré
-# 183 products in 5 languages @2018-10-02
 
 < en: concentrated grape must
 fr: moût de raisin concentré rectifié
@@ -50355,14 +49328,10 @@ hr: kuhani mošt od grožđa
 hu: Főzőtt szólómust
 it: mosto cotto
 nl: gekookte druivenmost
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:moût-de-raisin-cuit
-# 117 products in 4 languages @2018-10-02
 
 < en: concentrated grape must
 < en: cooked grape must
 fr: moût de raisin concentré et cuit
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:moût-de-raisin-concentré-et-cuit
-# 36 products in 1 language @2018-10-02
 
 # Technically this is a grape, but not one you will find in the shop
 
@@ -50397,7 +49366,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q958314
 wikipedia:en: https://en.wikipedia.org/wiki/List_of_grape_varieties
-# ingredient/fr:cépages has 52 products @2019-01-18
 
 
 # description:en:Babić is a native Croatian red wine grape common to the Northern Dalmatia region.
@@ -50441,7 +49409,6 @@ en: cabernet
 xx: cabernet
 de: Cabernet
 es: cabernet, vino cabernet
-# ingredient/fr:cabernet has 5 products @2019-01-19
 
 # description:en:Cabernet Franc is one of the major black grape varieties worldwide.
 
@@ -50460,7 +49427,6 @@ zh: 品麗珠
 # pcd: franc cabernet
 wikidata:en: Q63591
 wikipedia:en: https://en.wikipedia.org/wiki/Cabernet_Franc
-# ingredient/fr:Cabernet-franc has 19 products @2019-01-19
 
 
 # description:en:Cabernet Sauvignon is one of the world's most widely recognized red wine grape varieties.
@@ -50495,7 +49461,6 @@ zh: 赤霞珠
 # zh-tw: 赤霞珠
 wikidata:en: Q207310
 wikipedia:en: https://en.wikipedia.org/wiki/Cabernet_Sauvignon
-# ingredient/fr:Cabernet-Sauvignon has 26 products @2019-01-20
 
 
 # description:en:Carignan (also known as Mazuelo, Bovale Grande, Cariñena, Carinyena, Samsó, Carignane, and Carignano) is a red grape variety of Spanish origin that is more commonly found in French wine but is widely planted throughout the western Mediterranean and around the globe.
@@ -50517,7 +49482,6 @@ zh: 佳利酿
 # ceb: karinyeno
 wikidata:en: Q251054
 wikipedia:en: https://en.wikipedia.org/wiki/Carignan
-# ingredient/fr:Carignan has 15 products @2019-01-19
 
 
 # description:en:Chardonnay is a green-skinned grape variety used in the production of white wine.
@@ -50568,8 +49532,6 @@ zh: 莎当妮
 # zh-tw:莎當妮
 wikidata:en: Q213332
 wikipedia:en: https://en.wikipedia.org/wiki/Chardonnay
-# ingredient/fr:Chardonnay has 19 products @2019-01-19
-# ingredient/fr:Chardonnay-blanc has 1 product @2019-01-19
 
 < en: varietal
 en: chasselas
@@ -50589,7 +49551,6 @@ ciqual_food_name:en: Grape, Chasselas, raw
 description:en: Chasselas or Chasselas blanc is a wine grape variety grown in Switzerland, France, Germany, Portugal, Hungary, Romania, New Zealand and Chile.
 wikidata:en: Q939724
 wikipedia:en: https://en.wikipedia.org/wiki/Chasselas
-# ingredient/fr:chasselas has 4 products @2019-01-18
 
 
 # description:en:Cinsaut or Cinsault is a red wine grape, whose heat tolerance and productivity make it important in Languedoc-Roussillon
@@ -50615,7 +49576,6 @@ ru: Сенсо
 sv: Cinsault
 wikidata:en: Q1092578
 wikipedia:en: https://en.wikipedia.org/wiki/Cinsaut
-# ingredient/fr:Cinsault has 12 products @2019-01-19
 
 
 # description:en:Debit is a white wine grape variety grown primarily along the Northern & Central Dalmatian Coast of Croatia.
@@ -50663,7 +49623,6 @@ ru: гаме
 zh: 佳美
 wikidata:en: Q12982
 wikipedia:en: https://en.wikipedia.org/wiki/Gamay
-# ingredient/fr:gamay has 6 products @2019-01-21
 
 
 < en: varietal
@@ -50707,8 +49666,6 @@ zh: 歌海娜
 # zh-hant:格納希
 wikidata:en: Q390242
 wikipedia:en: https://en.wikipedia.org/wiki/Grenache
-# ingredient/fr:Grenache has 34 products in french @2019-01-18
-# ingredient/fr:Grenache-Noir has 6 products @2019-01-19
 
 
 # description:en:Grk Bijeli or Grk is a white grape variety used for wine.
@@ -50732,7 +49689,6 @@ ja: グロロ
 zh: 果若
 wikidata:en: Q268579
 wikipedia:en: https://en.wikipedia.org/wiki/Grolleau_(grape)
-# ingredient/fr:Grolleau has 1 product @2019-01-21
 
 
 # description:en:Gros Manseng (sometimes translated:Large Manseng, rarely "Big Manseng") is a white wine grape variety that is grown primarily in South West France, and is part of the Manseng family.
@@ -50744,7 +49700,6 @@ de: Gros Manseng
 ja: クロ・マンサン
 wikidata:en: Q462851
 wikipedia:en: https://en.wikipedia.org/wiki/Gros_Manseng
-# ingredient/fr:Gros-Manseng has 2 products @2019-01-20
 
 
 # description:de:Lambrusco Salamino ist eine Rotweinsorte, die eine von über 60 Varietäten aus der Familie der Lambrusco ist.
@@ -50755,7 +49710,6 @@ xx: lambrusco salamino
 de: Lambrusco Salamino
 wikidata:en: Q1801495
 wikipedia:de: https://de.wikipedia.org/wiki/Lambrusco_Salamino
-# ingredient/fr:Lambrusco-Salamino has 1 product @2019-01-20
 
 
 # desciption:en:Vinova loza (lat. Vitis vinifera) is a plant from the Vitaceae family. Some of the common names in Croatia are čokot, loza, trs, vinoloza or wine vine.
@@ -50783,7 +49737,6 @@ uk: мальбек
 zh: 馬爾貝克
 wikidata:en: Q1414045
 wikipedia:en: https://en.wikipedia.org/wiki/Malbec
-# ingredient/fr:Malbec has 3 products @2019-01-20
 
 
 # description:en:Malvasia (Italian pronunciation: [malvaˈziːa], also known as Malvazia) is a group of wine grape varieties grown historically in the Mediterranean region, Balearic Islands, Canary Islands and the island of Madeira, but now grown in many of the winemaking regions of the world.
@@ -50848,7 +49801,6 @@ sl: мерло
 sv: мерло
 wikidata:en: Q213338
 wikipedia:en: https://en.wikipedia.org/wiki/Merlot
-# ingredient/fr:merlot has 26 products @2019-01-17
 
 
 # description:en:Mourvèdre (also known as Mataró or Monastrell) is a red wine grape variety that is grown in many regions around the world
@@ -50867,7 +49819,6 @@ uk: мурведр
 uz: murvedr
 wikidata:en: Q161864
 wikipedia:en: https://en.wikipedia.org/wiki/Mourvèdre
-# ingredient/fr:Mourvèdre has 17 products @2019-01-19
 
 
 # description:en:Muscadelle is a white wine grape variety.
@@ -50879,7 +49830,6 @@ de: Muscadelle
 ja: ミュスカデル
 wikidata:en: Q1934770
 wikipedia:en: https://en.wikipedia.org/wiki/Muscadelle
-# ingredient/fr:Muscadelle has 4 products @2018-01-20
 
 
 # description:en:Muscat of Alexandria is a white wine grape that is a member of the Muscat family of Vitis vinifera.
@@ -50903,12 +49853,10 @@ zh: 亞歷山大麝香
 # zh-hant:亞歷山大麝香葡萄
 wikidata:en: Q1651827
 wikipedia:en: https://en.wikipedia.org/wiki/Muscat_of_Alexandria
-# ingredient/fr:Muscat-d'Alexandrie has 2 products @2019-01-19
 
 
 < en: varietal
 fr: Muscat sec
-# ingredient/fr:Muscat-sec has 2 products @2019-01-20
 
 
 # description:en:Nielluccio is a red wine grape variety that is widely planted on Corsica.
@@ -50923,7 +49871,6 @@ it: nielluccio
 ja: ニエルキオ
 wikidata:en: Q3341280
 wikipedia:en: https://en.wikipedia.org/wiki/Nielluccio
-# ingredient/fr:Niellucciu has 2 products @2019-01-20
 
 
 # description:en:Petit Manseng (sometimes translated:Small Manseng, rarely "Little Manseng") is a white wine grape variety that is grown primarily in South West France.
@@ -50937,7 +49884,6 @@ nl: petit-manseng
 zh: 小满胜
 wikidata:en: Q462509
 wikipedia:en: https://en.wikipedia.org/wiki/Petit_Manseng
-# ingredient/fr:Petit-Manseng has 1 product @2019-01-19
 
 
 # description:en:Petit Verdot is a variety of red wine grape, principally used in classic Bordeaux blends.
@@ -50953,7 +49899,6 @@ ja: プチ・ヴェルド
 ru: пти вердо
 zh: 小維多
 wikipedia:en: https://en.wikipedia.org/wiki/Petit_Verdot
-# ingredient/fr:Petit-verdot has 2 products @2019-01-20
 
 
 # description:en:Pinot Meunier, pronounced [pi.no mø.nje], also known as Meunier or Schwarzriesling, is a variety of black wine grape most noted for being one of the three main varieties used in the production of Champagne
@@ -50970,7 +49915,6 @@ ja: ピノ・ムニエ
 ru: пино менье
 sl: postič
 wikipedia:en: https://en.wikipedia.org/wiki/Pinot_Meunier
-# ingredient/fr:Meunier has 3 products @2019-01-20
 
 
 # description:en:PINOT NOIR is a red wine grape variety of the species Vitis vinifera.
@@ -51024,7 +49968,6 @@ zh: 黑比诺
 # zh-tw:黑比诺
 wikidata:en: Q223701
 wikipedia:en: https://en.wikipedia.org/wiki/Pinot_noir
-# fr:pinot-noir has 20 products in 1 language @2018-10-29
 
 # description:en:Plavac Mali (Croatian pronunciation: [plǎːʋat͡s mǎli]), a cross between Crljenak Kaštelanski (ancestral Zinfandel) and Dobričić grapes, is the primary red wine grape grown along the Dalmatian coast of Croatia.
 
@@ -51095,7 +50038,6 @@ hr: sciacarello
 it: sciacallo
 wikidata:en: Q1527364
 wikipedia:en: https://en.wikipedia.org/wiki/Sciacarello
-# ingredient/fr:Sciaccarellu has 1 product @2019-01-20
 
 
 < en: varietal
@@ -51114,7 +50056,6 @@ zh: 賽美蓉
 description:en: Sémillon is a golden-skinned grape used to make dry and sweet white wines, mostly in France and Australia.
 wikidata:en: Q391558
 wikipedia:en: https://en.wikipedia.org/wiki/Sémillon
-# ingredient/fr:Sémillon has 5 products @2019-01-20
 
 # description:en:Susac Crni is a native red wine grape in the Kvarner region of Croatia.
 
@@ -51142,7 +50083,6 @@ sl: Zeleni silvanec
 description:en: Sylvaner or Silvaner is a variety of white wine grape grown primarily in Alsace and Germany, where its official name is Grüner Silvaner.
 wikidata:en: Q1133517
 wikipedia:en: https://en.wikipedia.org/wiki/Silvaner
-# ingredient/fr:sylvaner has 1 product in french @2019-01-18
 
 < en: varietal
 en: syrah
@@ -51171,7 +50111,6 @@ zh: 西拉葡萄
 description:en: Syrah, also known as Shiraz, is a dark-skinned grape variety grown throughout the world and used primarily to produce red wine.
 wikidata:en: Q332720
 wikipedia:en: https://en.wikipedia.org/wiki/Syrah
-# ingredient/fr:Syrah has 47 products @2019-01-18
 
 
 < en: varietal
@@ -51382,7 +50321,6 @@ usda_ndb_code:en: 9322
 usda_ndb_name:en: Tamarinds, raw
 wikidata:en: Q28178875
 wikipedia:en: https://en.wikipedia.org/wiki/Tamarind
-# ingredient/fr:tamarin has 107 products in 5 languages @2019-02-07
 
 #processing:en: en:extract
 #<en:tamarind
@@ -51395,7 +50333,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Tamarind
 #nl:tamarinde-extract
 #pl:ekstrakt z tamaryndowca
 #sv:tamarindextrakt
-# 585 in 9 @2021-10-02
 
 < en: tamarind
 en: tamarind paste
@@ -51528,7 +50465,6 @@ it: concentrato vegetale
 pl: koncentraty warzyw
 pt: Concentrado de vegetal, concentrado de vegetais
 sv: grönsakskoncentrat
-# ingredient/fr:concentre-de-legumes has 89 products in 4 languages @2020-05-21
 
 < en: vegetable
 fr: légumes et jus de cuisson de légumes
@@ -51710,8 +50646,6 @@ usda_ndb_proxy_code:en: 11213
 usda_ndb_proxy_name:en: Endive, raw
 wikidata:en: Q178547
 # wikidata:en:Q28604477 what is this?
-# category/endives has 8 products @2019-05-22
-# ingredient/endive has 125 products @2019-05-22
 
 < en: endive
 en: raw endive
@@ -51821,7 +50755,6 @@ usda_ndb_code:en: 11952
 usda_ndb_name:en: Radicchio, raw
 wikidata:en: Q767765
 wikipedia:en: https://en.wikipedia.org/wiki/Radicchio
-# 703 in 7 @2021-10-03
 
 < en: endive
 en: curly endive, frisée lettuce
@@ -51848,7 +50781,6 @@ ciqual_food_name:fr: Salade ou chicorée frisée, crue
 # description:fr:La frisée, ou chicorée frisée est une salade couramment cultivée.
 wikidata:en: Q2963415
 wikipedia:fr: https://fr.wikipedia.org/wiki/Chicorée_frisée
-# 201 in 5 @2021-10-03
 
 < en: endive
 en: broad-leaved endive, Batavian endive, escarole, flat endive
@@ -52082,7 +51014,6 @@ ciqual_food_name:fr: Laitue iceberg, crue
 usda_ndb_code:en: 11252
 usda_ndb_name:en: Lettuce, iceberg (includes crisphead types), raw
 wikidata:en: Q1310886
-# 357 in 10 @2021-10-08
 
 < en: iceberg lettuce
 en: frillice iceberg lettuce, frillice lettuce
@@ -52169,7 +51100,6 @@ usda_ndb_code:en: 11190
 usda_ndb_name:en: Cornsalad, raw
 wikidata:en: Q158954
 wikipedia:en: https://en.wikipedia.org/wiki/Valerianella_locusta
-# 262 in 7 @2021-10-03
 
 ###################################################################################################
 #
@@ -52250,8 +51180,6 @@ usda_ndb_code:en: 11147
 usda_ndb_name:en: Chard, swiss, raw
 wikidata:en: Q157954
 wikipedia:en: https://en.wikipedia.org/wiki/Chard
-# ingredient/fr:blette/languages has 88 products in 8 languages @2019-03-22
-# category/chards has 16 products @2019-05-22
 
 < en: chard
 en: chard concentrate
@@ -52515,7 +51443,6 @@ de: Gehackter Spinat
 es: espinacas picadas
 it: spinaci tritati
 nl: gehakte spinazie
-# ingredient/fr:epinards-haches has 26 products in 2 languages @2019-05-24
 
 < en: spinach
 en: spinach puree
@@ -52635,8 +51562,6 @@ usda_ndb_code:en: 11591
 usda_ndb_name:en: Watercress, raw
 wikidata:en: Q150452
 wikipedia:en: https://en.wikipedia.org/wiki/Watercress
-# ingredient/watercress has 107 products in 4 languages @2019-04-13
-# ingredient/fr:cresson has 61 products in 5 languages @2018-12-14
 
 # description:en:Cress (Lepidium sativum), sometimes referred to as garden cress (or curly cress) to distinguish it from similar plants also referred to as cress (from old Germanic cresso which means sharp, spicy), is a rather fast-growing, edible herb.
 
@@ -52720,7 +51645,6 @@ usda_ndb_code:en: 11203
 usda_ndb_name:en: Cress, garden, raw
 wikidata:en: Q27033
 wikipedia:en: https://en.wikipedia.org/wiki/Garden_cress
-# 8 in 4 @2021-10-04
 
 < en: leaf vegetable
 en: sweet potato leaves
@@ -52744,7 +51668,6 @@ he: עלי גפן, עלה גפן
 hr: list vinove loze
 it: foglie di vite
 eurocode_2_group_3:en: 8.10.40
-# ingredient/fr:feuilles-de-vigne has 27 products in 5 languages @2019-02-10
 vegan:en: yes
 vegetarian:en: yes
 
@@ -52897,7 +51820,6 @@ tt: Кычыткан
 uk: Кропива
 uz: Gazanda
 zh: 蕁麻
-# ingredient/fr:ortie has 97 products in 5 languages @2019-05-06
 eurocode_2_group_3:en: 8.10.48
 # ast:Urtica
 # azb:گیجیت‌کن
@@ -53006,7 +51928,6 @@ zh: 酸模
 ciqual_food_code:en: 20111
 ciqual_food_name:en: Sorrel, raw
 ciqual_food_name:fr: Oseille, crue
-# 138 in 5 @2021-12-01
 eurocode_2_group_3:en: 8.10.50
 # azb:عادی او‌لیک
 # csb:kwasné zelé
@@ -53279,8 +52200,6 @@ usda_ndb_proxy_code:en: 11090
 usda_ndb_proxy_name:en: Broccoli, raw
 wikidata:en: Q47722
 wikipedia:en: https://en.wikipedia.org/wiki/Broccoli
-# ingredient/broccoli has 1167 products in 10 languages @2018-10-16
-# category/broccoli has 150 products @2019-05-24
 
 < en: broccoli
 en: raw broccoli
@@ -53299,7 +52218,6 @@ hr: cvjetić brokule
 it: fiore di broccolo
 nl: broccoliroosjes, broccoli roosjes
 sv: broccolibukett, broccolibuketter
-# ingredient/fr:brocolis-en-fleurettes has 17 products in 3 languages @2019-05-24
 carbon_footprint_fr_foodges_ingredient:fr: Brocoli (France)
 carbon_footprint_fr_foodges_value:fr: 0.4
 eurocode_2_group_3:en: 8.15.12
@@ -53314,7 +52232,6 @@ hr: brokula kres
 it: crescione di broccoli
 nl: broccoli cress
 sv: broccolikrasse
-# en:broccoli-cress has 1 product in 1 language @2018-10-16
 
 < en: broccoli
 en: romanesco broccoli, Broccolo Romanesco, Romanesque cauliflower, Romanesco
@@ -53388,7 +52305,6 @@ usda_ndb_proxy_code:en: 11135
 usda_ndb_proxy_name:en: Cauliflower, raw
 wikidata:en: Q23900272
 wikipedia:en: https://en.wikipedia.org/wiki/Cauliflower
-# en:cauliflower has 660 products in 5 languages @2018-10-17
 
 < en: cauliflower
 en: raw cauliflower
@@ -53406,7 +52322,6 @@ hr: cvjetovi cvjetače
 it: cimette di cavolfiore
 nl: Bloemkoolroosjes
 sv: blomkålsbuketter, blomkålsbukett
-# ingredient/fr:choux-fleurs-en-fleurettes has 15 products in 6 languages @2019-05-24
 
 < en: cauliflower
 en: green cauliflower
@@ -53457,7 +52372,6 @@ usda_ndb_code:en: 11109
 usda_ndb_name:en: Cabbage, raw
 wikidata:en: Q14328596
 wikipedia:en: https://en.wikipedia.org/wiki/Cabbage
-# fr:chou has 374 products in 4 languages @2018-10-20
 
 < en: cabbage
 fr: Chou pommé, Chou cabus
@@ -53598,7 +52512,6 @@ ecobalyse:en: white-cabbage-non-eu
 #wuu:卷心菜
 #yue:椰菜
 wikidata:en: Q35051
-# 930 in 13 @2021-09-29
 
 # description:en:The red cabbage (purple-leaved varieties of Brassica oleracea Capitata Group) is a kind of cabbage, also known as purple cabbage, red kraut, or blue kraut after preparation.
 
@@ -53653,7 +52566,6 @@ ciqual_food_name:en: Red cabbage, raw
 ciqual_food_name:fr: Chou rouge, cru
 ecobalyse:en: red-cabbage-non-eu
 ecobalyse_labels_en_organic:en: red-cabbage-organic
-# 988 in 9 @2021-09-28
 eurocode_2_group_3:en: 8.15.24
 # bar:blaukraut
 # bho:लाल पत्ता गोभी
@@ -53763,7 +52675,6 @@ zh: 小白菜
 ciqual_food_code:en: 20167
 ciqual_food_name:en: Chinese cabbage (nappa cabbage or bok choy), raw
 ciqual_food_name:fr: Chou chinois ou pak-choi ou pé-tsai, cru
-# 128 in 5 @2021-09-29
 eurocode_2_group_3:en: 8.15.28
 #arz:ملفوف صينى
 #yue:白菜
@@ -53864,7 +52775,6 @@ eurocode_2_group_3:en: 8.15.40
 usda_ndb_code:en: 11098
 usda_ndb_name:en: Brussels sprouts, raw
 wikidata:en: Q150463
-# fr:chou-de-Bruxelles has 41 products in 2 languages @2018-10-19
 
 # Brassica oleracea var. sabellica
 # be careful with the translation found on packages.
@@ -54111,7 +53021,6 @@ za: byaekgaiqlanz
 zh: 芥藍
 wikidata:en: Q1677369
 wikipedia:en: https://en.wikipedia.org/wiki/Gai_lan
-# ingredient/en:gai-lan has 2 products in 1 language @2020-06-13
 
 # description:en:SAUERKRAUT (lit. 'sour cabbage') is finely cut raw cabbage that has been fermented by various lactic acid bacteria.
 
@@ -54172,7 +53081,6 @@ vi: Dưa cải Đức
 vo: züdöfabrasid
 yi: זויערקרויט
 zh: 德国酸菜
-# en:sauerkraut has 166 products in 3 languages @2018-10-19
 eurocode_2_group_2:en: 8.70
 eurocode_2_group_3:en: 8.70.60
 # bar:Sauakraut
@@ -54212,7 +53120,6 @@ hr: sok od kiselog kupusa
 it: succo di crauti
 nl: zuurkoolsap
 pl: sok z kapusty kiszonej, sok z kiszonej kapusty, sok z kwaszonej kapusty
-# en:sauerkraut-juice has 8 products in 3 languages @2018-10-19
 
 < en: white cabbage
 en: kimchi
@@ -54337,7 +53244,6 @@ usda_ndb_proxy_code:en: 11143
 usda_ndb_proxy_name:en: Celery, raw
 wikidata:en: Q23012379
 wikipedia:en: https://en.wikipedia.org/wiki/Celery
-# fr:celeri has 4877 products in 10 languages @2018-10-21
 
 < en: celery
 en: raw celery
@@ -54371,11 +53277,9 @@ hr: lišće celera
 it: foglie di sedano
 nl: selderblad, bladselderij
 pl: liść selera, liście selera, seler liść
-# fr:feuilles-de-céleri has 39 products in 4 languages @2018-10-21
 
 < en: celery
 fr: garniture de céleri
-# fr:garniture-de-céleri has 27 products in 1 language @2018-10-20
 
 < en: celery
 en: celery puree
@@ -54403,7 +53307,6 @@ fi: sellerimehutiiviste
 fr: jus de céleri concentré, jus concentré de céleri
 hr: koncentrirani sok od celera
 it: succo di sedano concentrato
-# fr:jus-concentré-de-céleri has 64 products in 1 language @2018-10-21
 
 < en: concentrated celery juice
 en: powdered concentrated celery juice
@@ -54416,7 +53319,6 @@ it: succo di sedano concentrato in polvere
 fr: extrait de céleri
 fi: selleriuute
 nl: selderextract
-# fr:extrait-de-céleri has 58 products @2018-10-20
 
 < en: celery
 # < en:seed
@@ -54433,8 +53335,6 @@ pl: nasiona selera
 sv: sellerifrö
 usda_ndb_code:en: 2007
 usda_ndb_name:en: Spices, celery seed
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:graines-de-céleri
-# 66 products in 3 languages @2018-10-07
 
 < en: celery
 en: celery powder
@@ -54446,13 +53346,10 @@ hr: celer u prahu
 it: sedano in polvere
 nl: selderpoeder
 wikipedia:en: https://en.wikipedia.org/wiki/Celery_powder
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:céleri-en-poudre
-# 41 products in 4 languages @2018-10-07
 
 < en: carrot juice
 < en: celery
 fr: jus concentré de céleri et de carotte
-# fr:jus-concentré-de-céleri-et-de-carotte has 31 products in 1 language @2018-10-20
 
 # <en:category:en:Plant-based foods
 < en: stalk vegetable
@@ -54639,7 +53536,6 @@ wikidata:en: Q20767168
 # plant:wikidata:en:Q7535
 wikipedia:en: https://en.wikipedia.org/wiki/Rhubarb
 # 502 in 4 languages @2021-10-25
-# category/rhubarbs has 4 products 22019-05-22
 
 < en: rhubarb
 en: raw rhubarb
@@ -54722,7 +53618,6 @@ nl: chichoreivezel, chichoreiwortelvezel
 pl: błonnik z cykorii, błonnik z korzenia cykorii, włókna z korzenia cykorii
 sk: vláknina z koreňa čakanky
 sv: cikoriarotfiber, fiber från cikoriarot, cikoriafiber
-# ingredient/fr:fibre-de-chicoree has 254 products in 5 languages @2018-12-10
 
 < en: chicory fibre
 < en: oligofructose fibre
@@ -54734,7 +53629,6 @@ fr: chicorée soluble
 es: achicoria en polvo
 nl: oploscichorei, poeder met witlof, cichorei
 pt: chicória solúvel
-# ingredient/fr:chicorée-soluble has 70 products in 4 languages @2018-12-10
 ciqual_food_code:en: 18152
 ciqual_food_name:en: Chicory, powder, instant
 ciqual_food_name:fr: Chicorée, poudre soluble
@@ -54751,7 +53645,6 @@ it: estratto di cicoria, Estratti di cicoria
 nl: cichorei-extract, chicorei extract
 pl: ekstrakt z cykorii
 pt: extrato de chicória, extracto de chicória
-# ingredient/extract-of-chicory has 31 products @2019-04-04
 
 < en: shoot vegetable
 en: belgian endive
@@ -54766,7 +53659,6 @@ hu: cikória
 it: Cicoria Belga
 la: Cichorium intybus var. foliosum
 nl: witlof
-# 451 in 16 @2021-09-05
 carbon_footprint_fr_foodges_ingredient:fr: Endive
 carbon_footprint_fr_foodges_value:fr: 1.2
 ciqual_food_code:en: 20026
@@ -55032,7 +53924,6 @@ ciqual_proxy_food_code:en: 20279
 ciqual_proxy_food_name:en: Asparagus, green, raw
 ciqual_proxy_food_name:fr: Asperge, verte, crue
 description:en: Asparagus, or garden asparagus, folk name sparrow grass, scientific name Asparagus officinalis is a spring vegetable, a flowering perennial plant species in the genus Asparagus;
-# en:asparagus has 301 products in 6 languages @2018-11-11
 eurocode_2_group_3:en: 8.25.10
 usda_ndb_2_code:en: 11018
 usda_ndb_2_name:en: Asparagus, frozen, unprepared
@@ -55061,7 +53952,6 @@ ciqual_food_code:en: 20279
 ciqual_food_name:en: Asparagus, green, raw
 ciqual_food_name:fr: Asperge, verte, crue
 wikidata:en: Q35075688
-# 170 in 7 @2021-09-23
 
 < en: green asparagus
 es: Espárragos verdes sin pelar
@@ -55083,7 +53973,6 @@ it: asparagi bianchi
 nl: witte asperges
 pl: białe szparagi, biały szparag, białych szparagów
 pt: Espargos brancos
-# fr:asperges blanches has 46 products in 4 languages @2018-11-11
 
 #< en:white asparagus
 #fr: asperges blanches coupées
@@ -55254,7 +54143,6 @@ description:en: The bamboos are evergreen perennial flowering plants in the subf
 eurocode_2_group_3:en: 8.25.40
 wikidata:en: Q35922
 wikipedia:en: https://en.wikipedia.org/wiki/Bamboo
-# ingredient/fr:bambou has 54 products @2019-02-03
 # vegetable fiber (bamboo, chicory, potato)
 # Légumes (pousses d'haricots mungo, oignons, haricots verts, chou blanc, bambou, carottes, pommes de terre)
 
@@ -55327,7 +54215,6 @@ it: fibra di bambù, fibre di bambù
 nl: bamboevezel, bamboevezels
 pl: błonnik bambusowy, błonnik roślinny bambusowy
 sv: bambufiber
-# ingredient/fr:fibre-de-bambou has 186 products in 5 languages  @2019-02-03
 
 < en: bamboo fibre
 en: bamboo shoot fiber
@@ -55336,7 +54223,6 @@ fr: fibres de pousses de bambou
 hr: vlakna izdanaka bambusa
 it: fibra di germoglio di bambù
 nl: vezels van bamboescheuten
-# ingredient/fr:fibres-de-pousses-de-bambou has 77 products in 5 languages @2019-02-03
 
 < en: bamboo
 en: sasa veitchii
@@ -55391,7 +54277,6 @@ sk: cvikly
 sv: rödbeta, rödbetor, rödbets
 carbon_footprint_fr_foodges_ingredient:fr: Betteraves
 carbon_footprint_fr_foodges_value:fr: 0.2
-# en:beetroot has 319 products in 5 languages @2018-10-22
 ciqual_proxy_food_code:en: 20091
 ciqual_proxy_food_name:fr: Betterave rouge, crue
 description:en: BEETROOT is the taproot portion of the beet plant
@@ -55422,7 +54307,6 @@ pt: beterraba vermelha
 ciqual_food_code:en: 20091
 ciqual_food_name:fr: Betterave rouge, crue
 comment:en: As beetroots do not have to be red, the red ones are kept separate
-# fr:betterave-rouge has 298 products in 6 languages @2018-10-22
 
 
 < en: red beetroot
@@ -55446,7 +54330,6 @@ ro: pudră de sfeclă roșie
 #fr:poudre de betterave
 #it:Polvere di barbabietola
 #pl:burak w proszku, proszek z buraka
-# fr:poudre-de-betterave has 55 products in 1 language @2018-10-22
 
 < en: beetroot
 en: beetroot syrup
@@ -55470,7 +54353,6 @@ nl: bietensap
 no: rødbetsaft
 pl: sok z buraka, sok buraczany
 sv: rödbetsjuice
-# fr:jus-de-betterave has 46 products in 3 languages @2018-10-22
 
 < en: beetroot juice
 en: beetroot juice concentrate
@@ -55484,7 +54366,6 @@ it: succo concentrato di barbabietola
 nl: bietensapconcentraat, rode bietensapconcentraat
 pl: koncentrat soku z buraka
 sk: koncentrát šťavy z cvikly
-# fr:jus-de-betterave-concentré has 71 products in 4 languages @2018-10-22
 
 < en: beetroot
 fr: concentré de betterave
@@ -55507,7 +54388,6 @@ sv: rödbetskoncentrat
 fr: fibres de betterave
 fi: juurikaskuitu
 sv: betfiber
-#  fr:fibres-de-betterave has 43 products in 1 language @2018-10-22
 
 < en: beetroot juice
 < en: red beetroot
@@ -55517,7 +54397,6 @@ de: Rote Betesaft, Rote Bete Saft
 #fr:jus de betterave rouge
 #it:succo di barbabietole rosse
 #nl:rodebietensap
-# fr:jus-de-betterave-rouge has 38 products @2018-10-21
 
 < en: beetroot juice concentrate
 < en: red beetroot juice
@@ -55525,7 +54404,6 @@ en: red beetroot juice concentrate
 de: Rote Bete-Saftkonzentrat, Rote Betesaft aus Fruchtsaftkonzentrat
 #fr:jus de betterave rouge concentré, concentré de jus de betterave rouge, jus concentré de betterave rouge
 #nl:geconcentreerd rodebietensap
-# fr:jus-de-betterave-rouge-concentré has 37 products in 4 languages @2018-10-21
 
 < en: beetroot
 en: beetroot sprouts
@@ -55537,7 +54415,6 @@ hr: klice cikle
 it: germogli di barbabietola
 nl: bietenkiemen
 pl: kiełki buraka
-# en:beetroot-sprouts has 1 product in 1 language @2018-10-21
 
 ###################################################################################################
 #
@@ -55659,8 +54536,6 @@ usda_ndb_proxy_code:en: 11090
 usda_ndb_proxy_name:en: Broccoli, raw
 wikidata:en: Q47722
 wikipedia:en: https://en.wikipedia.org/wiki/Broccoli
-# ingredient/broccoli has 1167 products in 10 languages @2018-10-16
-# category/broccoli has 150 products @2019-05-24
 
 < en: broccoli
 en: raw broccoli
@@ -55676,7 +54551,6 @@ hr: cvjetić brokule
 it: fiore di broccolo
 nl: broccoliroosjes, broccoli roosjes
 sv: broccolibukett, broccolibuketter
-# ingredient/fr:brocolis-en-fleurettes has 17 products in 3 languages @2019-05-24
 carbon_footprint_fr_foodges_ingredient:fr: Brocoli (France)
 carbon_footprint_fr_foodges_value:fr: 0.4
 eurocode_2_group_3:en: 8.15.12
@@ -55708,7 +54582,6 @@ hr: brokula kres
 it: crescione di broccoli
 nl: broccoli cress
 sv: broccolikrasse
-# en:broccoli-cress has 1 product in 1 language @2018-10-16
 
 < en: broccoli
 en: romanesco broccoli, Broccolo Romanesco, Romanesque cauliflower, Romanesco
@@ -55840,7 +54713,6 @@ eurocode_2_group_3:en: 8.15.40
 usda_ndb_proxy_code:en: 11098
 usda_ndb_proxy_name:en: Brussels sprouts, raw
 wikidata:en: Q150463
-# fr:chou-de-Bruxelles has 41 products in 2 languages @2018-10-19
 
 < en: brussels sprouts
 en: raw brussels sprouts
@@ -55911,7 +54783,6 @@ usda_ndb_code:en: 11994
 usda_ndb_name:en: Broccoli, chinese, raw
 wikidata:en: Q1677369
 wikipedia:en: https://en.wikipedia.org/wiki/Gai_lan
-# ingredient/en:gai-lan has 2 products in 1 language @2020-06-13
 
 ###################################################################################################
 #
@@ -56029,7 +54900,6 @@ usda_ndb_code:en: 11116
 usda_ndb_name:en: Cabbage, chinese (pak-choi), raw
 wikidata:en: Q18968514
 wikipedia:en: https://en.wikipedia.org/wiki/Bok_choy
-# 128 in 5 @2021-09-29
 
 ###################################################################################################
 #
@@ -56128,7 +54998,6 @@ usda_ndb_code:en: 11112
 usda_ndb_name:en: Cabbage, red, raw
 wikidata:en: q263203
 wikipedia:en: https://en.wikipedia.org/wiki/Red_cabbage
-# 988 in 9 @2021-09-28
 
 # <en:category:en:Fresh plant-based foods
 < en: shoot vegetable
@@ -56160,7 +55029,6 @@ usda_ndb_proxy_code:en: 43392
 usda_ndb_proxy_name:en: Hearts of palm, raw
 wikidata:en: Q743144
 wikipedia:en: https://en.wikipedia.org/wiki/Heart_of_palm
-# fr:coeurs-de-palmier has 16 products in 3 languages @2018-10-19
 
 < en: shoot vegetable
 en: pokeberry shoots
@@ -56242,8 +55110,6 @@ usda_ndb_proxy_code:en: 11282
 usda_ndb_proxy_name:en: Onions, raw
 wikidata:en: Q3406628
 wikipedia:en: https://en.wikipedia.org/wiki/Onion
-# ingredient/onion has 12754 products in 18 languages @2018-12-06
-# category/onions has 233 products @2019-05-22
 
 < en: onion
 en: raw onion
@@ -56357,8 +55223,6 @@ nl: zilveruitjes, zilverui
 sv: Syltlök
 # wikipedia:en:https://en.wikipedia.org/wiki/Pickled_onion ????
 wikidata:en: Q2477614
-# ingredient/fr:petits-oignons-blancs has 14 products in 4 languages @2018-12-06
-# ingredient/fr:petits-oignons has 53 products @2018-11-06
 
 < en: onion
 en: red onion, red onions
@@ -56396,8 +55260,6 @@ tr: kırmızı soğan
 wikidata:en: Q622350
 wikipedia:en: https://en.wikipedia.org/wiki/Red_onion
 # pnb:لال پیاز
-# ingredient/red-onions has 76 products in english @2018-12-06
-# ingredient/fr:oignon-rouge has 93 products in 6 languages @2018-12-06
 
 < en: onion
 en: Roscoff onions
@@ -56472,7 +55334,6 @@ usda_ndb_code:en: 11293
 usda_ndb_name:en: Onions, welsh, raw
 wikidata:en: Q27938
 wikipedia:en: https://en.wikipedia.org/wiki/Allium_fistulosum
-# ingredient/fr:ciboule has 127 products in 6 languages @2019-04-16
 
 < en: onion
 en: yellow onion
@@ -56486,7 +55347,6 @@ nl: Gele ui
 sv: gul lök
 wikidata:en: Q8051898
 wikipedia:en: https://en.wikipedia.org/wiki/Yellow_onion
-# ingredient/fr:oignons-jaunes has 15 products @2019-05-25
 
 < en: onion
 en: white onion
@@ -56511,7 +55371,6 @@ hr: svježi luk
 it: cipolla fresca
 nl: verse uien
 ru: лук свежий
-# ingredient/fresh-onions has 485 products in 3 languages @2018-12-06
 
 < en: onion
 en: young green onion tops
@@ -56530,7 +55389,6 @@ de: Zwiebelsaftkonzentrat
 fi: sipulimehutiiviste
 nl: geconcentreerd uiensap
 sv: lökjuicekoncentrat
-# ingredient/fr:jus-d’oignon-concentré has 48 products in 5 languages @2018-12-06
 
 #processing:en: en:dried
 #processing:en: en:dehydrated
@@ -56562,7 +55420,6 @@ ciqual_food_name:en: Onion, dried
 ciqual_food_name:fr: Oignon, séché
 usda_ndb_code:en: 11284
 usda_ndb_name:en: Onions, dehydrated flakes
-# 12664 in 22 @2021-09-10
 
 #category/onion-powder
 #processing:en: en:powder
@@ -56600,7 +55457,6 @@ tr: soğan tozu
 usda_ndb_code:en: 2026
 usda_ndb_name:en: Spices, onion powder
 wikidata:en: Q7093931
-# 24139 in 36 @2021-09-10
 
 # description:en:The PEARL ONION (Allium ampeloprasum var. sectivum or A. ampeloprasum 'Pearl-Onion Group'), also known as button or baby onions in the UK, or creamers in the US, is a close relative of the leek
 
@@ -56616,7 +55472,6 @@ it: cipolla perlata
 pl: cebula perłowa, cebulka perłowa
 wikidata:en: Q508630
 wikipedia:en: https://en.wikipedia.org/wiki/Pearl_onion
-# ingredient/fr:oignons-grelots has 96 products in french @2018-11-06
 
 < en: onion
 en: Onion Extract
@@ -56633,7 +55488,6 @@ nl: uienextract
 pl: ekstrakt z cebuli, ekstrakty z cebuli, ekstrakt cebulowy
 pt: extrato de cebolo, extracto de cebolo
 sv: lökextrakt
-# ingredient/fr:extrait-d’oignon has 119 products in 3 languages @2018-12-06
 
 #< en: compound
 en: fried onion
@@ -56657,14 +55511,12 @@ nn: friterad lök
 pt: cebolas pre fritas
 ru: лук жареный
 sv: forhåndsstekt løk
-# ingredient/fr:oignons-préfrits has 422 products in 4 languages @2018-12-06
 
 < en: pre fried onions
 fr: oignon préfrit à l'huile de tournesol
 it: cipolla prefritta in olio di girasole
 nl: voorgebakken ui in zonnebloemolie
 sv: lök brynt i solrosolja
-# ingredient/fr:oignon-préfrit-à-l'huile-de-tournesol has 44 products in 3 languages @2018-12-06
 
 < en: onion-family vegetable
 < en: root vegetable
@@ -57069,7 +55921,6 @@ usda_ndb_proxy_code:en: 11215
 usda_ndb_proxy_name:en: Garlic, raw
 wikidata:en: Q21546392
 wikipedia:en: https://en.wikipedia.org/wiki/Garlic
-# en:garlic has 22470 products in 18 languages @2018-10-23
 
 < en: garlic
 en: tender garlic
@@ -57095,7 +55946,6 @@ nl: knoflookpuree
 pl: przecier z czosnku, przecier czosnkowy
 sv: vitlökspuré
 # In process de:Knoblauchpüree
-# en:garlic-puree has 775 products in 5 languages @2018-10-23
 
 < en: garlic
 en: garlic paste
@@ -57108,7 +55958,6 @@ hr: pasta od češnjaka
 it: Impasto d'aglio
 # ja:ガーリックペースト # see ingredients_processings.txt
 pl: pasta czosnkowa
-# en:garlic-paste has 35 products in 2 languages @2018-10-23
 
 #en:processing:en:powder removed due to specific nutritional data
 < en: garlic
@@ -57259,7 +56108,6 @@ bg: пресен чесън
 fr: ail frais
 hr: svježi češnjak
 it: aglio fresco
-# fr:ail-frais has 31 products in 1 language @2018-10-22
 ciqual_proxy_food_code:en: 11000
 ciqual_proxy_food_name:en: Garlic, fresh
 ciqual_proxy_food_name:fr: Ail, cru
@@ -57278,7 +56126,6 @@ fr: extrait d'ail
 hr: ekstrakt češnjaka
 it: estratto d'aglio, estratto di aglio
 pl: ekstrakt czosnku, ekstrakt z czosnku
-# fr:extrait-d'ail has 71 products in 4 languages @2018-10-22
 
 < en: garlic
 en: garlic oil
@@ -57397,7 +56244,6 @@ usda_ndb_proxy_name:en: Chives, raw
 #plant: wikidata:en:Q51148
 wikidata:en: Q61046162
 wikipedia:en: https://en.wikipedia.org/wiki/Chives
-# 4350 in 20 @2021-10-19
 
 < en: chives
 en: fresh chives
@@ -57710,7 +56556,6 @@ usda_ndb_code:en: 11124
 usda_ndb_name:en: Carrots, raw
 wikidata:en: Q81
 wikipedia:en: https://en.wikipedia.org/wiki/Carrot
-# en:carot has 8224 products in 15 languages @2018-10-21
 
 < en: carrot
 fr: carotte nantaise, carottes nantaises
@@ -57751,7 +56596,6 @@ pl: marchew gotowana, marchew ugotowana
 #it: carote biologiche
 #nl: biologische wortel
 #ru: морковь свежая
-# en:organic-carrots has 580 products in 3 languages @2018-10-20
 
 < en: carrot
 en: baby carrots
@@ -57762,22 +56606,18 @@ hr: mlade mrkve
 it: carote baby
 usda_ndb_code:en: 11960
 usda_ndb_name:en: Carrots, baby, raw
-# fr:jeunes-carottes has 34 products in 1 language @2018-10-20
 
 #< en: carrot
 #fr: carottes en rondelles
 #de: Karotten in Scheiben
 #it: Carote e lamelle
-# fr:carottes-en-rondelles has 54 products in 3 languages @2018-10-20
 
 #< en: carrot
 #fr: carottes en morceaux
-# fr:carottes-en-morceaux has 28 products in 1 language @2018-10-20
 
 #< en: carrot
 #fr: carottes râpées
 #nl: geraspte wortelen
-# fr:carottes-râpées has 107 products in 3 languages @2018-10-20
 
 #< en: carrot
 #en: carrot purée
@@ -57790,7 +56630,6 @@ usda_ndb_name:en: Carrots, baby, raw
 #it: puré di carote
 #pl: przecier marchwiowy
 # In process de:Karottenpüree
-# fr:purée-de-carotte has 52 products in 2 languages @2018-10-20
 ciqual_food_code:en: 20261
 ciqual_food_name:en: Carrots, puree
 ciqual_food_name:fr: Carotte, purée
@@ -57809,7 +56648,6 @@ lt: morkų koncentratas, dažiklis morkų koncentratas
 pl: koncentrat z marchwi, koncentrat marchwi, koncentrat z marchwii, koncentrat marchwii
 ro: concentrat de morcov
 sv: morotkoncentrat, morotskoncentrat
-# fr:concentré-de-carotte has 221 products in 4 languages @2018-10-10
 
 < en: carrot concentrate
 < en: colouring plant concentrate
@@ -57829,7 +56667,6 @@ ja: 人参エキス
 nl: wortelextract, kleurend wortelextract
 pt: extrato de cenoura, extrato de cenouras, extracto de cenoura, extracto de cenouras
 sv: morotsextrakt
-# fr:extrait-de-carotte has 176 products in 6 languages @0218-10-20
 
 < en: carrot extract
 en: colouring carrot extract
@@ -57861,7 +56698,6 @@ fr: fibre de carotte, fibres de carotte
 de: Karottenfasern
 fi: porkkanakuitu
 nl: wortelvezel
-# fr:fibre-de-carotte has 174 products in 2 languages @2018-10-20
 
 < en: carrot
 fr: carottes déshydratées
@@ -57874,7 +56710,6 @@ pl: marchew suszona
 pt: cenouras desidratadas
 sl: suseno korenje
 sv: torkad morot
-# fr:carottes-déshydratées has 59 products i 4 languages @2018-10-20
 
 < en: carrot
 en: yellow carrot
@@ -57887,7 +56722,6 @@ it: carota gialla
 nl: gele wortel
 pl: żółta marchew
 sv: gul morot, gula morötter
-# fr:carotte-jaune has 132 products in 4 languages @2018-10-20
 
 < en: carrot
 en: orange carrot
@@ -57928,7 +56762,6 @@ nl: zwarte wortel
 pl: czarna marchew, czarnej marchwi
 sv: svart morot, svart morots
 wikidata:en: Q11767451
-# fr:carotte-noire has 122 products in 4 languages @2018-10-20
 
 #< en:black carrot
 < en: vegetable juice
@@ -57944,7 +56777,6 @@ lv: melno burkānu sula
 nl: zwarte wortelsap
 pl: sok z czarnej marchwi
 sv: svartmorotjuice
-# fr:jus-de-carotte-noire has 34 products in 3 languages @2018-10-20
 
 # The french pourpre is translated to black in dutch and german
 
@@ -57957,8 +56789,6 @@ hr: koncentrirani sok crne mrkve
 it: succo di carota nera concentrato, succo di carote nere concentrato, concentrato da succo di carote nere
 nl: zwarte wortelsapconcentraat, geconcentreerd zwarte wortelsap
 pl: zagęszczony sok z czarnej marchwi, skoncentrowany sok z czarnej marchwi
-# fr:jus-de-carotte-noire-concentré has 26 products in 2 languages @2018-10-20
-# fr:jus-de-carotte-pourpre-concentré has 22 products @2018-10-20
 
 < en: black carrot
 en: concentrated black carrot, black carrot concentrate
@@ -58016,7 +56846,6 @@ usda_ndb_proxy_code:en: 11655
 usda_ndb_proxy_name:en: Carrot juice, canned
 wikidata:en: Q1190074
 wikipedia:en: https://en.wikipedia.org/wiki/Carrot_juice
-# en:carot-juice has 188 products in 4 languages 2018-10-20
 
 < en: carrot juice
 en: canned carrot juice
@@ -58038,7 +56867,6 @@ nl: Geconcentreerd wortelsap
 no: gulrotkonsentrat
 ru: Концентрированный морковный сок
 sv: morotjuicekoncentrat
-# fr:jus-concentré-de-carotte has 122 products in 1 language @2018-10-20
 
 #This is not the same as concentrate carrot juice, this one has been reconstructed with water
 < en: carrot juice
@@ -58100,7 +56928,6 @@ ciqual_food_name:fr: Salsifis noir, cru
 eurocode_2_group_3:en: 8.38.20
 wikidata:en: Q385259
 wikipedia:en: https://en.wikipedia.org/wiki/Scorzonera_hispanica
-# ingredient/fr:salsifis has 58 products in 5 languages @2019-04-05
 
 < en: salsify
 en: salsify juice concentrate
@@ -58156,7 +56983,6 @@ usda_ndb_proxy_code:en: 11141
 usda_ndb_proxy_name:en: Celeriac, raw
 wikidata:en: Q575174
 wikipedia:en: https://en.wikipedia.org/wiki/Celeriac
-# fr:céleri-rave has 399 products in 4 languages @2018-10-20
 
 < en: celeriac
 en: raw celeriac
@@ -58168,7 +56994,6 @@ usda_ndb_name:en: Celeriac, raw
 
 < en: celeriac
 fr: céleri rave râpé
-# fr:céleri-rave-râpé has 17 products in 1 language @2018-10-20
 
 < en: celeriac
 fr: jus de céleri-rave concentré, jus de céleri rave concentré, jus concentré de céleri rave
@@ -58336,7 +57161,6 @@ usda_ndb_code:en: 11507
 usda_ndb_name:en: Sweet potato, raw, unprepared (Includes foods for USDA's Food Distribution Program)
 wikidata:en: Q37937
 wikipedia:en: https://en.wikipedia.org/wiki/Sweet_potato
-# ingredient/fr:patate-douce has 327 products in 6 languages @2018-12-22
 
 en: Cooked sweet potato
 it: patata dolce cotta
@@ -58772,7 +57596,6 @@ usda_ndb_code:en: 11352
 usda_ndb_name:en: Potatoes, flesh and skin, raw
 wikidata:en: Q16587531
 wikipedia:en: https://en.wikipedia.org/wiki/Potato
-# en:potato has 2269 products in 23 languages @2018-10-15
 
 < en: potato
 en: new potato, new potatoes
@@ -58787,7 +57610,6 @@ it: patate da tavola
 
 < en: potato
 fr: Pommes de terre de consommation à chair ferme
-# ingredient/fr:pommes-de-terre-de-consommation-a-chair-ferme has 9 products @2019-06-01
 
 < en: potato
 en: British potato
@@ -58815,7 +57637,6 @@ pl: Mąka ziemniaczana
 sv: potatismjöl
 usda_ndb_code:en: 11413
 usda_ndb_name:en: Potato flour
-# ingredient/en:potato-flour has 1998 products in 4 languages @2020-05-23
 
 < fr: Pommes de terre de consommation à chair ferme
 fr: Pommes de terre de consommation à chair ferme bio
@@ -58853,7 +57674,6 @@ it: patata cotta
 nl: gegaarde aardappel
 ro: cartofi fierți
 sv: kokt potatis
-# en:cooked-potato has 62 products in 1 language @2018-10-15
 
 < en: potato
 en: potato skin
@@ -58908,7 +57728,6 @@ zh: 馬鈴薯泥
 # zh_yue:薯茸
 wikidata:en: Q322787
 wikipedia:en: https://en.wikipedia.org/wiki/Mashed_potato
-# fr:purée-de-pomme-de-terre has 152 products in 1 language @2018-10-15
 
 < en: mashed potato
 en: instant mashed potatoes
@@ -58930,7 +57749,6 @@ nl: aardappelvlokken
 pl: płatki ziemniaczane
 ru: картофельние хлопья, картофельные-хлопья
 sv: potatisflingor, potatisflinga
-# fr:flocon-de-pomme-de-terre has 937 products in 12 languages @2018-10-15
 
 < en: potato flakes
 en: dehydrated potato flakes
@@ -58942,11 +57760,9 @@ fr: flocons de pomme de terre déshydratés
 hr: dehidrirane pahuljice krumpira
 it: fiocchi di patate disidratati
 sl: krompirjevi kosmiči
-# fr:flocons-de-pomme-de-terre-déshydratés has 100 products in 2 languages @2018-10-15
 
 < en: potato flakes
 fr: flocons de pomme de terre réhydratés
-# fr:flocons-de-pomme-de-terre-réhydratés has 71 products in 1 language @2018-10-15
 
 < en: vegetable fiber
 en: potato fiber, potato fibre
@@ -58963,7 +57779,6 @@ nl: aardappelvezel, aardappelvezels
 no: potetfiber, potetfibre
 pl: błonnik ziemniaczany
 sv: potatisfiber
-# en:potato-fibre has 110 products in 4 languages @2018-10-15
 
 # fr:pommes de terre préfrites is a compound ingredient:Pomme de terre préfrite [pomme de terre, huile de tournesol, dextrose de blé]
 
@@ -58971,7 +57786,6 @@ sv: potatisfiber
 fr: pommes de terre préfrites
 nl: voorgebakken aardappel
 sv: forstekt potatis
-# fr:pommes-de-terre-préfrites has 151 products in 3 languages @2018-10-15
 carbon_footprint_fr_foodges_ingredient:fr: Frites surgelées
 carbon_footprint_fr_foodges_value:fr: 1.3
 
@@ -59103,7 +57917,6 @@ zh: 法式生菜沙拉
 description:en: Crudités (plural only) are traditional French appetizers consisting of sliced or whole raw vegetables[1] which are typically dipped in a vinaigrette or other dipping sauce. Examples of crudités include celery sticks, carrot sticks, cucumber sticks, bell pepper strips, broccoli, cauliflower, fennel, and asparagus spears.
 wikidata:en: Q2142465
 wikipedia:en: https://en.wikipedia.org/wiki/Crudités
-# ingredient/fr:crudités has 74 products in french @2019-03-29
 
 ###################################################################################################
 #
@@ -59192,7 +58005,6 @@ ecobalyse:en: avocado-non-eu
 eurocode_2_group_3:en: 8.40.60
 wikidata:en: Q961769
 wikipedia:en: https://en.wikipedia.org/wiki/Avocado
-# 858 in 12 @2021-09-21
 
 en: Guacamole
 it: guacamole
@@ -59282,7 +58094,6 @@ usda_ndb_proxy-name:en: Borage, raw
 usda_ndb_proxy_code:en: 11613
 wikidata:en: Q147075
 wikipedia:en: https://en.wikipedia.org/wiki/Borage
-# 27 in 4 @2021-09-05
 
 < en: borage
 en: raw borage
@@ -59426,7 +58237,6 @@ zh: 庫拉索蘆薈
 description:en: ALOE VERA is a succulent plant species of the genus Aloe.
 wikidata:en: Q80079
 wikipedia:en: https://en.wikipedia.org/wiki/Aloe_vera
-# ingredient/aloe-vera has 114 products in 6 languages @2019-02-03
 
 < en: aloe vera
 en: Aloe vera juice
@@ -59440,7 +58250,6 @@ hr: sok od aloe vere
 it: succo di aloe vera
 nl: aloe vera sap
 pl: sok aloesowy, sok z aloesu
-# ingredient/aloe-vera-juice has 62 products in 5 languages @2019-02-03
 
 # no products @2019-02-03
 #<en:aloe vera
@@ -59608,7 +58417,6 @@ usda_ndb_proxy_code:en: 11209
 usda_ndb_proxy_name:en: Eggplant, raw
 wikidata:en: Q7540
 wikipedia:en: https://en.wikipedia.org/wiki/Eggplant
-# en:aubergine has 733 products in 9 languages @2018-10-17
 
 < en: aubergine
 en: raw aubergine
@@ -59631,16 +58439,12 @@ nl: gegrilde aubergine
 ciqual_food_code:en: 20300
 ciqual_food_name:en: Eggplant, flesh and skin, roasted/baked
 # treatment:en:en:gril
-# fr:aubergine-grillée has 54 products in 1 language @2018-10-17
-# fr:aubergines-grillées has 123 products in 4 languages @2018-10-17
 
 
 < en: aubergine
 fr: aubergine préfrite, aubergines préfrites
 it: melanzane prefritte
 nl: voorgebakken aubergines
-# fr:aubergine-préfrite has 28 products in 1 language @2018-10-17
-# fr:aubergines-préfrites has 86 products in 2 languages @2018-10-17
 vegan:en: maybe
 vegetarian:en: maybe
 
@@ -59649,7 +58453,6 @@ cs: smažený lilek
 fr: aubergines frites
 vegan:en: maybe
 vegetarian:en: maybe
-# fr:aubergines-frites has 41 products in 1 language @2018-10-17
 
 < en: aubergine
 en: dried aubergine
@@ -59685,7 +58488,6 @@ nl: acaciavezels
 pl: błonnik akacjowy
 pt: fibras de acácia
 sv: akaciafiber, akaciefiber
-# ingredient/fr:fibre-d’acacia has 131 products @2019-03-03
 
 
 en: prebiotics
@@ -59725,7 +58527,6 @@ sr: Galaktooligosaharid
 zh: 低聚半乳糖
 wikidata:en: Q2315231
 wikipedia:en: https://en.wikipedia.org/wiki/Galactooligosaccharide
-# ingredient/fr:galacto-oligosaccharides has 39 products in 4 languages @2019-03-01
 # dietary fiber (galacto-oligosaccharides, fructo-oligosaccharides)
 
 < en: galacto-oligosaccharides
@@ -59755,7 +58556,6 @@ it: farina di Konjac
 < en: carrot
 < en: pumpkin
 fr: concentré de carotte et de citrouille
-# ingredient/fr:concentré-de-carotte-et-de-citrouille has 55 products in 2 languages @2019-05-23
 
 < fr: concentré de carotte et de citrouille
 de: Färbende Konzentrate Karotte und Kürbis
@@ -59933,7 +58733,6 @@ usda_ndb_code:en: 11226
 usda_ndb_name:en: Jerusalem-artichokes, raw
 wikidata:en: Q32979618
 wikipedia:en: https://en.wikipedia.org/wiki/Jerusalem_artichoke
-# ingredient/jerusalem-artichoke has 37 products @2019-02-03
 
 
 en: pale-leaf woodland sunflower
@@ -60035,7 +58834,6 @@ usda_ndb_code:en: 11298
 usda_ndb_name:en: Parsnips, raw
 wikidata:en: Q104413481
 wikipedia:en: https://en.wikipedia.org/wiki/Parsnip
-# ingredient/fr:panais has 372 products in 5 languages @2018-12-4
 
 < en: parsnip
 en: Cooked parsnip
@@ -60183,8 +58981,6 @@ usda_ndb_code:en: 11429
 usda_ndb_name:en: Radishes, raw
 wikidata:en: Q7224565
 wikipedia:en: https://en.wikipedia.org/wiki/Radish
-# ingredient/fr:Radis has 393 products in 4 languages @2019-05-16
-# category/radish has 2 products @2019-05-22
 # usage:en:fruit and vegetable concentrates (safflower, radish, black carrot, lemon, hibiscus)
 
 < en: radish
@@ -60321,7 +59117,6 @@ zh: 沙拉
 #wikipedia:en:https://en.wikipedia.org/wiki/Leaf_vegetable
 #wikipedia:de:https://de.wikipedia.org/wiki/Salatpflanze
 #wikipedia:fr:https://fr.wikipedia.org/wiki/Salade_(plante)
-# ingredient/fr:salade has 483 products in 4 languages @2019-05-17
 carbon_footprint_fr_foodges_ingredient:fr: Salade
 carbon_footprint_fr_foodges_value:fr: 0.8
 wikipedia:en: https://en.wikipedia.org/wiki/Salad
@@ -60330,7 +59125,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Salad
 en: batavia
 fr: batavia
 sv: batavia
-# ingredient/fr:batavia has 21 products in french @2019-02-26
 
 < en: batavia
 en: green baby batavia
@@ -60432,7 +59226,6 @@ de: Babyrucola
 fr: Jeunes pousses de roquette
 hr: beba rikula
 it: rucola baby
-# 86 in 2 @2021-10-04
 
 < en: salad
 en: wild rocket
@@ -60457,7 +59250,6 @@ hr: hrastova lisna salata
 it: lattuga foglia di quercia
 nl: Eikenbladsla
 wikidata:en: Q2590939
-# ingredient/fr:feuille-de-chene has 13 products in french @2019-05-24
 
 < en: oak leaf lettuce
 fr: feuille de chene verte
@@ -60470,8 +59262,6 @@ fr: mélange de salades, salade mélangée
 de: Mischsalat
 it: Insalata mista
 sv: salladsmix
-# ingredient/fr:mélange-de-salades has 50 products in 4 languages @2019-01-28
-# ingredient/fr:salade-mélangée has 91 products in french @2019-02-03
 # Salade mélangée (laitue, chicorée et roquette)
 # Mélange de salade  (scarole, frisée, chicorée rouge, roquette)
 
@@ -60486,7 +59276,6 @@ de: gemischter Salat
 es: ensalada mixta
 hr: miješana salata
 it: insalata composta
-# ingredient/fr:salade-composée has 97 products in french @2019-04-16
 # usage:fr: Salade composée 88% : Scarole, carotte râpées, maïs (maïs, sucre, sel), emmental 12%, dés de jambon cuit supérieur 12% (jambon de porc 10,9%, sel, sirop de glucose, dextrose, arômes naturels, antioxydant : ascorbate de sodium, conservateur: nitrite de sodium), frisée, chicorée rouge.
 
 # do not make pepper a synonym of bell pepper
@@ -60584,7 +59373,6 @@ ecobalyse:en: bellpepper-unheated-greehouse
 eurocode_2_group_3:en: 8.40.20
 wikidata:en: Q1548030
 wikipedia:en: https://en.wikipedia.org/wiki/Bell_pepper
-# fr:poivron has 1581 products in 11 languages @2018-10-15
 
 
 # make "yellow bell pepper" the canonical name
@@ -60641,7 +59429,6 @@ sv: Grön paprika
 ciqual_food_code:en: 20085
 ciqual_food_name:en: Sweet pepper, green, raw
 ciqual_food_name:fr: Poivron vert, cru
-# 4183 in 15 @2021-10-14
 
 < en: green bell pepper
 en: italian bell pepper
@@ -60724,8 +59511,6 @@ hr: zelena i crvena paprika
 it: Peperoni dolci rossi e verdi
 nl: rode en groene paprika's
 sv: röd och grön paprika
-# fr:poivrons-verts-et-rouges has 32 products in 1 language @2018-10-15
-# fr:poivrons-rouges-et-verts has 143 products in 5 languages @2018-10-15
 
 < en: red bell pepper
 < en: yellow bell pepper
@@ -60737,7 +59522,6 @@ hr: crvena i žuta paprika
 it: peperoni rossi e gialli
 nl: rode en gele paprika
 sv: röd och gul paprika
-# fr:poivrons-rouges-et-jaunes has 54 products in 5 languages @2018-10-15
 
 # category/chili-peppers
 < en: fruit vegetable
@@ -60880,7 +59664,6 @@ fr: piment inca, piments inca
 #it:estratto di peperoncino
 #nl:pimentextract
 #sv:chilipepparextrakt
-# ingredient/fr:extrait-de-piment has 72 products in 6 languages @2019-04-15
 
 #process:en: en:pureed
 < en: chili pepper
@@ -60891,7 +59674,6 @@ fi: chilipyree, chilisose
 fr: purée de piments
 hr: pire od čilija
 it: purea di peperoncino
-# ingredient/fr:purée-de-piments has 136 products in 4 languages @2019-04-15
 # usage:fr:purée de piments (piments, sel)
 
 #process:en: en:paste
@@ -60974,7 +59756,6 @@ nb: rød chili pepper, rød chili
 nl: rode peper, rode chilipeper, rode chili, rode chili peper, spaanse peper
 pl: czerwona papryka chili, czerwona papryczka chili, czerwone papryczki chili, papryczka czerwona chilli
 sv: röd chili, röd chilipeppar
-# ingredient/fr:piment-rouge has 314 products in 7 languages @2019-4-15
 
 < en: red chili pepper
 en: red chili purée, red chilli purée
@@ -61022,7 +59803,6 @@ hr: ljuta začinska paprika, peperoncini, mini ljute papričice cijele, feferoni
 hu: csípős paprika
 it: peperoncino piccante
 nl: scherpe peperoni, scherpsmakende pepers
-# ingredient/fr:piment-fort has 391 products in 7 languages @2019-04-14
 # usage:en:hot peppers (hot peppers, water, vinegar, sugar, table salt, stabilizer [E 509])
 
 < en: chili pepper
@@ -61046,7 +59826,6 @@ origins:en: en:france
 protected_name_type:en: en:aoc
 wikidata:en: Q1538429
 wikipedia:en: https://en.wikipedia.org/wiki/Espelette_pepper
-# ingredient/fr:piment-d’espelette has 371 products in 5 languages @2019-04-15
 # scoville:en:1500-2500
 
 < en: chili pepper
@@ -61091,7 +59870,6 @@ usda_ndb_code:en: 11979
 usda_ndb_name:en: Peppers, jalapeno, raw
 wikidata:en: Q504133
 wikipedia:en: https://en.wikipedia.org/wiki/Jalape%C3%B1o
-# ingredient/fr:piments-jalapeño has 104 products in 4 languages @2019-04-15
 
 < en: jalapeno pepper
 en: green jalapeno peppers, green jalapeno
@@ -61103,7 +59881,6 @@ hr: zelene jalapeno paprike
 it: peperoni jalapeno verdi
 pl: zielona papryka jalapeño, zielona papryka jalapeno, papryka zielona jalapeño
 sv: grön jalapeño
-# ingredient/en:green-jalapeno-peppers has 103 products in 1 language @2020-05-24
 
 # description:en:A CHIPOTLE or chilpotle, is a smoke-dried ripe jalapeño chili pepper used for seasoning.
 
@@ -61162,7 +59939,6 @@ vi: ớt hiểm
 # min:lado kutu
 wikidata:en: Q432426
 wikipedia:en: https://en.wikipedia.org/wiki/Bird%27s_eye_chili
-# ingredient/en:thai-chili has 5 products in 1 language @2020-05-25
 
 < en: chili pepper
 en: allspice, all spice, jamaica pepper, myrtle pepper
@@ -61184,7 +59960,6 @@ usda_ndb_code:en: 2001
 usda_ndb_name:en: Spices, allspice, ground
 wikidata:en: Q158468
 wikipedia:en: https://en.wikipedia.org/wiki/Allspice
-# ingredient/fr:piment-de-la-jamaïque has 148 products in 5 languages @2019-04-15
 
 < en: chili pepper
 fr: piment Oiseau
@@ -61201,8 +59976,6 @@ sv: habanero chili
 wikidata:en: Q764375
 wikipedia:en: https://en.wikipedia.org/wiki/Habanero
 # scoville:en:100000-350000
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:habanero-chili
-# 1 entry @ 2019-10-31
 
 # description:en:A PIMIENTO, pimento, or cherry pepper is a variety of large, red, heart-shaped chili pepper (Capsicum annuum) that measures 3 to 4 in (7 to 10 cm) long and 2 to 3 in (5 to 7 cm) wide (medium, elongate).
 
@@ -61226,7 +59999,6 @@ usda_ndb_proxy_code:en: 11943
 usda_ndb_proxy_name:en: Pimento, canned
 wikidata:en: Q1236127
 wikipedia:en: https://en.wikipedia.org/wiki/Pimiento
-# ingredient/en:pimiento has 268 products in 2 languages @2020-06-13
 
 < en: pimiento
 en: canned pimiento
@@ -61246,7 +60018,6 @@ sv: guajillo chili
 vi: ớt guajillo
 wikidata:en: Q5613350
 wikipedia:en: https://en.wikipedia.org/wiki/Guajillo_chili
-# ingredient/en:guajillo-chili has 11 products in 1 language @2020-12-22
 
 < en: chili pepper
 en: spicy red pepper
@@ -61392,8 +60163,6 @@ fr: Pâte de paprika
 hr: pasta od paprike
 it: pasta di paprika
 pl: pasta paprykowa
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:paprikatahna
-# 1 entry @ 2019-10-31
 
 
 < en: paprika
@@ -61547,7 +60316,6 @@ ecobalyse_origins_en_european_union:en: tomato-greehouse-eu
 ecobalyse_origins_en_france:en: tomato-greenhouse-fr
 eurocode_2_group_3:en: 8.40.10
 wikidata:en: Q20638126
-# ingredient/tomato has 6812 products in 21 languages @2018-12-26
 
 < en: tomato
 en: organic tomato
@@ -61559,7 +60327,6 @@ fr: tomates biologiques, tomates issues de l'agriculture durable
 hr: organska rajčica
 it: pomodoro biologico
 nl: biologische tomaat, biologische tomaten
-# ingredient/fr:tomates-biologiques has 19 products in french @2019-05-29
 
 < en: tomato
 en: fresh tomatoes
@@ -61578,7 +60345,6 @@ carbon_footprint_fr_foodges_ingredient:fr: Tomate fraiche hors saison (France)
 carbon_footprint_fr_foodges_value:fr: 2.3
 #carbon_footprint_fr_foodges_ingredient:fr:Tomate fraiche importée (Espagne)
 #carbon_footprint_fr_foodges_value:fr:0.7
-# ingredient/fresh-tomatoes has 89 products in 4 languages @2018-12-26
 
 < en: tomato
 en: grilled tomato
@@ -61589,7 +60355,6 @@ fr: tomate grillée
 hr: rajčica na žaru
 it: pomodoro grigliato
 nl: gegrilde tomaat
-# ingredient/grilled-tomato has 5 products in french @2018-12-26
 
 en: Dehydrated and reconstituted tomato soup
 fr: Soupe à la tomate déshydratée reconstituée
@@ -61602,7 +60367,6 @@ ciqual_food_name:fr: Soupe à la tomate, déshydratée reconstituée
 en: diced tomatoes in tomato juice
 it: pomodori a dadini in succo di pomodoro
 lt: pjaustyti pomidorai savo sultyse
-# ingredient has 771 products @2021-08-16
 
 < en: tomato
 en: cherry tomato, cherry tomatoes
@@ -61622,7 +60386,6 @@ nn: cocktailtomater
 pl: pomidor koktajlowy, pomidory koktajlowe, pomidorów koktajlowych, pomidorki koktajlowe
 pt: tomates cerejas, tomates cereja
 sv: körsbärstomater, cherrytomater, cocktailtomater
-# ingredient/fr:tomates-cerise has 432 products in 10 languages @2018-12-26
 ciqual_food_code:en: 20172
 ciqual_food_name:en: Tomato, cherry, raw
 ciqual_food_name:fr: Tomate cerise, crue
@@ -61656,7 +60419,6 @@ sv: babyplommontomater
 fr: tomates semi-séchées, tomate mi-séchée, tomates mi-séchées
 de: Tomaten halbgetrocknete, halbgetrocknete Tomaten
 it: pomodori semiseccchi
-# ingredient/fr:tomates-semi-séchées has 38 products in 4 languages @2018-12-26
 
 < fr: tomates semi-séchées
 fr: tomates semi-séchées marinées, tomates semi-déshydratées et marinées
@@ -61681,7 +60443,6 @@ ja: ドライトマト
 ciqual_food_code:en: 20189
 ciqual_food_name:en: Tomato, dried
 ciqual_food_name:fr: Tomate, séchée
-# ingredient/fr:tomate-séchée has 423 products in 9 languages @2018-12-26
 
 #process:en: en:sundried
 < en: dried tomatoes
@@ -61701,7 +60462,6 @@ usda_ndb_code:en: 11955
 usda_ndb_name:en: Tomatoes, sun-dried
 wikidata:en: Q978399
 wikipedia:en: https://en.wikipedia.org/wiki/Sun-dried_tomato
-# ingredient/fr:tomates-sechees-au-soleil has 281 products in 1 language @2020-05-21
 
 #<en:sundried tomatoes
 #en:Dried tomato in oil, Dried tomatoes in oil, Sun-Dried tomato in oil, Sun-Dried tomatoes in oil
@@ -61712,7 +60472,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sun-dried_tomato
 
 < en: dried tomatoes
 fr: tomates séchées réhydratées
-# ingredient/fr:tomates-séchées-réhydratées has 47 products in french @2018-12-26
 
 < en: tomato
 en: peeled tomatoes
@@ -61727,13 +60486,10 @@ nl: gepelde tomaten
 pt: tomate pelado
 carbon_footprint_fr_foodges_ingredient:fr: Tomate pelées ou pulpe de tomate
 carbon_footprint_fr_foodges_value:fr: 1.4
-# ingredient/fr:tomate-pelée has 195 products in 2 languages @2018-12-26
-# ingredient/en:peeled-tomatoes has 47 products in english @2018-12-24
 
 < en: peeled tomatoes
 fr: tomates entières pelées
 nl: gepelde hele tomaten
-# ingredient/fr:tomate-entières-pelées has 41 products in 2 languages @2018-12-26
 
 < en: tomato
 en: chopped tomato, chopped tomatoes
@@ -61753,7 +60509,6 @@ pl: krojane pomidory
 pt: Tomates cortados
 sk: krájané rajčiny
 sv: Hackade tomater
-# ingredient/en:chopped-tomatoes has 15 products in english @2018-12-24
 
 < en: tomato
 en: tomato cubes
@@ -61770,8 +60525,6 @@ nl: tomatenblokjes
 pl: pomidory w kostkach
 pt: tomate en cubos
 sk: kocky rajčín
-# ingredient/fr:tomates-en-dés has 27 products in 4 languages @2018-12-26
-# ingredient/fr:dés-de-tomates has 53 products in french @2018-12-26
 # usage:en:  (tomato, tomato juice)
 
 < en: tomato cubes
@@ -61796,8 +60549,6 @@ nb: knust tomat
 nl: geplette tomaten
 # pl:Przecier pomidorowy is puree according to google
 sv: krossade tomater
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:tomaattimurska
-# 1 entry @ 2019-10-31
 
 < en: crushed tomato
 en: finely crushed tomato
@@ -61815,11 +60566,9 @@ it: Pomodoro pelato e tritato
 nl: gepelde gehakte tomaten
 carbon_footprint_fr_foodges_ingredient:fr: Tomate pelées ou pulpe de tomate
 carbon_footprint_fr_foodges_value:fr: 1.4
-# ingredient/fr:tomate-pelee-concassee has 281 products in 3 languages @2018-12-24
 
 < en: crushed peeled tomato
 fr: tomates pelées concassées au jus
-# ingredient/fr:tomates-pelées-concassées-au-jus has 94 products in french @2018-12-26
 
 < en: chopped tomatoes
 en: tomato pulp
@@ -61836,7 +60585,6 @@ pt: polpa de tomate
 sv: tomatkött
 carbon_footprint_fr_foodges_ingredient:fr: Tomate pelées ou pulpe de tomate
 carbon_footprint_fr_foodges_value:fr: 1.4
-# ingredient/fr:pulpe-de-tomate has 501 products in 6 languages @2018-12-26
 ciqual_food_code:en: 20169
 ciqual_food_name:fr: Tomate, pulpe, appertisée
 
@@ -61855,7 +60603,6 @@ se: mosade tomater
 sv: passerade tomater
 carbon_footprint_fr_foodges_ingredient:fr: Sauce tomate
 carbon_footprint_fr_foodges_value:fr: 2.9
-# ingredient/fr:coulis-de-tomates has 165 products in 4 languages @2018-12-26
 
 < en: tomato
 en: tomato purée
@@ -61903,15 +60650,12 @@ fr: Purée de tomates biologiques
 hr: organski pire od rajčice
 it: passata di pomodoro biologica
 nl: biologische tomatenpuree
-# ingredient/nl:biologische-tomatenpuree has 1 product @2019-05-24
 
 # fr:purée-de-tomate-mi-réduite could be a synonym of en:tomato-purée
 
 < en: tomato purée
 fr: purée de tomate mi-réduite, purée de tomates mi-concentrée, purée de tomates mi-réduites
 nl: half ingedikte tomatenpuree
-# ingredient/fr:purée-de-tomates-mi-concentrée has 28 products in 4 languages @2018-12-26
-# ingredient/fr:purée-de-tomate-mi-réduite has 309 products in 5 languages @2018-12-26
 
 < fr: purée de tomate mi-réduite
 fr: purée de tomates mi-réduite reconstituée
@@ -61969,7 +60713,6 @@ it: concentrato di pomodoro in scatola
 ciqual_food_code:en: 20068
 ciqual_food_name:en: Tomato paste, concentrated, canned
 ciqual_food_name:fr: Tomate, concentré, appertisé
-# ingredient/en:concentrated-tomato-purée has 92 products in 4 languages @2018-12-26
 
 # en:double-concentrated-tomato can be a compound ingredient, eg Tomatenmark doppelt konzentriert (Tomaten, Speisesalz)
 
@@ -61985,7 +60728,6 @@ fr: double concentré de tomate, purée de tomates double concentré, purée de 
 it: doppio concentrato di pomodoro
 nl: Dubbel geconcentreerde tomatenpuree
 sl: dvojni paradižnikov koncentrat
-# ingredient/fr:double-concentré-de-tomate has 520 products in 8 languages @2018-12-26
 
 < en: double concentrated tomato
 en: Canned double concentrate tomato paste
@@ -62000,8 +60742,6 @@ ciqual_food_name:fr: Tomate, double concentré, appertisé
 fr: purée de tomates reconstituée, purée de tomates à base de concentré, purée de tomate à base de concentré
 de: Tomatenpüree aus Konzentrat, Tomatenmark aus Konzentrat
 # hr:pire rajčice iz koncentrata
-# ingredient/fr:puree-de-tomates-reconstituee has 127 products in french @2018-12-26
-# ingredient/fr:purée-de-tomates-à-base-de-concentré has 94 products in 2 languages @2018-12-26
 
 < en: tomato purée
 fr: purée de tomates triple concentrée, triple concentré de tomate
@@ -62028,12 +60768,10 @@ en: tomato powder, powdered tomato
 processing:en: powder
 usda_ndb_code:en: 11548
 usda_ndb_name:en: Tomato powder
-# ingredient/powdered-tomato has 546 products in 10 languages @2018-12-26
 
 < en: chopped tomatoes
 < en: tomato purée
 fr: pulpe de tomates avec morceaux et purée de tomates
-# ingredient/fr:pulpe-de-tomates-avec-morceaux-et-purée-de-tomates has 12 products in french @2018-12-26
 
 < en: tomato
 en: tomato juice
@@ -62057,7 +60795,6 @@ sv: tomatjuice
 tr: domates suyu
 carbon_footprint_fr_foodges_ingredient:fr: Tomate pelées ou pulpe de tomate
 carbon_footprint_fr_foodges_value:fr: 1.4
-# ingredient/en:tomato-juice has 2171 products in 10 languages @2018-12-26
 
 < en: tomato juice
 fr: jus de tomate à partir de concentré, jus de tomates à base de concentré, jus de tomates reconstitué
@@ -62067,7 +60804,6 @@ fi: tomaattimehu tiivisteestä
 it: succo di pomodoro ricavato da concentrato
 nl: tomatensap uit sapconcentraat
 pl: sok pomidorowy z zagęszczonego soku pomidorowego, sok pomidorowy z zagęszczonego soku, sok pomidorowy z koncentratu, sok pomidorowy odtworzony z zagęszczonego soku pomidorowego
-# ingredient/fr:jus-de-tomate-à-partir-de-concentré has 149 products @2018-12-26
 
 < en: tomato juice
 fr: jus concentré de tomate
@@ -62254,7 +60990,6 @@ usda_ndb_proxy_code:en: 11564
 usda_ndb_proxy_name:en: Turnips, raw
 wikidata:en: Q3916957
 wikipedia:en: https://en.wikipedia.org/wiki/Turnip
-# ingredient/turnip has 592 products in 7 languages @2019-05-18
 
 < en: turnip
 en: unprepared frozen turnip
@@ -62311,7 +61046,6 @@ description:en: Eleocharis dulcis, the Chinese water chestnut or water chestnut,
 ifct_food_code:en: F016
 ifct_food_name:en: Water Chestnut
 wikidata:en: Q932664
-# fr:châtaigne-d'eau has 87 products in 5 languages @2018-10-15
 
 < en: vegetable
 en: Nelumbo
@@ -62441,8 +61175,6 @@ usda_ndb_proxy_code:en: 11422
 usda_ndb_proxy_name:en: Pumpkin, raw
 wikidata:en: Q165308
 wikipedia:en: https://en.wikipedia.org/wiki/Pumpkin
-# fr:courge has 88 products in 4 languages @2018-10-26
-# ingredient/fr:potiron has 439 products in 6 languages @2019-04-08
 
 < en: pumpkin
 en: raw pumpkin
@@ -62476,7 +61208,6 @@ hr: sok od bundeve
 it: succo di zucca
 nl: Pompoensap
 pl: sok z dyni, sok dyniowy
-# fr:jus-de-potiron has 54 products in 5 languages @2019-04-08
 
 < en: pumpkin juice
 en: concentrated pumpkin juice
@@ -62767,7 +61498,6 @@ it: zucchine grigliate
 nl: gegrilde courgette
 ciqual_food_code:en: 20313
 ciqual_food_name:en: Courgette or zucchini, flesh and skin, roasted/baked
-# en:grilled-courgette has 238 products in 5 languages @2018-10-26
 
 < en: Courgette
 fr: courgettes en rondelles
@@ -62830,8 +61560,6 @@ comment:en: Why is this listed as a vegetable?
 description:en: Turnip rape (Brassica rapa subsp. oleifera, also called field mustard or rybs in some regions) is grown for its seeds, which are pressed for oil. It's one of the plants used to produce canola oil (along with rapeseed, Brassica napus). Young leaves of turnip rape can be eaten as leafy greens, similar to mustard greens or other brassica greens, in some regional cuisines.
 wikidata:en: Q3337246
 wikipedia:fr: https://fr.wikipedia.org/wiki/Navette_(plante)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:rypsi
-# 379 entries @ 2016-5-07
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -62962,7 +61690,6 @@ description:en: A BEAN is a seed of one of several genera of the flowering plant
 eurocode_2_group_3:en: 7.10.30
 rare_crop:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Phaseolus_vulgaris
-# ingredient/fr:haricots has 92 products in 4 languages @2019-06-02
 
 < en: beans
 en: bean sprouts, beansprouts
@@ -63474,7 +62201,6 @@ nl: witte bonen
 pl: fasola biała
 ru: фасоль белая
 sv: vit böna, vita bönor
-# ingredient/fr:lingots-blancs has 8 products @2019-06-02
 eurocode_2_group_3:en: 7.10.30
 eurocode_2_group_4:en: 7.10.30.10
 
@@ -63807,7 +62533,6 @@ pt: feijão-frade, feijão frade
 si: කවුපී
 vi: Đậu dải trắng rốn nâu
 zh: 黑眼豆
-# ingredient/nl:zwarte-oogbonen has 1 product @2019-05-24
 eurocode_2_group_3:en: 7.10.46
 # pnb:لوبیا
 wikidata:en: Q3246973
@@ -63835,7 +62560,6 @@ fi: leikkopapu, leikkopavut
 fr: flageolets
 hr: flažoleti
 it: flageolets
-# ingredient/fr:flageolets has 74 products in 2 languages @2019-02-25
 carbon_footprint_fr_foodges_ingredient:fr: Haricot blanc en conserve (type cassoulet)
 carbon_footprint_fr_foodges_value:fr: 2
 ecobalyse:en: flageolet-bean-eu
@@ -63851,12 +62575,10 @@ fr: flageolets verts
 hr: zelene flažolete
 it: fagioli nani
 nl: groene flageolets
-# ingredient/fr:flageolets-verts has 139 products in 6 languages @2019-02-25
 
 < en: green flageolets
 fr: flageolets verts extra-fins
 nl: extra fijne groene flageolets
-# ingredient/fr:flageolets-verts-extra-fins has 30 products in 2 languages @2019-02-25
 
 ###################################################################################################
 #
@@ -63959,7 +62681,6 @@ usda_ndb_proxy_code:en: 16076
 usda_ndb_proxy_name:en: Lupins, mature seeds, raw
 wikidata:en: Q13582643
 wikipedia:en: https://en.wikipedia.org/wiki/Lupin_bean
-# 957 in 12 @2021-10-01
 
 < en: lupin
 en: raw mature lupin
@@ -64019,18 +62740,15 @@ ciqual_proxy_food_code:en: 20534
 ciqual_proxy_food_name:en: lupin grain, raw
 ciqual_proxy_food_name:fr: Lupin, graine crue
 eurocode_2_group_3:en: 7.10.xx
-# 330 in 8 @2021-10-01
 
 #< en: compound
 fr: vermicelle de pois
 nl: vermicelli van erwten
-# ingredient/fr:vermicelle-de-pois has 28 products @2019-02-15
 # vermicelle de pois (eau, amidon de pois)
 
 < fr: vermicelle de pois
 fr: vermicelle de pois réhydraté, vermicelles de pois réhydratés
 nl: gerehydrateerde vermicelli van erwten
-# ingredient/fr:vermicelles-de-pois-réhydratés has 43 products @2019-02-18
 
 ###################################################################################################
 #
@@ -64173,7 +62891,6 @@ usda_ndb_proxy_code:en: 16052
 usda_ndb_proxy_name:en: Broadbeans (fava beans), mature seeds, raw
 wikidata:en: Q131342
 wikipedia:en: https://en.wikipedia.org/wiki/Vicia_faba
-# ingredient/fr:feve has 54 products in french @2019-02-17
 
 < en: broad bean
 < en: pulse
@@ -64450,7 +63167,6 @@ eurocode_2_group_3:en: 8.45.10
 rare_crop:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Pea
 # wikidata:en:Q29472543 (seems more the vegetable)
-# ingredient/fr:pois has 259 products in 7 languages @2019-05-10
 # usage:fr:amidon (blé, pomme de terre, pois, maïs)
 
 # <en:pea
@@ -64604,7 +63320,6 @@ rare_crop:en: yes
 # wikidata:en:Q81375 # this is actually the plant not the legume
 wikidata:en: Q33832605
 wikipedia:en: https://en.wikipedia.org/wiki/Chickpea
-# ingredient/fr:pois-chiche has 700 products in 13 languages @2019-02-15
 
 < en: chickpea
 en: pedrosillano chickpeas
@@ -64809,7 +63524,6 @@ fr: petits pois doux, petit pois doux, pois doux
 it: pisello dolce
 nl: zoete doperwten
 sv: söta ärtor
-# ingredient/fr:petits-pois-doux has 38 products in 3 languages @2019-02-07
 
 < fr: petits pois doux
 en: extra fine sweat peas
@@ -64913,7 +63627,6 @@ ciqual_proxy_food_name:en: Split pea, raw
 eurocode_2_group_3:en: 7.10.10
 wikidata:en: Q2265406
 wikipedia:en: https://en.wikipedia.org/wiki/Split_pea
-# ingredient/fr:pois-cassés has 71 products in 3 languages @2019-04-03
 
 < en: split pea
 en: dried split pea
@@ -64935,7 +63648,6 @@ fr: pois cassés verts
 hr: zeleni grašak
 it: piselli verdi spezzati
 nl: groene spliterwten
-# ingredient/fr:pois-casses-verts has 13 products in 4 languages
 
 < en: split pea
 en: yellow split pea
@@ -65132,7 +63844,6 @@ eurocode_2_group_3:en: 7.10.25
 < en: lentils
 fr: lentilles réhydratées, lentilles sèches trempées
 fi: kuivattu linssi, kuivatut linssit
-# ingredient/fr:lentilles-réhydratées has 54 products @2019-06-02
 
 < en: lentils
 en: precooked lentils
@@ -65143,7 +63854,6 @@ hr: prethodno kuhana leća
 it: lenticchie precotte
 nl: voorgekookte linzen
 pl: soczewica gotowana
-# ingredient/fr:lentilles-précuites has 57 products @2019-06-02
 
 < en: lentils
 de: gelbe Linsen, Linsen gelb
@@ -65166,7 +63876,6 @@ pt: lentilhas verde
 sv: gröna linser
 carbon_footprint_fr_foodges_ingredient:fr: Lentilles vertes
 carbon_footprint_fr_foodges_value:fr: 0.3
-# ingredient/fr:lentille-verte has 228 products in 7 languages @2019-06-02
 
 < en: green lentils
 en: organic green lentils
@@ -65195,11 +63904,9 @@ fr: lentilles vertes cuites
 hr: kuhana zelena leća
 it: lenticchie verdi cotte
 nl: gekookte groene linzen
-# ingredient/fr:lentilles-vertes-cuites has 65 products @2019-06-02
 
 < en: green lentils
 fr: lentilles vertes précuites
-# ingredient/fr:lentilles-vertes-précuites has 49 products @2019-06-02
 
 < en: lentils
 en: yellow lentils
@@ -65223,8 +63930,6 @@ sv: röda linser
 ciqual_food_code:en: 20535
 ciqual_food_name:en: Lentil, pink or red, dried
 ciqual_food_name:fr: Lentille corail, sèche
-# ingredient/fr:lentilles-rouges has 40 products in 3 languages @2019-06-02
-# ingredient/fr:lentilles-corail has 131 products in 6 languages @2019-06-02
 usda_ndb_proxy_code:en: 16144
 usda_ndb_proxy_name:en: Lentils, pink or red, raw
 
@@ -65242,7 +63947,6 @@ fi: vihreät ja punaiset linssit
 hr: zelena i crvena leća
 it: lenticchie verdi e rosse
 sv: gröna och röda linser
-# ingredient/sv:gröna-och-röda-linser has 1 product in 2 languages @2020-06-13
 
 < en: red lentils
 en: organic red lentils
@@ -65253,7 +63957,6 @@ it: lenticchie rosse biologiche
 
 < en: red lentils
 fr: lentilles rouges décortiquées
-# ingredient/fr:lentilles-rouges-decortiquees has 11 products @2019-06-02
 
 < en: lentils
 en: black lentils
@@ -65325,8 +64028,6 @@ nl: linsenmeel
 sv: linsmjöl
 ciqual_proxy_food_code:en: 20359
 ciqual_proxy_food_name:en: Lentil, dried (average)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:linssijauho
-# 1 entry @ 2019-10-31
 
 < en: lentil flour
 en: wholemeal lentil flour
@@ -65449,12 +64150,6 @@ uz: Yongʻoq
 vi: Hạch
 yi: נוס
 zh: 坚果
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruit-à-coque
-# 158 products in 1 languages @2018-10-07
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruits-à-coques
-# 438 products in 4 languages @2010-10-08
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:fruits-à-coque
-# 2099 products in 5 languages @2018-10-07
 nutriscore_fruits_vegetables_nuts:en: yes
 vegan:en: yes
 vegetarian:en: yes
@@ -65619,7 +64314,6 @@ ifct_food_name:en: Almond
 usda_ndb_code:en: 12061
 usda_ndb_name:en: Nuts, almonds
 wikidata:en: Q184357
-# ingredient/almond has 25389 products in 38 languages @2021-08-17
 # TODO Split French and English
 
 < en: almond
@@ -65661,7 +64355,6 @@ nl: amandel met vlies
 pt: amêndoa com pele, amêndoas com pele
 ciqual_food_code:en: 15000
 ciqual_food_name:en: Almond, (with peel)
-# ingredient/almond-with-skin has 4 products in 2 languages @2018-10-06
 
 < en: almond
 en: almond without skin, Marcona almonds without skin, Peeled marcona almonds
@@ -65675,7 +64368,6 @@ it: Mandorle pelate
 nl: amandel zonder vlies
 pl: migdały łuskane
 pt: amêndoa sem pele, amêndoas sem pele, amêndoa pelada, amêndoas peladas
-# ingredient/almond-without-skin has 18 products in 1 language @2018-10-06
 
 < en: almond
 en: almond pulp
@@ -65687,7 +64379,6 @@ it: polpa di mandorle
 nl: amandelpulp
 pl: masa migdałowa
 pt: polpa de amêndoa, polpa de amêndoas
-# ingredient/almond-pulp has 1 product in 1 language @2018-10-06
 
 < en: almond
 en: blanches almonds, almonds blanched
@@ -65700,7 +64391,6 @@ it: mandorle sbianchite
 pl: migdały blanszowane
 usda_ndb_code:en: 12062
 usda_ndb_name:en: Nuts, almonds, blanched
-# ingredient/fr:amandes-blanchies has 31 products in 5 languages @2018-10-06
 
 < en: blanches almonds
 en: raw blanched almonds
@@ -65721,7 +64411,6 @@ fr: amandes entières, amandes complètes
 hr: cijeli bademi
 it: mandorle intere
 pt: amêndoa inteira, amêndoas inteiras
-# ingredient/fr:amandes-entières has 44 products @2018-10-06
 
 < en: almond
 en: powdered almonds
@@ -65735,7 +64424,6 @@ ja: アーモンドパウダー
 nl: amandelen in poedervorm
 pt: amêndoa em pó, amêndoas em pó
 sv: mandelpulver
-# ingredient/fr:amande-en-poudre has 233 products in 8 languages @2018-10-06
 
 < en: almond
 en: almond flour
@@ -65772,14 +64460,11 @@ nl: gemalen amandelen
 sv: mandelkross
 # in processing de:gemahlene Mandeln, gehackte Mandeln, mandeln gemahlen
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:amandes-hachées
-# 51 products in 4 languages @2018-10-06
-# 60 products in 5 languages @2018-10-06
 
 < en: almond
 fr: amandes décortiquées
 de: Mandelkerne
 it: mandorle sgusciate
-# ingredient/fr:amandes%20décortiquées has 64 products in 3 languages @2018-10-06
 
 < en: almond
 en: almonds pieces
@@ -65792,7 +64477,6 @@ it: mandorle spezzate
 nl: amandelstukjes
 pl: kawałki migdałów
 sv: mandelbitar
-# ingredient/fr:éclats-d'amandes has 73 products in 4 languages @2018-10-06
 
 < en: almond
 en: roasted almonds, dry roasted almonds
@@ -65806,7 +64490,6 @@ it: mandorle tostate
 nl: geroosterde amandelen
 pt: amêndoa torrada, amêndoas torradas
 ro: migdale coapte
-# ingredient/fr:amandes%20grillées has 159 products in 5 languages @2018-10-06
 
 < en: almond
 en: flaked almonds
@@ -65820,7 +64503,6 @@ ja: スライスアーモンド
 nl: amandelschilfers, amandelschaafsel
 pl: migdały w płatkach, płatki migdałów, migdały płatki
 pt: amêndoa laminada, amêndoas laminadas
-# 191 products in 7 languages @2018-10-06
 
 < en: tree nut
 en: bitter almond
@@ -65835,8 +64517,6 @@ pt: amêndoa amarga, amêndoas amargas
 sv: Bittermandel
 # aeb-arab:لوز مرّ
 wikidata:en: Q902704
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:amandes-amères
-# 39 products in 3 languages @2018-10-06
 
 < en: tree nut
 en: sweet almond
@@ -65847,7 +64527,6 @@ hr: slatki badem
 it: mandorle dolci
 pt: amêndoa doce, amêndoas doces
 sv: sötmandel
-# ingredient/fr:amande-douce has 5 products in 1 language @2020-06-13
 
 # fr:pâte d'amande can be a compound ingredient
 
@@ -65868,8 +64547,6 @@ ciqual_proxy_food_name:en: Almond paste or marzipan, prepacked
 ciqual_proxy_food_name:fr: Pâte d'amande, préemballée
 usda_ndb_code:en: 12071
 usda_ndb_name:en: Nuts, almond paste
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pâte-d'amande
-# 216 products in 5 languages @2018-10-06
 
 < en: almond paste
 en: prepacked Almond paste
@@ -65893,8 +64570,6 @@ pt: amêndoa caramelizada, amêndoas caramelizadas
 < en: preparation
 fr: praliné aux amandes et aux noisettes
 nl: amandelen-hazelnotenpraliné
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:praliné-aux-amandes-et-aux-noisettes
-# 31 products in 2 languages @2018-10-06
 
 < en: preparation
 fr: pâte de praliné
@@ -65962,7 +64637,6 @@ description:en: The Brazil nut (Bertholletia excelsa) is a South American tree i
 description:fr: Le Noyer du Brésil ou Noyer d’Amazonie (Bertholletia excelsa) produit la noix du Brésil, formée d’une coque épaisse et dure, d’une dizaine de centimètres de diamètre, contenant une vingtaine de graines, elles-mêmes enfermées dans un tégument lignifié. À l’intérieur, l’amande blanche, comestible, riche en lipide, est commercialisée dans le monde entier.
 description:nl: De paranoot wordt geleverd door een boom (Bertholletia excelsa) uit de familie Lecythidaceae. De vrucht van de paranoot is hard, kegelvormig, weegt zo'n 2 kg en heeft een diameter van 10 tot 15 cm. In deze vrucht bevinden zich 10 - 25 paranoten. De boom wordt nauwelijks geteeld. De gehele productie komt bijna alleen van in het wild verzamelde noten uit Brazilië, Peru en Bolivia.
 wikidata:en: Q22810770
-# ingredient/brazil-nut has 892 products in 15 languages @2021-08-14
 
 ###################################################################################################
 #
@@ -66027,7 +64701,6 @@ ifct_food_name:en: Cashew nut
 usda_ndb_proxy_code:en: 12087
 usda_ndb_proxy_name:en: Nuts, cashew nuts, raw
 wikidata:en: Q28788216
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/cashew-nuts
 # 999 in 12 languages products @2018-10-05
 
 < en: cashew nuts
@@ -66153,7 +64826,6 @@ origins:en: en:europe
 #it:purea di castagne
 #nl:kastanjepuree
 #pt:puré de castanha, puré de castanhas
-# ingredient/fr:purée-de-châtaignes has 33 products in 2 languages @2018-10-07
 
 #process:en:cooked
 #<en:chestnut
@@ -66176,8 +64848,6 @@ fr: marron, marrons
 de: Maronen, Marroni
 it: marroni
 wikidata:en: Q3177204
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:marron
-# 218 products in 5 languages @2018-10-07
 
 < fr: marron
 fr: Marrons UE
@@ -66193,7 +64863,6 @@ fr: Marrons UE
 #fr:Marrons entiers
 #it:Castagne intere
 #pt:Castanhas inteiras
-# ingredient/fr:marrons-entiers has 23 products @2019-05-24
 
 #<fr:Marrons entiers
 #fr:Marrons entiers bio
@@ -66204,16 +64873,12 @@ fr: crème de marrons
 hr: kesten namaz
 it: crema di castagne
 pt: créme de castanha, créme de castanhas
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:crème-de-marrons
-# 53 products in 1 language @2018-10-07
 # usage:fr:(sucre, châtaignes, eau, extrait pur de vanille)
 
 #process:en:pureed
 #<fr:marron
 #fr:purée de marrons
 # In process de:Marronipüree
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:purée-de-marrons
-# 41 products in 3 languages @2018-10-07
 
 ###################################################################################################
 #
@@ -66345,7 +65010,6 @@ usda_ndb_code:en: 12120
 usda_ndb_name:en: Nuts, hazelnuts or filberts
 wikidata:en: Q578307
 wikipedia:en: https://en.wikipedia.org/wiki/Hazelnut
-# 4124 products @2018-10-07
 
 < en: hazelnut
 en: Piedmont hazelnut, PGI Piedmont hazelnut
@@ -66392,7 +65056,6 @@ it: nocciole tostate
 ciqual_food_code:en: 15033
 ciqual_food_name:en: Hazelnut, grilled
 ciqual_food_name:fr: Noisette grillée
-# 495 in 10 @2021-09-01
 
 < en: hazelnut
 fr: noisettes décortiquées
@@ -66402,7 +65065,6 @@ nb: hasselnøttkjerner
 pt: miolo de avelã
 ru: ядро ореха фундука
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:noisettes-décortiquées
-# 42 products in 4 languages @2018-10-07
 
 < en: hazelnut
 en: hazelnut kernel, hazelnut kernels
@@ -66413,14 +65075,12 @@ hr: lješnjak jezgra
 it: nocciole intere
 pt: avelã inteira, avelãs inteiras
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:noisettes-entières
-# 118 products in 4 languages @2018-10-07
 
 < fr: noisettes entières
 fr: noisettes entières torréfiées
 nl: hele gegrilde hazelnoten
 pt: avelã inteira torrada, avelâs inteiras torradas, avelã inteira tostada, avelâs inteiras tostadas
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:noisettes-entières-torréfiées
-# 15 products in 1 language @2018-10-007
 
 #processing:en: en:chopped
 < en: hazelnut
@@ -66432,7 +65092,6 @@ it: nocciole tritate
 #fr:noisettes hachées
 #it:nocciole tritate
 #nl:gehakte hazelnoot, gehakte hazelnoten
-# 221 products in 7 @2021-09-01
 
 #<en:chopped hazelnuts
 #en:chopped toasted hazelnuts
@@ -66447,7 +65106,6 @@ it: Nocciola rosolata tostata
 nl: geroosterde gehakte hazelnoten
 pl: siekane i prażone orzeszki laskowe
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:noisettes-hachées-grillées
-# 55 products in 3 languages @2018-10-07
 
 #processing:en: en:ground
 < en: hazelnut
@@ -66459,23 +65117,18 @@ it: nocciole macinate
 #fr:noisettes moulues, noisettes broyées
 #it:nocciole macinate
 #nl:gemalen hazelnoten
-# 275 in 17 @2021-09-01
 
 < en: hazelnut
 fr: éclats de noisettes
 de: Haselnusssplitter, Haselnussstücke
 # hr:komadić lješnjaka # see ingredients_processings.txt
 it: nocciole a scaglie
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:éclats-de-noisettes
-# 145 products in 4 languages @2018-10-06
 
 # éclats de noisettes caramélisés is a compound producte, i.e. (noisettes, sucre de canne)
 
 #<en:compound
 fr: éclats de noisettes caramélisés
 fi: karamellisoidut hasselpähkinät
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:éclats-de-noisettes-caramélisés
-# 54 products in 1 language @2018-10-07
 
 < en: hazelnut
 en: hazelnut paste
@@ -66497,8 +65150,6 @@ pt: pasta de avelã, pasta de avelãs
 ro: pastă de alune de pădure
 sk: oriešková pasta
 sv: hasselnötspasta, hasselnötpasta, hasselnötsmassa
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/hazelnut-paste
-# 965 products in 14 languages @2018-10-06
 
 #<en:compound
 en: hazelnut paste with pieces of biscuits
@@ -66527,8 +65178,6 @@ fr: praliné noisettes
 hr: praline od lješnjaka
 it: pralinato di nocciole, granella di nocciole
 nl: hazelnootpraliné
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:praliné-noisettes
-# 121 products in 3 languages @2018-10-07
 
 < en: ground hazelnuts
 < fr: éclats de noisettes
@@ -66538,8 +65187,6 @@ fr: éclats de noisettes et noisettes moulues
 hr: naribane i mljevene lješnjake
 it: nocciole tostate a scaglie
 ru: ядро ореха фундука дробленое
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:éclats-de-noisettes-et-noisettes-moulues
-# 14 products in 3 languages @2018-10-07
 
 # No products
 
@@ -66695,10 +65342,6 @@ ecobalyse_labels_en_organic:en: peanut-organic
 usda_ndb_proxy_code:en: 16087
 usda_ndb_proxy_name:en: Peanuts, all types, raw
 wikidata:en: Q37383
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:arachide
-# 1147 products in 9 languages @2018-10-05
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuète
-# 806 products in 19 languages @2018-10-06
 
 < en: peanut
 en: raw peanut
@@ -66743,8 +65386,6 @@ ciqual_food_code:en: 15037
 ciqual_food_name:en: Peanut, grilled
 ciqual_food_name:fr: Cacahuète, grillée
 wikidata:en: Q110495337
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuètes-grillées
-# 66 products in 6 languages @2018-10-06
 
 < en: roasted peanut
 en: organic roasted peanut, organic roasted peanuts
@@ -66759,7 +65400,6 @@ it: arachidi tostate biologiche
 nl: biologische geroosterde pinda's
 pt: amendoim torrado biológico
 sv: ekologisk rostad jordnöt, ekologiska rostade jordnötter, ekologisk rostade jordnötter
-# ingredient/nl:biologische-geroosterde-pinda-s has 1 product @2019-05-24
 
 < en: roasted peanut
 en: milled roasted peanut, milled roasted peanuts
@@ -66772,8 +65412,6 @@ it: arachidi tostate macinate
 nl: geroosterde germalen pinda's
 pt: amendoim torrado moído, amendoins torrados moídos
 sv: mald rostad jordnöt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cacahuètes-grillées-moulues
-# 53 products in 6 languages @2018-10-06
 
 < en: peanut
 en: shelled peanut, shelled peanuts
@@ -66786,7 +65424,6 @@ it: arachidi sgusciate
 nl: Pinda's in de dop
 pt: amendoim sem casca
 sv: jordnöt utan skal, jordnötter utan skal
-# ingredient/nl:pinda-s-in-de-dop has 1 product @2019-05-24
 
 < en: peanut
 en: peanut with shell
@@ -66823,7 +65460,6 @@ zh: 花生粉
 usda_ndb_proxy_code:en: 16100
 usda_ndb_proxy_name:en: Peanut flour, low fat
 wikidata:en: Q7157936
-# ingredient/en:peanut-flour has 786 products in 3 languages @2020-06-11
 
 # USDA_REVIEW: USDA name has qualifier 'low fat' not in taxonomy entry
 < en: peanut flour
@@ -66880,7 +65516,6 @@ usda_ndb_proxy_name:en: Peanut butter, reduced sodium
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q147651
-# ingredient/en:peanut-butter has 2899 products in 13 languages @2021-07-12
 
 < en: peanut butter
 en: reduced sodium peanut butter
@@ -67047,8 +65682,6 @@ ecobalyse:en: pistachio-non-eu
 usda_ndb_proxy_code:en: 12151
 usda_ndb_proxy_name:en: Nuts, pistachio nuts, raw
 wikidata:en: Q14959225
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pistache
-# 613 products in 9 languages @2018-10-05
 
 < en: pistachio nuts
 en: raw pistachio nuts
@@ -67098,8 +65731,6 @@ fr: pâte de pistache
 hr: pasta od pistacija, pasta s pistacijama
 it: pasta di pistacchio
 pl: pasta z pistacji, pasta pistacjowa
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pâte-de-pistache
-# 75 products @2018-10-05
 
 < en: pistachio paste
 en: pistachio flavor paste
@@ -67225,8 +65856,6 @@ it: gherigli di noci, noci comuni
 nb: Valnøttkjerner
 nl: Gepelde walnoot, walnootpitten
 pt: Miolo de noz
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cerneaux-de-noix
-# 78 products in 4 languages @2018-10-05
 ciqual_food_code:en: 15005
 ciqual_food_name:en: Walnut, dried, husked
 ciqual_food_name:fr: Noix, séchée, cerneaux
@@ -67388,8 +66017,6 @@ vegetarian:en: yes
 # zh-sg:种子
 # zh-tw:種子
 wikidata:en: Q40763
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:graines
-# 304 products in 7 languages @2018-10-06
 
 < en: seed
 en: oilseed, oilseeds
@@ -67462,7 +66089,6 @@ usda_ndb_proxy_code:en: 2002
 usda_ndb_proxy_name:en: Spices, anise seed
 wikidata:en: Q33873455
 wikipedia:en: https://en.wikipedia.org/wiki/Anise
-# ingredient/fr:graine-d'anis-vert has 25 products in 1 language @2018-10-07
 
 < en: aniseed
 en: aniseseed
@@ -67477,7 +66103,6 @@ fr: anis bio
 hr: organski anis
 it: anice bio
 nl: biologisch anijszaad, anijs bio
-# ingredient/nl:biologisch-anijszaad has 1 product @2019-05-24
 
 < en: coriander
 < en: seed
@@ -67510,7 +66135,6 @@ ciqual_food_name:fr: Coriandre, graine
 usda_ndb_code:en: 2013
 usda_ndb_name:en: Spices, coriander seed
 wikidata:en: Q20856764
-# 1002 in 14 @2019-09-26
 
 #processing:en: :en:powder
 #<en:coriander seeds
@@ -67524,7 +66148,6 @@ wikidata:en: Q20856764
 #ja:コリアンダー
 #nl:korianderpoeder
 #sv:korianderpulver
-# ingredient/fr:coriandre-en-poudre has 54 products in 4 languages @2018-10-07
 
 ###################################################################################################
 #
@@ -67580,7 +66203,6 @@ la: Salvia hispanica
 nl: chia
 pl: szałwia hiszpańska, chia, salvia hispanica, szałwii hiszpańskiej
 description:en: SALVIA HISPANICA, commonly known as CHIA, is a species of flowering plant in the mint family, Lamiaceae
-# ingredient/chia has 430 products @2021-08-20
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q27688832
@@ -67776,7 +66398,6 @@ vi: thì là ai cập
 #yue:孜然
 zh: 孜然
 openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:graines-de-cumin
-# 7180 in 23 @2021-09-18
 
 < en: cumin
 en: cumin seeds
@@ -67814,7 +66435,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Cumin
 #it:cumino macinato
 #nn:malt kummin
 #openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:cumin-moulu
-# 52 products in 3 languages @2018-10-07
 
 #<en:seed
 #en:cumin powder
@@ -67848,13 +66468,11 @@ ciqual_food_name:fr: Fenouil, graine
 usda_ndb_code:en: 2018
 usda_ndb_name:en: Spices, fennel seed
 wikidata:en: Q27658833
-# 742 in 12 @2021-09-27
 
 #<en:fennel seed
 #en:organic fennel seed
 #fi:luomu fenkolinsiemen
 #nl:biologisch venkelzaad
-# ingredient/nl:biologisch-venkelzaad has 1 product @2019-05-24
 
 
 # description:en:Pine nuts, also called piñón or pinoli, are the edible seeds of pines (family Pinaceae, genus Pinus).
@@ -67923,7 +66541,6 @@ nutriscore_fruits_vegetables_nuts:en: no
 usda_ndb_proxy_code:en: 12147
 usda_ndb_proxy_name:en: Nuts, pine nuts, dried
 wikipedia:en: https://en.wikipedia.org/wiki/Pine_nut
-# ingredient/fr:pignons has 98 products in 4 languages @2018-12-05
 
 < en: pine nuts
 en: dried pine nuts
@@ -67973,7 +66590,6 @@ lv: lini
 nl: lijn
 pl: len, lnu
 pt: Linho
-# ingredient/fr:lin has 239 products in 6 languages @2018-12-06
 
 < en: flax
 < en: seed
@@ -68142,7 +66758,6 @@ fr: graines de melon
 hr: sjeme dinje
 it: semi di melone
 sv: melonfrön
-# ingredient/en:melon-seed has 4 products in 1 language @2020-06-13
 
 ###################################################################################################
 #
@@ -68190,8 +66805,6 @@ ciqual_proxy_food_name:en: Pumpkin and squash, seed, dried
 usda_ndb_proxy_code:en: 12014
 usda_ndb_proxy_name:en: Seeds, pumpkin and squash seed kernels, dried
 wikidata:en: Q3056521
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:graine-de-courge
-# 234 products in 5 languages @2018-10-07
 
 < en: pumpkin seed
 en: dried pumpkin and squash seed kernels
@@ -68282,7 +66895,6 @@ nutriscore_fruits_vegetables_nuts:en: no
 wikidata:en: Q2007388
 wikipedia:en: https://en.wikipedia.org/wiki/Poppy_seed
 wiktionary:en: poppyseed
-# 2090 in 17 @2021-09-10
 
 < en: poppyseed
 en: blue poppy seed
@@ -68427,11 +67039,9 @@ allergens:en: en:sesame-seeds
 ciqual_food_code:en: 15010
 ciqual_food_name:en: Sesame seed
 wikidata:en: Q2763698
-# ingredient/fr:sésame has 1745 products @2018-10-05
 
 < en: sesame
 fr: sésame doré
-# ingredient/fr:sesame-dore has 13 products in french @2019-06-04
 
 < en: sesame
 en: white sesame
@@ -68480,8 +67090,6 @@ ciqual_food_name:en: Sesame seed
 ciqual_food_name:fr: Sésame, graine
 usda_ndb_proxy_code:en: 12201
 usda_ndb_proxy_name:en: Seeds, sesame seed kernels, dried (decorticated)
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:graines-de-sesame
-# 1632 products in 11 languages @2018-10-05
 
 
 < en: sesame seeds
@@ -68528,12 +67136,9 @@ fr: graines de sesame bio
 hr: organske sjemenke sezama
 it: semi du sesamo bio
 nl: biologisch sesamzaad
-# ingredient/nl:biologisch-sesamzaad has 5 products @2019-05-24
 
 < en: sesame
 fr: sésame complet
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sésame-complet
-# 35 products in 4 languages @2018-10-05
 
 < en: sesame
 en: high-fat sesame flour
@@ -68571,8 +67176,6 @@ ro: pastă de susan, pastă de seminte de susan
 sv: sesampasta, sesam-kräm, sesam pasta
 usda_ndb_code:en: 12169
 usda_ndb_name:en: Seeds, sesame butter, paste
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:pâte-de-sésame
-# 105 products in 4 languages @2018-10-05
 
 #category/tahini
 < en: sesame paste
@@ -68696,7 +67299,6 @@ nutriscore_fruits_vegetables_nuts:en: no
 usda_ndb_proxy_code:en: 12036
 usda_ndb_proxy_name:en: Seeds, sunflower seed kernels, dried
 wikidata:en: Q1076906
-# 7103 in 28 @2021-09-07
 
 < en: sunflower seed
 en: dried sunflower seed kernels
@@ -68715,7 +67317,6 @@ usda_ndb_name:en: Seeds, sunflower seed flour, partially defatted
 # fr:graines de tournesol décortiquées
 # it:semi di girasole sbucciati
 # pl:nasiona słonecznika łuskane, łuskane nasiona słonecznika, słonecznik łuskany
-# ingredient/fr:graines-de-tournesol-decortiquees has 25 products @2019-05-31
 
 < en: sunflower seed
 en: sunflower seed paste
@@ -68827,14 +67428,10 @@ nl: peperextract
 pl: ekstrakt pieprzu
 pt: extrato de pimenta, extracto de pimenta
 sv: pepparextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/pepper-extract
-# 400 products in 6 languages @2018-10-08
 
 < en: pepper extract
 fr: extrait naturel de poivre
 fi: luontainen pippuriuute
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-naturel-de-poivre
-# 81 products in 1 language @2018-10-08
 
 < en: black pepper
 < en: white pepper
@@ -68896,7 +67493,6 @@ ciqual_food_name:fr: Poivre blanc, poudre
 usda_ndb_code:en: 2032
 usda_ndb_name:en: Spices, pepper, white
 wikidata:en: Q744814
-# 5825 in 24 @2021-09-28
 
 #processing:en: en:ground
 #<en:white pepper
@@ -68908,8 +67504,6 @@ wikidata:en: Q744814
 #fr:poivre blanc moulu
 #nl:gemalen witte peper
 #sv:mald vitpeppar, vitpepparpulver
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:poivre-blanc-moulu
-# 66 products in 3 languages @2018-10-08
 
 ###################################################################################################
 #
@@ -68929,8 +67523,6 @@ it: Peperone verde
 nl: groene peper
 pl: zielony pieprz, pieprz zielony
 sv: grönpeppar
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:poivre-vert
-# 193 products @2018-10-08
 
 ###################################################################################################
 #
@@ -69005,7 +67597,6 @@ ciqual_proxy_food_name:fr: Poivre noir, poudre
 ecobalyse:en: black-pepper
 usda_ndb_code:en: 2030
 usda_ndb_name:en: Spices, pepper, black
-# 17037 in 39 @2021-09-28
 
 
 < en: black pepper
@@ -69017,8 +67608,6 @@ fr: graines de poivre noir, poivre noir en grains
 hr: zrna crnog papra, papar crni zrno
 it: pepe nero in grani
 nl: zwarte peperkorrels
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/black-peppercorns
-# 60 products in 2 languages @2018-10-08
 
 < en: black pepper
 en: cracked black pepper
@@ -69031,8 +67620,6 @@ nl: grove zwarte peper
 ro: piper negru măcinat
 ru: перец черный молотый, перец-чёрный-молотый
 uk: перець чорний мелений
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:poivre-noir-concassé
-# 64 products @2018-10-08
 
 #processing:en:powder
 < en: black pepper
@@ -69053,8 +67640,6 @@ hr: ekstrakt crnog papra
 it: Estratto di pepe nero
 nl: zwarte peperextract, zwartepeperextract
 sv: svartpepparextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/black-pepper-extract
-# 66 products in 3 languages @2018-10-08
 
 < en: black pepper
 < en: green pepper
@@ -69124,7 +67709,6 @@ tr: Çeşni
 uk: Смакові добавки
 vi: Phụ gia
 zh: 食品添加剂
-# ingredient/fr:condiment has 360 products in 6 languages @2019-03-09
 vegan:en: maybe
 vegetarian:en: maybe
 # ast:Condimentu
@@ -69144,7 +67728,6 @@ fi: Jauhemainen mauste
 fr: condiment en poudre, condiments en poudre
 hr: začin u prahu
 it: condimento in polvere
-# ingredient/fr:condiment-en-poudre has 274 products in 4 languages @2019-03–09
 
 #< en: compound
 < en: condiment
@@ -69157,8 +67740,6 @@ fr: mélange de condiments, assaisonnement aromatisé, mélange aromatique
 hr: miješani začini
 it: condimenti misti
 pl: mix przyprawowy, mieszanka przypraw aromatyczno-smakowych
-# ingredient/fr:mélange-de-condiments has 161 products @2019-03-09
-# ingredient/fr:assaisonnement-aromatisé has 45 products @2019-04-04
 # usage:fr:assaisonnement aromatisé (arôme, amidon de pomme de terre, extrait de levure, sel, poudre de tomate, graisse de poule, poudre de bœuf, thym)
 # usage:fr:mélange aromatique (maltodextrine, arômes naturels, épices et plantes aromatiques, sel, saccharose, extrait de crustacé )
 
@@ -69234,7 +67815,6 @@ usda_ndb_code:en: 16112
 usda_ndb_name:en: Miso
 wikidata:en: Q235169
 wikipedia:en: https://en.wikipedia.org/wiki/Miso
-# ingredient/fr:miso has 46 products in 2 languages @2020-06-13
 
 < en: miso
 en: red miso paste
@@ -69280,10 +67860,8 @@ sl: začimbe
 sr: začini
 sv: krydda, kryddor, kryddört, krydd
 zh: 香料
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:aromate
 carbon_footprint_fr_foodges_ingredient:fr: Épices
 carbon_footprint_fr_foodges_value:fr: 2.2
-# 903 products in 4 languages @2018-10-08
 nutriscore_fruits_vegetables_nuts:en: no
 vegan:en: yes
 vegetarian:en: yes
@@ -69431,7 +68009,6 @@ ro: condimente și extracte de condimente
 ru: экстракты специй
 sl: začimbe in ekstrati začimb
 sv: kryddor och kryddextrakt
-# ingredient/fr:epices-et-extrait-d'epices has 135 products in 3 languages @2020-05-21
 
 < en: spice
 en: mixed spices
@@ -69449,7 +68026,6 @@ nl: gemengde specerijen
 pl: mieszanka przypraw, mieszanka przyprawowa, mieszanina przypraw, mieszanina przyprawowa
 ro: amestec de condimente
 sv: kryddblandning, kryddmix
-# ingredient/nl:gemengde-specerijen has 2 products @2019-05-24
 
 < en: mixed spices
 en: zaatar, zaatar blend
@@ -69496,7 +68072,6 @@ wikidata:en: Q206491
 wikipedia:en: https://en.wikipedia.org/wiki/Lemon_pepper
 # usage:en:lemon pepper(salt, sugar, citric acd, black pepper, garlic, celery seed, onion, tricalcium phosphate, and silicone dioxide (to make free flowing), lemon oil, and yellow lake #5)
 # mainIngredient:en:salt
-# ingredient/en:lemon-pepper has 29 products in 1 language @2020-05-21
 
 # description:en:HERBAL PEPPER is a seasoning popular in Poland, created as a substitute to peppercorns in times of shortage, still popular to this day.
 
@@ -69519,7 +68094,6 @@ hr: začinska pasta
 it: pasta di spezie
 sv: kryddpasta
 # usage:en:Spice Paste (14%) [Ginger, Garlic, Acidity Regulator (260), Vegetable Gum (415), Salt, Water)].
-# ingredient/en:spice-paste has 1 product in 1 language @2020-06-13
 
 < en: plant
 en: plant extracts
@@ -69533,7 +68107,6 @@ hr: biljni ekstrakti
 nb: planteekstrakt
 nl: plantextracten
 pl: ekstrakty roślinne, roślinne ekstrakty
-# ingredient/fr:extraits-de-plantes has 69 products in 4 languages @2019-05-29
 
 < en: plant extracts
 en: organic plant extracts
@@ -69541,7 +68114,6 @@ fi: luomu kasviuute
 fr: extraits de plantes bio
 hr: organski biljni ekstrakti
 nl: biologische plantextracten
-# ingredient/fr:extraits-de-plantes-bio has 9 products in french @2019-05-29
 # usage:fr:Extraits de plantes Bio: Aubépine Bio, Fleur d'oranger Bio, Passiflore Bio, Houblon Bio, Mélisse Bio
 
 < en: herb
@@ -69702,7 +68274,6 @@ usda_ndb_proxy_name:en: Spices, caraway seed
 wikipedia:en: https://en.wikipedia.org/wiki/Caraway
 # wikidata:en:Q26811 for the plant
 # wikidata:en:Q61670763 for the seed
-# ingredient/fr:carvi has 276 products in 7 languages @2019-05-13
 
 < en: caraway
 en: caraway seed
@@ -69784,7 +68355,6 @@ usda_ndb_name:en: Spices, pepper, red or cayenne
 wikidata:en: Q6598
 wikipedia:en: https://en.wikipedia.org/wiki/Cayenne_pepper
 # scoville:en:30000-50000
-# 4498 in 23 @2021-09-28
 
 < en: cayenne pepper
 en: dried cayenne pepper
@@ -69852,7 +68422,6 @@ ciqual_proxy_food_name:fr: Curry, poudre
 usda_ndb_proxy_code:en: 2015
 usda_ndb_proxy_name:en: Spices, curry powder
 wikidata:en: Q1144935
-# 972 in 10 @2021-09-17
 
 # Probably curry powder is a synonym of curry
 # With the translations be careful that they refer to the powder and not plain curry
@@ -69896,7 +68465,6 @@ usda_ndb_code:en: 2015
 usda_ndb_name:en: Spices, curry powder
 wikidata:en: Q1144935
 wikipedia:en: https://en.wikipedia.org/wiki/Curry_powder
-# 231 products in 8 languages @2018-10-11
 
 < en: spice
 en: curry paste
@@ -69915,7 +68483,6 @@ sv: currypasta, curry pasta
 description:en: CURRY PASTE usually refers to a paste used as a cooking ingredient in the preparation of a curry.
 wikidata:en: Q5195232
 wikipedia:en: https://en.wikipedia.org/wiki/Curry_paste
-# ingredient/en:curry-paste has 39 products in 1 language @2020-06-08
 
 < en: curry paste
 en: red curry paste
@@ -69930,7 +68497,6 @@ nn: raud karripasta
 pl: czerwona pasta curry
 sv: röd currypasta
 wikidata:en: Q67201118
-# ingredient/en:red-curry-paste has 66 products in 1 language @2020-06-08
 
 ###################################################################################################
 #
@@ -70128,7 +68694,6 @@ usda_ndb_name:en: Spices, turmeric, ground
 #<en:turmeric extract
 #bg:натурален екстракт от куркума
 #fr:extrait naturel de curcuma
-# fr:extrait-naturel-de-curcuma has 23 products in 1 language @2018-10-11
 
 ###################################################################################################
 #
@@ -70205,7 +68770,6 @@ usda_ndb_proxy_code:en: 2025
 usda_ndb_proxy_name:en: Spices, nutmeg, ground
 wikidata:en: Q83165
 wikipedia:en: https://en.wikipedia.org/wiki/Nutmeg
-# 6807 in 22 @202109-23
 
 < en: nutmeg
 en: nutmeg nut
@@ -70330,7 +68894,6 @@ ciqual_proxy_food_name:en: Cardamom, powder
 usda_ndb_code:en: 2006
 usda_ndb_name:en: Spices, cardamom
 wikipedia:en: https://en.wikipedia.org/wiki/Cardamom
-# en:cardamon has 416 products in 12 languages @2018-10-24
 
 < en: cardamom
 en: green cardamom, elettaria cardamomum
@@ -70532,7 +69095,6 @@ ciqual_proxy_food_name:fr: Cannelle, poudre
 usda_ndb_proxy_code:en: 2010
 usda_ndb_proxy_name:en: Spices, cinnamon, ground
 wikidata:en: Q28165
-# fr:cannelle has 1851 products in 14 languages @2018-10-24
 
 #comment:en:kept for ciqual
 < en: cinnamon
@@ -70616,7 +69178,6 @@ nl: Ceylonkaneel
 description:en: CINNAMOMUM VERUM, called true cinnamon tree or Ceylon cinnamon tree is a small evergreen tree belonging to the family Lauraceae, native to Sri Lanka.
 wikidata:en: Q370239
 wikipedia:en: https://en.wikipedia.org/wiki/Cinnamomum_verum
-# 58 in 6 @2021-09-20
 
 
 ###################################################################################################
@@ -70732,7 +69293,6 @@ description:en: CLOVEs are the aromatic flower buds of a tree in the family Myrt
 usda_ndb_proxy_code:en: 2011
 usda_ndb_proxy_name:en: Spices, cloves, ground
 wikipedia:en: https://en.wikipedia.org/wiki/Clove
-# 4654 in 26 @2021-09-21
 
 < en: clove
 en: ground clove
@@ -70840,7 +69400,6 @@ usda_ndb_proxy_code:en: 2019
 usda_ndb_proxy_name:en: Spices, fenugreek seed
 wikidata:en: Q133205
 wikipedia:en: https://en.wikipedia.org/wiki/Fenugreek
-# fr:fenugrec has 171 products in 5 languages @2018-10-23
 
 < en: fenugreek
 en: fenugreek leaf, fenugreek leaves
@@ -70865,7 +69424,6 @@ fr: feuille de fenugrec séchée
 hr: osušeni list piskavice
 it: foglie di fieno greco essiccate
 nl: gedroogd fenegriekblad
-# en:dried-fenugreek-leaves has 6 products in 2 languages @2018-10-23
 
 < en: fenugreek
 < en: seed
@@ -70958,7 +69516,6 @@ sv: galanga
 zh: 高良薑
 wikidata:en: Q734727
 wikipedia:en: https://en.wikipedia.org/wiki/Galangal
-# fr:galanga has 122 products in 6 languages @2018-10-25
 
 < en: galangal
 en: black galangal
@@ -71115,7 +69672,6 @@ usda_ndb_proxy_code:en: 11216
 usda_ndb_proxy_name:en: Ginger root, raw
 wikidata:en: Q35625
 wikipedia:en: https://en.wikipedia.org/wiki/Ginger
-# en:gingembre has 1506 products in 8 languages @2018-10-25
 
 < en: ginger
 en: raw ginger
@@ -71156,7 +69712,6 @@ ciqual_food_name:fr: Gingembre, poudre
 usda_ndb_code:en: 2021
 usda_ndb_name:en: Spices, ginger, ground
 wikidata:en: Q58183281
-# 923 in 12 @2021-09-28
 
 #processing:en: en:puree
 #<en:ginger
@@ -71168,7 +69723,6 @@ wikidata:en: Q58183281
 #it:purea di zenzero
 #nl:gemberpuree
 #sv:ingefärspuré, ingefära puré
-# fr:purée-de-gingembre has 118 products in 6 languages @2018-10-25
 
 < en: ginger
 en: ginger paste
@@ -71178,8 +69732,6 @@ fr: Pâte de gingembre
 hr: pasta od đumbira
 it: pasta di zenzero
 pl: pasta imbirowa
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:inkiv%C3%A4%C3%A4ritahna
-# 1 entry @ 2019-10-31
 
 #processing:en: en:juice
 #<en:ginger
@@ -71190,7 +69742,6 @@ pl: pasta imbirowa
 #fr:Jus de gingembre
 #hr:sok od đumbira
 #sv:ingefärsjuice
-# ingredient/en:ginger-juice has 304 products in 2 languages @2020-05-23
 
 #processing:en: en:extract
 < en: ginger
@@ -71331,7 +69882,6 @@ vegan:en: maybe
 vegetarian:en: yes
 wikidata:en: Q131748
 wikipedia:en: https://en.wikipedia.org/wiki/Mustard_(condiment)
-# 20828 in 37 @2021-09-09
 
 < en: mustard
 en: American mustard
@@ -71386,7 +69936,6 @@ usda_ndb_proxy_name:en: Spices, mustard seed, ground
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q1937700
-# 12112 in 26 @2019-09-09
 
 #<en:mustard seed
 #fr:Graines de moutarde issues de l'agriculture durable
@@ -71444,7 +69993,6 @@ fr: graines de moutarde jaune et brune
 hr: žute i smeđe sjemenke gorušice
 it: semi di senape gialla e marrone
 sv: gult och brunt senapsfrö
-# ingredient/fr:graines-de-moutarde-jaune-et-brune has 11 products in 1 language @2020-06-11
 
 #processing:en: en:powder
 < en: mustard seed
@@ -71468,8 +70016,6 @@ sv: senapspulver, senapsfröpulver
 usda_ndb_code:en: 2024
 usda_ndb_name:en: Spices, mustard seed, ground
 wikidata:en: Q57655865
-# fr:farine-de-moutarde has 127 products in 5 languages @2018-09-22
-# fr:moutarde-en-poudre has 34 products in 4 languages @2018-10-25
 
 #<en:mustard flour
 #en:yellow mustard flour
@@ -71510,7 +70056,6 @@ description:fr: La moutarde de Dijon est une moutarde française originaire de l
 description:pt: A mostarda de Dijon é uma variedade de mostarda forte muito usada na culinária francesa.
 wikidata:en: Q204226
 wiktionary:en: Dijon_mustard
-# 3445 in 9 @2021-09-10
 
 < en: strong mustard
 < fr: moutarde de dijon
@@ -71525,14 +70070,12 @@ fr: moutarde forte
 hr: jaka gorušica
 it: senape forte
 nl: sterke mosterd
-# 34 in 2 @2021-09-10
 
 < en: mustard
 fr: moutarde à l'ancienne
 bg: еднозърнеста горчица
 nl: ambachtelijke mosterd
 sv: gammaldags senap
-# 389 in 5 @2021-09-10
 
 < en: flavouring
 < en: mustard
@@ -71567,7 +70110,6 @@ uk: Рожевий перець
 description:en: A PINK PEPPERCORN is a dried berry of the shrub Schinus molle, commonly known as the Peruvian peppertree. Although a peppercorn is the dried fruit of a plant from the genus Piper, pink peppercorns came to be called such because they resemble peppercorns, and because they, too, have a peppery flavour. As they are members of the cashew family, they may cause allergic reactions including anaphylaxis for persons with a tree nut allergy.
 wikidata:en: Q2497744
 wikipedia:en: https://en.wikipedia.org/wiki/Pink_peppercorn
-# ingredient/fr:baies-roses has 141 products in 5 languages @2019-04-16
 # usage:fr:épice (baies roses)
 
 # description:en:A spice commonly called star anise, staranise, star anise seed, Chinese star anise, or badian that closely resembles anise in flavor is obtained from the star-shaped pericarps of the fruit of I. verum which are harvested just before ripening. Star anise contains anethole, the same compound that gives the unrelated anise its flavor. Star anise is an ingredient of the traditional five-spice powder of Chinese cooking.
@@ -71621,8 +70163,6 @@ uk: Бодян справжній
 vi: Đại hồi
 wa: Anisse-sitoele
 zh: 八角
-# fr:anis-étoilé has 72 products in 4 languages @2018-10-24
-# ingredient/fr:badiane has 121 products in 3 languages @2019-04-26
 carbon_footprint_fr_foodges_ingredient:fr: Anis - Badiane
 carbon_footprint_fr_foodges_value:fr: 2.7
 # hak:Pat-kok
@@ -71654,7 +70194,6 @@ ro: cimbru
 sv: kyndel
 wikidata:en: Q19787919
 wikipedia:en: https://en.wikipedia.org/wiki/Summer_savory
-# 739 in 7 @2021-09-17
 
 < en: coriander
 < en: herb
@@ -71681,7 +70220,6 @@ eurocode_2_group_3:en: 12.20.38
 usda_ndb_proxy_code:en: 11165
 usda_ndb_proxy_name:en: Coriander (cilantro) leaves, raw
 wikidata:en: Q65523167
-# 4528 in 9 @2021-09-28
 
 < en: coriander leaf
 en: fresh raw coriander leaf
@@ -71695,7 +70233,6 @@ ifct_food_name:en: Coriander, leaves
 usda_ndb_code:en: 11165
 usda_ndb_name:en: Coriander (cilantro) leaves, raw
 wikidata:en: Q65523167
-# 4528 in 9 @2021-09-28
 
 # processing:en: en:dried
 < en: coriander leaf
@@ -71838,7 +70375,6 @@ usda_ndb_proxy_name:en: Dill weed, fresh
 wikidata:en: Q59659860
 #plant: wikidata:en:q26686
 wikipedia:en: https://en.wikipedia.org/wiki/Dill
-# 2303 in 24 @2021-09-16
 
 < en: dill
 en: fresh dill
@@ -71870,7 +70406,6 @@ usda_ndb_name:en: Spices, dill seed
 #en:organic dill seed
 #fi:luomu tillinsiemen
 #nl:biologisch dillezaad
-# ingredient/nl:biologisch-dillezaad has 1 product @2019-05-24
 
 #processing:en: en:dried
 #<en:dill
@@ -72002,7 +70537,6 @@ usda_ndb_proxy_code:en: 2063
 usda_ndb_proxy_name:en: Rosemary, fresh
 wikidata:en: Q68315046
 wikipedia:en: https://en.wikipedia.org/wiki/rosemary
-# 4543 in 27 @2021-09-16
 
 < en: rosemary
 en: fresh rosemary
@@ -72047,14 +70581,10 @@ usda_ndb_name:en: Spices, rosemary, dried
 #pt:extratos de rosmaninho, extractos de rosmaninho
 #ro:extract de rozmarin
 #sv:rosmarinextrakt, extrakt av rosmarin
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-romarin
-# 1304 products in 9 languages @2018-10-09
 
 #<en:extracts of rosemary
 #fr:extrait naturel de romarin
 #fi:luontainen rosmariiniuute
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-naturel-de-romarin
-# 70 products in 1 language @2018-10-09
 
 ###################################################################################################
 #
@@ -72118,7 +70648,6 @@ usda_ndb_proxy_code:en: 11972
 usda_ndb_proxy_name:en: Lemon grass (citronella), raw
 wikidata:en: Q33913
 wikipedia:en: https://en.wikipedia.org/wiki/Cymbopogon
-# ingredient/lemongrass has 713 products in 10 languages @2019-05-17
 
 < en: lemongrass
 en: raw lemongrass
@@ -72219,7 +70748,6 @@ zh: 薄荷
 ciqual_food_code:en: 11027
 ciqual_food_name:en: Mint, fresh
 ciqual_food_name:fr: Menthe, fraîche
-# 4098 in 25 @2021-10-11
 eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.54
 # ang:minte
@@ -72257,8 +70785,6 @@ it: foglio di menta, foglie di menta intere
 pl: liść mięty, liście mięty
 ifct_food_code:en: G016
 ifct_food_name:en: Mint leaves
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/mint-leaves
-# 50 products in 2 languages @2018-10-10
 
 < en: mint
 en: mint oil
@@ -72336,7 +70862,6 @@ usda_ndb_proxy_code:en: 2066
 usda_ndb_proxy_name:en: Spearmint, dried
 wikidata:en: Q160114
 wikipedia:en: https://en.wikipedia.org/wiki/Spearmint
-# 289 in 11 @2021-10-11
 
 < en: spearmint
 en: fresh spearmint
@@ -72433,8 +70958,6 @@ usda_ndb_proxy_code:en: 2064
 usda_ndb_proxy_name:en: Peppermint, fresh
 wikidata:en: Q156037
 wikipedia:en: https://en.wikipedia.org/wiki/Peppermint
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/peppermint
-# 510 products in 6 languages @2018-10-10
 
 < en: peppermint
 en: fresh peppermint
@@ -72483,7 +71006,6 @@ pl: olejek z mięty pieprzowej
 pt: óleo de hortelã-pimenta
 ru: масло мяты перечной
 sv: pepparmintolja, pebermynte olie
-# 1088 in 14 @2021-10-11
 
 #<en:peppermint oil
 ##en:organic peppermint oil
@@ -72492,7 +71014,6 @@ sv: pepparmintolja, pebermynte olie
 #fi:luomu piparminttuöljy
 #fr:huile de menthe poivrée biologique
 #nl:biologische pepermuntolie
-# ingredient/nl:biologische-pepermuntolie has 1 product @2019-05-24
 # usage:nl:natuurlijk aroma (biologische pepermuntolie)
 
 < en: mint
@@ -72502,8 +71023,6 @@ fr: menthe douce
 hr: slatka metvica
 it: menta dolce
 pt: hortelã-comum
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:menthe-douce
-# 156 in 7 @2021-10-11
 
 
 # description:en:The dried fruits of some sumac species are ground to produce a tangy, crimson spice popular in many countries.
@@ -72673,7 +71192,6 @@ usda_ndb_processing:en: en:dried
 #plant: wikidata:en:Q155814
 wikidata:en: Q103554747
 wikipedia:en: https://en.wikipedia.org/wiki/Tarragon
-# 779 in 15 @2021-09-16
 
 < en: tarragon
 en: fresh tarragon
@@ -72690,7 +71208,6 @@ ciqual_food_name:fr: Estragon, frais
 #fi:rakuunan lehti, rakuunan lehdet
 #fr:feuille d’estragon
 #nl:dragonblad
-# ingredient/tarragon-leaves has 8 products in 2 languages @2019-05-17
 
 
 ###################################################################################################
@@ -72752,7 +71269,6 @@ usda_ndb_proxy_code:en: 2049
 usda_ndb_proxy_name:en: Thyme, fresh
 wikidata:en: Q3215980
 wikipedia:en: https://en.wikipedia.org/wiki/Thyme
-# 7086 in 18 @2021-09-16
 
 < en: thyme
 en: fresh thyme
@@ -72770,7 +71286,6 @@ usda_ndb_name:en: Thyme, fresh
 #fr:thym bio
 #it:timo bio
 #nl:biologische tijm
-# ingredient/fr:thym-bio has 10 products in 3 languages @2019-05-25
 
 #processing:en: en:dried kept here due to nutrition ciqual
 < en: thyme
@@ -72801,7 +71316,6 @@ usda_ndb_name:en: Spices, thyme, dried
 #es:extracto de tomillo
 #fi:timjamiuute
 #fr:extrait de thym
-# en:thyme-extract has 27 products in 1 language @2018-10-10
 
 ###################################################################################################
 #
@@ -72854,7 +71368,6 @@ zh: 马鞭草
 # zh-tw:馬鞭草
 wikidata:en: Q161417
 wikipedia:en: https://en.wikipedia.org/wiki/Verbena_officinalis
-# fr:verveine has 106 products in 6 languages @2018-10-15
 
 < en: verbena
 en: organic verbena
@@ -72863,7 +71376,6 @@ fr: verveine bio
 hr: organska verbena
 it: verbena biologica
 nl: biologisch ijzerhard
-# ingredient/fr:verveine-bio has 12 products in french @2019-05-25
 
 < en: verbena
 fr: feuilles de verveine
@@ -73115,8 +71627,6 @@ usda_ndb_proxy_code:en: 2044
 usda_ndb_proxy_name:en: Basil, fresh
 wikidata:en: Q38859
 wikipedia:en: https://en.wikipedia.org/wiki/Basil
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:basilic
-# 3605 products in 14 languages @2108-10-10
 
 < en: basil
 en: Fresh basil
@@ -73149,8 +71659,6 @@ hr: sušeni bosiljak
 it: basilico essiccato
 nl: gedroogde basilicum
 pl: bazylia suszona, suszona bazylia
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/dried-basil
-# 64 products in 4 languages @2018-10-10
 ciqual_food_code:en: 11032
 ciqual_food_name:en: Basil, dried
 ciqual_food_name:fr: Basilic, séché
@@ -73169,8 +71677,6 @@ it: Estratto di basilico
 nl: basilicumextract
 pl: ekstrakt z bazylii, wyciąg z bazylii
 pt: extrato de manjericão, extracto de manjericão
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-basilic
-# 32 products in 4 languages @2108-10-10
 
 < en: basil
 fr: basilic en poudre
@@ -73236,7 +71742,6 @@ usda_ndb_proxy_code:en: 2008
 usda_ndb_proxy_name:en: Spices, chervil, dried
 wikidata:en: Q21281535
 wikipedia:en: https://en.wikipedia.org/wiki/Chervil
-# 392 in 8 @2021-09-15
 
 < en: chervil
 en: fresh chervil
@@ -73325,7 +71830,6 @@ usda_ndb_proxy_code:en: 2038
 usda_ndb_proxy_name:en: Spices, sage, ground
 wikidata:en: Q1111359
 wikipedia:en: https://en.wikipedia.org/wiki/Salvia_officinalis
-# 1379 in 15 @2021-09-16
 
 < en: sage
 en: fresh sage
@@ -73433,8 +71937,6 @@ sr: Selen
 sv: Libbsticka
 uk: Любисток лікарський
 zh: 欧当归
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:livèche
-# 241 products in 5 languages @2018-10-10
 eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.48
 # csb:Lëbiszk
@@ -73471,7 +71973,6 @@ it: radice di levistico
 nl: lavaswortel
 pl: korzeń lubczyku, korzeń lubczyka
 sv: libbstickarot
-# ingredient/fr:racine-de-liveche has 40 products in 4 languages @2020-05-24
 
 ###################################################################################################
 #
@@ -73550,8 +72051,6 @@ zh: 矢車菊
 # zh-sg:矢車菊
 # zh-tw:矢車菊
 wikidata:en: Q156921
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:bleuets
-# 23 products @2018-10-10
 
 # Comment:en:In french bleuets are either en:cornflower or en:blueberry
 
@@ -73634,7 +72133,6 @@ openfoodfacts:en: https://world.openfoodfacts.org/ingredient/fr:soucis
 wikidata:en: Q145930
 # wikidata:en:Q147281
 wikipedia:en: https://en.wikipedia.org/wiki/Calendula_officinalis
-# 2 products in 3 languages @2018-10-10
 
 < en: herb
 en: sweet woodruff, woodruff
@@ -73737,7 +72235,6 @@ usda_ndb_proxy_name:en: Spices, marjoram, dried
 wikidata:en: Q96181239
 # plant: wikidata:en:Q22694
 wikipedia:en: https://en.wikipedia.org/wiki/Marjoram
-# 1584 in 22 @2021-09-17
 
 < en: marjoram
 en: dried marjoram
@@ -73774,7 +72271,6 @@ ciqual_food_code:en: 11060
 ciqual_food_name:en: Provence herbs, dried
 ciqual_food_name:fr: Herbes de Provence, séchées
 wikidata:en: Q913548
-# 1290 in 9 @2021-09-17
 
 
 ###################################################################################################
@@ -73817,7 +72313,6 @@ eurocode_2_group_3:en: 12.20.58
 #plant: wikipedia:en:Q134283
 wikipedia:en: Q92581152
 # plante:https://fr.wikipedia.org/wiki/Origanum_vulgare
-# 9423 in 29 @2021-09-17
 
 #processing:en:dehydrated
 < en: oregano
@@ -73832,7 +72327,6 @@ ciqual_food_name:en: Oregano, dried
 ciqual_food_name:fr: Origan, séché
 usda_ndb_code:en: 2027
 usda_ndb_name:en: Spices, oregano, dried
-# ingredient/fr:origan-déshydraté has 57 products in french @2018-12-29
 
 #processing:en en:powder
 #<en:oregano
@@ -73917,8 +72411,6 @@ usda_ndb_code:en: 2004
 usda_ndb_name:en: Spices, bay leaf
 wikidata:en: Q2370943
 wikipedia:en: https://en.wikipedia.org/wiki/Bay_leaf
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:laurier
-# 3758 in 22 @2021-09-19
 
 < en: bay leaf
 en: bay leaf extract
@@ -74067,7 +72559,6 @@ eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.24
 wikidata:en: Q14169150
 wikipedia:en: https://en.wikipedia.org/wiki/Chamomile
-# ingredient/fr:camomille has 92 products in 4 languages @2018-12-28
 
 < en: camomile
 en: camomile flower
@@ -74153,7 +72644,6 @@ vi: chi ngưu bàng
 zh: 牛蒡属
 wikidata:en: Q27257
 wikipedia:en: https://en.wikipedia.org/wiki/Arctium
-# ingredient/fr:bardane has 11 products in 1 language @2020-06-13
 
 # description:en:Capparis spinosa, the caper bush is best known for the edible flower buds (capers), often used as a seasoning, and the fruit (caper berries)
 
@@ -74183,7 +72673,6 @@ usda_ndb_proxy_code:en: 2054
 usda_ndb_proxy_name:en: Capers, canned
 wikidata:en: Q3229775
 wikipedia:en: https://en.wikipedia.org/wiki/Caper
-# ingredient/fr:câpre has 494 products in 6 languages @2018-12-4
 
 < en: capers
 en: canned capers
@@ -74342,7 +72831,6 @@ zh: 芫荽
 description:en: Coriander (Coriandrum sativum), also known as cilantro or Chinese parsley, is an annual herb in the family Apiaceae.
 wikidata:en: Q41611
 wikipedia:en: https://en.wikipedia.org/wiki/Coriander
-# ingredient/fr:coriander has 2255 products in 13 languages @2018-12-05
 
 < en: coriander
 en: coriander flavour, coriander aroma
@@ -74350,7 +72838,6 @@ da: koriandersmag, korianderaroma
 es: aroma de cilantro
 fr: arôme de coriandre
 sv: koriandersmak, korianderarom
-# ingredient/fr:arôme de coriandre has 1 products in 2 languages @2018-12-05
 
 < en: coriander
 en: coriander paste
@@ -74361,7 +72848,6 @@ fr: Pâte de coriandre
 hr: pasta od korijandera
 it: pasta di coriandolo
 sv: korianderpasta
-# ingredient/fi:korianteritahna has 1 product in 1 language @2020-06-13
 
 < en: plant
 fr: feuilles de mûrier
@@ -74433,7 +72919,6 @@ zh: 瓜拿納
 # zh-tw:瓜拿納
 wikidata:en: Q209089
 wikipedia:en: https://en.wikipedia.org/wiki/Guarana
-# ingredient/fr:guarana has 43 products in 4 languages @2019-01-27
 
 < en: guarana
 en: guarana extract
@@ -74447,7 +72932,6 @@ it: estratto di guarana
 nl: guarana-extract
 ru: экстракт гуараны
 sv: guaranaextrakt
-# ingredient/fr:extrait-de-guarana has 53 products in 4 languages @2019-01-27
 # guarana extract (maltodextrin, guarana extract)
 
 < en: guarana
@@ -74459,7 +72943,6 @@ fr: extrait de graine de guarana
 hr: ekstrakt sjemena guarane
 it: estratto di semi di guaranà
 sv: guaranafröextrakt
-# ingredient/en:guarana-seed-extract has 142 products in 1 language @2020-05-23
 
 < en: guarana
 de: Guaranasamenpulver
@@ -74505,7 +72988,6 @@ sr: hmelj
 sv: humle
 uk: Хміль
 xh: Ii-hops
-# ingredient/fr:houblon has 949 products in 26 languages @2018-12-01
 eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.38
 # en-ca:Hops
@@ -74530,7 +73012,6 @@ nl: hopextract
 pl: ekstrakt z chmielu
 pt: extrato de lupolo, extracto de lupolo
 sk: chmelovy extract
-# ingredient/fr:extrait-de-houblon has 155 products in 15 languages @2018-12-01
 
 < en: hops
 en: hops flavour
@@ -74564,7 +73045,6 @@ fi: humalaöljy
 hr: ulje od hmelja
 it: olio di luppolo
 sv: humleolja
-# ingredient/en:hop-oil has 1 product in 1 language @2020-06-13
 
 < en: hops
 en: processed hops
@@ -74657,7 +73137,6 @@ zh: 刺柏
 # war:Franc pectî
 wikidata:en: Q26325
 wikipedia:en: https://en.wikipedia.org/wiki/Juniper
-# ingredient/fr:genièvre has 75 products in 4 languages @2019-03-30
 
 
 # description:en:A JUNIPER BERRY is the female seed cone produced by the various species of junipers. Juniper berries are used in northern European and particularly Scandinavian cuisine to "impart a sharp, clear flavor" to meat dishes. Besides Norwegian and Swedish dishes, juniper berries are also sometimes used in German, Austrian, Czech, Polish and Hungarian cuisine, often with roasts (such as German sauerbraten). Northern Italian cuisine, especially that of the South Tyrol, also incorporates juniper berries.
@@ -74774,7 +73253,6 @@ zh: 薰衣草
 # zh-tw:薰衣草
 wikidata:en: Q171892
 wikipedia:en: https://en.wikipedia.org/wiki/Lavandula
-# ingredient/lavender has 99 products in 4 languages @2019-01-21
 
 < en: lavender
 en: lavender flower, lavender flowers
@@ -74788,7 +73266,6 @@ it: fiore di lavanda
 nb: lavendelblomst
 nl: lavendelbloem
 sv: lavendelblomma
-# ingredient/fr:fleurs-de-lavande has 23 products in 5 languages @2020-06-13
 
 
 # description:en:LEMON BALM (Melissa officinalis), is a perennial herbaceous plant in the mint family Lamiaceae. Lemon balm is used as a flavouring in ice cream and herbal teas, both hot and iced, often in combination with other herbs such as spearmint. In alternative medicine it is used as a sleep aid and digestive aid.
@@ -74847,7 +73324,6 @@ th: สะระแหน่
 uk: Меліса лікарська
 vi: Tía tô đất
 zh: 蜜蜂花
-# ingredient/fr:mélisse has 118 products in 5 languages @2019-04-27
 eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.42
 # azb:درمان لیمون اوْتو
@@ -74913,7 +73389,6 @@ it: Fiori di tiglio
 nl: Linde, lindebloesem
 wikidata:en: Q127849
 wikipedia:en: https://en.wikipedia.org/wiki/Tilia
-# ingredient/fr:tilleul has 109 products in 4 languages @2019-01-23
 
 
 ###################################################################################################
@@ -74986,7 +73461,6 @@ hr: ekstrakt korijena panaks ginsenga, panax ginseng
 it: estratto di radice di Panax ginseng
 ru: экстракт женьшеня
 sv: panax ginseng rotextrakt
-# ingredient/en:panax-ginseng-root-extract has 117 products in 2 languages @2020-05-21
 
 ###################################################################################################
 #
@@ -75080,8 +73554,6 @@ description:en: LIQUORICE or licorice is the root of Glycyrrhiza glabra from whi
 # yue:洋甘草
 wikidata:en: Q257106
 wikipedia:en: https://en.wikipedia.org/wiki/Liquorice
-# ingredient/fr:réglisse has 237 products in 6 languages @2018-12-28
-# category/liquorice has 27 products @2019-05-22
 
 < en: liquorice
 en: organic liquorice
@@ -75092,7 +73564,6 @@ fr: réglisse bio
 hr: organski sladić
 it: liquirizia biologica
 nl: biologisch zoethout
-# ingredient/nl:biologisch-zoethout has 1 product @2019-05-24
 
 < en: liquorice
 en: liquorice extract
@@ -75107,11 +73578,9 @@ nb: lakrisekstrakt
 nl: Zoethoutextract
 pt: extrato de alcaçuz, extracto de alcaçuz
 sv: lakritsextrakt, lakritsexstrakt
-# ingredient/fr:extrait-de-réglisse has 137 products in 9 languages @2018-12-28
 
 < en: liquorice extract
 fr: suc de réglisse
-# ingredient/fr:suc-de-réglisse has 56 products in 4 languages @2018-12-28
 
 < en: liquorice
 en: liquorice root, licorice root
@@ -75124,7 +73593,6 @@ it: radice di liquirizia
 nb: lakrisrot
 nl: Zoethoutwortel
 sv: lakritsrot
-# ingredient/fr:racine-de-réglisse has 51 products in 4 languages @2018-12-28
 
 < en: liquorice root
 en: liquorice root extract
@@ -75162,7 +73630,6 @@ fi: lakritsipasta
 hr: pasta od sladića
 it: pasta di liquirizia
 sv: lakritspasta
-# ingredient/fi:lakritsipasta has 1 product in 3 languages @2020-12-21
 
 ###################################################################################################
 #
@@ -75312,7 +73779,6 @@ description:en: Mate is a traditional South American caffeine-rich infused drink
 # zh-tw:瑪黛茶
 wikidata:en: Q203540
 wikipedia:en: https://en.wikipedia.org/wiki/Mate_(drink)
-# ingredient/fr:mate has 39 products @2019-05-27
 
 < en: mate
 en: organic yerba mate leaves, organic yerba mate
@@ -75383,7 +73849,6 @@ zh: 旋果蚊草子
 # kbd:Сэтэней
 wikidata:en: Q147176
 wikipedia:en: https://en.wikipedia.org/wiki/Filipendula_ulmaria
-# fr:reine-des-prés has 37 products in 1 language @2018-10-15
 
 
 # description:en:The olive, known by the botanical name Olea europaea, is a species of small tree in the family Oleaceae
@@ -75430,7 +73895,6 @@ th: นํ้า
 tr: zeytin
 tt: зәйтүн
 zh: 阿塞图纳
-# ingredient/olive has 2637 products in 9 languages @2018-12-01
 carbon_footprint_fr_foodges_ingredient:fr: Olives "Pays du Sud" en boite
 carbon_footprint_fr_foodges_value:fr: 1.7
 ciqual_food_code:en: 13184
@@ -75485,7 +73949,6 @@ pl: zielone oliwki, zielona oliwka, zielonych oliwek, oliwki zielone
 ru: Зелёные оливки
 sv: gröna oliver
 tr: yeşil zeytin
-# ingredient/fr:olive-verte has 577 products in 6 languages @2018-12-01
 ciqual_food_code:en: 13033
 ciqual_food_name:en: Olives, green, in brine
 wikidata:en: Q26879770
@@ -75498,7 +73961,6 @@ fr: olives vertes dénoyautées
 hr: zelene masline bez koštice
 it: olive verdi denocciolate
 nl: ontpitte groene olijven
-# ingredient/fr:olives-vertes-dénoyautées has 129 products in 4 languages @2018-12-01
 
 < en: green olive
 en: green olives with pits
@@ -75517,7 +73979,6 @@ fr: olives vertes et noires
 hr: zelene i crne masline
 it: olive verdi e nere
 no: grønne og svarte oliven
-# ingredient/fr:olives-vertes-et-noires has 22 products in 3 languages @2018-12-01
 
 < en: olive
 en: black olive
@@ -75536,7 +73997,6 @@ pl: czarne oliwki, czarna oliwka, czarnych oliwek, oliwka czarna, oliwki czarne
 pt: azeitonas pretas
 sv: svarta oliver
 tr: siyah zeytin
-# ingredient/black-olive has 872 products in 7 languages @2018-12-01
 # ciqual_food_code:en:13032
 # ciqual_food_name:en:Olives, black, in brine
 ciqual_food_code:en: 13186
@@ -75551,7 +74011,6 @@ it: aroma naturale di oliva
 
 < en: black olive
 fr: olives noires avec noyau
-# ingredient/fr:olives-noires-avec-noyau has 58 products in french @2018-12-01
 
 < en: black olive
 fr: olives noires confites entières
@@ -75577,8 +74036,6 @@ it: olive Kalamata
 pl: oliwki Kalamata, oliwek Kalamata
 wikidata:en: Q6350358
 wikipedia:en: https://en.wikipedia.org/wiki/Kalamata_olive
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:kalamataoliivi
-# 1 entry @ 2019-10-31
 
 < en: black olive
 en: kalamon olive
@@ -75591,7 +74048,6 @@ hr: kalamon maslina
 it: oliva Kalamon
 pl: oliwki kalamon
 sv: kalamonoliver
-# ingredient/fr:olives-noires-kalamon has 3 products in 1 language @2020-05-25
 
 < en: kalamon olive
 en: whole kalamon olive
@@ -75655,7 +74111,6 @@ de: Orangenblätter
 fr: feuilles d'oranger
 hr: narančasto lišće
 it: foglie d'arancio
-# ingredient/fr:feuilles-d'oranger has 65 products in 4@2019-04-13
 
 < en: plant
 en: orange blossom
@@ -75770,7 +74225,6 @@ zh: 奎寧
 # zh-tw:奎寧
 wikidata:en: Q189522
 wikipedia:en: https://en.wikipedia.org/wiki/Quinine
-# ingredient/fr:quinine has 111 products in 5 languages @2019-04-26
 # usage:en:flavourings (contains quinine)
 
 
@@ -75903,7 +74357,6 @@ zh: 南非茶
 # sr-ec:Роибос
 # sr-el:Roibos
 wikipedia:en: https://en.wikipedia.org/wiki/Rooibos
-# ingredient/fr:rooibos has 119 products in 10 languages @2019-04-23
 
 < en: rooibos
 fr: Rooibos d'Afrique du Sud
@@ -75916,7 +74369,6 @@ fr: rooibos biologique
 hr: organski rooibos
 it: rooibos biologico
 nl: biologische rooibos
-# ingredient/nl:biologische-rooibos has 1 product @2109-05-24
 
 # en:rose
 # fr:rose
@@ -75933,7 +74385,6 @@ hr: ružine latice
 it: petalo di rosa
 pl: płatki róży, płatki róż
 ro: petale de trandafiri
-# ingredient/en:rose-petals has 72 products in 4 languages @2018-12-29
 
 < en: rose petals
 en: rose water
@@ -75994,7 +74445,6 @@ usda_ndb_code:en: 9311
 usda_ndb_name:en: Roselle, raw
 wikidata:en: Q319390
 wikipedia:en: https://en.wikipedia.org/wiki/Roselle_(plant)
-# fr:fleurs-de-carcadé has 12 products in 3 languages @2018-10-15
 
 < en: roselle flower
 en: raw roselle
@@ -76067,7 +74517,6 @@ zh: 朱槿
 # zh_yue:大紅花
 wikidata:en: Q159534
 wikipedia:en: https://en.wikipedia.org/wiki/Hibiscus_rosa-sinensis
-# ingredient/fi:kiinanruusu has 2 products in 4 languages @2020-06-27
 
 # description:en:Safflower (Carthamus tinctorius) is a highly branched, herbaceous, thistle-like annual plant.
 
@@ -76154,7 +74603,6 @@ fr: fleur de carthame
 hr: cvijet šafranike
 it: fiore di cartamo
 pl: kwiat krokosza barwierskiego, kwiatu krokosza barwierskiego
-# ingredient/fr:fleur-de-carthame has 34 products in 4 languages @2019-03-13
 
 < en: concentrate
 < en: safflower
@@ -76169,7 +74617,6 @@ nl: saffloerconcentraat
 pl: koncentrat z krokosza barwierskiego, koncentrat krokosza barwierskiego
 sv: safflor koncentrat
 # ingredient/fr:concentré-de-carthame in 92 products in 6 languages @2019-03-13
-# ingredient/fr:extrait-de-carthame has 122 products @2019-03-13
 
 < en: safflower concentrate
 es: concentrado de cártamo con efecto colorante
@@ -76371,7 +74818,6 @@ ecobalyse_origins_en_european_union:en: sunflower-eu
 ecobalyse_origins_en_france:en: sunflower-fr
 wikidata:en: Q26949
 wikipedia:en: https://en.wikipedia.org/wiki/Helianthus
-# en:sunflower has 16610 products @2018-10-15
 
 < en: sunflower
 en: sprouted sunflower seeds
@@ -76605,7 +75051,6 @@ ciqual_food_name:fr: Thé infusé, non sucré
 # zh-sg:茶
 # zh-tw:茶
 wikipedia:en: https://en.wikipedia.org/wiki/Tea
-# ingredient/tea has 217 products in 5 languages @2019-04-21
 
 < en: tea
 en: tea leaf, tea leaves
@@ -76635,7 +75080,6 @@ nl: theeextract, thee-extract
 sr: ekstrakt čaja
 sv: te-extrakt
 # sr-el:ekstrakt čaja
-# ingredient/fr:extrait-de-thé has 109 products in 7 languages @2019-04-21
 
 en: Brewed oolong tea without sugar
 fr: Thé oolong infusé non sucré
@@ -76718,7 +75162,6 @@ ciqual_food_name:fr: Thé noir, infusé, non sucré
 # zh-tw:紅茶
 wikidata:en: Q203415
 wikipedia:en: https://en.wikipedia.org/wiki/Black_tea
-# ingredient/black-tea has 751 products in 13 languages @2019-04-22
 
 < en: black tea
 < en: herbal tea
@@ -76744,7 +75187,6 @@ fi: ceylonin musta tee
 fr: thé noir du Sri Lanka, thé noir Ceylan, Thé noir de Ceylan
 hr: cejlonski crni čaj
 it: tè nero di Ceylon
-# ingredient/fr:the-noir-ceylan has 14 products in french @2019-05-25
 
 < en: Ceylon black tea
 en: organic Ceylon black tea
@@ -76770,7 +75212,6 @@ hr: ekstrakt crnog čaja
 it: estratto di tè nero
 nl: zwarte thee extract
 pl: ekstrakt czarnej herbaty
-# ingredient/black-tea-extract has 200 products in 5 languages @2019-04-22
 
 # description:en:Green tea is a type of tea that is made from Camellia sinensis leaves and buds that have not undergone the same withering and oxidation process used to make oolong teas and black teas.
 
@@ -76860,7 +75301,6 @@ ciqual_food_name:fr: Thé vert, infusé, non sucré
 # zh-hk:綠茶
 wikidata:en: Q484083
 wikipedia:en: https://en.wikipedia.org/wiki/Green_tea
-# ingredient/green-tea has 902 products in 14 languages @2019-04-21
 
 < en: green tea
 en: matcha, matcha green tea, matcha tea
@@ -76920,7 +75360,6 @@ fr: thé vert Ceylan
 hr: cejlonski zeleni čaj
 it: tè verde di Ceylon
 nl: groene Ceylonthee
-# ingredient/fr:the-vert-ceylan has 13 products in 2 languages @2019-05-25
 
 < en: green tea
 en: green tea from China
@@ -76947,7 +75386,6 @@ pl: ekstrakt z zielonej herbaty
 pt: extrato de ché verde, extracto de ché verde
 ru: экстракт зеленого чая
 sv: grönt te-extrakt
-# ingredient/fr:extrait-de-thé-vert has 189 products in 9 languages @2019-04-21
 
 < en: green tea extract
 en: green tea extract powder
@@ -76972,7 +75410,6 @@ fr: thé blanc
 hr: bijeli čaj
 it: tè bianco
 pl: biała herbata, herbata biała
-# ingredient/en:white-tea has 77 products @2023-07-01
 
 < en: elderflower
 < en: white tea
@@ -77086,7 +75523,6 @@ zh: 香草
 # yue:雲呢拿
 wikidata:en: Q13241
 wikipedia:en: https://en.wikipedia.org/wiki/Vanilla
-# ingredient/vanilla has 4542 products in 14 languages @2019-02-24
 # en:process:en:powdered
 
 < en: vanilla
@@ -77100,7 +75536,6 @@ it: Vaniglia naturale
 nl: Natuurlijke vanille
 pt: Baunilha natural
 ru: натуральная ваниль
-# ingredient/fr:vanille-naturelle has 113 products in 3 languages @2019-02-24
 
 < en: vanilla
 en: pure vanilla
@@ -77118,7 +75553,6 @@ hr: bourbon vanilije, burbon vanilije
 it: vaniglia Bourbon
 nl: bourbonvanille, Bourbon vanille
 pl: wanilia bourbon, bourbon wanilia
-# ingredient/fr:vanille-bourbon has 150 products in 4 languages @2019-02-24
 
 < en: Bourbon vanilla
 < en: preparation
@@ -77141,7 +75575,6 @@ pt: vanille em pó
 sv: vaniljpulver
 ciqual_proxy_food_code:en: 11057
 ciqual_proxy_food_name:en: Vanilla, pod
-# ingredient/fr:vanille-en-poudre has 110 products in 10 languages @2019-02-24
 
 < en: Bourbon vanilla
 < en: vanilla powder
@@ -77195,7 +75628,6 @@ ciqual_proxy_food_name:fr: Vanille, extrait alcoolique
 usda_ndb_code:en: 2050
 usda_ndb_name:en: Vanilla extract
 wikidata:en: Q10749869
-# 13922 in 35 @2021-10-04
 
 < en: vanilla extract
 en: pure vanilla extract
@@ -77205,7 +75637,6 @@ fi: puhdas vaniljauute
 fr: extrait pur de vanille
 hr: čisti ekstrakt vanilije
 it: estratto puro di vaniglia
-# ingredient/fr:extrait-pur-de-vanille has 65 products in 5 languages @2019-02-24
 
 < en: natural extract
 < en: vanilla extract
@@ -77226,7 +75657,6 @@ ro: extract natural de vanilie
 sr: prirodni ekstrakt vanile
 sv: naturlig vaniljextrakt
 zh: 天然香草精精
-# ingredient/fr:extrait-naturel-de-vanille has 559 products in 13 languages @2019-02-24
 
 < en: Bourbon vanilla
 < en: vanilla extract
@@ -77243,7 +75673,6 @@ nl: Bourbon vanille-extract
 pl: ekstrakt z wanilii bourbon, ekstrakt wanilii bourbon
 ro: extract de vanilie Bourbon
 sv: bourbon vaniljextrakt
-# ingredient/fr:extrait-de-vanille-bourbon has 236 products in 14 languages @2019-02-24
 
 # To make vanilla look like vanilla
 
@@ -77260,7 +75689,6 @@ nl: vanillestokje, vanillestokjes
 pl: laski wanilii, laska wanilii
 pt: vagem de baunilha
 sv: vaniljstång, vaniljböna
-# ingredient/fr:gousse-de-vanille has 207 products in 5 languages @2019-02-24
 carbon_footprint_fr_foodges_ingredient:fr: Gousse de Vanille
 carbon_footprint_fr_foodges_value:fr: 2.6
 
@@ -77278,7 +75706,6 @@ hr: mljevene mahune vanilije
 it: semi di vaniglia macinat, vaniglia in bacche macinata
 pl: kawałki wanilii, laska wanilii w proszku, mielona laska wanilii
 sv: mald vaniljstång, vaniljstångbitar
-# ingredient/fr:gousses-de-vanille-moulues has 45 products in 4 languages @2019-02-24
 
 < en: vanilla pod
 en: exhausted vanilla pod, exhausted vanilla bean
@@ -77287,7 +75714,6 @@ fr: gousse de vanille épuisée, gousses de vanille épuisées
 hr: iscrpljena mahuna vanilije
 it: baccello di vaniglia esausto
 nl: uitgeputte vanillestokjes, geëxtraheerde vanillestokjes, leeg vanillestokje
-# ingredient/fr:gousse-de-vanille-épuisée has 55 products in 3 languages @2019-02-24
 
 < en: exhausted vanilla pod
 en: exhausted ground vanilla pod, exhausted ground vanilla bean
@@ -77296,7 +75722,6 @@ fr: gousses de vanille épuisées broyées, gousses de vanille broyées épuisé
 hr: iscrpljena samljevena mahuna vanilije
 it: baccelli di vaniglia curati macinati
 nl: gemalen geëxtraheerde vanillestokjes
-# ingredient/fr:gousses-de-vanille-épuisées-broyées has 167 products in 9 languages @2019-02-24
 
 < en: Bourbon vanilla
 < en: exhausted ground vanilla pod
@@ -77314,15 +75739,12 @@ fi: bourbon-vaniljakodat
 fr: gousses de vanille bourbon, fève de vanille bourbon
 hr: sjemenke bourbon vanilije, vanilija štapić bourbon
 it: baccello di vaniglia Bourbon, bacche di vaniglia Bourbon, bourbon vanilla bean
-# ingredient/fr:gousses-de-vanille-bourbon has 50 products in 4 languages @2019-02-24
 
 < en: Bourbon vanilla beans
 fr: vanille bourbon naturelle en gousse
-# ingredient/fr:vanille-bourbon-naturelle-en-gousse has 27 products in french @2019-02-24
 
 # < en:Bourbon vanilla beans
 # de: gemahlene Bourbon-Vanilleschoten, Bourbon-Vanilleschote gemahlen  # see ingredients_processing.txt
-# ingredient/de:Bourbon-Vanilleschote-gemahlen has 7 products in 4 languages @2019-02-24
 
 < en: Bourbon vanilla beans
 de: Bourbonvanilleschotenextrakt
@@ -77344,7 +75766,6 @@ hr: sjemenke vanilije
 it: semi di vaniglia
 nl: vanillezaad, vanillezaadjes
 sv: vaniljfrö
-# ingredient/fr:graines-de-vanille has 42 products in 4 languages @2019-02-24
 
 < en: vanilla seeds
 en: exhausted vanilla seeds
@@ -77352,7 +75773,6 @@ de: Vanillesamen extrahiert
 fr: grains de vanille épuisés, grains de vanille épuisée, graines de vanille épuisées
 hr: iscrpljene sjemenke vanilije
 it: semi di vaniglia estratti
-# ingredient/fr:grains-de-vanille-épuisés has 31 products in 5 languages @2019-02-24
 
 < en: preparation
 < en: vanilla
@@ -77398,7 +75818,6 @@ zh: 山葵
 usda_ndb_code:en: 11990
 usda_ndb_name:en: Wasabi, root, raw
 wikipedia:en: https://en.wikipedia.org/wiki/Wasabi
-# ingredient/wasabi has 132 products in 5 languages @2019-03-13
 
 # description:en:RHODIOLA ROSEA (commonly golden root, rose root, roseroot, Aaron's rod, Arctic root, king's crown, lignum rhodium, orpin rose) is a perennial flowering plant in the family Crassulaceae.
 
@@ -77448,7 +75867,6 @@ zh: 红景天
 # war:rhodiola rosea
 wikidata:en: Q161665
 wikipedia:en: https://en.wikipedia.org/wiki/Rhodiola_rosea
-# ingredient/en:rhodiola-rosea has 8 products in 1 language @2020-06-13
 
 < en: berries
 en: Cape gooseberry, Cape gooseberries, goldenberry, goldenberries, golden berry, golden berries, Peruvian groundcherry, groundcherries, poha
@@ -77516,7 +75934,6 @@ zh: 睡茄
 # war:withania somnifera
 wikidata:en: Q852660
 wikipedia:en: https://en.wikipedia.org/wiki/Withania_somnifera
-# ingredient/en:ashwagandha has 16 products in 2 languages @2020-06-13
 
 < en: plant
 en: Yacón
@@ -77728,7 +76145,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q37868
 wikipedia:en: https://en.wikipedia.org/wiki/Algae
-# ingredient/algae has 135 products in 4 languages @2019-01-27
 
 < en: algae
 en: chlorella, chlorella algae
@@ -77774,7 +76190,6 @@ description:en: CHLORELLA is a genus of single-celled green algae belonging to t
 # pt-br:Clorela
 wikidata:en: Q133017
 wikipedia:en: https://en.wikipedia.org/wiki/Chlorella
-# fr:chlorella has 42 products in 3 languages @2018-10-28
 
 < en: algae
 en: spirulina
@@ -77813,7 +76228,6 @@ usda_ndb_code:en: 11666
 usda_ndb_name:en: Seaweed, spirulina, raw
 wikidata:en: Q285335
 wikipedia:en: https://en.wikipedia.org/wiki/Spirulina_(dietary_supplement)
-# ingredient/fr:spirulina has 61 products in 4 languages @2019-01-23
 # usage:en:concentrated extracts (Spirulina platensis, safflower flower)
 
 < en: spirulina
@@ -77824,7 +76238,6 @@ fr: spiruline déshydratée
 hr: dehidrirana spirulina
 it: spirulina disidratata
 nl: gedehydrateerde spirulina
-# ingredient/fr:spiruline-deshydratee has 10 products in french @2019-05-28
 
 < en: spirulina
 en: spirulina powder
@@ -77851,7 +76264,6 @@ it: concentrato di spirulina
 nl: Spirulinaconcentraat
 pl: koncentrat spiruliny, barwiący koncentrat spiruliny
 ro: concentrat de spirulină, concentrat de spirulina
-# ingredient/fr:concentré-de-spiruline has 138 products in 4 languages @2019-04-23
 
 # description:en:SEAWEED or macroalgae refers to several species of macroscopic, multicellular, marine algae.
 # not sure if this should kept separate from en:algae
@@ -77930,7 +76342,6 @@ fr: concentré d'algues
 hr: koncentrat algi
 it: concentrato di alghe
 nl: algenconcentraat
-# ingredient/algae-concentrate has 10 products @2019-02-22
 # färbendes Lebensmittel:Saflorkonzentrat, Algenkonzentrat
 
 < en: seaweed
@@ -77941,27 +76352,22 @@ fi: kuivattu merilevä
 fr: algues déshydratées
 hr: dehidrirana morska trava
 it: alghe disidratate
-# ingredient/fr:algues-déshydratées has 15 products @2019-02-22
 
 < en: dehydrated seaweed
 fr: algues réhydratées
-# ingredient/fr:algues-réhydratées has 3 products @2019-02-22
 
 < en: seaweed
 fr: algue laminaire en poudre
 
 < en: seaweed
 fr: Algues bretonnes
-# ingredient/fr:Algues-bretonnes has 2 products @2019-02-22
 
 < en: seaweed
 fr: algues de Bretagne nord
-# ingredient/fr:algues-de-Bretagne-nord has 1 product @2019-02-22
 
 
 < en: seaweed
 fr: paillettes d'algues
-# ingredient/fr:paillettes-d'algues has 1 product @2019-02-22
 
 < en: algae
 en: algae extract
@@ -77993,7 +76399,6 @@ hr: lithothamnium calcareum
 it: Lithothamnium calcareum
 la: Lithothamnium calcareum
 nl: Lithothamnium calcareum
-# ingredient/fr:Lithothamnium-calcareum has 71 products @2020-05-12
 
 
 
@@ -78015,7 +76420,6 @@ ja: ダルス
 nl: Dulse
 nn: Søl
 pl: algi morskie dulse, dulse
-# ingredient/fr:dulse has 59 products @2019-02-14
 ciqual_food_code:en: 20988
 ciqual_food_name:en: Dulse (Palmaria palmata), dried or dehydrated
 ciqual_food_name:fr: Dulse (Palmaria palmata), séchée ou déshydratée
@@ -78043,7 +76447,6 @@ la: Palmaria palmata
 #nl:Verwerkt Eucheuma-wier
 #description:en:Eucheuma, commonly known as gusô, is a seaweed algae that may be brown, red, or green in color.
 #wikipedia:en:https://en.wikipedia.org/wiki/Eucheuma
-# ingredient/fr:algues-euchema-transformées has 147 products in 4 languages @2019-02-22
 
 
 < en: seaweed
@@ -78068,7 +76471,6 @@ description:en: Fucus is a genus of brown algae found in the intertidal zones of
 # sco:Tang
 wikidata:en: Q180597
 wikipedia:en: https://en.wikipedia.org/wiki/Fucus
-# ingredient/fr:fucus has 32 products in 2 languages @2021-08-13
 
 #<en:Fucus
 #en:Toothed wrack or bladder wrack (Fucus serratus et vesiculosus) dried or dehydrated
@@ -78189,8 +76591,6 @@ description:en: Nori (海苔) is the Japanese name for edible seaweed (a "sea ve
 eurocode_2_group_3:en: 8.55.30
 wikidata:en: Q201565
 wikipedia:en: https://en.wikipedia.org/wiki/Nori
-# ingredient/fr:nori has 51 products in 4 languages @2019-02-22
-# ingredient/fr:porphyra-umbilical has 1 product @2019-02-22
 
 
 < en: seaweed
@@ -78242,7 +76642,6 @@ eurocode_2_group_3:en: 8.55.30
 # zh-tw:石蓴
 wikidata:en: Q1109330
 wikipedia:en: https://en.wikipedia.org/wiki/Sea_lettuce
-# ingredient/fr:laitue-de-mer has 73 products in 4 languages @2019-02-22
 
 
 
@@ -78264,8 +76663,6 @@ ciqual_food_name:en: Sea thong (Himanthalia elongata), dried or dehydrated
 ciqual_food_name:fr: Haricot de mer (Himanthalia elongata), séchée ou déshydratée
 description:en: HIMANTHALIA ELONGATA is a brown alga (class Phaeophyta or Phaeophyceae) in the order Fucales, also known by the common names thongweed, sea thong and sea spaghetti.
 wikidata:en: Q1636443
-# ingredient/fr:spaghetti-de-mer has 7 products in french @2019-02-22
-# ingredient/fr:haricot-de-mer has 9 products in french @2019-02-22
 wikipedia:en: https://en.wikipedia.org/wiki/Himanthalia_elongata
 
 
@@ -78279,7 +76676,6 @@ hr: ascophyllum
 it: ascophyllum
 la: Ascophyllum
 wikipedia:en: https://en.wikipedia.org/wiki/Ascophyllum
-# ingredient/fr:Ascophyllum has 9 products in french @2019-02-22
 
 < en: seaweed
 en: kelp
@@ -78318,7 +76714,6 @@ description:en: KOMBU (from Japanese: 昆布, translit. konbu) is edible kelp fr
 eurocode_2_group_3:en: 8.55.20
 wikidata:en: Q11261547
 wikipedia:en: https://en.wikipedia.org/wiki/Kombu
-# ingredient/fr:kombu has 20 products in french @2019-02-22
 
 < en: kelp
 en: tangle, oarweed
@@ -78352,7 +76747,6 @@ it: laminaria
 la: Laminaria
 wikidata:en: Q310748
 wikipedia:en: https://en.wikipedia.org/wiki/Laminaria
-# ingredient/fr:Laminaria has 13 products in french @2019-02-22
 
 < en: kelp
 en: wakame
@@ -78379,7 +76773,6 @@ description:en: Wakame (ワカメ), UNDARIA PINNATIFIDA, is a species of edible 
 eurocode_2_group_3:en: 8.55.40
 wikidata:en: Q864682
 wikipedia:en: https://en.wikipedia.org/wiki/Wakame
-# ingredient/fr:wakamé has 152 products in 9 languages @2021-08-14
 
 < en: seaweed
 la: Porphyra yezoensis
@@ -78413,7 +76806,6 @@ zh: 米曲菌, 米麴菌
 #zh-sg: 米曲菌
 #zh-tw: 米麴菌
 wikidata:en: Q865501
-# ingredient/fr:koji has 53 products @2019-02-15
 
 < en: koji
 la: Aspergillus sojae
@@ -78445,7 +76837,6 @@ ru: Тегумент
 sv: integument
 # de-ch:Integument
 wikidata:en: Q26736348
-# ingredient/fr:téguments has 32 products in french @2019-03-01
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -78549,7 +76940,6 @@ vo: Söögisiin
 wa: Magnåve tchampion, Tchampion-åbusson
 yi: שוועמל
 zh: 食用蕈, 蕈類
-# en:mushroom has 1817 products in 16 languages @2018-11-02
 carbon_footprint_fr_foodges_ingredient:fr: Champignons de Paris
 carbon_footprint_fr_foodges_value:fr: 1.9
 ciqual_food_code:en: 20056
@@ -78641,7 +77031,6 @@ it: estratto di funghi, estratti di funghi
 nl: champignonextract, paddestoelenextract
 pl: ekstrakt grzybowy, ekstrakt z grzybów
 sv: svampextrakt, champinjonextrakt
-# en:mushroom-extract has 94 products in 4 languages @2018-11-02
 
 < en: mushroom
 en: mushroom powder
@@ -78729,8 +77118,6 @@ usda_ndb_code:en: 11239
 usda_ndb_name:en: Mushrooms, Chanterelle, raw
 wikidata:en: Q188749
 wikipedia:en: https://en.wikipedia.org/wiki/Cantharellus_cibarius
-# ingredient/fr:cantharellus-cibarius has 26 products in 3 languages @2018-12-16
-# ingredient/fr:girolles has 90 products in 3 languages @2018-12-16
 
 < en: mushroom
 en: boletus
@@ -78820,7 +77207,6 @@ ciqual_proxy_food_code:en: 20160
 ciqual_proxy_food_name:en: Cep or boletus mushroom, raw
 wikidata:en: Q19740
 wikipedia:en: https://en.wikipedia.org/wiki/Boletus_edulis
-# en:cep has 98 products in 5 languages @2018-11-02
 
 < en: cep
 en: dried cep, dried porcini mushroom, dried porcini mushrooms
@@ -78981,7 +77367,6 @@ usda_ndb_code:en: 11260
 usda_ndb_name:en: Mushrooms, white, raw
 wikidata:en: Q227690
 wikipedia:en: https://en.wikipedia.org/wiki/Agaricus_bisporus
-# fr:champignons de Paris has 857 products in 9 languages @2018-11-01
 
 #process
 #< en: champignon
@@ -79129,7 +77514,6 @@ description:en: LACTARIUS is a genus of mushroom-producing, ectomycorrhizal fung
 # zh-hant:乳菇屬
 wikidata:en: Q748899
 wikipedia:en: https://en.wikipedia.org/wiki/Lactarius
-# ingredient/fr:lactaires has 53 products in french @2019-0121
 
 # description:en:LACTARIUS DELICIOSUS, commonly known as the saffron milk cap and red pine mushroom, is one of the best known members of the large milk-cap genus Lactarius in the order Russulales.
 
@@ -79174,7 +77558,6 @@ sv: Tallblodriska
 tt: Җирән гөмбә
 uk: Рижик смачний
 zh: 松乳菇
-# ingredient/fr:lactarus-déliciosus has 2 products in french @2019-01-22
 eurocode_2_group_3:en: 8.50.45
 # olo:Leppysieni
 # sah:Бэс кубачыына
@@ -79261,7 +77644,6 @@ usda_ndb_code:en: 11240
 usda_ndb_name:en: Mushrooms, morel, raw
 wikidata:en: Q371101
 wikipedia:en: https://en.wikipedia.org/wiki/Morchella
-# ingredient/fr:morilles has 101 products in 4 languages @2019-03-03
 
 < en: morels
 fr: Morilles séchées
@@ -79384,7 +77766,6 @@ zh: 鱗傘屬
 # zh-hans:鳞伞属
 description:en: The mushroom commonly sold as "chestnut mushroom" is typically Pholiota adiposa (sometimes marketed varieties are hybrids/cultivars developed for the table), native to East Asia and popularized by Japanese cultivators.
 wikipedia:en: https://en.wikipedia.org/wiki/Pholiota
-# ingredient/fr:pholiotes has 69 products in french @2019-01-22
 
 
 # description:en:Pholiota microspora, commonly known as Pholiota nameko or shortly nameko (ナメコ), is a small, amber-brown mushroom with a slightly gelatinous coating
@@ -79407,7 +77788,6 @@ sv: Namekotofsskivling
 zh: 滑菇
 # zh-tw:光滑環銹傘
 wikipedia:en: https://en.wikipedia.org/wiki/Pholiota_microspora
-# ingredient/fr:Pholiota-nameko has 5 products @2019-01-22
 
 
 # description:en:KUEHNEROMYCES MUTABILIS (synonym:Pholiota mutabilis), commonly known as the sheathed woodtuft, is an edible mushroom that grows in clumps on tree stumps or other dead wood.
@@ -79492,7 +77872,6 @@ uk: Маслюк звичайний
 # zh-tw:黃乳牛肝菌
 wikidata:en: Q816730
 wikipedia:en: https://en.wikipedia.org/wiki/Suillus_luteus
-# fr:bolets-jaunes has 72 products @2018-11-01
 
 
 # description:en:Volvariella volvacea (also known as paddy straw mushroom or straw mushroom) is a species of edible mushroom cultivated throughout East and Southeast Asia and used extensively in Asian cuisines.
@@ -79525,7 +77904,6 @@ zh: 草菇
 eurocode_2_group_3:en: 8.50.60
 wikidata:en: Q641656
 wikipedia:en: https://en.wikipedia.org/wiki/Volvariella_volvacea
-# https://world.openfoodfacts.org/ingredient/fr:Volvaire has 2 products @2019-01-22
 
 
 # description:en:SUILLUS GRANULATUS is a pored mushroom of the genus Suillus in the family Suillaceae.
@@ -79558,7 +77936,6 @@ uk: Маслюк зернистий
 # sah:Бараах саһархайа
 # zh-tw:點柄乳牛肝菌
 wikidata:en: Q1142857
-# fr:Suillus granulatus has 4 products in 1 language @2018-11-01
 
 < en: mushroom
 en: shiitake, lentinula edodes, lentinus edodes, shiitake mushrooms
@@ -79585,8 +77962,6 @@ usda_ndb_2_name:en: Mushrooms, shiitake, dried
 usda_ndb_2_process:en: en:dried
 usda_ndb_code:en: 11238
 usda_ndb_name:en: Mushrooms, shiitake, raw
-# fr:champignon-noir has 111 products in 2 languages @2018-11-01
-# ingredient/fr:Lentinus-edodes has 21 products in french @2018-01-22
 
 < en: mushroom extract
 < en: shiitake
@@ -79683,7 +78058,6 @@ usda_ndb_code:en: 11987
 usda_ndb_name:en: Mushrooms, oyster, raw
 wikidata:en: Q186451
 wikipedia:en: https://en.wikipedia.org/wiki/Pleurotus_ostreatus
-# fr:pleurotes has 119 products @2018-11-01
 
 
 # description:en:MARASMIUS OREADES, the Scotch bonnet, is also known as the fairy ring mushroom or fairy ring champignon.
@@ -79721,7 +78095,6 @@ zh: 硬柄小皮傘
 # zh-hk:硬柄小皮傘
 wikidata:en: Q752492
 wikipedia:en: https://en.wikipedia.org/wiki/Marasmius_oreades
-# ingredient/fr:Marasmius-Oreades has 1 product @2018-01-22
 
 < en: mushroom
 en: wood ear, Jew's ear, black fungus, Auricularia auricula-judea, Auricularia Auricula Judea
@@ -79784,7 +78157,6 @@ usda_ndb_name:en: Fungi, Cloud ears, dried
 usda_ndb_process:en: en:dried
 wikidata:en: Q321342
 wikipedia:en: https://en.wikipedia.org/wiki/Auricularia_auricula-judae
-# fr:Oreilles de Judas has 24 products in 5 languages @2018-11-01
 
 < en: mushroom
 en: pepeiao
@@ -79834,7 +78206,6 @@ description:en: A TRUFFLE is the fruiting body of a subterranean ascomycete fung
 eurocode_2_group_3:en: 8.50.30
 wikidata:en: Q2690965
 wikipedia:en: https://en.wikipedia.org/wiki/Truffle
-# ingredient/en:truffle has 14 products in 2 languages @2020-06-13
 
 
 # description:en:tuber MELANOSPORUM is a species of truffle native to Southern Europe. It is one of the most expensive edible mushrooms in the world. In cooking, black truffles are used to refine the taste of meat, fish, soups and risotto.
@@ -79862,7 +78233,6 @@ sr: Crna gomoljača
 sv: Perigordtryffel
 tr: Perigord trüfü
 zh: 黑松露
-# ingredient/black-truffle has 39 products in 4 languages @2019-04-23
 
 
 # description:en:The SUMMER TRUFFLE (Tuber aestivum) is a species of truffle, found in almost all European countries.
@@ -79892,7 +78262,6 @@ sv: Sommartryffel
 uk: Трюфель літній
 wikidata:en: Q74692
 wikipedia:en: https://en.wikipedia.org/wiki/Tuber_aestivum
-# ingredient/fr:tuber-aestivum has 35 products in 4 languages @2018-12-14
 
 
 # description:en:the white truffle (Tuber magnatum), is a species of truffle in the order Pezizales and family Tuberaceae. It is found in southern Europe.
@@ -79924,7 +78293,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Tuber_magnatum
 < en: mushroom
 fr: Chanterelle, chanterelles
 wikipedia:fr: https://fr.wikipedia.org/wiki/Chanterelle
-# ingredient/fr:chanterelles has 51 products @2019-04-06
 
 # <en:fungus
 en: rhizopus
@@ -79978,13 +78346,11 @@ zh: 青黴菌
 # zh-hk:青黴菌
 wikidata:en: Q843136
 wikipedia:en: https://en.wikipedia.org/wiki/Penicillium
-# ingredient/fr:penicillium has 29 products in 3 languages @2019-01-30
 
 < en: penicillium
 en: pencillium roqueforti
 xx: Penicillium roqueforti
 de: pencillium roqueforti (Edelschimmel)
-# ingredient/fr:penicillium-roqueforti has 103 products @2019-01-30
 
 < en: penicillium
 en: penicillium glaucum
@@ -79996,7 +78362,6 @@ en: penicillium candidum
 xx: penicillium candidum
 sv: penicillium candida, penicillium candidum
 wikidata:en: Q3942999
-# ingredient/en:penicillium-candidum has 25 products in 1 language @2020-05-25
 
 < en: Craterellus
 en: yellow foot
@@ -80027,7 +78392,6 @@ hr: proizvod od gljiva quorn
 it: quorn prodotto a base di fungo
 description:en: QUORN is a meat substitute product originating in the UK and sold primarily in Europe, but also available in 19 countries.
 wikipedia:en: https://en.wikipedia.org/wiki/Quorn
-# ingredient/fr:produit-champignon-quorn has 13 products @2019-02-15
 
 #<en:compound
 < en: sauce
@@ -80206,7 +78570,6 @@ za: Duzbya
 zh: 鱼, 魚
 zu: inhlanzi
 allergens:en: en:fish
-# ingredient/fish has 7147 products in 12 languages @2018-12-21
 #carbon_footprint_fr_foodges_ingredient:fr:Poisson sauvage entier
 #carbon_footprint_fr_foodges_value:fr:10.2
 carbon_footprint_fr_foodges_ingredient:fr: Poisson sauvage (filet)
@@ -80369,7 +78732,6 @@ pt: Peixe branco
 ru: Белая рыба
 sl: Bela riba
 sv: Vitfisk
-# ingredient/fr:poisson-blanc has 59 products @2019-03-11
 # Theragra chalcogramma ou Merluccius productus ou Merluccius gayi ou Merluccius hubbsi
 ciqual_food_code:en: 26249
 ciqual_food_name:fr: Poisson blanc, cuit (aliment moyen)
@@ -80384,7 +78746,6 @@ fr: extrait de poisson
 de: Fischextrakt
 fi: kalauute
 nl: visextract
-# ingredient/fr:extrait-de-poisson has 123 products in 3 languages @2018-12-29
 
 #<en:fish
 #en:processing:en:powdered
@@ -80395,8 +78756,6 @@ nl: visextract
 #it:pesce in polvere
 #nl:vispoeder
 #sv:fiskpulver
-# ingredient/fr:poisson-en-poudre has 97 products in 4 languages @2019-04-08
-# ingredient/fr:poudre-de-poisson has 31 products in 2 languages @2019-02-03
 
 < en: fish
 en: fish meat
@@ -80408,7 +78767,6 @@ fr: chair de poisson, chair de poissons
 hr: meso ribe
 it: carne di pesce
 pl: mięso ryb
-# ingredient/fr:chair-de-poisson has 355 products in 2 languages @2018-12-29
 
 < en: fish meat
 < en: white fish
@@ -80433,8 +78791,6 @@ fr: fumet de poisson, fumet
 it: fumetto di pesce
 wikidata:en: Q30748629
 wikipedia:fr: https://fr.wikipedia.org/wiki/Fumet_de_poisson
-# ingredient/fr:fumet has 45 products in french @2019-03-01
-# ingredient/fr:fumet-de-poisson has 187 products in french @2018-12-29
 
 < fr: fumet de poisson
 fr: fumet de poissons de la Méditerranée
@@ -80456,7 +78812,6 @@ fr: bouillon de poisson
 hr: riblji bujon
 it: brodo di pesce
 sv: fiskbuljong
-# ingredient/en:fish-stock has 54 products in 2 languages @2020-06-13
 
 < en: broth
 < en: clam
@@ -80494,7 +78849,6 @@ it: pesce di scoglio, scorfano
 ja: 根魚
 wikidata:en: Q26261896
 wikipedia:en: https://en.wikipedia.org/wiki/Rockfish
-# ingredient/fr:poissons-de-roche has 5 products @2019-01-01
 # structure:inner:role:synonym:optional, eg poissons de roche (congre, rascasse, grondin)
 
 < en: fish
@@ -80598,12 +78952,10 @@ zh: 海水魚
 # zh-hk:海水魚
 wikidata:en: Q5364423
 wikipedia:fr: https://fr.wikipedia.org/wiki/Liste_des_poissons_de_mer_utilisés_en_cuisine
-# ingredient/fr:poisson-de-mer has 1 product @2019-01-01
 
 < en: crustacean
 < en: fish
 fr: poissons et crustacés mis en œuvre, poissons et crustacés mis en oeuvre
-# ingredient/fr:poissons-et-crustacés-mis-en-œuvre has 1 product in french @2019-01-01
 carbon_footprint_fr_foodges_ingredient:fr: Moules/autres crustacés
 carbon_footprint_fr_foodges_value:fr: 10.7
 
@@ -80682,7 +79034,6 @@ nl: Alaska koolvisfilet
 pl: filet z mintaja, filety z mintaja
 ro: file de cod Alaska
 sv: alaska pollock-filé, filé av alaska pollock
-# ingredient/alaskan-pollock-fillet has 88 products @2018-12-29
 
 # description:en:An anchovy is a small, common forage fish of the family Engraulidae.
 
@@ -80758,7 +79109,6 @@ ifct_food_code:en: P003
 ifct_food_name:en: Anchovy
 wikidata:en: Q192662
 wikipedia:en: https://en.wikipedia.org/wiki/Anchovy
-# 2820 in 19 @2021-09-12
 
 < en: anchovy
 la: Stolephorus spp
@@ -80780,7 +79130,6 @@ nl: ansjovispasta
 pl: pasta z anchois
 wikidata:en: Q3897482
 wikipedia:en: https://en.wikipedia.org/wiki/Anchovy_paste
-# ingredient/fr:pâte-d’anchois has 101 products @2019-01-06
 
 #process:en: en:extract
 #<en:anchovy
@@ -80792,13 +79141,11 @@ wikipedia:en: https://en.wikipedia.org/wiki/Anchovy_paste
 #it:estratto d'acciughe
 #nl:ansjovisextract
 #sv:ansjovisextrakt
-# ingredient/anchovy-extract has 158 products in 7 languages @2019-01-06
 
 #process:en: en:salted
 #<en:anchovy
 #en:salted anchovy
 #fr:anchois salés
-# ingredient/fr:anchois-salés has 43 products in 4 languages @2019-01-12
 # Anchois salés (Anchois, sel)
 
 < en: anchovy
@@ -80809,7 +79156,6 @@ fi: anjovisfilee
 fr: filets d'anchois
 hr: filet inćuna, fileti inćuna
 it: Filetti d'acciuga
-# ingredient/fr:filets-d'anchois has 36 products in 4 languages @2019-01-06
 
 #process:en: en:salted
 #<en:anchovy filets
@@ -80818,7 +79164,6 @@ it: Filetti d'acciuga
 #fi:suolattu anjovisfilee
 #fr:filets d'anchois salés
 #it:filetti di acciughe salate
-# 50 in 4 @2021-09-12
 
 < en: anchovy filets
 en: marinated anchovy fillets
@@ -80847,8 +79192,6 @@ description:en: The European anchovy (Engraulis encrasicolus) is a forage fish s
 wikidata:en: 188387
 # translations can not be trusted
 wikipedia:en: https://en.wikipedia.org/wiki/European_anchovy
-# ingredient/fr:Engraulis-encrasicolus has 32 products @2019-01-12
-# ingredient/fr:Engraulis-encrasicholus has 1 product @2019-01-12
 
 < en: fish
 < en: white fish
@@ -80896,7 +79239,6 @@ sv: Marulk
 tr: Fener balığı
 uk: Морський чорт
 zh: 釣鮟鱇
-# ingredient/en:angler-fish has 2 products @2019-01-12
 ciqual_food_code:en: 26018
 ciqual_food_name:en: Anglerfish, raw
 ciqual_food_name:fr: Lotte ou baudroie, crue
@@ -80949,7 +79291,6 @@ ru: Полосатая зубатка
 se: Stáinnir
 sr: Морски вук
 sv: Havskatt
-# ingredient/fr:loup-d’atlantique has 1 product @2019-01-15
 ciqual_food_code:en: 26075
 ciqual_food_name:en: Atlantic bass, raw
 ciqual_food_name:fr: Bar ou loup de l'Atlantique, cru
@@ -81009,7 +79350,6 @@ zh: 藍鱈, Micromesistius poutassou
 description:en: The blue whiting, Micromesistius poutassou, one of the two species in the genus Micromesistius in the cod family, is common in the northeast Atlantic Ocean from Morocco to Iceland and Spitsbergen
 wikidata:en: Q743248
 wikipedia:en: https://en.wikipedia.org/wiki/Blue_whiting
-# ingredient/fr:merlan-bleu has 3 products @2018-12-31
 
 
 < en: fish
@@ -81087,7 +79427,6 @@ description:en: The burbot (Lota lota) is the only gadiform (cod-like) freshwate
 usda_ndb_proxy_code:en: 15006
 usda_ndb_proxy_name:en: Fish, burbot, raw
 wikipedia:en: https://en.wikipedia.org/wiki/Burbot
-# ingredient/fr:lotte has 10 products in french @2018-12-31
 
 < en: burbot
 en: raw burbot
@@ -81187,7 +79526,6 @@ description:nl: De lodde (Mallotus villosus) is de enige vertegenwoordiger van h
 # zh-tw:毛鱗魚
 wikidata:en: Q143359
 wikipedia:en: https://en.wikipedia.org/wiki/Capelin
-# ingredient/fr:capelan has 8 products in french @2021-08-14
 
 < en: capelin
 en: Capelin raw
@@ -81259,7 +79597,6 @@ sv: Torsk, Torskfiskar, Torskfisk
 tr: Morina
 vi: Cá tuyết
 zh: 鱈魚
-# ingredient/cod has 401 products in 5 languages @2018-12-29
 ciqual_food_code:en: 26043
 ciqual_food_name:en: Cod, raw
 ciqual_food_name:fr: Cabillaud, cru
@@ -81286,7 +79623,6 @@ fr: chair de morue
 fr: filet de cabillaud, filets de cabillaud
 fi: turskafilee
 sv: torskfilé, filér av torsk
-# ingredient/fr:filet-de-cabillaud has 32 products in french @2018-12-29
 
 < en: cod
 en: smoked cod roe
@@ -81298,7 +79634,6 @@ it: uova di merluzzo affumicate
 
 < en: smoked cod roe
 fr: oeufs de cabillaud salés et fumés, œufs de cabillaud fumés et salés, oeufs de cabillaud fumés et salés
-# ingredient/fr:œufs-de-cabillaud-fumés-et-salés has 30 products in french @2018-12-29
 
 < en: cod
 en: cod liver
@@ -81378,7 +79713,6 @@ vi: Cá tuyết Thái Bình Dương
 zh: 大头鳕
 wikidata:en: Q783575
 wikipedia:en: https://en.wikipedia.org/wiki/Pacific_cod
-# ingredient/fr:Gadus-macrocephalus has 20 products in 3 languages @2018-12-31
 # structure:inner:role:synonym, eg Cabillaud (Gadus Macrocephalus)
 
 
@@ -81391,7 +79725,6 @@ hr: ikra bakalara
 it: uova di merluzzo
 vegan:en: no
 vegetarian:en: no
-# ingredient/fr:œufs-de-cabillaud has 69 products in french @2018-12-29
 
 
 
@@ -81410,7 +79743,6 @@ it: corvina
 la: Cilus gilberti
 pl: Corvina
 zh: 吉氏毛突石首魚
-# ingredient/corvina has 2 products @2019-01-13
 wikidata:en: Q2017562
 wikipedia:en: https://en.wikipedia.org/wiki/Cilus_gilberti
 
@@ -81433,7 +79765,6 @@ nb: Snabeluer
 nl: Diepzeeroodbaars
 sv: Djuphavskungsfisk
 zh: 尖吻平鮋
-# ingredient/fr:dorade-sébaste has 2 products @2019-01-15
 carbon_footprint_fr_foodges_ingredient:fr: Bar ou dorade d'élevage (filet)
 carbon_footprint_fr_foodges_value:fr: 12
 ciqual_food_code:en: 26132
@@ -81509,7 +79840,6 @@ sv: Havsål
 tr: Mığrı
 uk: Морський вугор звичайний
 zh: 歐洲康吉鰻
-# ingredient/fr:congre has 9 products @2018-12-31
 ciqual_food_code:en: 26127
 ciqual_food_name:en: Conger, raw
 ciqual_food_name:fr: Congre, cru
@@ -81873,8 +80203,6 @@ description:en: The European plaice (Pleuronectes platessa) is a commercially im
 # frr:Skol
 # pcd:Càrlé
 wikipedia:en: https://en.wikipedia.org/wiki/European_plaice
-# ingredient/fr:carrelet has 2 products in 3 languages @2018-12-31
-# ingredient/fr:Pleuronectes-platessa has 6 products in 3 languages @2018-12-31
 # structure:inner:role:synonym, eg carrelet (Pleuronectes platessa)
 
 #<en:European plaice
@@ -81946,7 +80274,6 @@ sv: Knotfiskar
 tr: Kırlangıç
 uk: Триглові
 zh: 角魚科
-# ingredient/fr:grondin has 8 products in french @2019-01-01
 ciqual_food_code:en: 26106
 ciqual_food_name:en: Red gurnard, raw
 ciqual_food_name:fr: Grondin, cru
@@ -82006,7 +80333,6 @@ sv: Kolja
 tr: Mezgit
 uk: Пікша
 zh: 黑線鱈
-# ingredient/fr:Melanogrammus-aeglefinus has 16 products @2019-01-14
 ciqual_food_code:en: 26122
 ciqual_food_name:en: Haddock, raw
 ciqual_food_name:fr: Églefin, cru
@@ -82066,7 +80392,6 @@ ciqual_food_name:en: European hake, raw
 ciqual_food_name:fr: Merlu, cru
 wikidata:en: Q1289807
 wikipedia:en: https://en.wikipedia.org/wiki/Hake
-# ingredient/fr:merlu-blanc has 34 products in french @2018-12-30
 
 
 < en: hake
@@ -82128,7 +80453,6 @@ sv: Chilensk kummel
 zh: 秘魯無鬚鱈
 wikidata:en: Q2348852
 wikipedia:en: https://en.wikipedia.org/wiki/Merluccius_gayi
-# ingredient/fr:Merluccius-gayi has 2 products @2018-12-30
 # structure:inner:role:synonym, eg Merlu blanc (Merluccius capensis, Merluccius gayi, Merlusccius productus)
 
 # description:en:The North Pacific hake, Pacific hake, Pacific whiting, or jack salmon (Merluccius productus) is a ray-finned fish in the genus Merluccius, found in the northeast Pacific Ocean
@@ -82155,7 +80479,6 @@ zh: 北太平洋梭鳕
 wikidata:en: Q919598
 wikipedia:en: https://en.wikipedia.org/wiki/North_Pacific_hake
 # structure:outer:role:synonym, eg nasello del Pacifico (Merluccius productus)
-# ingredient/fr:Merluccius-productus has 6 products @2018-12-30
 # structure:inner:role:synonym, eg nasello del Pacifico (Merluccius productus)
 
 
@@ -82182,7 +80505,6 @@ sv: Argentinsk kummel
 zh: 赫氏無鬚鱈
 wikidata:en: Q1868257
 wikipedia:en: https://en.wikipedia.org/wiki/Argentine_hake
-# ingredient/fr:Merluccius-hubbsi has 3 products in french @2018-12-31
 # structure:inner:role:synonym, eg Filet de merlu blanc (Merluccius hubbsi)
 
 < en: fish
@@ -82348,7 +80670,6 @@ description:nl: zilvergrijze zoutwatervis, geschikt voor comsumptie
 wikidata:en: Q3127419
 wikipedia:en: https://en.wikipedia.org/wiki/Herring
 wiktionary:en: herring
-# 509 in 14 @2021-09-10
 
 < en: herring
 en: herring fillet, herring fillets
@@ -82361,7 +80682,6 @@ hr: file haringe
 it: filetti di aringa
 nl: haringfilet
 pl: filety śledziowe, filety ze śledzia, filet ze śledzia, filet śledziowy
-# 250 in 6 @2021-09-10
 
 # description:en:Atlantic herring (Clupea harengus) is a herring in the family Clupeidae.
 
@@ -82474,7 +80794,6 @@ zh: 皇带鱼科
 # zh-hk:皇帶魚科
 wikidata:en: Q1078201
 wikipedia:en: https://en.wikipedia.org/wiki/Oarfish
-# ingredient/fr:ruban has 1 product in french @2019-01-01
 
 < en: fish
 en: pangas, pangasius
@@ -82535,7 +80854,6 @@ ciqual_food_code:en: 26133
 ciqual_food_name:en: Pouting, raw
 ciqual_food_name:fr: Tacaud, cru
 description:en: Trisopterus luscus (bib, pout whiting, pout or most commonly pouting) is a seafish belonging to the cod family (Gadidae).
-# ingredient/fr:tacaud has 11 products in french @2018-12-31
 wikidata:en: Q599799
 wikipedia:en: https://en.wikipedia.org/wiki/Trisopterus_luscus
 
@@ -82605,8 +80923,6 @@ sq: pollock
 sv: gråsej, sej
 uk: Сайда
 zh: 綠青鱈
-# ingredient/fr:Lieu-Noir has 17 products in french @2019-01-02
-# ingredient/fr:colin-lieu has 12 products @2019-01-02
 ciqual_food_code:en: 26134
 ciqual_food_name:en: Saithe, raw
 ciqual_food_name:fr: Lieu noir, cru
@@ -82720,7 +81036,6 @@ ifct_food_name:en: Salmon
 # wikidata:en:Q2796766
 # wikipedia:en:https://en.wikipedia.org/wiki/Salmon
 wikipedia:en: https://en.wikipedia.org/wiki/Salmon_as_food
-# ingredient/salmon has 1659 products in 6 languages @2018-12-29
 #TODO check proxy
 
 < en: salmon
@@ -82745,7 +81060,6 @@ nl: rauwe zalm
 pl: surowy łosoś
 pt: Salmão cru
 ru: сырая лосось
-# ingredient/raw-salmon has 100 products in 3 languages @2021-08-15
 ciqual_food_code:en: 26036
 ciqual_food_name:en: Salmon, raw, farmed
 ciqual_food_name:fr: Saumon, cru, élevage
@@ -82777,7 +81091,6 @@ ciqual_food_name:fr: Saumon, cru, sauvage
 < en: salmon
 fr: saumon cuit
 de: Lachs gekocht
-# ingredient/fr:saumon-cuit has 49 products in 2 languages @2018-12-29
 
 #<fr:saumon cuit
 #en:Steamed salmon
@@ -82809,7 +81122,6 @@ it: filetto di salmone
 nl: zalmfilet
 sv: laxfilé
 wikidata:en: Q67994034
-# ingredient/fr:filet-de-saumon has 46 products in 5 languages @2020-12-19
 
 < en: salmon
 fr: pavés de saumon
@@ -82830,7 +81142,6 @@ fr: saumon fumé
 hr: dimljeni losos
 it: salmone affumicato
 nl: gerookte zalm
-# ingredient/smoked-salmon has 292 products in 4 languages @2018-12-29
 carbon_footprint_fr_foodges_ingredient:fr: Truite/Saumon fumé d'élevage
 carbon_footprint_fr_foodges_value:fr: 5.5
 ciqual_food_code:en: 26037
@@ -82930,7 +81241,6 @@ zh: 大西洋鮭
 description:en: The Atlantic salmon (Salmo salar) is a species of ray-finned fish in the family Salmonidae.
 wikidata:en: Q188879
 wikipedia:en: https://en.wikipedia.org/wiki/Atlantic_salmon
-# ingredient/fr:saumon-atlantique has 687 products in 5 languages @2018-12-29
 
 < en: atlantic salmon
 en: smoked atlantic salmon
@@ -82996,7 +81306,6 @@ zh: 鈎吻鮭
 # zh-tw:鈎吻鮭
 wikidata:en: Q475211
 wikipedia:en: https://en.wikipedia.org/wiki/Chum_salmon
-# ingredient/fr:Oncorhynchus-kéta has 22 products @2019-01-14
 
 
 # en:description:Pink salmon or humpback salmon (Oncorhynchus gorbuscha) is a species of anadromous fish in the salmon family.
@@ -83042,8 +81351,6 @@ zh: 驼背大马哈鱼
 # zh-hk:駝背大馬哈魚
 wikidata:en: Q673380
 wikipedia:en: https://en.wikipedia.org/wiki/Pink_salmon
-# ingredient/fr:saumon-rose-du-pacifique has 46 products in french @2018-12-29
-# ingredient/oncorhynchus-gorbuscha has 27 products @2019-01-14
 # http://www.marinespecies.org/aphia.php?p=taxdetails&id=127182
 
 
@@ -83085,7 +81392,6 @@ zh: 紅鮭
 # zh-hant:紅鮭
 wikidata:en: Q44064
 wikipedia:en: https://en.wikipedia.org/wiki/Sockeye_salmon
-# ingredient/fr:oncorhynchus-nerka has 54 products in 4 languages @2019-03-01
 
 
 # en:description:The European pilchard (Sardina pilchardus) is a species of ray-finned fish in the monotypic genus Sardina.
@@ -83169,7 +81475,6 @@ ifct_food_name:en: Sardine
 #wikidata:en:Q208600
 wikidata:en: Q7423795
 wikipedia:en: https://en.wikipedia.org/wiki/European_pilchard
-# 1553 in 20 @2021-09-15
 
 #processing:en: en:fillet
 < en: sardine
@@ -83200,7 +81505,6 @@ sk: filety sardiniek
 #processing:en: en:selected
 #<en:sardine
 #fr:sardines sélectionnées
-# ingredient/fr:sardines-sélectionnées has 16 products @2019-02-03
 
 #processing:en: en:pre-cooked
 #<en:sardine
@@ -83403,7 +81707,6 @@ usda_ndb_code:en: 15109
 usda_ndb_name:en: Fish, surimi
 wikidata:en: Q815740
 wikipedia:en: https://en.wikipedia.org/wiki/Surimi
-# ingredient/fr:surimi has 145 products in 2 languages @2019-01-12
 # surimi (protéines de muscles de poisson, sucre)
 
 < en: surimi
@@ -83412,7 +81715,6 @@ de: Surimi-Krebsfleischimitat aus Fischmuskeleiweiß geformt
 
 < en: surimi
 fr: préparation à base de surimi
-# ingredient/fr:préparation-à-base-de-surimi has 21 products in french @2019-02-03
 # préparation de surimi  (chair de poisson, stabilisants:sorbitol, polyphosphates)
 
 < en: surimi
@@ -83440,7 +81742,6 @@ fr: cohana
 he: נימי
 hr: thread-fin bream
 # pam:Bisugo
-# ingredient/fr:cohana has 5 products in french @2019-01-07
 
 # description:en:Nemipterus is a genus of fish in the family Nemipteridae found in the Indian and Pacific Ocean
 
@@ -83449,7 +81750,6 @@ en: Nemipterus spp
 it: nemipterus spp
 wikidata:en: Q1842575
 wikipedia:en: https://en.wikipedia.org/wiki/Nemipterus
-# ingredient/fr:Nemipterus-spp has 2 products in french @2019-01-07
 
 
 # description:en:Tilapia is the common name for nearly a hundred species of cichlid fish from the  coelotilapine, coptodonine, heterotilapine, oreochromine, pelmatolapiine and tilapiine tribes (formerly all were in Tilapiini).
@@ -83555,7 +81855,6 @@ ifct_food_name:en: Tuna
 wikidata:en: Q2346039
 wikipedia:en: https://en.wikipedia.org/wiki/Tuna
 # 2838 @2021-09-02
-# ingredient/tuna has 1347 products in 10 languages @2019-01-02
 
 < en: Tuna
 en: Raw tuna
@@ -83635,7 +81934,6 @@ agribalyse_proxy_food_name:fr: Miettes de thon à l'huile, appertisées
 fr: filets de thon
 de: Thunfisch Filets
 fi: tonnikalafilee
-# ingredient/fr:filets-de-thon has 24 products in 2 languages @2019-02-02
 
 < en: tuna
 en: tuna steak
@@ -83650,12 +81948,10 @@ de: gegarter Thunfisch, Thunfisch gegart
 fr: thon précuit, thon précuit haché
 hr: kuhano meso tune
 it: tonno precotto
-# ingredient/fr:thon-précuit has 30 products in french @2019-01-02
 
 < en: tuna
 fr: Ventrèches de thon
 it: ventresca di tonno
-# ingredient/fr:Ventrèches-de-thon has 1 product @2019-01-02
 
 < en: tuna
 en: albacore
@@ -83691,8 +81987,6 @@ sv: Långfenad tonfisk
 th: ปลาทูน่าครีบยาว
 tr: Beyaz ton balığı
 zh: 长鳍金枪鱼
-# ingredient/fr:thon-0blanc has 47 products in 3 languages @2019-02-02
-# ingredient/fr:thon-blanc-germon has 64 products in french @2019-01-02
 ciqual_food_code:en: 26076
 ciqual_food_name:en: Albacore, raw
 ciqual_food_name:fr: Thon germon ou thon blanc, cru
@@ -83779,7 +82073,6 @@ description:pt: O bonito, bonito-listado, gaiado, atum-bonito e atum-gaiado (Kat
 # zh-tw:正鰹
 wikidata:en: Q633957
 wikipedia:en: https://en.wikipedia.org/wiki/Skipjack_tuna
-# 644 products in 16 @2021-09-03
 
 < en: skipjack tuna
 en: skipjack tuna fillet
@@ -83904,7 +82197,6 @@ ciqual_food_code:en: 26214
 ciqual_food_name:en: Blue grenadier, raw
 ciqual_food_name:fr: Grenadier bleu ou hoki de Nouvelle-Zélande cru
 wikipedia:en: https://en.wikipedia.org/wiki/Blue_grenadier
-# 17 in 7 @2021-09-14
 
 # en:description:Le grenadier patagonien appelé en espagnol merluza de cola (Macruronus magellanicus) est un poisson marin de la famille des Merlucciidae qui appartient de ce fait à l'ordre des Gadiformes.
 
@@ -83923,7 +82215,6 @@ sv: Chilensk hoki
 zh: 南美尖尾無鬚鱈
 wikidata:en: Q648967
 wikipedia:fr: https://fr.wikipedia.org/wiki/Grenadier_patagonien
-# ingredient/fr:Macruronus-magellanicus has 1 product @2018-12-31
 # structure:inner:role:synonym, eg Hoku argentin (Macruronus magellanicus)
 
 # Perhaps a synonym
@@ -84047,7 +82338,6 @@ uk: Скумбрія атлантична
 vi: Cá thu Đại Tây Dương
 #es:caballa need name for atlantic version
 wikidata:en: Q30153
-# ingredient/fr:scomber-scombrus has 63 products in 3 languages @2018-12-30
 # structure:inner:role:synonym, eg sgombri (Scomber scombrus)
 
 < en: mackerel
@@ -84109,7 +82399,6 @@ ciqual_food_name:en: Horse mackerel, raw
 ciqual_food_name:fr: Chinchard, cru
 wikidata:en: Q982933
 wikipedia:en: https://en.wikipedia.org/wiki/Trachurus
-# ingredient/fr:chinchard has 1 product in french @2019-01-01
 # description:en:Oarfish are large, greatly elongated, pelagic lampriform fish belonging to the small family Regalecidae
 
 
@@ -84120,7 +82409,6 @@ pt: filetes de carapau
 # compound product eg Filets de maquereaux cuits au court-bouillon (filets de maquereaux 55%, sel, épices et aromates)
 
 fr: filets de maquereaux cuits au court-bouillon
-# ingredient/fr:filets-de-maquereaux-cuits-au-court-bouillon has 33 products in french @2018-12-30
 # structure:outer:role:compound, eg Filets de maquereaux cuits au court-bouillon (filets de maquereaux 55%, sel, épices et aromates)
 
 #comment:en:We need more products to figure out how the generic name bream is divided over specific species.
@@ -84235,7 +82523,6 @@ en: ling
 fr: lingue, julienne
 hr: vrijesak
 la: Molva
-# ingredient/fr:lingue has 1 product @2019-01-16
 ciqual_food_code:en: 26130
 ciqual_food_name:en: Ling, raw
 ciqual_food_name:fr: Julienne ou Lingue, crue
@@ -84298,7 +82585,6 @@ tl: Bakoko
 uk: Спарові
 vi: Họ Cá tráp
 zh: 鯛科
-# ingredient/fr:dorade has 3 products @2018-12-30
 carbon_footprint_fr_foodges_ingredient:fr: Bar ou dorade d'élevage (filet)
 carbon_footprint_fr_foodges_value:fr: 12
 description:en: The Sparidae are a family of fish in the order Perciformes, commonly called sea breams and porgies.
@@ -84399,7 +82685,6 @@ description:it: Il dentice (Dentex dentex) è un pesce d'acqua salata appartenen
 description:nl: De tandbrasem (Dentex dentex) is een straalvinnige vis uit de familie van zeebrasems (Sparidae). Dentex dentex is voor de visserij van aanzienlijk commercieel belang.
 wikidata:en: Q143503
 wikipedia:en: https://en.wikipedia.org/wiki/Common_dentex
-# ingredient/common-dentex has 1 product @2021-08-19
 
 #<en:seabream
 #en:blackspot seabream
@@ -84448,7 +82733,6 @@ uk: Пагель
 description:fr: Les pageots (Pagellus) forment un genre de poissons marins perciformes de la famille des Sparidae
 wikidata:en: Q1654733
 wikipedia:fr: https://fr.wikipedia.org/wiki/Pagellus
-# ingredient/fr:pageot has 1 product in french @2019-01-01
 
 
 < en: seabream
@@ -84591,7 +82875,6 @@ description:pt: O espadarte (Xiphias gladius), meca, e por vezes incorretamente 
 # zh-tw:劍旗魚
 wikidata:en: Q164327
 wikipedia:en: https://en.wikipedia.org/wiki/Swordfish
-# ingredient/swordfish has 16 products in 2 languages @2018-12-29
 
 
 # en:description:Trout is the common name for a number of species of freshwater fish belonging to the genera Oncorhynchus, Salmo and Salvelinus, all of the subfamily Salmoninae of the family Salmonidae.
@@ -84659,7 +82942,6 @@ zh: 鱒魚
 # rue:Пструг
 wikidata:en: Q2258881
 wikipedia:en: https://en.wikipedia.org/wiki/Trout
-# ingredient/fr:truite has 53 products in 3 languages @2018-12-30
 
 < en: trout
 en: farmed trout
@@ -84734,7 +83016,6 @@ tr: Gökkuşağı alabalığı
 uk: Пструг райдужний
 vi: Cá hồi vân
 zh: 虹鱒
-# ingredient/fr:truite-arc-en-ciel has 81 products in 3 languages @2018-12-30
 carbon_footprint_fr_foodges_ingredient:fr: Truite d'élevage, entière
 carbon_footprint_fr_foodges_value:fr: 4.9
 description:en: The rainbow trout (Oncorhynchus mykiss) is a trout and species of salmonid native to cold-water tributaries of the Pacific Ocean in Asia and North America.
@@ -84780,8 +83061,6 @@ hr: dimljena kalifornijska pastrva
 it: trota iridea affumicata
 ciqual_proxy_food_code:en: 27009
 ciqual_proxy_food_name:en: Rainbow trout, raw, farmed
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:savustettu-kirjolohi
-# 1 entry @ 2019-10-31
 
 # <fr:truite
 # fr:truite d'élevage entière
@@ -84802,8 +83081,6 @@ fi: kirjolohifilee
 fr: Filethe de truite arc-en-ciel
 hr: file kalifornijske pastrve
 it: filetto di trota iridea
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:kirjolohifilee
-# 1 entry @ 2019-10-31
 
 # category:en:arctic-char
 < en: salmon
@@ -84841,7 +83118,6 @@ sv: Fjällröding
 uk: Палія арктична
 zh: 北極紅點鮭
 description:en: The Arctic char or Arctic charr (Salvelinus alpinus) is a cold-water fish in the family Salmonidae, native to alpine lakes and arctic and subarctic coastal waters. The flesh is fine-flaked and medium firm. The colour is between light pink and deep red, and the taste is like something between trout and salmon.
-# ingredient/arctic-char has 2 products @2021-08-19
 description:de: Der Seesaibling, Wandersaibling oder die Rotforelle (Salvelinus alpinus) gehört zur Gattung der Saiblinge.
 description:es: El salvelino (Salvelinus alpinus), también llamado trucha alpina o trucha ártica es un pez anádromo de la familia Salmonidae nativo de lagos alpinos y aguas costeras de las regiones árticas y subárticas.
 description:fr: L’Omble chevalier (Salvelinus alpinus) est une espèce de poissons de la famille des salmonidés. Les ombles de l'Arctique sont très populaires comme poissons d'élevage dans de nombreux pays pour plusieurs raisons. La chair de l'omble est souvent plus délicate dans la texture et la saveur que les autres salmonidés.
@@ -84881,7 +83157,6 @@ ru: Жёлтая тригла
 sv: Fenknot
 uk: Морський півень жовтий
 zh: 細鱗綠鰭魚
-# ingredient/fr:rouget has 7 products in french @2019-01-01
 # poissons entiers pêchés en Méditerranée (25%) (grondin, capelan, pageot, mulet, rascasse,vive, rouget)
 ciqual_food_code:en: 26085
 ciqual_food_name:en: Surmullet or red mullet, raw
@@ -84958,7 +83233,6 @@ zh: 鱷鱚科
 # roa-tara:Tràscene
 wikidata:en: Q649808
 wikipedia:en: https://en.wikipedia.org/wiki/Weever
-# ingredient/fr:vive has 1 product in french @2019-01-01
 
 
 # description:en:Merlangius merlangus, commonly known as whiting or merling, is an important food fish in the eastern North Atlantic Ocean and the northern Mediterranean
@@ -85020,7 +83294,6 @@ ciqual_food_name:fr: Merlan, cru
 # zh-hk:牙鱈
 # zh-sg:牙鳕
 # zh-tw:牙鳕
-# ingredient/fr:merlan has 11 products @2019-01-15
 wikidata:en: Q273083
 wikipedia:en: https://en.wikipedia.org/wiki/Merlangius
 
@@ -85058,11 +83331,9 @@ wikipedia:en: https://en.wikipedia.org/wiki/Greater_argentine
 fr: brochet
 br: begeg
 wikipedia:fr: https://fr.wikipedia.org/wiki/Brochet
-# ingredient/fr:brochet has 27 products @2019-01-01
 
 < fr: brochet
 fr: chair de brochet
-# ingredient/fr:chair-de-brochet has 27 products in french @2019-02-03
 
 
 < en: fish
@@ -85072,7 +83343,6 @@ it: pollack
 ciqual_food_code:en: 26129
 ciqual_food_name:en: Pollack, raw
 ciqual_food_name:fr: Lieu jaune ou colin, cru
-# ingredient/fr:lieu has 40 products @2018-01-02
 # colin (lieu) de l'Alaska (Theragra chalcogramma)
 # Colin (lieu) (Pollachius virens)
 # lieu (lieu 25%, huile de colza, sel, échalotes, gélatine de poisson)
@@ -85087,7 +83357,6 @@ br: Meilh
 fr: mulet
 hr: cipal
 it: triglia
-# ingredient/fr:mulet has 2 products in french @2019-01-01
 ciqual_food_code:en: 26091
 ciqual_food_name:en: Mullet, raw
 ciqual_food_name:fr: Mulet, cru
@@ -85100,7 +83369,6 @@ wikipedia:fr: https://fr.wikipedia.org/wiki/Mulet_(poisson)
 en: spiny scorpionfish
 fr: rascasse
 it: scorfano spinoso
-# ingredient/fr:rascasse has 4 products in french @2018-12-31
 ciqual_food_code:en: 26063
 ciqual_food_name:en: Spiny scorpionfish, raw
 ciqual_food_name:fr: Rascasse, crue
@@ -85112,7 +83380,6 @@ fr: œufs de lompe, oeufs de lompe
 vegan:en: no
 vegetarian:en: no
 wikipedia:fr: https://fr.wikipedia.org/wiki/Œufs_de_lump
-# ingredient/fr:oeufs-de-lompe has 38 products in french @2019-02-20
 
 # comment:en:Is the only difference the colorant added?
 
@@ -85173,8 +83440,6 @@ vegetarian:en: no
 # zh-hans:水生有壳动物
 wikidata:en: Q6501235
 wikipedia:en: https://en.wikipedia.org/wiki/Shellfish
-# ingredient/shellfish has 18 products @2019-01-12
-# ingredient/fr:fruits-de-mer has 38 products @2019-01-12
 
 < en: shellfish
 en: shellfish extract
@@ -85292,7 +83557,6 @@ zh: 软体动物
 # wuu:软体动物
 # yue:軟體動物
 allergens:en: en:molluscs
-# ingredient/fr:mollusque has 1890 products in 6 languages @2018-01-03
 carbon_footprint_fr_foodges_ingredient:fr: Moules/autres crustacés
 carbon_footprint_fr_foodges_value:fr: 10.7
 wikidata:en: Q25326
@@ -85354,7 +83618,6 @@ zh: 鸟蛤科
 # zh-hk:泥蚶
 wikidata:en: Q860002
 wikipedia:en: https://en.wikipedia.org/wiki/Cockle_(bivalve)
-# ingredient/cockles has 2 products @2019-01-12
 
 
 # en:description:Cuttlefish or cuttles are marine molluscs of the order Sepiida.
@@ -85466,7 +83729,6 @@ ru: Лекарственная каракатица, Sepia officinalis
 # nds-nl:Eenfachen Dintenfisch, Sepia officinalis
 # vls:Intespuger, Sepia officinalis
 wikipedia:en: https://en.wikipedia.org/wiki/Common_cuttlefish
-# ingredient/fr:Sepia-officinalis has 4 products @2019-01-14
 
 
 # en:description:Sepiella inermis, common name spineless cuttlefish, is an edible species of cuttlefish.
@@ -85481,7 +83743,6 @@ it: Sepiella inermis
 la: Sepiella inermis
 zh: 曼氏无针乌贼, Sepiella inermis
 wikipedia:en: https://en.wikipedia.org/wiki/Sepiella_inermis
-# ingredient/fr:Sepiella-inermis has 2 products in french @2019-01-05
 
 # en:description:The pharaoh cuttlefish (Sepia pharaonis) is a large cuttlefish species, growing to 42 cm in mantle length and 5 kg in weight
 
@@ -85531,7 +83792,6 @@ sq: Midhje
 tr: Midye
 vi: Trai
 zh: 淡菜類
-# ingredient/fr:moule has 207 products @2019-01-04
 ciqual_food_code:en: 10014
 ciqual_food_name:en: Mussel, common, raw
 ciqual_food_name:fr: Moule commune, crue
@@ -85545,14 +83805,12 @@ wikipedia:en: https://en.wikipedia.org/wiki/Mussel
 
 < en: mussel
 fr: moules glazurées
-# ingredient/fr:moules-glazurées has 1 product @2019-01-05
 
 < en: mussel
 fr: jus de moules, jus de moule
 
 < en: mussel
 fr: moules cuites
-# ingredient/fr:moules-cuites has 2 products @2019-02-05
 
 < fr: moules cuites
 fr: moules du Pacifique décoquillées cuites
@@ -85587,7 +83845,6 @@ ciqual_food_code:en: 10026
 ciqual_food_name:en: Mediterranean mussel, raw
 ciqual_food_name:fr: Moule de Méditerranée, crue
 wikipedia:en: https://en.wikipedia.org/wiki/Mediterranean_mussel
-# ingredient/fr:Mytilus-galloprovincialis has 13 products @2019-01-04
 
 # en:description:The blue mussel (Mytilus edulis), also known as the common mussel, is a medium-sized edible marine bivalve mollusc in the family Mytilidae, the mussels.
 
@@ -85624,7 +83881,6 @@ wikidata:en: Q27855
 
 < en: blue mussel
 fr: Mytilus edulis pêchées en Atlantique Nord
-# ingredient/fr:Mytilus-edulis has 55 products @2019-01-05
 
 
 # en:description:The Chilean mussel or Chilean blue mussel (Mytilus platensis) is a species of blue mussel native to the coasts of Chile, Argentina
@@ -85642,7 +83898,6 @@ sl: Čilska klapavica, Mytilus chilensis
 uk: Мідія чилійська, Mytilus chilensis
 wikidata:en: Q384733
 wikipedia:en: https://en.wikipedia.org/wiki/Chilean_mussel
-# ingredient/fr:Mytilus-chilensis has 26 products in 3 languages @2019-01-14
 
 
 # en:description: The octopus is a soft-bodied, eight-limbed mollusc of the order Octopoda.
@@ -85676,7 +83931,6 @@ ifct_food_code:en: R003
 ifct_food_name:en: Octopus
 wikidata:en: Q611843
 wikipedia:en: https://en.wikipedia.org/wiki/Octopus
-# ingredient/fr:poulpes has 51 products @2019-01-02
 
 < en: octopus
 en: Common cooked octopus
@@ -85684,7 +83938,6 @@ fr: poulpe cuit
 hr: obična kuhana hobotnica
 it: polpo cotto comune
 nl: gekookte inktvis
-# ingredient/fr:poulpe-cuit has 5 products in french @2019-01-03
 # Poulpe cuit (Octopus Vulgaris)
 ciqual_food_code:en: 10079
 ciqual_food_name:en: Octopus, common, cooked
@@ -85703,12 +83956,10 @@ it: polpo Egina
 la: Octopus Aegina
 wikidata:en: Q2936535
 wikipedia:nl: https://nl.wikipedia.org/wiki/Octopus_aegina
-# ingredient/fr:Octopus-Aegina has 1 product in french @2019-01-07
 
 
 < en: octopus
 fr: poulpe en lamelles
-# ingredient/fr:poulpe-en-lamelles has 1 product @2019-01-05
 
 < en: octopus
 en: common octopus, Octopus vulgaris
@@ -85755,7 +84006,6 @@ zh: 普通章魚, Octopus vulgaris
 # zh-tw:真蛸, Octopus vulgaris
 wikidata:en: Q651361
 wikipedia:en: https://en.wikipedia.org/wiki/Common_octopus
-# ingredient/fr:Octopus-vulgaris has 7 products @2019-01-03
 # poulpes (Octopus vulgaris)
 
 
@@ -85776,7 +84026,6 @@ nl: Muskus achtarm, Eledone moschata
 sl: Moškatna hobotnica, Eledone moschata
 wikidata:en: Q2296077
 wikipedia:en: https://en.wikipedia.org/wiki/Eledone_moschata
-# ingredient/fr:Eledone-moschata has 2 products @2019-01-04
 
 
 ###################################################################################################
@@ -85865,7 +84114,6 @@ ciqual_food_name:fr: Huître, sans précision, crue
 ifct_food_code:en: Q006
 ifct_food_name:en: Oyster
 wikipedia:en: https://en.wikipedia.org/wiki/Oyster
-# ingredient/fr:huitre has 11 products @2018-01-14
 
 < en: oyster
 fr: extrait d'huître
@@ -86000,7 +84248,6 @@ la: Argopecten irradians
 zh: 海湾扇贝
 wikidata:en: Q3018372
 wikipedia:en: https://en.wikipedia.org/wiki/Argopecten_irradians
-# ingredient/fr:Argopecten-irradians has 10 products @2019-01-13
 
 
 < en: scallop
@@ -86013,7 +84260,6 @@ la: Argopecten Gibbus
 sr: Ostrea gibba
 wikidata:en: Q3017111
 wikipedia:en: https://en.wikipedia.org/wiki/Argopecten_gibbus
-# ingredient/fr:Argopecten-Gibbus has 1 product @2019-01-12
 
 < en: scallop
 en: American sea scallop, Canadian sea scallop
@@ -86077,8 +84323,6 @@ sv: Pilgrimsmussla
 # pt-br:Vieira
 wikidata:en: Q1249634
 wikipedia:en: https://en.wikipedia.org/wiki/Pecten_maximus
-# ingredient/fr:noix-de-Saint-Jacques has 216 products @2019-01-12
-# ingredient/fr:Pecten-maximus has 25 products @2019-01-12
 
 < en: scallop
 en: Patagonian scallop
@@ -86088,7 +84332,6 @@ fr: Pétoncle de Patagonie
 hr: patagonijska jakobova kapica
 it: capesante della Patagonia
 la: Zygochlamys patagonica, Chlamys zygopatagonica
-# ingredient/fr:Zygochlamys-patagonica has 87 products @2019-01-12
 
 
 < en: scallop
@@ -86104,7 +84347,6 @@ zh: 华贵栉孔扇贝
 # zh-hant:高貴海扇蛤
 # zh-hk:高貴海扇蛤
 # zh-tw:高貴海扇蛤
-# ingredient/fr:Chlamys-nobilis has 20 products in french @2019-01-13
 
 
 < en: scallop
@@ -86122,7 +84364,6 @@ description:it: Argopecten purpuratus è un mollusco appartenente alla famiglia 
 description:nl: Argopecten purpuratus is een tweekleppigensoort uit de familie van de Pectinidae.
 wikidata:en: Q3412062
 wikipedia:en: https://en.wikipedia.org/wiki/Argopecten_purpuratus
-# ingredient/fr:Argopecten-purpuratus has 68 products @2019-01-12
 
 < en: Peruvian scallop
 en: Peruvian scallop without coral
@@ -86152,7 +84393,6 @@ sr: Ostrea elegans
 zh: 女王扇貝
 wikidata:en: Q1746507
 wikipedia:en: https://en.wikipedia.org/wiki/Queen_scallop
-# ingredient/fr:Chlamys-opercularis has 81 products @2019-01-12
 
 # en:description:Argopecten gibbus (Atlantic calico scallop) is a species of medium-sized edible marine bivalve mollusk in the family Pectinidae, the scallops
 
@@ -86164,7 +84404,6 @@ hr: pjegava jakobova kapica
 it: capesante maculate
 la: Argopecten irradians concentricus, Argopecten circularis
 wikidata:en: Q30749478
-# ingredient/fr:Argopecten-circularis has 10 products in french @2019-01-13
 
 
 < en: scallop
@@ -86177,7 +84416,6 @@ la: Chlamys albida, Chlamys albidus
 wikidata:en: Q3802698
 wikipedia:nl: https://nl.wikipedia.org/wiki/Chlamys_albida
 # https://www.sealifebase.ca/summary/Chlamys-albida.html
-# ingredient/fr:Chlamys-albidus has 12 products @2018-01-13
 
 
 ###################################################################################################
@@ -86247,7 +84485,6 @@ zh: 海鞘
 # zh-sg:海鞘
 # zh-tw:海鞘
 wikidata:en: Q190090
-# ingredient/sea-squirt has 4 products @2019-01-13
 
 
 ###################################################################################################
@@ -86352,8 +84589,6 @@ zh: 蜗牛
 # zh-tw:蝸牛
 wikidata:en: Q308841
 wikipedia:en: https://en.wikipedia.org/wiki/Snail
-# ingredient/fr:escargot has 2 products @2019-01-16
-# ingredient/fr:escargots has 7 products in french @2019-01-16
 
 < en: snail
 la: Helix aspersa, Cornu aspersum
@@ -86446,7 +84681,6 @@ ur: قیر ماہی مچھلی
 uz: Kalmarlar
 vi: Bộ Mực ống
 zh: 十腕总目
-# ingredient/fr:calmar has 25 products in 2 languages @2019-01-04
 ciqual_food_code:en: 10001
 ciqual_food_name:en: Squid, raw
 ciqual_food_name:fr: Calmar ou calamar ou encornet, cru
@@ -86480,7 +84714,6 @@ fr: anneaux de calmar blanchis, anneaux de calmars blanchis
 
 < en: squid
 fr: blanc de calmars
-# ingredient/fr:Blanc-de-calmars has 1 product @2019-01-04
 
 < en: squid
 fr: calmar géant
@@ -86508,7 +84741,6 @@ it: Illex Argentinus
 la: Illex Argentinus
 wikidata:en: Q2262870
 wikipedia:en: https://en.wikipedia.org/wiki/Illex_argentinus
-# ingredient/fr:Illex-Argentinus has 7 products @2019-01-07
 
 
 # description:en:The Humboldt squid (Dosidicus gigas), also known as jumbo squid, jumbo flying squid, pota, or diablo rojo (red devil), is a large, predatory squid living in the waters of the Humboldt Current in the eastern Pacific Ocean.
@@ -86539,7 +84771,6 @@ vi: Mực Humboldt, Dosidicus Gigas
 zh: 美洲大赤魷, Dosidicus Gigas
 wikidata:en: Q925444
 wikipedia:en: https://en.wikipedia.org/wiki/Humboldt_squid
-# ingredient/fr:Dosidicus-Gigas has 28 products in 5 languages @2019-01–03
 
 
 < en: squid
@@ -86553,7 +84784,6 @@ zh: 杜氏槍魷, Uroteuthis duvaucelii
 description:en: Uroteuthis duvaucelii, also known as the Indian Ocean Squid or Indian Squid, is an Indo-West Pacific species of squid with a wide range throughout the Indian Ocean
 wikidata:en: Q3829827
 wikipedia:en: https://en.wikipedia.org/wiki/Uroteuthis_duvauceli
-# ingredient/fr:Loligo-duvauceli has 7 products in french @2019-01-04
 
 < en: squid
 en: mitre squid, Uroteuthis chinensis
@@ -86564,7 +84794,6 @@ it: calamaro mitra
 la: Uroteuthis chinensis
 zh: 中國槍魷, Uroteuthis chinensis
 wikidata:en: Q920979
-# ingredient/fr:Loligo-chinensis has 2 products @2019-01-04
 
 < en: squid
 en: swordtip squid
@@ -86588,7 +84817,6 @@ la: Doryteuthis gahi, Loligo Gahi
 description:en: Doryteuthis gahi, also known as the Patagonian squid and locally as calamar, is a small-sized squid belonging to the family Loliginidae.
 wikidata:en: Q13596602
 wikipedia:en: https://en.wikipedia.org/wiki/Doryteuthis_gahi
-# ingredient/fr:Loligo-Gahi has 1 product @2019-01-04
 
 < en: squid
 en: cephalopod ink
@@ -86659,8 +84887,6 @@ zh: 蛤蜊
 # zh-hk:蛤蜊
 wikidata:en: Q1192868
 wikipedia:en: https://en.wikipedia.org/wiki/Clam
-# ingredient/clam has 8 products in english @2019-01-13
-# ingredient/fr:palourdes has 15 products in 2 languages @2019-01-06
 
 < en: clam
 en: clam meat
@@ -86806,7 +85032,6 @@ vegan:en: no
 vegetarian:en: no
 wikidata:en: Q25364
 wikipedia:en: https://en.wikipedia.org/wiki/Crustacean
-# ingredient/fr:crustacé has 2263 products @2019-01-06
 
 < en: crustacean
 fr: extrait de crustacé
@@ -86925,12 +85150,9 @@ description:en: CRABS are decapod crustaceans of the infraorder Brachyura, which
 # zea:Krabb'n
 wikidata:en: Q40802
 wikipedia:en: https://en.wikipedia.org/wiki/Crab
-# ingredient/fr:crabe has 83 products in 4 languages @2019-01-07
-# ingredient/crab has 30 products in english @2019-01-07
 
 < en: crab
 fr: chair de crabe
-# ingredient/fr:chair-de-crabe has 48 products in french @2019-01-07
 
 < en: crab
 en: crab extract
@@ -86940,7 +85162,6 @@ fr: extrait de crabe
 hr: ekstrakt rakova
 it: estratto di granchio
 sv: krabbextrakt
-# ingredient/fr:extrait-de-crabe has 25 products in french @2019-01-07
 
 < en: flavouring
 en: crab flavour
@@ -86977,10 +85198,8 @@ pt: Caranguejola
 ru: Большой сухопутный краб
 sk: Krab piesočný
 sv: Krabbtaska
-# ingredient/fr:tourteau has 13 products @2019-01-14
 wikidata:en: Q752188
 wikipedia:en: https://en.wikipedia.org/wiki/Cancer_pagurus
-# ingredient/fr:cancer-pagurus has 12 products @2019-01-14
 
 < en: crab
 en: crab substitute
@@ -87040,8 +85259,6 @@ description:en: CRAYFISH, also known as crawfish, crawdads, crawlfish,[1] crawld
 # zh-hk:淡水龍蝦
 wikidata:en: Q1211742
 wikipedia:en: https://en.wikipedia.org/wiki/Crayfish
-# ingredient/fr:écrevisse has 10 products @2019-01-12
-# ingredient/fr:écrevisses has 13 products @2019-01-12
 
 # description:en:Procambarus clarkii is a species of cambarid freshwater crayfish, native to northern Mexico, and southern and southeastern United States, but also introduced elsewhere
 
@@ -87160,8 +85377,6 @@ description:en: LOBSTERS comprise a family (Nephropidae, sometimes also Homarida
 # wuu:龙虾
 # yue:海螯蝦科
 wikipedia:en: https://en.wikipedia.org/wiki/Lobster
-# ingredient/en:lobster has 48 products in english @2019-01-07
-# ingredient/fr:homard has 79 products in 3 languages @2019-01-07
 
 # description:en:Homarus gammarus, known as the European lobster or common lobster, is a species of clawed lobster from the eastern Atlantic Ocean, Mediterranean Sea and parts of the Black Sea.
 
@@ -87191,7 +85406,6 @@ sv: Europeisk hummer, Homarus gammarus
 zh: 歐洲螯龍蝦, Homarus gammarus
 wikidata:en: Q27690
 wikipedia:en: https://en.wikipedia.org/wiki/Homarus_gammarus
-# fr:Homarus-gammarus has 4 products @2019-01-11
 
 
 # en:description:The American lobster (Homarus americanus) is a species of lobster found on the Atlantic coast of North America, chiefly from Labrador to New Jersey.
@@ -87239,14 +85453,12 @@ wikipedia:en: https://en.wikipedia.org/wiki/American_lobster
 fr: pulpe de homard
 de: Hummerfleisch
 fi: hummerin liha
-# ingredient/fr:pulpe-de-homard has 5 products in 3 languages @2019-01-07
 
 < en: American lobster
 < en: broth
 fr: bouillon de homard
 de: Hummerbouillon
 sv: hummerfond
-# ingredient/fr:bouillon-de-homard has 2 products @2019-01-07
 # compound ingredient
 
 
@@ -87298,11 +85510,9 @@ description:en: SPINY LOBSTERS, also known as langustas, langouste, or rock lobs
 # sr-ec:Лангуст
 # yue:龍蝦
 wikidata:en: Q916760
-# ingredient/fr:langouste has 5 products @2019-01-14
 
 < en: spiny lobster
 fr: têtes et pinces de langoustines
-# ingredient/fr:têtes-et-pinces-de-langoustines has 2 products @2019-01-12
 
 
 # description:en:Panulirus argus, the Caribbean spiny lobster,[2] is a species of spiny lobster that lives on reefs and in mangrove swamps in the western Atlantic Ocean.
@@ -87354,7 +85564,6 @@ ru: Норвежский омар, Nephrops norvegicus
 sh: Škamp, Nephrops norvegicus
 sv: Havskräfta, Nephrops norvegicus
 zh: 挪威海螯蝦, Nephrops norvegicus
-# ingredient/fr:Nephrops-norvegicus has 5 products in french @2019-01-11
 ciqual_food_code:en: 10024
 ciqual_food_name:en: Norway lobster, raw
 ciqual_food_name:fr: Langoustine, crue
@@ -87362,7 +85571,6 @@ ciqual_food_name:fr: Langoustine, crue
 # zh-hans:挪威海螯虾, Nephrops norvegicus
 # zh-hant:挪威海螯蝦, Nephrops norvegicus
 # zh-hk:挪威海螯蝦, Nephrops norvegicus
-# ingredient/fr:langoustines has 68 products @2019-01-11
 wikidata:en: Q551915
 
 < en: flavouring
@@ -87432,7 +85640,6 @@ usda_ndb_proxy_code:en: 15270
 usda_ndb_proxy_name:en: Crustaceans, shrimp, raw
 wikidata:en: Q1517781
 wikipedia:en: https://en.wikipedia.org/wiki/Shrimp
-# ingredient/fr:crevette has 840 products in 7 languages @2019-01-06
 
 < en: shrimp
 en: cooked shrimp, cooked prawn
@@ -87476,7 +85683,6 @@ sv: räkpasta
 
 < en: shrimp
 fr: crevettes décortiquées, crevette décortiquée
-# ingredient/fr:crevettes-décortiquées has 46 products in french @2019-01-06
 
 < en: shrimp
 en: shrimp powder
@@ -87487,25 +85693,20 @@ it: polvere di gamberetti
 ja: エビパウダー
 nl: garnalenpoeder
 sv: räkpulver
-# ingredient/fr:poudre-de-crevette has 40 products in french @2019-01-06
 
 < en: shrimp
 fr: queues de crevettes
-# ingredient/fr:queues-de-crevettes has 11 products in french @2019-01-13
 
 < fr: queues de crevettes
 fr: queues de crevettes décortiquées
-# ingredient/fr:queues-de-crevettes-décortiquées has 5 products in french @2019-01-06
 
 < en: shrimp
 fr: Crevettes entières crues
-# ingredient/fr:Crevettes-entières-crues has 5 products @2019-01-13
 
 < en: shrimp
 en: pink shrimps, pink schrimp
 fr: crevette rose, crevettes roses
 it: gamberetti rosa
-# ingredient/fr:crevettes-roses has 13 products @2019-01-06
 ciqual_food_code:en: 10059
 ciqual_food_name:en: deep water pink shrimp, raw
 ciqual_food_name:fr: Crevette rose, crue
@@ -87532,7 +85733,6 @@ vi: Họ Tôm he
 zh: 對蝦科
 wikidata:en: Q683918
 wikipedia:en: https://en.wikipedia.org/wiki/Penaeidae
-# ingredient/fr:Penaeidae has 5 products @2018-12-14
 
 < en: shrimp
 en: deep-sea shrimp, gamba prawns, gamba shrimps
@@ -87545,8 +85745,6 @@ hr: dubokomorski škampi
 la: Aristeidae
 wikidata:en: Q360351
 wikipedia:en: https://en.wikipedia.org/wiki/Aristeidae
-# ingredient/fr:gamba has 2 products @2019-01-13
-# ingredient/fr:gambas has 13 products @2019-01-13
 # gambas (gambas, sel)
 
 < en: deep-sea shrimp
@@ -87589,7 +85787,6 @@ zh: 草蝦, Penaeus monodon
 # yue:大虎蝦, Penaeus monodon
 # zh-tw:斑節對蝦, Penaeus monodon
 wikipedia:en: https://en.wikipedia.org/wiki/Penaeus_monodon
-# ingredient/fr:Penaeus-monodon has 16 products @2019-01-13
 
 < en: deep-sea shrimp
 fr: crevettes tropicale décortiqué crue
@@ -87633,7 +85830,6 @@ it: heterocarpus
 la: Heterocarpus, Heterocarpus spp
 wikidata:en: Q3932367
 wikipedia:en: https://en.wikipedia.org/wiki/Heterocarpus
-# ingredient/fr:Heterocarpus-spp has 2 products in french @2019-01-06
 
 # en:description:Crangon crangon is a commercially important species of caridean shrimp fished mainly in the southern North Sea
 
@@ -87664,9 +85860,7 @@ uk: Шримс звичайний, Crangon crangon
 # nds:Granaat, Crangon crangon
 # pcd:Soetréle, Crangon crangon
 # vls:Nôordzêegeirnoar, Crangon crangon
-# ingredient/fr:crevettes-grises has 9 products in french @2019-01-06
 wikipedia:en: https://en.wikipedia.org/wiki/Crangon_crangon
-# ingredient/fr:Crangon-crangon has 6 products @2019-01-06
 
 < en: shrimp
 en: northern prawn, Pandalus borealis
@@ -87693,7 +85887,6 @@ sv: Nordhavsräka, Pandalus borealis
 vi: Tôm hồng, Pandalus borealis
 zh: 北极虾, Pandalus borealis
 wikidata:en: Q122181
-# ingredient/fr:Pandalus-borealis has 41 products @2020-08-06
 
 # en:description:Parapenaeopsis sculptilis, commonly known as the Rainbow Shrimp, is a marine crustacean that is widely reared for food
 
@@ -87706,7 +85899,6 @@ it: gamberetti arcobaleno
 la: Parapenaeopsis sculptilis, Parapenaeopsis, Parapenaeopsis spp
 wikidata:en: Q14025149
 wikipedia:en: https://en.wikipedia.org/wiki/Parapenaeopsis_sculptilis
-# ingredient/fr:Parapenaeopsis-spp has 1 product @2019-01-06
 
 < en: shrimp
 en: parapenaeopsis stylifera
@@ -87714,17 +85906,14 @@ xx: parapenaeopsis stylifera
 de: Parapenaeopsis Stylifera
 wikidata:en: Q6491649
 wikipedia:nl: https://nl.wikipedia.org/wiki/Parapenaeopsis_stylifera
-# ingredient/fr:Parapenaeopsis-stylifera has 1 product @2019-01-06
 
 < en: shrimp
 la: Solenocera spp
 wikidata:en: Q10673156
-# ingredient/fr:Solenocera-spp has 2 products @2019-01-06
 
 < en: shrimp
 la: Metapenaeus affinis, Metapaneus affinis
 wikipedia:nl: https://nl.wikipedia.org/wiki/Metapenaeus_affinis
-# ingredient/fr:Metapaneus-affinis has 1 product @2019-01-06
 
 
 < en: shrimp
@@ -87736,7 +85925,6 @@ is: bleikrækja
 description:en: Pandalus jordani is een garnalensoort uit de familie van de Pandalidae.
 wikidata:en: Q4470579
 wikipedia:nl: https://nl.wikipedia.org/wiki/Pandalus_jordani
-# ingredient/fr:Pandalus-jordani has 3 products @2108-12-14
 
 < en: shrimp
 la: Solenocera Crassicornis
@@ -87769,7 +85957,6 @@ ur: اسپغول
 description:en: Psyllium, or ispaghula, is the common name used for several members of the plant genus Plantago whose seeds are used commercially for the production of mucilage. It can be used for the fibres or as infusion.
 wikidata:en: Q15258700
 wikipedia:en: https://en.wikipedia.org/wiki/Psyllium
-# ingredient/fr:psyllium has 89 products in 4 languages @2018-12-17
 
 en: psyllium seed
 da: loppefrø
@@ -88029,7 +86216,6 @@ vegan:en: no
 vegetarian:en: yes
 wikidata:en: Q10987
 wikipedia:en: https://en.wikipedia.org/wiki/Honey
-# 23961 in 36 @2021-09-04
 
 < en: honey
 en: bee honey
@@ -88052,7 +86238,6 @@ pl: miód pszczeli
 #de:Purer Honig
 #es:miel pura
 #fr:Miel pur
-# ingredient/fr:miel-pur has 3 products @2019-0-28
 
 < en: honey
 en: organic honey
@@ -88064,7 +86249,6 @@ fr: miel bio, miel biologique, miel issu de l'agriculture biologique
 hr: organski med
 it: miele biologico
 nl: biologische honing
-# ingredient/nl:biologische-honing has 4 products @2019-05-24
 
 #process:en: en:unpasteurized
 #<en:honey
@@ -88089,7 +86273,6 @@ fr: miel-liquide
 hr: tekući med
 it: miele liquido
 nl: vloeibare honing
-# ingredient/fr:miel-liquide has 12 products in french @2019-05-28
 
 < en: honey
 en: creamy honey, Creamy nectar honey, Honey with creamy flowers
@@ -88097,8 +86280,6 @@ de: Honig cremig
 fr: miel crémeux, miel de nectar crémeux, miel de fleurs crémeux
 hr: kremasti med
 it: miele cremoso
-# 15 products in 4 @2021-09-04
-# ingredient/fr:miel-de-fleurs-cremeux has 4 products @2019-05-28
 
 < en: creamy honey
 fr: miel crémeux bio, miel de fleurs crémeux issu de l'agriculture biologique
@@ -88114,7 +86295,6 @@ hr: med cvjetni, cvjetni med
 it: miele di fiori
 nl: bloemenhoning, bloemen-honing
 pl: miód kwiatowy
-# ingredient/flower-honey has 165 products in 5 languages @2018-12-17
 
 < en: flower honey
 fr: miel toutes fleurs
@@ -88122,7 +86302,6 @@ de: Mischblütenhonig
 es: miel mil flores
 it: miele millefiori
 pl: miód wielokwiatowy, miód nektarowy wielokwiatowy
-# 31 products in 4 @2019-05-28
 
 < en: organic honey
 < fr: miel toutes fleurs
@@ -88133,7 +86312,6 @@ it: miele biologico di millefiori
 < en: flower honey
 < en: honey from France
 fr: miel de fleurs de France
-# 9 products in french @2021-09-05
 
 
 #<en:flower honey
@@ -88158,7 +86336,6 @@ fr: miel de fleurs sauvages
 hr: med od divljeg cvijeća
 it: miele di fiori selvatici
 nl: wilde bloemen honing
-# 138 products in 3 @2021-09-05
 
 ##################### HONEY FROM SPECIFIC FLOWERS
 
@@ -88172,7 +86349,6 @@ fr: miel d'acacia, miel de acacia
 hr: bagremov med
 it: miele d'acacia
 nl: acaciahoning
-# 192 products in 7 @2021-09-05
 
 #<en:acacia honey
 #<en:organic honey
@@ -88189,7 +86365,6 @@ fr: miel d'acacia de france, miel d'acacia récolté en France, Miel d'acacia de
 hr: bagremov med iz Francuske
 it: miele di acacia proveniente dalla Francia
 nl: Acaciahoning uit Frankrijk
-# 12 products in FR @2021-09-21
 
 < en: acacia honey
 #<en:honey from Italy
@@ -88215,7 +86390,6 @@ fr: miel baies roses
 
 < en: honey
 fr: miel de Bourdaine
-# 3 products @2021-09-05
 
 < en: honey
 fr: miel de bruyere
@@ -88238,7 +86412,6 @@ fr: miel de châtaignier, miel de chataigner, miel de fleurs de chataignier
 de: Kastanienhonig
 it: miele di castagno
 nl: kastanjehoning
-# 49 in 4 @2021-09-05
 
 #<fr:miel de châtaignier
 #fr:miel de châtaignier biologique, miel de chataignier issu de l'agriculture biologique
@@ -88249,7 +86422,6 @@ fr: miel de châtaignier origine France, Miel de châtaignier récolté en Franc
 
 < en: honey
 fr: miel de citronnier
-# 13 products in 2 @2021-09-05
 
 #<fr:miel de citronnier
 #fr:miel de citronnier biologique, miel de citronnier bio
@@ -88257,7 +86429,6 @@ fr: miel de citronnier
 < en: honey from Spain
 < fr: miel de citronnier
 fr: miel de citronnier d'Espagne
-# ingredient/fr:miel-de-citronnier-d-espagne has 3 products @2019-05-28
 
 < en: honey
 en: eucalyptus honey
@@ -88267,7 +86438,6 @@ fr: miel d'eucalyptus
 hr: med od eukaliptusa
 it: miele di eucalipto
 nl: eucalyptushoning
-# 15 products @2021-09-05
 
 #<en:eucalyptus honey
 #en:organic eucalyptus honey
@@ -88294,7 +86464,6 @@ fr: miel de lavande, Miels de lavande, miel de lavande maritime, miel de nectar 
 hr: med od lavande
 it: miele di lavanda
 nl: Lavandelhoning, Lavendelhoningen
-# ingredient/fr:miel-de-lavande has 39 products @2019-05-23
 wikidata:en: Q43683476
 
 < en: honey from France
@@ -88309,7 +86478,6 @@ fr: Miel de lavande de Provence
 hr: med od lavande iz Provanse
 it: miele di lavanda della Provenza
 nl: lavendelhoning uit de Provence
-# ingredient/fr:miel-de-lavande-de-provence has 11 products in french @2019-05-28
 
 < en: honey
 fr: miel de litchi
@@ -88319,7 +86487,6 @@ fr: Miel de luzerne
 
 < en: honey
 fr: miel de mandarinier
-# ingredient/fr:miel-de-mandarinier has 3 products @2019-05-28
 
 < en: honey
 en: Manuka honey
@@ -88329,7 +86496,6 @@ fi: manuka-hunaja, manukahunaja
 fr: miel de Manuka
 hr: manuka med
 it: miele di Manuka
-# ingredient/fr:miel-de-manuka has 5 products @2019-05-28
 
 < en: honey
 de: Mokaranahonig
@@ -88346,7 +86512,6 @@ fr: miel d'oranger, miel de fleur d'oranger
 hr: med od narančinog cvijeta
 it: miele di fiori d'arancio
 nl: sinaasappelbloesemhoning
-# ingredient/fr:miel-d'oranger has 24 products in french @2019-05-23
 
 < en: orange blossom honey
 fr: miel d'oranger biologique
@@ -88362,7 +86527,6 @@ fi: rosmariinihunaja
 fr: miel de romarin
 hr: med od ružmarina
 it: miele di rosmarino
-# ingredient/fr:miel-de-romarin has 10 products in 3 languages @2019-05-28
 
 #<en:rosemary honey
 #fr:miel de romarin bio
@@ -88384,7 +86548,6 @@ de: Tannenhonig
 es: miel de abeto
 it: miele di abete
 nl: sparrenhoning
-# ingredient/fr:miel-de-sapin has 11 products in french @2019-05-28
 
 < en: honey from France
 < fr: miel de sapin
@@ -88404,7 +86567,6 @@ hr: suncokretov med
 it: miele di girasole
 nl: zonnebloemhoning
 pl: miód słonecznikowy
-# ingredient/fr:miel-de-tournesol has 7 products in french @2019-05-28
 
 < en: honey
 en: Thyme honey
@@ -88417,7 +86579,6 @@ fr: miel de thym
 hr: med od majčine dušice
 it: miele di timo
 nl: Tijmhoning
-# ingredient/fr:miel-de-thym has 18 products in 3 languages@2019-05-23
 
 < en: Thyme honey
 < en: honey from Spain
@@ -88432,7 +86593,6 @@ hr: lipov med
 it: miele di tiglio
 nl: Lindebloesemhoning
 pl: miód lipowy
-# ingredient/fr:miel-de-tilleul has 13 products @2019-05-23
 
 < en: honey from France
 < fr: Miel de tilleul
@@ -88457,7 +86617,6 @@ fi: Sekoitehunaja
 fr: mélange de miels
 hr: mješavina meda
 it: miscela di mieli
-# ingredient/fr:melange-de-miels has 11 products in french @2019-05-24
 
 < en: blend of honeys
 en: mix of flower honeys
@@ -88465,7 +86624,6 @@ de: Mischung aus Blütenhonig
 fr: mélange de miels de fleurs
 hr: mješavina cvjetnih medova
 it: miscela di mieli di fiori
-# ingredient/fr:melange-de-miels-de-fleurs has 6 products @2019-05-28
 
 < en: blend of honeys
 en: blend of EU honeys
@@ -88474,7 +86632,6 @@ fr: mélange de miels originaires de l'UE
 hr: mješavina eu medova
 it: miscela di mieli europei
 nl: mengsel van honing uit de EU
-# ingredient/fr:melange-de-miels-originaires-de-l-ue has 5 products in french @2019-05-28
 
 < en: blend of honeys
 en: blend of non-EU honey
@@ -88483,7 +86640,6 @@ fr: mélange de miels non originaires de l'UE, mélange de miels non originaires
 hr: mješavina meda izvan EU
 nl: gemengde niet-EU-honing
 sv: blandning av icke-eu-honung
-# ingredient/fr:melange-de-miels-non-originaires-de-l-ue has 5 products @2019-05-28
 
 < en: blend of honeys
 en: Blend of EU and non-EU honeys
@@ -88494,8 +86650,6 @@ fr: mélange de miels originaires et non originaires de l'ue, melange de miels o
 hr: mješavina meda iz EU i izvan EU
 nl: gemengde EG- en niet EG honing
 sv: blandning av honung från länder inom och utanför eu
-# ingredient/fr:mélange-de-miels-originaires-et-non-originaires-de-l’ue has 25 products in french @2018-12-17
-# ingredient/fr:melange-de-miels-originaires-et-non-originaires-de-la-ce has 11 products @2019-05-28
 
 ##################### HONEY FROM SPECIFIC AREAS
 
@@ -88508,7 +86662,6 @@ fr: miel de forêt
 hr: šumski med
 it: miele di bosco
 nl: boshoning
-# ingredient/fr:miel-de-foret has 9 products @2019-05-28
 
 < en: forest honey
 fr: miel de foret d'italie
@@ -88524,7 +86677,6 @@ fr: miel de montagne, miel de fleurs de montagne
 hr: planinski med
 it: miele di montagna
 nl: berghoning
-# ingredient/fr:miel-de-montagne has 16 products in french @2019-03-23
 
 < en: mountain honey
 en: organic mountain honey
@@ -88557,7 +86709,6 @@ it: miele dalla Nuova Zelanda
 
 < en: mountain honey
 fr: miel de montagne du Chili
-# ingredient/fr:miel-de-montagne-du-chili has 3 products @2019-08-25
 
 < en: honey
 en: honey from France
@@ -88568,13 +86719,11 @@ fr: miel de France, miel récolté en france, miel de Poitou-Charentes, miel de 
 hr: med iz Francuske
 it: miele dalla Francia
 nl: honing uit Frankrijk
-# ingredient/fr:miel-de-france has 20 products in french @2019-05-28
 
 < en: honey from France
 en: honey from the Gâtinais
 fr: miel du Gâtinais
 it: miele del Gâtinais
-# ingredient/fr:miel-du-gatinais has 7 products @2019-05-28
 
 < en: honey from France
 en: honey from the Provence
@@ -88582,7 +86731,6 @@ de: Honig aus der Provence
 fr: miel de provence
 hr: med iz Provanse
 it: miele di Provenza
-# ingredient/fr:miel-de-provence has 5 products @2019-05-28
 
 < en: honey
 en: honey from Spain
@@ -88603,7 +86751,6 @@ fr: miel de printemps
 hr: proljetni med
 it: miele di primavera
 nl: voorjaarshoning
-# ingredient/fr:miel-de-printemps has 4 products in french @2019-05-28
 
 < en: honey
 fr: Miel et propolis verte
@@ -88918,7 +87065,6 @@ zh: 葡萄糖醛酸內酯
 # zh-tw:葡萄糖醛酸內酯
 wikidata:en: Q411638
 wikipedia:en: https://en.wikipedia.org/wiki/Glucuronolactone
-# ingredient/fr:glucuronolactone has 31 products in 5 languages @2019-02-09
 
 
 # description:en:GUM BASE is the non-nutritive, non-digestible, water-insoluble masticatory delivery system used to carry sweeteners, flavors, and any other substances in chewing gum and bubble gum. It provides all the basic textural and masticatory properties of gum. The actual composition of gum base is usually a trade secret.
@@ -88936,7 +87082,6 @@ pl: baza gumowa
 sv: gummibas, tuggummibas
 wikidata:en: Q5618000
 wikipedia:en: https://en.wikipedia.org/wiki/Gum_base
-# ingredient/fr:gomme-base has 435 products in 4 languages @2019-05-18
 
 < en: plant
 en: tree gum, plant gum, vegetable gum
@@ -89007,7 +87152,6 @@ zh: 薄荷醇
 # zh-tw:薄荷醇
 wikidata:en: Q407418
 wikipedia:en: https://en.wikipedia.org/wiki/Menthol
-# ingredient/menthol has 245 products in 8 languages @2019-05-09
 
 
 
@@ -89063,7 +87207,6 @@ zh: 亚硫酸盐
 # zh-tw:亞硫酸鹽
 wikidata:en: Q413363
 wikipedia:en: https://en.wikipedia.org/wiki/Sulfite
-# ingredient/fr:sulfite has 3512 products in 10 languages @2018-12-11
 
 
 
@@ -89223,7 +87366,6 @@ zh: 咖啡
 zu: Ikhofi
 carbon_footprint_fr_foodges_ingredient:fr: Café moulu
 carbon_footprint_fr_foodges_value:fr: 15.7
-# ingredient/en:coffee has 1637 products in 10 languages @2018-11-30
 ciqual_proxy_food_code:en: 18003
 ciqual_proxy_food_name:en: Coffee, ground
 ecobalyse:en: coffee-ground
@@ -89360,7 +87502,6 @@ fr: café biologique
 hr: organska kava
 it: caffè biologico
 nl: koffie van biologische oorsprong
-# ingredient/nl:koffie-van-biologische-oorsprong has 1 product @2019-05-24
 
 < en: coffee
 en: decaffeinated coffee
@@ -89372,7 +87513,6 @@ fr: café décaféiné
 hr: dekofeinizirani kave
 it: Caffè decaffeinato
 nl: Cafeïnevrije koffie
-# ingredient/fr:cafe-decafeine has 8 products @2019-06-03
 ciqual_food_code:en: 18070
 ciqual_food_name:en: Decaffeinated not instant coffee, without sugar, ready-to-drink
 
@@ -89405,7 +87545,6 @@ hr: kava u prahu
 it: caffè in polvere
 nl: koffiepoeder
 sv: kaffepulver
-# ingredient/fr:café-en-poudre has 39 products in 6 languages @2018-11-30
 
 < en: coffee
 en: arabica coffee, coffee Arabica, arabica, coffea arabica
@@ -89454,7 +87593,6 @@ uk: Кава аравійська
 uz: Coffea arabica
 vi: Cà phê chè
 zh: 小果咖啡
-# ingredient/fr:café-arabica has 38 products in 5 languages @2018-11-30
 ciqual_proxy_food_code:en: 18003
 ciqual_proxy_food_name:en: Coffee, ground
 wikidata:en: Q47685
@@ -89479,7 +87617,6 @@ fr: café Arabica de Colombie en poudre
 
 < en: arabica coffee
 fr: café moulu pur arabica, café moulu arabica, café moulu 100 arabica
-# ingredient/fr:café-moulu-pur-arabica has 35 products in 4 languages @2018-11-30
 
 < fr: café moulu pur arabica
 fr: cafe moulu pur arabica bio
@@ -89491,7 +87628,6 @@ de: gerösteter Arabica-Kaffee
 es: café arábica tostado
 hr: pržena arabica kava
 it: caffè arabica tostato
-# ingredient/fr:cafe-arabica-torréfié has 18 products in french @2019-05-23
 
 < en: arabica coffee
 en: arabica coffee extract
@@ -89501,8 +87637,6 @@ fr: extraits de café arabica
 hr: ekstrakt kave arabica
 it: estratto di caffè Arabica
 sv: arabica kaffeextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:arabica-kahviuute
-# 1 entry @ 2019-10-31
 
 < en: coffee
 en: coffea robusta, coffea canephora
@@ -89564,7 +87698,6 @@ nl: gemalen koffie
 ro: cafea măcinată
 carbon_footprint_fr_foodges_ingredient:fr: Café moulu
 carbon_footprint_fr_foodges_value:fr: 15.7
-# ingredient/fr:café-moulu has 151 products in 5 languages @2018-11-30
 ciqual_food_code:en: 18003
 ciqual_food_name:en: Coffee, ground
 ciqual_food_name:fr: Café, moulu
@@ -89579,7 +87712,6 @@ hr: pržene mljevene kave
 it: caffè torrefatto macinato
 nl: gemalen gebrande koffie, gebrande koffie gemalen, gebrande en gemalen koffie
 pt: café torrado moído
-# ingredient/fr:café-torréfié-moulu has 85 products in 4 languages @2018-11-30
 
 < en: ground coffee
 fr: Café moulu en capsules
@@ -89606,7 +87738,6 @@ hr: pržena kava
 it: caffè torrefatto
 nl: gebrande koffie
 pt: café torrado
-# ingredient/fr:café-torréfié has 58 products in 5 languages @2018-11-30
 
 < en: roasted coffee
 en: roasted coffee beans
@@ -89617,7 +87748,6 @@ fr: café torréfié en grains
 hr: pržena kava u zrnu
 it: caffè torrefatto in chicchi
 nl: gebrande koffiebonen
-# ingredient/fr:cafe-torrefie-en-grains has 8 products @2019-0-27
 
 #processing:en en:extract
 #<en:coffee
@@ -89634,7 +87764,6 @@ nl: gebrande koffiebonen
 #pt:extrato de café, extracto de café
 #ro:extract din cafea
 #sv:kaffeextrakt
-# ingredient/fr:extrait-de-café has 279 products in 5 languages @2018-11-30
 
 #processing:en: en:liquid
 #processing:en en:extract
@@ -89702,7 +87831,6 @@ description:en: INSTANT COFFEE is a beverage derived from brewed coffee beans th
 wikidata:en: Q858049
 wikipedia:en: https://en.wikipedia.org/wiki/Instant_coffee
 wiktionary:en: instant_coffee
-# 1171 in 16 @2021-09-10
 
 #processing:en: en:freeze dried
 #<en:instant coffee
@@ -89775,7 +87903,6 @@ tr: kreatin
 uk: креатин
 vi: creatine
 zh: 肌酸
-# ingredient/fr:creatine has 9 products in 1 language @2020-05-23
 vegan:en: maybe
 vegetarian:en: maybe
 # ast:creatina
@@ -89793,7 +87920,6 @@ hr: kreatin monohidrat
 it: Monoidrato di creatina
 pl: monohydrat kreatyny
 wikidata:en: Q27271832
-# ingredient/fr:creatine-monohydrate has 23 products in 3 languages @2020-05-23
 
 en: plant stanol
 de: Pflanzenstanole
@@ -89803,7 +87929,6 @@ hr: biljka stanol
 it: stanolo vegetale
 pl: stanole roślinne
 sv: växtstanol
-# ingredient/fr:stanols-vegetaux has 3 products in 2 languages @2020-06-13
 vegan:en: yes
 vegetarian:en: yes
 
@@ -89816,14 +87941,12 @@ hr: biljni stanol ester
 it: estere di stanolo vegetale
 pl: estry stanoli roślinnych
 sv: växtstanolester
-# ingredient/fr:esters-de-stanols-vegetaux has 4 products in 3 languages @2020-06-13
 
 en: plant sterol ester
 es: éster de esterol vegetal, ésteres de esteroles vegetales
 fi: kasvisteroliesteri, kasvisteroliesterit
 fr: ester de stérol végétal, esters de stérol végétal
 pl: estry steroli roślinnych
-# ingredient/fr:esters-de-sterol-vegetal has 29 products in 3 languages @2020-12-21
 vegan:en: yes
 vegetarian:en: yes
 
@@ -89885,7 +88008,6 @@ ecobalyse_labels_en_organic:en:
 ecobalyse_labels_en_organic_origins_en_france:en:
 ecobalyse_origins_en_european_union:en:
 ecobalyse_origins_en_france:en: cucumber-fr-offseason
-# 6546 products in 22 @2021-09-02
 eurocode_2_group_3:en: 8.40.30
 nutriscore_fruits_vegetables_nuts:en: yes
 usda_ndb_2_code:en: 11206
@@ -89943,7 +88065,6 @@ ro: castraveți murați
 en: gherkin, pickled or unpickled gherkin
 sv: inläggningsgurka
 description:en: GHERKIN can refer to either a pickled small cucumber (esp. in Ireland and the UK) or an unpickled small cucumber
-# ingredient/gherkin has 1006 products in 8 languages @2018-12-01
 
 #< en: compound
 < en: pickled gherkin
@@ -89956,7 +88077,6 @@ nl: augurken op azijn
 ciqual_food_code:en: 11004
 ciqual_food_name:en: Gherkin, pickled in vinegar
 # usage:de:Essiggurken [Gurken, Branntweinessig, Zucker, Kochsalz]
-# fr:cornichons-au-vinaigre has 39 products in 2 languages @2018-12-01
 eurocode_2_group_2:en: 8.70
 eurocode_2_group_3:en: 8.70.40
 
@@ -89977,7 +88097,6 @@ fi: etikkakurkut
 fr: concombres au vinaigre
 hr: ocat krastavci
 it: cetrioli all'aceto
-# ingredient/fr:concombres-au-vinaigre has 19 products in 4 languages @2019-05-15
 
 # <en:cucumber
 # fr:Concombre produit sous serre chauffée
@@ -89994,7 +88113,6 @@ fr: jus de concombre
 hr: sok od krastavaca
 it: Succo di cocomero
 nl: komkommersap
-# ingredient/cucumber-juice has 84 products in 3 languages @2019-05-15
 
 # <en:cucumber juice
 # en:pascalised cucumber juice
@@ -90022,7 +88140,6 @@ fr: jus de concombre à base de concentré
 hr: sok od krastavca iz koncentrata
 it: succo di cetriolo da concentrato
 nl: komkommersap uit concentraat
-# ingredient/cucumber-juice-from-concentrate has 1 product @2019-05-15
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -90116,7 +88233,6 @@ vegetarian:en: no
 # zh-sg:家禽# zh-tw:家禽
 wikidata:en: Q178559
 wikipedia:en: https://en.wikipedia.org/wiki/Poultry
-# ingredient/fr:volaille has 99 products in 4 languages @2019-03-11
 
 < en: poultry
 en: poultry protein
@@ -90150,7 +88266,6 @@ it: carne di pollame separata meccanicamente
 
 < en: poultry meat
 fr: viande de volaille traitée en salaison
-# ingredient/fr:viande-de-volaille-traitée-en-salaison has 30 products in french @2019-04-16
 
 < en: poultry
 # <en:skin
@@ -90164,7 +88279,6 @@ hr: koža peradi
 it: Pelle di pollame
 nl: gevogeltevel
 pl: skórki drobiowe, skórki z drobiu
-# ingredient/fr:peau-de-volaille has 76 products in french @2019-03-29
 
 < en: poultry
 en: poultry liver
@@ -90179,7 +88293,6 @@ zh: 禽类肝脏
 ciqual_food_code:en: 40108
 ciqual_food_name:en: Liver, poultry, raw
 ciqual_food_name:fr: Foie, volaille, cru
-# 260 in 3 @2021-0-10
 
 < en: poultry
 fr: jus de cuisson de volaille
@@ -90395,8 +88508,6 @@ usda_ndb_proxy_code:en: 5332
 usda_ndb_proxy_name:en: Chicken, ground, raw
 wikidata:en: Q780
 wikipedia:en: https://en.wikipedia.org/wiki/Chicken_as_food
-# ingredient/chicken has 872 products @2019-05-18
-# category/chickens has 3369 products in 18 languages @2019-05-18
 
 < en: chicken
 en: free range chicken
@@ -90418,7 +88529,6 @@ en: traditional free-range chicken, farm reared chicken, farm raised chicken
 de: Huhn aus Freilandhaltung
 fr: poulet fermier, poulet fermier élevé en plein air
 hr: tradicionalni slobodni uzgoj piletine
-# ingredient/fr:poulet-fermier has 13 products in french @2019-05-25
 
 < en: chicken
 en: whole chicken, whole chickens
@@ -90456,7 +88566,6 @@ hr: pilleće kožice
 it: osso di pollo
 nl: kippenbeenderen
 pl: kość z kurczaka, kości z kurczaka
-# ingredient/fr:os-de-poulet has 184 products in 5 languages @2019-05-10
 
 < en: chicken
 en: chicken heart
@@ -90492,7 +88601,6 @@ ciqual_food_code:en: 40111
 ciqual_food_name:en: Liver, chicken, raw
 ciqual_food_name:fr: Foie, poulet, cru
 wikidata:en: Q67210929
-# 341 in 9 @2021-09-11
 
 < en: chicken
 en: chicken stomach
@@ -90519,7 +88627,6 @@ ro: piele de pui
 sv: kycklingskinn
 usda_ndb_proxy_code:en: 5674
 usda_ndb_proxy_name:en: Chicken, skin (drumsticks and thighs), raw
-# ingredient/fr:peau-de-poulet has 215 products in 7 languages @2019-03-29
 
 < en: chicken skin
 en: raw chicken skin
@@ -90553,7 +88660,6 @@ sv: kycklingkött
 tr: tavuk eti
 zh: 鸡肉
 # wikidata:en:Q864693
-# ingredient/chicken-meat has 2349 products in 8 languages @2019-04-16
 carbon_footprint_fr_foodges_ingredient:fr: Cuisse de poulet
 carbon_footprint_fr_foodges_value:fr: 4.9
 ciqual_food_code:en: 36005
@@ -90621,7 +88727,6 @@ it: carne di pollo bianca
 
 < en: chicken meat
 fr: viande de cuisse de poulet
-# ingredient/fr:viande-de-cuisse-de-poulet has 53 products in french @2019-04-16
 
 < fr: viande de cuisse de poulet
 fr: Viande de haut de cuisse de poulet sans peau
@@ -90682,7 +88787,6 @@ fr: viande de poulet précuite
 hr: prethodno kuhano pileće meso
 it: carne di pollo precotta
 nl: voorgekookt kippenvlees, gegaard kippenvlees
-# ingredient/fr:viande-de-poulet-précuite has 9 products in french @2019-04-16
 
 < en: chicken meat
 en: chicken meat including chicken juices
@@ -90717,7 +88821,6 @@ sv: kycklingfilé, kycklinginnerfilé, kycklinglårfilé, filé av kyckling
 #ciqual_food_name:fr: Poulet, filet, sans peau, sauté/poêlé
 ciqual_food_code:en: 36019
 #ciqual_food_name:en: Chicken, breast, without skin, raw
-# ingredient/fr:filet-de-poulet has 836 products in 6 languages @2019-03-19
 
 < en: chicken fillet
 en: chicken fillet with skin
@@ -90750,12 +88853,10 @@ fr: filet de poulet halal
 hr: halal pileći file
 it: filetto di pollo halal
 nl: halal kipfilet
-# ingredient/fr:filet-de-poulet-halal has 1 products @2019-05-19
 
 < en: chicken fillet
 fr: filet de poulet traité en salaison cuit
 nl: verhitte gepekelde kipfilet
-# ingredient/fr:filet-de-poulet-traité-en-salaison-cuit has 4 products @2019-05-19
 
 < fr: filet de poulet traité en salaison cuit
 fr: préparation à base de filets de poulet traités en salaison
@@ -90770,8 +88871,6 @@ de: Hühnerfleischpulver
 
 < de: hähnchenfilet
 fi: uunipaahdettu broilerinfilee
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:uunipaahdettu-broilerinfilee
-# 1 entry @ 2019-10-31
 
 < en: chicken meat
 en: chicken breast, chicken breast meat
@@ -90817,7 +88916,6 @@ it: filetto di petto di pollo
 nl: kippenborstfilet
 pl: filet z piersi kurczaka, filet z piersi z kurczaka, filety z piersi kurczaka, filety z piersi z kurczaka, filet z piersi kurcząt, mięso z fileta piersi kurczaka
 sv: kycklingbröstfilé
-# ingredient/fr:filet-de-poitrine-de-poulet has 9 products in 2 languages @2020-06-13
 
 < en: chicken meat
 en: chicken thigh, chicken drumstick
@@ -91031,7 +89129,6 @@ ciqual_food_code:en: 40121
 ciqual_food_name:en: Liver, duck, raw
 ciqual_food_name:fr: Foie, canard, cru
 wikidata:en: Q57655562
-# 1642 in 7 @2021-09-11
 
 < en: duck liver
 en: lean duck liver
@@ -91214,7 +89311,6 @@ zh: 火雞
 # yue:火雞
 wikipedia:en: https://en.wikipedia.org/wiki/Turkey_(bird)
 # usage:en:meat extracts [turkey, chicken]
-# ingredient/fr:dinde has 161 products in 4 languages @2019-04-16
 
 # description:en:TURKEY MEAT, commonly referred to as just turkey, is the meat from turkeys, typically domesticated turkeys. Turkeys are sold sliced and ground, as well as "whole" in a manner similar to chicken with the head, feet, and feathers removed. Frozen whole turkeys remain popular. Sliced turkey is frequently used as a sandwich meat or served as cold cuts.
 
@@ -91283,7 +89379,6 @@ usda_ndb_proxy_code:en: 5305
 usda_ndb_proxy_name:en: Turkey, Ground, raw
 wikidata:en: Q4200953
 wikipedia:en: https://en.wikipedia.org/wiki/Turkey_as_food
-# ingredient/fr:viande-de-dinde has 1257 products in 7 languages @2019-04-18
 
 < en: turkey
 en: raw ground turkey
@@ -91296,7 +89391,6 @@ nl: kalkoenhenvlees
 
 < en: turkey meat
 fr: viande de dinde halal
-# ingredient/fr:viande-de-dinde-halal has 6 products in french @2019-04-16
 
 < en: turkey meat
 en: turkey breast, turkey fillet, turkey breast meat
@@ -91313,8 +89407,6 @@ pl: pierś indyka, pierś z indyka, mięso z piersi indyka
 pt: Peito de peru
 sv: kalkonbröst
 tr: hindi göğsü
-# ingredient/fr:filet-de-dinde has 162 products in 5 languages @2019-04-16
-# ingredient/en:turkey-breast has 1255 products in 3 languages @2020-06-13
 carbon_footprint_fr_foodges_ingredient:fr: Blanc de dinde
 carbon_footprint_fr_foodges_value:fr: 6.5
 
@@ -91328,7 +89420,6 @@ fr: viande de dinde séparée mécaniquement, viande séparée mécaniquement de
 hr: mehanički otkošeno pureće meso
 it: carne di tacchino separata meccanicamente
 pl: mechanicznie oddzielone mięso z indyka, mięso oddzielone mechanicznie z indyka
-# ingredient/fr:viande-séparée-mécaniquement-de-dinde has 80 products in 4 languages @2019-04-16
 
 < en: turkey meat
 en: turkey thigh, turkey leg, turkey drumstick
@@ -91340,7 +89431,6 @@ hr: pureći zabatak
 it: coscia di tacchino
 carbon_footprint_fr_foodges_ingredient:fr: Cuisse de dinde
 carbon_footprint_fr_foodges_value:fr: 6.6
-# ingredient/fr:cuisse-de-dinde has 84 products in french @2019-04-16
 
 < en: turkey meat
 < en: turkey thigh
@@ -91351,7 +89441,6 @@ fr: viande de cuisse de dinde
 hr: meso purećeg zabatka
 it: carne di coscia di tacchino
 pl: mięso z uda indyka
-# ingredient/fr:viande-de-cuisse-de-dinde has 58 products in french @2019-04-16
 
 # <en:skin
 < en: poultry skin
@@ -91365,15 +89454,12 @@ hr: pureća koža
 it: pelle di tacchino
 nl: kalkoenvel
 pl: skórki z indyka, skórki indycze, skórki drobiowe z indyka
-# ingredient/fr:peau-de-dinde has 76 products in french @2019-03-01
 
 < en: turkey meat
 fr: viande de dinde traitée en salaison
-# ingredient/fr:viande-de-dinde-traitée-en-salaison has 35 products in french @2019-04-16
 
 < en: turkey meat
 fr: Escalopes de dinde
-# ingredient/fr:escalopes-de-dinde has 22 products @2019-05-23
 
 # category not available @2019-07-01
 < en: turkey meat
@@ -91569,7 +89655,6 @@ usda_ndb_proxy_code:en: 5157
 usda_ndb_proxy_name:en: Quail, meat and skin, raw
 wikidata:en: Q6072584
 wikipedia:en: https://en.wikipedia.org/wiki/Quail
-# ingredient/fr:cailles has 4 products @2019-05-31
 
 < en: quail
 en: raw quail meat and skin
@@ -91785,7 +89870,6 @@ fr: oeufs de categorie A
 hr: jaja kategorije a
 it: uova di categoria A, uova categoria A, uova cat a
 nl: categorie A eieren
-# ingredient/fr:oeufs-de-categorie-a has 6 products @2019-05-31
 
 < en: category A eggs
 en: fresh category A eggs
@@ -91883,7 +89967,6 @@ fr: quartiers d'œufs durs
 #de:Eier pasteurisiert
 #hr:pasterizirana jaja
 #it:uova pastorizzate
-# ingredient/fr:oeuf-pasteurisé has 57 products in 4 languages @2018-12-18
 
 < en: egg
 en: poached egg
@@ -91909,7 +89992,6 @@ nl: kippeneieren
 pl: jajko kurze, jajo kurze, jaja kurze, jajka kurze
 ru: яйцо куриное, яйца куриные
 tr: tavuk yumurtası
-# ingredient/fr:œufs-de-poules has 16 products in french @2018-12-18
 
 < en: chicken egg
 en: organic chicken egg
@@ -91931,7 +90013,6 @@ fr: œufs de poules élevées en cage, oeufs de poules élevées en cage, 20 oeu
 hr: jaja od kokoši u kavezu
 it: uova da galline allevate in gabbia
 pl: jaja z chowu klatkowego
-# ingredient/fr:oeufs-de-poules-élevées-en-cage has 53 products in french @2018-12-18
 
 < en: category A eggs
 < en: eggs from caged hens
@@ -91961,7 +90042,6 @@ it: uova di gallina allevate all'aperto
 nl: ei van hennen met vrije uitloop, scharrelkipheelei, scharrelkippenei
 pl: kurze jaja z wolnego wybiegu
 
-# ingredient/fr:oeufs-de-poules-elevees-en-plein-air has 242 products in 5 languages @2018-12-18
 
 < en: free range chicken eggs
 fr: œufs de poules élevées en plein air calibre moyen
@@ -91975,7 +90055,6 @@ it: uova biologiche di galline allevate all'aperto
 < en: category A eggs
 < en: free range chicken eggs
 fr: Œufs de catégorie A de poules élevées en plein air, Oeufs de catégorie A de poules élevées en plein air, 9 Œufs de catégorie A de poules élevées en plein air, Œufs frais de poules élevées en plein air de catégorie A
-# ingredient/fr:oeufs-de-categorie-a-de-poules-elevees-en-plein-air has 5 products @2019-05-31
 
 < en: free range chicken eggs
 fr: Oeufs frais de poule élevées en plein air, 12 Oeufs frais de poule élevées en plein air
@@ -91993,7 +90072,6 @@ fr: œufs de poules élevées en plein air pasteurisés, oeufs de poules élevé
 hr: pasterizirano jaje slobodnog uzgoja
 it: uovo pastorizzato allevato all'aperto
 nl: gepasteuriseerd ei van hennen met vrije uitloop
-# ingredient/fr:œufs-de-poules-élevées-en-plein-air-pasteurisés has 49 products in 3 languages @2018-12-18
 
 < en: egg
 en: barn eggs
@@ -92006,8 +90084,6 @@ hr: ambar jaja
 it: uova di allevamento al suolo
 nl: scharreleieren, scharrelei, scharrel-ei, ei van scharreleieren
 pl: jaja z chowu ściółkowego
-# ingredient/fr:œufs-d’élevage-au-sol has 168 products in 4 languages @2018-12-18
-# ingredient/fr:œufs-de-poules-élevées-au-sol has 111 products in 4 languages @2018-12-18
 
 < en: barn eggs
 nl: scharrel ei poeder
@@ -92019,7 +90095,6 @@ nl: scharrel ei poeder
 #es:huevo líquido pasteurizado
 #fr:œuf liquide pasteurisé, oeuf liquide pasteurisé
 #nl:gepasteuriseerd vloeibaar ei
-# ingredient/fr:oeuf-liquide-pasteurisé has 50 products in 2 languages @2018-12-18
 
 #process:en: en:powdered
 < en: egg
@@ -92046,7 +90121,6 @@ ru: Яичный порошок, меланж, яичный меланж, мел
 sv: äggpulver
 tr: yumurta tozu
 zh: 蛋粉
-# ingredient/powdered-egg has 623 products in 12 languages @2018-12-18
 #ciqual_food_code:en:22013
 #ciqual_food_name:en:Egg, powder
 #ciqual_food_name:fr:Oeuf, en poudre
@@ -92067,14 +90141,12 @@ ja: 全卵
 nl: hele eieren, geheel eieren
 pl: Całe jajo
 pt: Ovo inteiro
-# ingredient/fr:œuf-entier has 2004 products in 7 languages @2018-12-18
 
 < en: whole egg
 bg: пастьоризирани цели яйца
 de: Vollei pasteurisiert, pasteurisiertes Vollei
 fr: œuf entier pasteurisé, œufs entiers pasteurisés, oeuf entier pasteurisé, oeufs entiers pasteurisés
 it: uovo intero pastorizzato
-# ingredient/fr:oeuf-entier-pasteurisé has 51 products in 4 languages @2018-12-18
 
 < en: whole egg
 en: dried whole egg
@@ -92092,7 +90164,6 @@ it: uovo intero in polvere
 #fr:œuf entier en poudre, œufs entiers en poudre, poudre d'œuf entier, poudre d'œufs entiers, oeuf entier en poudre, oeufs entiers en poudre, poudre d'oeuf entier, poudre d'oeufs entiers
 #it:uovo intero in polvere
 #nl:heeleipoeder
-# ingredient/fr:œuf-entier-en-poudre has 592 products in 7 languages @2018-12-18
 
 < en: whole powdered egg
 en: whole powdered chicken egg
@@ -92113,7 +90184,6 @@ fi: Nestemäinen kokonainen muna
 fr: œuf entier liquide, œufs entiers liquides, oeuf entier liquide, oeufs entiers liquides
 hr: tekuća cijela jaja
 it: uovo intero liquido
-# ingredient/llwiquid-whole-egg has 131 products in 4 languages @2018-12-18
 
 < en: free range eggs
 < en: liquid whole egg
@@ -92135,18 +90205,15 @@ hr: cijela svježa jaja
 it: Uova fresche intere
 nl: hele verse eieren, heel vers ei
 pt: ovos inteiros frescos
-# ingredient/fr:oeuf-entier-frais has 456 products in 6 languages @2018-12-18
 
 < en: whole fresh eggs
 fr: œufs entiers extra-frais, oeufs entiers extra-frais
 nl: extra-verse hele eieren
-# fr:oeufs-entiers-extra-frais has 73 products in french @2018-12-18
 
 < en: whole egg
 fr: œuf entier d'élevage au sol, oeuf entier d'élevage au sol
 de: Vollei aus Bodenhaltung
 it: uovo intero da allevamento al suolo
-# ingredient/fr:oeuf-entier-d’élevage-au-sol has 10 products in 4 languages @2018-1-18
 
 < en: whole egg
 fr: oeuf entier issu de poules elevées en plein air
@@ -92162,7 +90229,6 @@ hr: cijelo tekuće pasterizirano jaje
 it: uovo intero liquido pastorizzato
 nl: gepasteuriseerd vloeibaar heel ei
 sv: helt pastöriserat ägg i flytande form
-# ingredient/fr:œuf-entier-liquide-pasteurisé has 143 products in 3 languages @2018-12-18
 
 < en: whole egg
 fr: oeufs entiers reconstitués
@@ -92194,12 +90260,10 @@ pl: jaja świeże
 pt: ovos frescos
 sk: čerstvá vajcia
 sv: Färska ägg
-# ingredient/fr:œufs-frais has 2651 products in 12 languages @2018-12-17
 
 < en: fresh egg
 fr: œufs extra-frais, oeufs extra-frais
 nl: extra verse eieren
-# ingredient/fr:œufs-extra-frais has 89 products in 3 languages @2018-12-18
 
 < en: fresh egg
 en: pasteurized fresh egg
@@ -92210,12 +90274,10 @@ fi: pastöroitu tuore muna
 fr: œufs frais pasteurisés, oeufs frais pasteurisés
 hr: pasterizirano svježe jaje
 it: Uovo fresco pastorizzato
-# ingredient/fr:oeufs-frais-pasteurisés has 60 products in 2 languages @2018-12-18
 
 < en: fresh egg
 fr: œufs frais de poules élevées en plein air, oeufs frais de poules élevées en plein air
 hr: svježa jaja iz slobodnog uzgoja
-# ingredient/fr:œufs-frais-de-poules-élevées-en-plein-air has 44 products in french @2018-12-18
 
 < en: fresh egg
 hr: svježa pasterizirana jaja iz podnog uzgoja, svježa pasterizirana jaja podnog uzgoja
@@ -92273,7 +90335,6 @@ th: ไข่ขาว
 tr: Yumurta beyazı, Yumurta akı
 uk: Яєчний білок
 zh: 蛋白
-# ingredient/fr:blanc-d-oeuf has 2748 products in 13 languages @2018-12-18
 ciqual_food_code:en: 22001
 ciqual_food_name:en: Egg white, raw
 ciqual_food_name:fr: Oeuf, blanc (blanc d'oeuf), cru
@@ -92328,7 +90389,6 @@ ciqual_food_name:en: Egg white, powder
 ciqual_food_name:fr: Oeuf, blanc (blanc d'oeuf), en poudre
 usda_ndb_code:en: 1173
 usda_ndb_name:en: Egg, white, dried
-# ingredient/fr:blancs-d-oeufs-en-poudre has 1124 products in 8 languages @2018-12-17
 
 < en: egg white
 en: free range egg white
@@ -92372,7 +90432,6 @@ hr: rehidrirani bjelanjak
 it: albume reidratato
 nl: gerehydrateerd eiwit
 sv: rehydrerad äggvita
-# ingredient/rehydrated-egg-white has 150 products in 5 languages @2018-12-18
 
 < en: egg white powder
 en: pasteurised egg white powder
@@ -92398,12 +90457,10 @@ fr: blanc d'oeuf en poudre de poules élevées au sol
 
 < en: egg white
 fr: blancs d'œufs pasteurisés, blancs d'oeufs pasteurisés
-# ingredient/fr:blancs-d’oeufs-pasteurisés has 54 products in french @2018-12-18
 
 
 < en: egg white
 fr: blanc d'œuf frais, blancs d'œufs frais, blanc d'œufs frais, blanc d'oeuf frais, blancs d'oeufs frais, blanc d'oeufs frais
-# ingredient/fr:blanc-d’œuf-frais has 81 products in french @2018-12-18
 
 # en:liquid egg white is a compound ingredient
 
@@ -92417,13 +90474,11 @@ fi: Nestemäinen munavalkuainen
 fr: blanc d’œuf liquide, blanc d’oeuf liquide
 hr: bjelanjak tekući
 it: Albume d'uovo liquido
-# ingredient/fr:blanc-d’_œuf_-liquide has 47 products in 3 languages @2018-12-18
 
 < en: liquid egg white
 fr: blanc d'œuf liquide pasteurisé, blanc d'oeuf liquide pasteurisé
 nl: gepasteuriseerd vloeibaar eiwit
 sv: pastöriserad äggvita i flytande form
-# ingredient/fr:blanc-d’œuf-liquide-pasteurisé has 80 products in 3 languages @2018-12-18
 
 < en: egg white
 en: egg protein
@@ -92437,7 +90492,6 @@ hr: bjelančevina jaja
 it: proteina dell'uovo, proteine dell'uovo
 ja: 卵たん白
 nl: ei-proteine
-# ingredient/egg-protein has 47 products in 5 languages @2018-12-18
 
 #< en: compound
 #category/meringues
@@ -92500,7 +90554,6 @@ description:pt: Suspiro ou merengue é um doce feito de claras de ovos e açúca
 #es,fr,nl,gl,jv
 wikidata:en: Q276276
 # usage:fr:meringue (blanc d'OEUF, sucre)
-# 6 in 2 @2021-09-09
 
 # description:en:EGG YOLK is the part of an egg which feeds the developing chicken embryo.
 
@@ -92563,7 +90616,6 @@ tl: apyak
 tr: Yumurta sarısı
 uk: Жовток
 zh: 蛋黃
-# ingredient/egg-yolk has 6004 products in 13 languages @2018-12-17
 ciqual_food_code:en: 22002
 ciqual_food_name:en: Egg yolk, raw
 ciqual_food_name:fr: Oeuf, jaune (jaune d'oeuf), cru
@@ -92635,7 +90687,6 @@ it: tuorlo d'uovo di gallina allevata all'aperto
 nl: Eigeel van vrije uitloop eieren, scharreleigeelpoeder, scharrelkippenei-eigeel, scharrelkippenei-eigeelpoeder
 pl: żółtko jaja kurzego z chowu z wolnego wybiegu, żółtko jaja kurzego z chowu na wolnym wybiegu, żółtko z jaja kurzego z chowu na wolnym wybiegu, żółtko jaja w proszku z chowu na wolnym wybiegu
 pt: gema de ovo de galinhas criadas ao ar livre
-# ingredient/fr:jaune-d’oeuf-de-poules-élevées-en-plein-air has 61 products in 2 languages @2018-12-18
 
 < en: free range egg yolk
 en: pasteurised Free Range Egg Yolk
@@ -92644,7 +90695,6 @@ fr: jaune d'œufs de poules élevées en plein air pasteurisés, jaune d'oeufs d
 hr: pasterizirani žumanjak jaja slobodnog uzgoja
 it: tuorlo d'uovo pastorizzato allevato all'aperto
 nl: gepasteuriseerd eigeel van eieren van hennen met vrije uitloop
-# ingredient/fr:jaune-d’œufs-de-poules-élevées-en-plein-air-pasteurisés has 27 products in 2 languages @2018-12-18
 
 < en: egg yolk
 en: dried yolk egg
@@ -92667,8 +90717,6 @@ nl: eigeelpoeder
 pl: żółtko jaja w proszku, żółtko jaj w proszku
 pt: gemas de ovo em pó
 sv: äggulepulver
-# ingredient/fr:poudre-de-jaunes-d’oeufs has 17 products in 3 languages @2018-12-17
-# ingredient/fr:jaunes-d’oeufs-en-poudre has 541 products in 7 languages @2018-12-17
 ciqual_food_code:en: 22003
 ciqual_food_name:en: Egg yolk, powder
 ciqual_food_name:fr: Oeuf, jaune (jaune d'oeuf), en poudre
@@ -92689,7 +90737,6 @@ hr: pasterizirani žumanjak
 it: tuorlo d'uova pastorizzato, tuorlo d'uovo pastorizzato
 pl: pasteryzowane żółtko jaja kurzego
 pt: gema de ovo pasteurizado
-# ingredient/fr:jaune-d’oeuf-pasteurisé has 81 products in 4 languages @2018-12-18
 
 < en: egg yolk
 en: liquid egg yolk, liquid yolk
@@ -92703,17 +90750,14 @@ hr: tekući žumanjak
 it: tuorlo d'uovo liquido
 nl: vloeibaar eigeel
 pl: płynne żółtko jaja
-# ingredient/fr:jaune-d’œuf-liquide has 42 products in 3 languages @2018-12-18
 
 < en: liquid egg yolk
 fr: jaune d'œuf liquide pasteurisé, jaune d'oeuf liquide pasteurisé
 nl: gepasteuriseerd vloeibaar eigeel
-# ingredient/fr:jaune-d’oeuf-liquide-pasteurisé has 74 products in 2 languages @2018-12-18
 
 < en: egg yolk
 fr: jaune d'œuf frais, jaunes d'œufs frais, jaune d'oeuf frais, jaunes d'oeufs frais, jaune d'œufs frais, jaune d'oeufs frais
 it: tuorlo d'uova fresche, tuorlo d'uovo fresco
-# ingredient/fr:jaune-d’oeuf-frais has 176 products in 3 languages @2018-12-17
 
 < en: egg yolk
 en: sugared egg yolk
@@ -92731,7 +90775,6 @@ nl: gesuikerd eigeel
 fr: jaune d'œuf salé, jaunes d'œufs salés, jaune d'oeuf salé, jaunes d'oeufs salés
 de: Eigelb gesalzen
 nl: gezouten eigeel
-# ingredient/fr:jaune-d-oeuf-sale has 119 products in 3 languages @2018-12-17
 
 # The context should determine what part of the egg is meant.
 
@@ -92769,7 +90812,6 @@ zh: 鹌鹑蛋
 # tg-latn:Tuxmi bedona
 wikidata:en: Q1572135
 wikipedia:en: https://en.wikipedia.org/wiki/Quail_eggs
-# ingredient/fr:oeufs-de-cailles has 25 products @2019-05-23
 
 < en: egg
 en: egg derivatives
@@ -92878,7 +90920,6 @@ hr: prirodni ekstrakt
 it: estratto naturale
 nl: natuurlijk extract
 pt: extrato natural, extracto natural
-# ingredient/fr:extraits-naturels has 72 products in french @2019-04-13
 # usage:fr: extraits naturels (dont céleri)
 
 < en: extract
@@ -92896,7 +90937,6 @@ nl: plantaardig extract, plantaardige extracten
 pl: ekstrakty warzyw, ekstrakt warzyw
 pt: extrato de vegetais, extracto de vegetais
 sv: grönsaksextrakt
-# ingredient/fr:extraits-végétaux has 224 products in 11 languages @2019-05-15
 # usage:fr: extraits végétaux (spiruline, chlorelle, brocoli, épinard, pousses d'orge, pousses de blé, persil, gingembre, algues bleu-vert, ail),
 # usage:fr: arômes naturels (extraits végétaux)
 
@@ -92924,7 +90964,6 @@ description:en: CONCENTRATE is the form of substance which has had the majority 
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q1355665
-# ingredients/en:concentrate has 288 products @2025-06-15
 
 # <en:part
 < en: extract
@@ -92934,8 +90973,6 @@ es: extracto concentrado
 fi: uutetiiviste
 fr: extrait concentré
 it: estratto concentrato
-# ingredient/fr:extrait-concentré has 31 products @2019-02-15
-# ingredients/en:concentrated-extract has 45 products @2025-06-15
 # concentrated extract (safflower flower)
 
 # description:en:PURÉE is cooked food, that has been ground, pressed, blended or sieved to the consistency of a soft creamy paste
@@ -92984,7 +91021,6 @@ sv: puré
 th: ปูว์เร
 uk: Пюре
 zh: 原漿
-# ingredient/fr:purée has 151 products @2018-10-05
 # used only to qualify another ingredient, ignore for ingredient analysis
 vegan:en: maybe
 vegetarian:en: maybe
@@ -93005,12 +91041,10 @@ hr: koncentrirani pire
 it: purea concentrata
 nl: geconcentreerde puree
 # in process de:Püreekonzentrat
-# ingredient/fr:purée-concentrée has 3 products in 4 languages @2019-05-10
 
 < en: concentrated purée
 < en: purée
 fr: purée et purée concentrée
-# ingredient/fr:purée-et-purée-concentrée has 138 products in french @2019-05-10
 
 # description:en:FIBER is a natural or synthetic substance that is significantly longer than it is wide.
 
@@ -93095,7 +91129,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q161
 wikipedia:en: https://en.wikipedia.org/wiki/Fiber
-# fibre has 270 products in 8 languages @2019-03-10
 
 < en: fiber
 en: soluble fibre, soluble fiber
@@ -93236,7 +91269,6 @@ ru: растительное волокно
 sl: rastlinske vlaknine
 sr: biljna vlakna
 sv: vegetabilisk fiber, vegetabiliska fibrer, vegetabilisk fibrer, växtfiber, växtfibrer
-# ingredient/fr:fibres-végétales has 536 products in 7 languages @2019-03-11
 nova:en: 4
 # pt-br:fibra vegetal
 vegan:en: yes
@@ -93261,7 +91293,6 @@ nl: erwtenvezel, erwtvezel
 pl: błonnik grochowy, błonnik grochu, włókna grochu
 ro: fibre de mazare
 sv: ärtfiber
-# ingredient/fr:fibre-de-pois has 173 products in 7 languages @2019-04-21
 
 < en: vegetable fiber
 en: chickpea fiber
@@ -93281,7 +91312,6 @@ it: fibra de barbabietola
 nb: sukkerbetefiber
 nl: suikerbietvezel
 sv: sockerbetsfiber
-# ingredient/en:sugar-beet-fibre has 10 products in 2 languages @2020-06-13
 
 # <en:part
 # en:animal part
@@ -93389,7 +91419,6 @@ wa: Oxhea
 yo: Egungun
 za: Ndok
 zh: 骨骼
-# ingredient/fr:os has 593 products in french @2019-04-25
 # usage:fr:bouillon (eau, os, viande de porc, oignon, poivre, ail, muscade, thym, laurier, clou de girofle)
 vegan:en: no
 vegetarian:en: no
@@ -93451,7 +91480,6 @@ nl: verguldsel
 pt: pigmento
 # wikidata:en:Q2760809
 wikipedia:en: https://en.wikipedia.org/wiki/Food_browning
-# ingredient/fr:dorure has 269 products in 7 languages @2019-04-22
 # usage:en:browning:skimmed milk
 
 en: wort
@@ -93528,8 +91556,6 @@ th: อาหารยัดไส้
 tr: Dolgu
 uk: Фарш
 zh: 餡
-# ingredient/fr:garniture has 1531 products in 9 languages @2018-12-01
-# ingredient/fr:farce has 884 products in 6 languages @2019-05-18
 vegan:en: maybe
 vegetarian:en: maybe
 # ast:Rellenu
@@ -93569,7 +91595,6 @@ nl: melkvulling
 pl: nadzienie mleczne, krem o smaku mlecznym
 pt: recheio de leite
 allergens:en: en:milk
-# ingredient/fr:fourrage-lait has 42 products in 5 languages @2019-02-03
 # fourrage au _lait_ 16% (sucre, huile, ….)
 vegan:en: no
 
@@ -93600,7 +91625,6 @@ pl: nadzienie malinowe, nadzienie o smaku malinowym, wsad owocowy z malin
 sv: hallonfyllning
 # usage:en:raspberry filling (raspberries, water, granulated sugar, pectin, and citric acid)
 # mainIngredient:en:raspberry
-# ingredient/en:raspberry-filling has 112 products in 1 language @2020-06-13
 ciqual_proxy_food_code:en: 31062
 ciqual_proxy_food_name:en: Jam, raspberry
 
@@ -93640,7 +91664,6 @@ sv: fyllning med vaniljsmak
 fr: pain au chocolat
 carbon_footprint_fr_foodges_ingredient:fr: Viennoiseries pain au chocolat
 carbon_footprint_fr_foodges_value:fr: 2.3
-# ingredient/fr:pain-au-chocolat has 17 products in french @2019-03-07
 
 #category/brioches
 en: brioche, Brioches
@@ -93815,7 +91838,6 @@ ciqual_food_code:en: 37001
 ciqual_food_name:en: Pizza base, raw
 ciqual_food_name:fr: Pâte à pizza crue
 likely_allergens:en: en:gluten
-# 93 in 5 @2021-09-26
 
 < en: pizza dough
 en: pizza crust
@@ -93850,7 +91872,6 @@ hr: kuhana tjestenina
 it: pasta già cotta
 nl: gekookte pasta
 sv: kokt pasta
-# ingredient/fr:pâte-cuite has 150 products in 3 languages @2018-12-10
 
 # comment:en:Can this be split in pasta and dough?
 
@@ -93863,8 +91884,6 @@ fr: pâtes précuites, pâte précuite, fond de pâte précuit
 hr: prethodno kuhana tjestenina
 it: Pasta precotta
 nl: voorgebakken pasta
-# ingredient/fr:pâte-précuites has 88 products in 5 languages @2018-12-10
-# ingredient/fr:fond-de-pâte-précuit has 18 products @2018-12-10
 
 # description:en:PASTA is type of noodle typically made from an unleavened dough of durum wheat flour mixed with water or eggs, and formed into sheets or various shapes, then cooked by boiling or baking. Rice flour, or legumes such as beans or lentils, are sometimes used in place of wheat flour to yield a different taste and texture, or as a gluten-free alternative. Pasta is a staple food of Italian cuisine.
 
@@ -93975,8 +91994,6 @@ ciqual_proxy_food_name:fr: Pâtes sèches standard, crues
 # zh-hans:意式面食
 # zh-hant:意式麵食
 pnns_group_2:en: Cereals
-# ingredient/fr:pâtes-alimentaires has 115 products 2019-05-20
-# ingredient/paste has 1809 products @2018-12-10
 vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q178
@@ -94034,8 +92051,6 @@ hr: svježa tjestenina
 it: pasta fresca
 nl: verse pasta
 pt: Massa fresca
-# ingredient/fr:pâtes-fraîches has 51 products in 4 languages @2019-02-03
-# ingredient/fr:pâtes-fraîches has 49 products in french @2018-12-10
 carbon_footprint_fr_foodges_ingredient:fr: Pâtes sèches
 carbon_footprint_fr_foodges_value:fr: 0.5
 
@@ -94046,7 +92061,6 @@ fi: kypsennetty tuore pasta
 fr: pâtes fraîches cuites
 hr: kuhana svježa tjestenina
 it: pasta fresca cotta
-# ingredient/fr:pâtes-fraîches-cuites has 19 products in french @2018-12-10
 
 < en: pasta
 fr: pâtes alimentaires aux oeufs cuites
@@ -94073,7 +92087,6 @@ uk: тальятеле
 # zh_yue: 細闊麪
 wikidata:en: Q20044
 wikipedia:en: https://en.wikipedia.org/wiki/Tagliatelle
-# ingredient/fr:tagliatelle has 5 products in 1 language @2020-06-13
 
 < en: tagliatelle
 en: cooked tagliatelle
@@ -94085,7 +92098,6 @@ hr: kuhane tagliatelle
 it: tagliatelle cotte
 nl: gekookte tagliatelle
 pt: tagliatelle cozido
-# ingredient/fr:tagliatelles-cuites has 27 products in 4 languages @2019-02-16
 # usage:fr:Tagliatelles cuites (eau, semoule de blé dur, oeufs, huile de colza, persil, stabilisant :E 500)
 
 
@@ -94179,7 +92191,6 @@ zh: 意大利粉
 # zh_yue:意粉
 wikidata:en: Q20026
 wikipedia:en: https://en.wikipedia.org/wiki/Spaghetti
-# ingredient/en:spaghetti has 30 products in 1 language @2020-06-13
 
 # description:en:LASAGNE are a type of wide, flat pasta, possibly one of the oldest types of pasta.
 
@@ -94242,7 +92253,6 @@ zh: 千層麵
 # zh_yue:千層麪
 wikidata:en: Q20034
 wikipedia:en: https://en.wikipedia.org/wiki/Lasagne
-# ingredient/fr:lasagnes has 4 products in 2 languages @2020-06-13
 
 # description:en:PENNE is an extruded type of pasta with cylinder-shaped pieces, their ends cut at a bias.  Penne is the plural form of the Italian penna (meaning feather but pen as well), deriving from Latin penna (meaning "feather" or "quill"), and is a cognate of the English word pen. When this format was created, it was intended to imitate the then-ubiquitous fountain pen's steel nibs.
 
@@ -94278,7 +92288,6 @@ uk: пенне
 zh: 直通粉
 wikidata:en: Q1063736
 wikipedia:en: https://en.wikipedia.org/wiki/Penne
-# ingredient/fr:penne has 21 products in 1 language @2020-06-12
 
 # description:en:LINGUINE is a type of pasta similar to fettuccine and trenette but elliptical in section rather than flat.
 
@@ -94301,13 +92310,11 @@ uk: лінґвіне
 # zh_yue:扁意粉
 wikidata:en: Q20035
 wikipedia:en: https://en.wikipedia.org/wiki/Linguine
-# ingredient/fr:linguine has 7 products in 1 language @2020-06-12
 
 < en: dough
 fr: pâte crue
 carbon_footprint_fr_foodges_ingredient:fr: Pâtes sèches
 carbon_footprint_fr_foodges_value:fr: 0.5
-# ingredient/fr:pâte-crue has 22 products in french @2018-12-10
 
 #< en: compound
 < en: pasta
@@ -94395,7 +92402,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: q192874
 wikipedia:en: https://en.wikipedia.org/wiki/Noodle
-# ingredient/fr:nouilles has 241 products in 7 languages @2019-05-08
 
 < en: noodle
 en: rice noodles
@@ -94495,7 +92501,6 @@ sv: pajdeg
 ciqual_food_code:en: 23410
 ciqual_food_name:en: Short crust pastry, raw
 ciqual_food_name:fr: Pâte brisée, crue
-# 89 in 4 @2021-09-06
 
 < en: dough
 fr: pâte feuilletée
@@ -94503,7 +92508,6 @@ de: Blätterteig
 hr: lisnato tijesto
 it: pasta sfoglia
 nl: bladerdeeg
-# ingredient/fr:pâte-feuilletée has 208 products in 8 languages @2018-12-10
 carbon_footprint_fr_foodges_ingredient:fr: Pâte à tarte
 carbon_footprint_fr_foodges_value:fr: 7.3
 
@@ -94656,13 +92660,11 @@ wikidata:en: Q17052976
 wikipedia:en: https://en.wikipedia.org/wiki/Gingerbread
 wiktionary:en: gingerbread
 # usage:en:Gingerbread: enriched wheat flour (flour, niacin, iron, ascorbic acid, thiamine mononitrate, riboflavin, folic acid), sugar, vegetable oil (palm), molasses, water, cinnamon, leavening (sodium bicarbonate), ginger, salt, caramel color.
-# 109 in 7 @2021-09-10
 
 #<en:compound
 fr: galette
 de: Fladenbrot
 it: galletta
-# ingredient/fr:galette has 125 products in 4 languages @2019-04-11
 # usage:fr:Galette: Eau, farine de blé noir, sel de Guérande
 
 #< en: compound
@@ -94674,7 +92676,6 @@ hr: vermicelli
 it: vermicelli
 nl: vermicelli
 pl: vermicelli
-# ingredient/fr:vermicelle has 41 products in 2 languages @2019-03-12
 # vermicelli (mungbonenzetmeel, maïszetmeel)
 
 < en: vermicelli
@@ -94729,7 +92730,6 @@ zh: 烤乾酪辣味玉米片
 # simple:nachos
 wikidata:en: Q466430
 wikipedia:en: https://en.wikipedia.org/wiki/Nachos
-# ingredient/en:nachos has 3 products in 1 language @2020-12-20
 
 # description:en:BREAD is a staple food prepared from a dough of flour and water, usually by baking.
 
@@ -94879,7 +92879,6 @@ zh: 麵包
 zu: isinkwa
 carbon_footprint_fr_foodges_ingredient:fr: Pain
 carbon_footprint_fr_foodges_value:fr: 1.5
-# ingredient/fr:pain has 411 products in 5 languages @2019-03-06
 nova:en: 3
 # ang:hlāf
 # arc:לחמא
@@ -95029,7 +93028,6 @@ fr: pain spécial cuit
 
 < en: special bread
 fr: pain de mie
-# ingredient/fr:pain-de-mie has 104 products in 4 languages @2019-03-07
 
 < en: special bread
 fr: Pain de mie aux céréales
@@ -95069,7 +93067,6 @@ allergens:en: en:sesame-seeds
 
 < en: special bread
 fr: pain de mie au son de blé
-# ingredient/fr:pain-de-mie-au-son-de-blé has 32 products in french @2019-03-07
 
 < en: special bread
 fr: pain spécial viennois, pain special viennois
@@ -95078,7 +93075,6 @@ fr: pain spécial viennois, pain special viennois
 fr: brisures de crêpe dentelle
 es: trozos de barquillo
 nl: gebroken flinterdunne flensjes
-# ingredient/fr:brisures-de-crêpe-dentelle has 125 products in 4 languages @2019-03-16
 # trozos de barquillo (harina de trigo, azúcar, aceite de girasol, leche desnatada en polvo, cebada malteada, sal)
 
 < en: bread
@@ -95111,8 +93107,6 @@ de: geriebenes Roggenbrot, geraspeltes Roggenbrot
 fi: ruisleipäraaste
 hr: ribani raženi kruh
 it: pane di segale grattugiato
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:ruisleip%C3%A4raaste
-# 1 entry @ 2019-10-31
 
 < en: rye bread
 en: wholemeal rye bread
@@ -95176,7 +93170,6 @@ zh: 皮塔饼
 # zh_yue:比得包
 wikidata:en: Q211340
 wikipedia:en: https://en.wikipedia.org/wiki/Pita
-# ingredient/fr:pain-pita has 3 products in 1 language @2020-06-13
 
 # description:en:A tortilla is a type of thin flatbread, typically made from nixtamalized corn or wheat flour.
 
@@ -95264,7 +93257,6 @@ zh: 法式长棍面包
 # zh_yue:百吉包
 wikidata:en: Q208172
 wikipedia:en: https://en.wikipedia.org/wiki/Baguette
-# ingredient/fr:baguette has 9 products in 5 languages @2020-12-22
 
 # description:en:A waffle is a dish made from leavened batter or dough that is cooked between two plates that are patterned to give a characteristic size, shape, and surface impression.
 
@@ -95334,7 +93326,6 @@ zh: 窩夫
 # zh-hant:窩夫
 wikidata:en: Q375
 wikipedia:en: https://en.wikipedia.org/wiki/Waffle
-# ingredient/fr:gaufre has 10 products @2019-04-12
 
 < en: waffle
 en: waffle with cocoa
@@ -95368,7 +93359,6 @@ hu: Nápolyi ostya
 it: wafer, wafer ripieni, wafer ripieno
 nl: Neapolitan wafer
 tr: Gofret
-# 143 products in 5 @2021-09-06
 description:en: Neapolitan wafers are a wafer and chocolate-cream sandwich biscuit.
 # bar:Neapolitana-Schnittn
 # lij:fru fru
@@ -95380,7 +93370,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Neapolitan_wafer
 fr: éclats de gaufrettes, éclats de gaufrette
 de: Hüppenflocken
 it: fiocchi di Hüppen
-# ingredient/fr:éclats-de-gaufrettes has 40 products in 4 languages @2019-02-13
 # éclats de gaufrette (sucre, farine de froment, huile végétales [tournesol, colza], beurre fondu, lactose, protéines lactiques, sel de cuisine, poudre à lever [E 500], extrait de malt d’orge, émulsifiant [E 322], antioxydant [E 306])
 
 #< en: compound
@@ -95393,7 +93382,6 @@ hr: napolitanka
 it: cialda, ostia, cialde, ostie
 nl: ongedesemd brood, ouwel
 pl: wafel, wafli
-# ingredient/fr:pain-azyme has 293 products in 6 languages @2019-03-07
 # pan ácimo (fécula de patata, agua, aceite de girasol)
 
 < en: wafer
@@ -95479,7 +93467,6 @@ zh: 意大利餃
 # zh-hant: 意大利餃
 wikidata:en: Q20053
 wikipedia:en: https://en.wikipedia.org/wiki/Ravioli
-# ingredient/ravioli has 92 products in 6 languages @2019-02-17
 # usage:fr:ravioli (water, durum wheat, 24% cream cheese, egg [open-air] 7%, mascarpone cheese, bread crumbs, coconut cream, 1% lemon juice, broth of vegetables, sugar, whey powder, juice of limes 0.3%, iodized cooking salt, lemon zest 0.2%, lemon extract 0.1%, syrup of limes, spices)
 
 < en: ravioli
@@ -95546,7 +93533,6 @@ ciqual_food_code:en: 24000
 ciqual_food_name:en: Biscuit (cookie)
 ciqual_food_name:fr: Biscuit sec, sans précision
 description:en: A BISCUIT is a flour-based baked food product, which is typically hard, flat and unleavened.
-# 896 in 19 @2021-09-06
 description:de: Ein Keks gehört zu den Dauerbackwaren, die meist aus fetthaltigem Teig mit mehr oder minder süßem Geschmack bestehen.
 description:es: La galleta es una preparación culinaria de pequeño tamaño, dulce o salada, horneada y hecha normalmente a base de harina de trigo, huevos, azúcar, mantequilla o aceites vegetales o grasas animales.
 description:fr: un biscuit est un petit gâteau sec, qui se décline dans plusieurs saveurs et formes.
@@ -95599,7 +93585,6 @@ hr: biskvit s maslacem
 it: biscotto al burro
 nl: boterkoekje
 pt: biscoitos de manteiga
-# ingredient/fr:Biscuits-au%-beurre has 3 products in french @2019-02-23
 
 
 # comment:en:The difference between speculoos and speculaas is not always clear and often one finds a wrong translation
@@ -95720,9 +93705,7 @@ ro: inveliş
 sl: skorjica
 sv: överdrag
 tr: kaplama
-# ingredient/fr:enrobage has 410 products in 18 languages @2019-05-11
 # usage:fr:Enrobage:farines (blé, seigle, et riz) (contient gluten) eau, amidon modifié, amidon et protéines de blé (contient gluten ), sel
-# ingredient/fr:enrobant has 79 products in 4 languages @2019-02-21
 # coating (water, wheat flour, modified corn starch, gluten of wheat, corn flour, corn starch, salt, potato starch)
 vegan:en: maybe
 vegetarian:en: maybe
@@ -95760,7 +93743,6 @@ hr: miliječno čokoladni preljev, preljev okusa mliječne čokolade, preljev od
 it: rivestimento di cioccolato al latte
 lt: pieniško šokolado glaistas
 sv: mjölkchokladsöverdrag
-# ingredient/en:milk-chocolate-coating has 99 products in 3 languages @2020-12-19
 
 < en: chocolate coating
 < en: dark chocolate
@@ -95815,8 +93797,6 @@ en: strawberry coating
 fr: nappage à la fraise
 hr: preljev od jagode
 it: rivestimento di fragole
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:nappage-à-la-fraise
-# 33 products @2018-10-01
 
 < en: berry coating
 en: cherry coating
@@ -95886,10 +93866,8 @@ sv: panering, ströbröd, paneringsmjöl, brödsmulor, skorpmjöl, kryddpanering
 uk: Паніровка
 vi: Vụn bánh mì
 zh: 麵包屑
-# fr:chapelure has 2441 products in 7 languages @2018-11-12
 ciqual_food_code:en: 7500
 ciqual_food_name:en: Breadcrumbs
-# ingredient/fr:panure has 462 products in 6 languages @2019-05-17
 vegan:en: maybe
 vegetarian:en: maybe
 # eml:Pan radû
@@ -95919,7 +93897,6 @@ da: rugbrødsrasp
 < en: breadcrumbs
 fr: chapelure de blé
 de: Weizenpaniermehl
-# fr:chapelure-de-blé has 185 products in 2 languages @2018-11-12
 
 < en: breadcrumbs
 en: panko
@@ -95927,7 +93904,6 @@ xx: panko
 de: Panko
 ru: панко
 wikidata:en: Q1820454
-# en:panko has 20 products in english @2018-11-12
 
 < en: breadcrumbs
 en: panada
@@ -95954,7 +93930,6 @@ ja: えび入り天かす
 
 #< en: compound
 fr: pain de mie au blé malté
-# ingredient/fr:pain-de-mie-au-blé-malté has 22 products in french @2019-02-09
 
 
 
@@ -96066,7 +94041,6 @@ description:nl: Cake is een eenvoudig soort gebak. Cake heeft een eenvoudig basi
 # yue:蛋糕
 wikidata:en: Q13276
 wikipedia:en: https://en.wikipedia.org/wiki/Cake
-# 6408 products @2019-05-20
 
 < en: cake
 en: flavored cake with cheese paste
@@ -96162,8 +94136,6 @@ zh: 可麗餅
 # zh-tw:可麗餅
 wikidata:en: Q12200
 wikipedia:en: https://en.wikipedia.org/wiki/Crêpe
-# ingredient/fr:crepe has 142 products in 4 languages @2019-02-05
-# category/crepes has 582 products @2019-05-18
 
 # mainIngredient:en:wheat
 en: wheat cakes
@@ -96172,7 +94144,6 @@ fr: galette de blé
 hr: pšenične pogače
 it: torte di grano
 allergens:en: en:gluten
-# ingredient/fr:galette-de-blé has 60 products in 4 languages @2019-02-09
 # Weizenfladen [ Weizenmehl, Wasser, Kokosnussöl, Kochsalz ]
 
 # mainIngredient:en:wheat
@@ -96194,8 +94165,6 @@ description:en: The "PETIT BEURRE", or "Véritable Petit Beurre", also known und
 likely_allergens:en: en:gluten
 wikidata:en: Q19573669
 wikipedia:en: https://en.wikipedia.org/wiki/Petit-Beurre
-# ingredient/fr:petit-beurre has 20 products in french @2018-02-08
-# category/petit-beurre has 263 products @2018-05-19
 
 fr: génoise, genoise
 
@@ -96247,7 +94216,6 @@ description:pt: Croûton é um pequeno pedaço de pão, frito ou assado com óle
 likely_allergens:en: en:gluten
 wikidata:en: Q1197400
 wikipedia:en: https://en.wikipedia.org/wiki/Crouton
-# 311 products in 9 @2021-09-02
 # usage:en:croutons (wheat flour, vegetable fat, edible salt, maltodextrin, grape sugar, onions, herbs, yeast extract, dehydrated garlic, flavoring, yeast, spice extract)
 
 de: Reisextrudat
@@ -96309,7 +94277,6 @@ zh: 木斯里
 # pt-br:muesli
 wikidata:en: Q52406
 wikipedia:en: https://en.wikipedia.org/wiki/Muesli
-# ingredient/fr:muesli has 46 products in 4 languages @2019-02-07
 
 de: Saatenmischung
 # usage:de: Saatenmischung (Sonnenblumenkerne, Buchweizen, Kürbiskerne, Leinsamen, Quinoa, Hirse, Mohn)
@@ -96416,7 +94383,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q177378
 wikipedia:en: https://en.wikipedia.org/wiki/Tofu
-# ingredient/fr:tofu has 369 products in 7 languages@2019-05-17
 # usage:fr:Tofu (graines de soja, eau, agents de coagulation :chlorure de magnésium, sulfate de calcium)
 
 < en: tofu
@@ -96470,7 +94436,6 @@ tr: şeker hamuru
 uk: помадка
 wikidata:en: Q1769523
 wikipedia:en: https://en.wikipedia.org/wiki/Fondant_icing
-# ingredient/fr:fondant has 65 products in 3 languages @2019-03-20
 # usage:fr:Fondant (sucre, sirop de glucose, eau)
 
 
@@ -96548,7 +94513,6 @@ description:nl: Marsepein is een deegachtig mengsel van gemalen amandelen en sui
 description:pt: Marzipã, marzipan ou maçapão é um doce, preparado a partir de uma pasta feita de amêndoas moídas, açúcar e claras de ovos
 wikidata:en: Q106252
 wikipedia:en: https://en.wikipedia.org/wiki/Marzipan
-# 84 in 11 @2021-09-01
 
 < en: marzipan
 en: prepacked marzipan
@@ -96619,7 +94583,6 @@ tr: Nuga
 uk: Нуга
 vi: Kẹo Hạnh Phúc
 zh: 牛轧糖
-# ingredient/nougat has 52 products in 5 languages @2019-02-08
 # nougat (cane sugar , hazelnuts 33%, cocoa mass, cocoa butter)
 ciqual_food_code:en: 31033
 ciqual_food_name:en: Nougat
@@ -96684,7 +94647,6 @@ zh: 花生糖
 # zh-hk:花生糖
 wikidata:en: Q708823
 wikipedia:en: https://en.wikipedia.org/wiki/Brittle_(food)
-# ingredient/fr:nougatine has 60 products in 4 languages @2019-02-09
 # nougatine (noisettes, sucre)
 
 < en: crocant
@@ -96705,7 +94667,6 @@ it: pralinato
 nl: praliné
 wikidata:en: Q3401308
 wikipedia:fr: https://fr.wikipedia.org/wiki/Praliné
-# ingredient/fr:praliné has 344 products in 5 languages @2019-05-14
 # usage:fr:praliné (sucre de canne brut*, noisettes*, pâte de cacao*, beurre de cacao*)
 
 fr: bonbon au cacao maigre
@@ -96746,7 +94707,6 @@ zh: 包糖衣
 # zh-hant:包糖衣
 wikidata:en: Q15223654
 wikipedia:en: https://en.wikipedia.org/wiki/Glaze_(cooking_technique)
-# ingredient/fr:glaçage has 86 products in 4 languages @2019-02-15
 # glassa (massa di cacao magro, zucchero, grasso vegetale)
 
 < en: glaze
@@ -96762,7 +94722,6 @@ pl: polewa czekoladowa, polewy czekoladowej
 ru: шоколадная глазурь
 sv: chokladglasyr, kakaoglasyr
 # usage:en:chocolate glaze (sugar, soybean oil, cocoa powder processed with alkali, palm oil, soy lecithin, vanilla)
-# ingredient/en:chocolate-glaze has 4 products in 1 language @2020-06-13
 
 < en: glaze
 en: cacao glaze
@@ -96817,7 +94776,6 @@ zh: 肉凍
 # sgs:Kuošelīna
 wikidata:en: Q837480
 wikipedia:en: https://en.wikipedia.org/wiki/Aspic
-# ingredient/fr:gelée has 166 products in 4 languages @2019-05-07
 # usage:en:jelly [water, pork gelatin, cooking salt, sugar, maltodextrin, condiment, coloring:ordinary caramel, preservative:E 202, acidifier:citric acid]
 
 
@@ -96874,7 +94832,6 @@ zh: 濃鹽水
 # ast:Salmoria
 wikidata:en: Q214403
 wikipedia:en: https://en.wikipedia.org/wiki/Brine
-# ingredient/fr:saumure has 150 products in 3 languages @2019-05-06
 # usage:en:brine (water, sea salt)
 
 
@@ -96965,8 +94922,6 @@ zh: 清汤
 # zh-tw:清湯
 wikidata:en: Q275068
 wikipedia:en: https://en.wikipedia.org/wiki/Broth
-# category/broths has 527 products @2019-05-19
-# ingredient/fr:bouillon has 1214 products in 6 languages @2019-02-25
 # brodo (acqua, osso di pollo, sale, spezie, carota, sedano (0,01%), cipolla, porro, scalogno, aglio, piante aromatiche)
 
 #category:en:beef-broth
@@ -96986,7 +94941,6 @@ nl: runderbuillon
 pl: bulion wołowy
 sv: nötköttsbuljong
 #wikipedia:en:no entry
-# ingredient/beef-broth has 1786 products in 10 languages @2021-08-19
 ciqual_food_code:en: 11001
 ciqual_food_name:en: Broth, stock or bouillon, beef, dehydrated
 ciqual_food_name:fr: Bouillon de boeuf, déshydraté
@@ -97005,7 +94959,6 @@ en: dehydrated broth, dehydrated stock
 de: Bouillon getrocknet
 fr: bouillon déshydraté
 it: brodo disidratato
-# ingredient/fr:bouillon-déshydraté has 57 products in french @2019-02-25
 
 < en: broth
 en: cooking broth
@@ -97032,7 +94985,6 @@ ciqual_food_code:en: 11174
 ciqual_food_name:en: Broth, stock or bouillon, poultry, dehydrated
 ciqual_food_name:fr: Bouillon de volaille, déshydraté
 vegan:en: no
-# ingredient/fr:fond-de-volaille has 226 products in french @2019-03-09
 vegetarian:en: no
 
 < en: fond
@@ -97064,7 +95016,6 @@ it: fondo di molluschi e crostacei
 en: flavored poultry fond
 fr: fond de volaille aromatisé
 it: fondo di pollame aromatizzato
-# ingredient/fr:fond-de-volaille-aromatisé has 39 products in french @2019-03-09
 
 < en: poultry broth
 en: dehydrated poultry stock, dehydrated poultry bouillon
@@ -97102,7 +95053,6 @@ ja: チキンスープ, チキンブイヨン
 nl: Kippenbouillon
 pl: Rosół z kurczaka
 sv: kycklingbuljong, kycklingfond
-# ingredient/fr:fond-de-poulet has 79 products in 4 languages @2019-05-18
 
 # description:en:VEGETABLE BROTH is made exclusively from vegetables.
 
@@ -97123,16 +95073,13 @@ sv: grönsaksbuljong
 vegan:en: maybe
 vegetarian:en: yes
 wikidata:en: Q42366457
-# ingredient/fr:bouillon-végétal has 40 products in 4 languages @2019-04-04
 
 
 fr: jus de cuisson
-# ingredient/fr:jus-de-cuisson has 43 products in french @2019-03-11
 
 #< en: compound
 # <en:mainIngredient:en:water
 fr: jus cuisiné
-# ingredient/fr:jus-cuisiné has 56 products in french @2019-03-29
 # usage:fr:jus cuisiné (eau, bouillon de poulet [sel, dextrose, graisse et viande de Poulet, arômes naturels, épices, plante aromatique], carottes, oignons, concentré de tomates)
 
 < en: broth
@@ -97148,7 +95095,6 @@ it: brodo di carne
 pl: wywar mięsny
 sv: köttbuljong, köttfond
 wikidata:en: Q67860017
-# ingredient/fr:bouillon-de-viande has 22 products in 4 languages @2020-06-13
 
 < en: broth
 en: white dashi
@@ -97232,7 +95178,6 @@ zh: 檸檬水
 # zh-hant:檸檬水
 wikidata:en: Q893
 wikipedia:en: https://en.wikipedia.org/wiki/Lemonade
-# ingredient/fr:limonade has 37 products in 5 languages @2019-02-16
 # usage:fr:Limonade  (eau gazéifiée, sucre, acidifiant :acide citrique ; anitioxydant :acide ascorbique ; arôme)
 
 #< en: compound
@@ -97330,8 +95275,6 @@ ciqual_food_name:en: Soy drink, plain, not fortified, prepacked
 description:en: SOY MILK or soymilk is a plant-based drink produced by soaking and grinding soybeans, boiling the mixture, and filtering out remaining particulates.
 wikidata:en: Q192199
 wikipedia:en: https://en.wikipedia.org/wiki/Soy_milk
-# ingredient/fr:tonyu has 105 products in 4 languages @2019-04-08
-# category/soy-milks has 417 products @2019-05-08
 # usage:fr:Tonyu (eau, graines de soja)
 
 #< en: compound
@@ -97437,7 +95380,6 @@ allergens:en: en:eggs
 # zh-hant:歐姆蛋
 wikidata:en: Q20129
 wikipedia:en: https://en.wikipedia.org/wiki/Omelette
-# ingredient/fr:omelette has 51 products in french @2019-03-11
 # omelette (oeufs, lait écrémé, emmental 1.6%, amidon de riz, sel ; acidifiant :acide citrique)
 
 # description:en:The outer layer of a food product.
@@ -97451,7 +95393,6 @@ fr: croûte
 hr: kora
 it: crosta
 nl: korst
-# ingredient/fr:croûte has 127 products in 6 languages @2019-04-13
 # usage:fr: croûte: herbes aromatiques bio
 # usage:fr: conservateur (croûte) : natamycine (contient lait)
 # usage/de: Kruste (mit Farbstoff [E 160b])
@@ -97480,7 +95421,6 @@ nl: korst niet eetbaar
 
 #< en: compound
 fr: crème pâtissière
-# ingredient/fr:crème-pâtissière has 113 products in french @2019-02-03
 # usage:fr:Crème pâtissière 30% (eau, sucre, transforméamidon, blancs d’œufs frais, poudre de lait entier, lactosérum en poudre, arômes naturels, arôme, maltodextrine, épaississant (gomme de xanthane), colorant (béta carotène))
 
 #< en: compound
@@ -97536,7 +95476,6 @@ description:pt: O chouriço ou chouriça é um enchido preparado com carne, gord
 wikidata:en: Q23374
 wikipedia:en: https://en.wikipedia.org/wiki/Chorizo
 
-# ingredient/fr:chorizo has 820 products in 15 languages @2021-08-17
 # usage:fr:chorizo (maigre et gras de porc, sel, épices et extraits d'épices, dextrose de blé, ferments lactiques, conservateurs :E301, E250)
 
 < en: meat
@@ -97708,7 +95647,6 @@ description:en: ICE CREAM is a sweetened frozen food typically eaten as a snack 
 # zh-my:冰淇淋
 # zh-sg:冰淇淋
 # zh-tw:冰淇淋
-# ingredient/ice-cream has 264 products in english @2019-04-29
 # usage:en:Ice cream:organic cream, organic milk, organic cane sugar, organic egg yolks, organic vanilla extract, organic locust bean gum, organic guar gum
 # usage:fr:glace (sucre, kirsch de Bâle-Campagne)
 
@@ -97740,7 +95678,6 @@ carbon_footprint_fr_foodges_value:fr: 1.5
 usda_ndb_code:en: 19095
 usda_ndb_name:en: Ice creams, vanilla
 wikidata:en: Q12071938
-# ingredient/fr:glace-à-la-vanille has 60 products in 2 languages @2019-04-29
 
 < en: ice cream
 en: chocolate ice cream
@@ -97823,7 +95760,6 @@ wikidata:en: Q1065990
 wikipedia:en: https://en.wikipedia.org/wiki/Lingonberry_jam
 # usage:fi:puolukkahillo 7,9 % [puolukka, sokeri, glukoosi-fruktoosisiirappi, vesi, hyytelöimisaineet (pektiinit, ksantaanikumi), happamuudensäätöaine (sitruunahappo), säilöntäaine (kaliumsorbaatti)]
 # mainIngredient:en:lingonberry
-# ingredient/fi:puolukkahillo has 2 products in 2 languages @2020-12-19
 
 #< en: compound
 < en: jam
@@ -97834,7 +95770,6 @@ hr: pekmez od crnog ribiza
 it: confettura di ribes, confettura di ribes nero, confettura al ribes nero
 # usage:fi:Mustaherukkahillo: Mustaherukka, sokeri, happamuudensäätöaine (E330), säilöntäaine (E202).
 # mainIngredient:en:blackcurrant
-# ingredient/en:blackcurrant-jam has 1 product in 1 language @2020-12-21
 
 #< en: compound
 en: jam, confiture
@@ -98040,7 +95975,6 @@ vi: Xốt
 vo: sod
 zh: 醬
 nova:en: 3
-# ingredient/sauce has 5701 products in 15 languages @2019-05-02
 vegan:en: maybe
 vegetarian:en: maybe
 # arz:صلصه
@@ -98161,7 +96095,6 @@ uk: Бешамель
 vi: Xốt béchamel
 zh: 白汁
 allergens:en: en:milk
-# ingredient/fr:sauce-béchamel has 89 products in 4 languages @2019-04-04
 # usage:en:Bechamel sauce (water, wheat flour, skimmed milk powder, sunflower oil, whey powder, whole cream, corn starch, salt iodized cooking, butter)
 ciqual_food_code:en: 11101
 ciqual_food_name:en: Bechamel sauce, prepacked
@@ -98347,7 +96280,6 @@ usda_ndb_code:en: 11935
 usda_ndb_name:en: Catsup
 wikidata:en: Q178143
 wikipedia:en: https://en.wikipedia.org/wiki/Ketchup
-# 599 in 10 @2021-10-18
 
 < en: ketchup
 en: low sodium catsup
@@ -98376,7 +96308,6 @@ pl: marynata
 pt: marinada
 sv: marinad
 wikidata:en: Q56296569
-# ingredient/fr:marinade has 146 products in in 4 languages @2019-04-27
 # usage:fr:marinade (olive oil, rapeseed oil, chives 4%, lemon essential oil 3%)
 
 < en: marinade
@@ -98601,7 +96532,6 @@ zh: 味醂
 # zh -hk:味醂
 wikidata:en: Q1045910
 wikipedia:en: https://en.wikipedia.org/wiki/Mirin
-# ingredient/fr:mirin has 74 products in 5 languages @2019-03-01
 # usage:fr:mirin (eau, glucose de maïs, sirop de tapioca, riz, alcool de sucre de canne)
 
 < en: mustard
@@ -98640,7 +96570,6 @@ nn: fiskesaus
 pl: sos rybny
 sv: fisksås
 allergens:en: en:fish
-# ingredient/fr:sauce-poisson has 106 products in 9 languages @2019-04-11
 # usage:en: fish sauce (anchovy (fish), salt, sugar)
 vegan:en: no
 vegetarian:en: no
@@ -98668,7 +96597,6 @@ ciqual_food_name:fr: Sauce Nuoc Mâm ou Sauce au poisson, préemballée
 wikidata:en: Q18456374
 wikipedia:fr: https://fr.wikipedia.org/wiki/Nuoc-mâm
 # category:fr:sauces-nuoc-mam
-# 260 in 7 @2021-10-18
 
 
 #en:category:en:Soy sauces
@@ -98751,8 +96679,6 @@ zh: 酱油
 # zh-hant:醬油
 # zh-tw:醬油
 allergens:en: en:soybeans
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sauce-au-soja
-# 449 products in 5 languages @2018-09-25
 ciqual_food_code:en: 11104
 ciqual_food_name:en: Soy sauce, prepacked
 ciqual_food_name:fr: Sauce soja, préemballée
@@ -98816,7 +96742,6 @@ ja: たまり
 nl: tamari
 pl: tamari, sos tamari, sos sojowy tamari
 wikidata:en: Q3514675
-# ingredient/fr:tamari has 84 products in 3 languages @2019-04-11
 # usage:nl: tamari (water, volle soja, zeezout, alcohol, fermentatiestarter)
 
 < en: soy sauce
@@ -98857,7 +96782,6 @@ ru: ремулад
 sv: remouladsås
 wikidata:en: Q1190414
 wikipedia:en: https://en.wikipedia.org/wiki/Remoulade
-# ingredient/fr:sauce-rémoulade has 22 products in french @2019-05-02
 # usage:fr: sauce rémoulade (eau, huile de colza, vinaigre, sirop de glucose-fructose, moutarde (eau, graines de moutarde, vinaigre, épices), amidon de mais, œuf, jaune d’œuf, amidon modifié (maïs cireux), sel, plantes aromatiques, épaississants: gomme e, gomme guar; acidifiant: acide lactique; arôme, conservateur: sorbate de potassium; colorant: riboflavines; épices, extrait d'oignon, extrait de poireau, édulcorant: sel d'aspartame-acésulfame, antioxydant: calcium disodium EDTA)
 
 
@@ -98890,7 +96814,6 @@ uk: Кисло-солодкий соус
 # zh-hant:甜酸醬
 wikidata:en: Q2550606
 wikipedia:en: https://en.wikipedia.org/wiki/Sweet_and_sour
-# ingredient/fr:sauce-aigre-douce has 72 products in 4 languages @2019-05-01
 
 
 # description:en:Teriyaki (kanji: 照り焼き) is a cooking technique used in Japanese cuisine in which foods are broiled or grilled with a glaze of soy sauce, mirin, and sugar.
@@ -98959,7 +96882,6 @@ vi: Sốt cà
 zh: 番茄沙司
 carbon_footprint_fr_foodges_ingredient:fr: Sauce tomate
 carbon_footprint_fr_foodges_value:fr: 2.9
-# ingredient/fr:préparation-à-base-de-tomates has 91 products in 5 languages @2018-12-26
 ciqual_proxy_food_code:en: 11107
 ciqual_proxy_food_name:en: Tomato sauce, with onions, prepacked
 # pnb:ٹماٹر سوس
@@ -98970,7 +96892,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Tomato_sauce
 
 < en: tomato sauce
 fr: sauce tomate cuite
-# ingredient/fr:sauce-tomate-cuite has 379 products in 5 languages @2018-12-26
 
 < en: tomato sauce
 fr: sauce tomate cuisinée
@@ -99029,7 +96950,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q842618
 wikipedia:en: https://en.wikipedia.org/wiki/Worcestershire_sauce
-# ingredient/fr:sauce-worcestershire has 30 products in 3 languages @2019-04-30
 # usage:de:Worcestershire Sauce (Malzessig, Melasse, Wasser, Kochsalz, Zwiebeln, Knoblauch, Zucker, Gewürze, Sardellen, Tamarindenextrakt, natürliche Aromen)
 
 < en: sauce
@@ -99063,7 +96983,6 @@ zh: 蕃茄肉醬
 # zh-hant: 蕃茄肉醬
 # zh-hk: 蕃茄肉醬
 # category:en:bolognese-sauce
-# ingredient/fr:sauce-bolognaise has 54 products in 5 Languages @2019-04-30
 ciqual_food_code:en: 11114
 ciqual_food_name:en: Tomato sauce, with meat or Bolognese sauce, prepacked
 ciqual_food_name:fr: Sauce tomate à la viande ou Sauce bolognaise, préemballée
@@ -99132,8 +97051,6 @@ zh: 醋酱
 # zh-hant:醋醬
 wikidata:en: Q847441
 wikipedia:en: https://en.wikipedia.org/wiki/Vinaigrette
-# ingredient/fr:sauce-vinaigrette has 33 products in french @2019-04-30
-# ingredient/fr:vinaigrette has 78 products in 4 languages @2019-03-04
 # vinaigrette (maltodextrine de maïs, vinaigre de vin, sucre, sel, oignon 0,2%, mélange d'épices, arômes naturels, arôme, épaississants:gomme de xanthane et pectine)
 # usage:fr:sauce vinaigrette (huile de colza, eau, huile d'olive vierge extra, vinaigre d'alcool, moutarde de Dijon, sel, amidon modifié de pomme de terre, épaississant :gomme xanthane)
 
@@ -99145,8 +97062,6 @@ fi: sitruuna-vinaigrette, sitruunavinegretti
 fr: Vinaigrette au citron
 hr: vinaigrette od limuna
 it: vinaigrette al limone
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:sitruunavinegretti
-# 1 entry @ 2019-10-31
 
 < en: vinaigrette
 fr: sauce vinaigrette au vinaigre balsamique
@@ -99175,7 +97090,6 @@ ciqual_food_name:fr: Sauce burger, préemballée
 < en: sauce
 fr: sauce blanche
 #openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sauce-blanche
-# 58 entries @2020-04-23
 
 < en: sauce
 en: prepared sauce
@@ -99184,7 +97098,6 @@ fi: Valmistettu kastike
 fr: sauce cuisinée
 hr: pripremljeni umak
 it: salsa preparata
-# ingredient/fr:sauce-cuisinée has 135 products in french @2018-09-26
 # usage:fr:Sauce cuisinée (eau, concentré de tomate, sel, graisse de canard*, ail, poivre)
 
 # <en:caramel
@@ -99203,7 +97116,6 @@ pl: sos karmelowy, sosu karmelowego
 pt: molho de caramelo
 ru: карамельный соус
 sv: kolasås
-# ingredient/fr:sauce-caramel has 54 products in 4 languages @2019-03-09
 # usage:fr:sauce au caramel (sirop de sucre inverti, eau, 14% sirop de sucre caramélisé)
 
 # category:en:not available @2019-07-01
@@ -99246,7 +97158,6 @@ description:de: Rahmsauce (auch Rahmsoße) sind mit Rahm bzw. Sahne verfeinerte 
 description:sv: Gräddsås är en sås baserad på grädde och kalvfond eller buljong.
 wikidata:en: Q10509700
 wikipedia:de: https://de.wikipedia.org/wiki/Rahmsauce
-# 23 in 6 @2021-09-06
 
 # en:description:HOT SAUCE, also known as chili sauce or pepper sauce, is any condiment, seasoning, or salsa made from chili peppers and other ingredients.
 
@@ -99278,7 +97189,6 @@ zh: 辣醬
 wikidata:en: Q522171
 wikipedia:en: https://en.wikipedia.org/wiki/Hot_sauce
 # usage:en:chili sauce [red chili peppers, distilled vinegar, garlic powder, sugar, salt, spice]
-# ingredient/en:hot-sauce has 488 products in 1 language @2020-06-13
 
 < en: hot sauce
 en: sambal
@@ -99628,7 +97538,6 @@ wikidata:en: Q316561
 wikipedia:en: https://en.wikipedia.org/wiki/Nonpareils
 # usage:en:nonpareils (sugar, corn starch, carnauba wax)
 # mainIngredient:en:sugar
-# ingredient/en:nonpareils has 87 products in 1 language @2020-06-13
 
 
 
@@ -99747,8 +97656,6 @@ pt: extrato de fruto, extrato de fruta, extrato de frutos, extrato de frutas, ex
 sv: fruktextrakt
 vegan:en: maybe
 vegetarian:en: yes
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-de-fruit
-# 54 products in 4 languages @2018-10-04
 
 < en: fruit extract
 en: apple extract, apple essence
@@ -99762,8 +97669,6 @@ it: estratto di mele, estratto di mela
 nl: appelextract
 pt: extrato de maçã, extracto de maçã
 sv: äppelkoncentrat, äppelextrakt, sötande äppelextrakt
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/apple-extract
-# 65 products in 4 languages @2018-10-04
 
 < en: citrus fruit extract
 < en: natural orange flavouring
@@ -99778,8 +97683,6 @@ it: estratto di arancia
 nl: sinaasappelextracten
 pl: ekstrakt z pomarańczy, ekstrakty z pomarańczy
 pt: extrato de laranja, extracto de laranja
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:extrait-d'orange
-# 44 products @2018-09-28
 
 # aromatic caramel is not considered an additive
 < en: caramel

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1580,7 +1580,6 @@ wikidata:en: Q101542317
 
 < en: No gluten
 en: GFCO Gluten Free
-# 71 products
 
 < en: No gluten
 en: Crossed Grain Trademark, CGT, Crossed Grain Symbol, Crossed Grain
@@ -5649,7 +5648,6 @@ nl: Zonder kleurstoffen of bewaarmiddelen
 pt: Sem corantes ou conservantes, sem corante ou conservante, sem corantes nem conservantes, sem corante nem conservante
 ru: Без красителей и консервантов
 th: ไม่เติมสีและวัตถุกันเสีย
-# 57 products in English that are not taxonomized with Without dyes or preservatives
 
 #instruction:en:Do NOT change the english key.
 en: No soy, soy free, without soy, free from soya

--- a/taxonomies/minerals.txt
+++ b/taxonomies/minerals.txt
@@ -262,7 +262,6 @@ yi: קאליום
 yo: Potassium
 za: Gyaz
 zh: 钾
-# ingredient/fr:potassium has 232 products in 4 languages @2019-05-10
 description:en: POTASSIUM is a chemical element with symbol K (from Neo-Latin kalium) and atomic number 19. Potassium ions are vital for the functioning of all living cells. The transfer of potassium ions across nerve cell membranes is necessary for normal nerve transmission; potassium deficiency and excess can each result in numerous signs and symptoms, including an abnormal heart rhythm and various electrocardiographic abnormalities. Fresh fruits and vegetables are good dietary sources of potassium.
 # ast:Potasiu
 # azb:پوتاسیوم
@@ -441,8 +440,6 @@ vi: Kali clorua
 # yue:氯化鉀
 zh: 氯化钾
 additives_classes:en: en:stabiliser, en:thickener
-# mineral/potassium-chloride has 2404 products in 16 languages @2019-05-19
-# ingredient/fr:chlorure-de-potassium has 731 products @2019-05-19
 # usage:pl:chlorek potasu (potas)
 description:en: POTASSIUM CHLORIDE (KCl) is a metal halide salt composed of potassium and chlorine. It can be used as a salt substitute for food. Potassium is vital in the human body, and potassium chloride by mouth is the common means to treat low blood potassium.
 e_number:en: 508
@@ -518,7 +515,6 @@ vi: Kali xitrat
 zh: 檸檬酸鉀
 # last wikidatasynchronisation 4-sep-2020
 additives_classes:en: en:sequestrant, en:stabiliser
-# additive/e332ii-tripotassium-citrate has 23 products in 2 languages @2019-04-22
 description:en: POTASSIUM CITRATE (also known as tripotassium citrate) is a potassium salt of citric acid with the molecular formula K3C6H5O7. As a food additive, potassium citrate is used to regulate acidity. It is also used in many soft drinks as a buffering agent.
 #azb:پوتاسیوم سیترات
 #zh-cn:柠檬酸钾
@@ -899,8 +895,6 @@ uk: Карбонат кальцію
 uz: Kalsiy karbonat
 vi: canxi cacbonat
 zh: 碳酸鈣
-# ingredient/calcium-carbonate has 4220 products in 10 languages @2019-02-03
-# mineral/calcium-carbonate has 4301 products @2019-02-03
 description:en: CALCIUM CARBONATE is a chemical compound with the formula CaCO3.
 # ast:Carbonato de calcio
 # azb:کلسیوم کربونات
@@ -921,7 +915,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Calcium_carbonate
 
 < en: calcium carbonate
 fr: agent d'enrobage carbonate de calcium
-# ingredient/fr:agent-d’enrobage-carbonate-de-calcium has 18 products in french @2019-02-03
 
 < en: Calcium
 en: calcium chloride
@@ -1006,8 +999,6 @@ sv: kalciumsalter av ortofosforsyra
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q57657491
-# ingredient/calcium-salts-from-orthophosphoric-acid has 9 products in french @2019-04-04
-# mineral/calcium-salts-of-orthophosphoric-acid has 28 products in 4 langages @2019-04-04
 
 # comment:en:CALCIUM GLUCONATE is for the moment listed in both the additves and ingredients taxonomy.
 < en: Calcium
@@ -1072,7 +1063,6 @@ sr: Kalcijum glicerilfosfat
 sv: kalciumglycerolfosfat
 description:en: Calcium glycerylphosphate (or calcium glycerophosphate) is a mineral supplement for Calcium.
 e_number:en: 383
-# ingredient/calcium-glycerophosphate has 1 product in french @2018-12-11
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q4119838
@@ -1171,7 +1161,6 @@ tr: Kalsiyum hidroksit
 uk: Гідроксид кальцію
 vi: Canxi hiđroxit
 zh: 氢氧化钙
-# ingredient/calcium-hydroxide has 152 products in 7 languages @2019-02-18
 description:en: CALCIUM HYDROXIDE (traditionally called slaked lime) is an inorganic compound with the chemical formula Ca(OH)2.
 # azb:کلسیوم هیدروکسید
 # kk-arab:ەزىلگەن اك
@@ -1471,7 +1460,6 @@ vi: magiê
 yi: מאגנעזיום
 yo: Magnésíọ̀mù
 zh: 镁
-# mineral/magnesium has 436 products @2019-04-26
 description:en: MAGNESIUM is a chemical element with symbol Mg and atomic number 12. The important interaction between phosphate and magnesium ions makes magnesium essential to the basic nucleic acid chemistry of all cells of all known living organisms. Spices, nuts, cereals, cocoa and vegetables are rich sources of magnesium. Green leafy vegetables such as spinach are also rich in magnesium.
 # ast:Magnesiu
 # azb:منیزیوم
@@ -1618,8 +1606,6 @@ ta: மெக்னீசயம் குளோரைடு
 uk: Хлорид магнію
 vi: Magie clorua
 zh: 氯化镁
-# ingredient/magnesium%20chloride has 207 products @2019-04-29
-# mineral/magnesium-chloride has 495 products in 7 languages @2019-04-29
 # usage:es:gelificante:cloruro de magnesio
 description:en: MAGNESIUM CHLORIDE is the name for the chemical compound with the formula MgCl2 and its various hydrates MgCl2(H2O)x. Magnesium chloride is an important coagulant used in the preparation of tofu from soy milk. In Japan it is sold as nigari (にがり, derived from the Japanese word for "bitter"), a white powder produced from seawater after the sodium chloride has been removed, and the water evaporated. It is also an ingredient in baby formula milk.
 # azb:کولورید منیزیوم
@@ -1872,8 +1858,6 @@ tr: Magnezyum sülfat
 uk: Сульфат магнію
 vi: Magie sulphat
 zh: 硫酸镁
-# ingredient/fr:sulfate-de-magnésium has 67 products in 4 languages @2019-04-10
-# mineral/magnesium-sulphate has 272 products in 6 languages @2019-04-10
 description:en: MAGNESIUM SULFATE is an inorganic salt with the formula MgSO4(H2O)x where 0≤x≤7. Magnesium sulfate as a medication is used to treat and prevent low blood magnesium and seizures in women with eclampsia.
 # ast:Sulfatu de magnesiu
 # azb:منیزیوم سولفات
@@ -2007,8 +1991,6 @@ sk: Citrát horečnatý
 sr: Magnezijum citrat
 sv: magnesiumcitrat
 tr: Magnezyum sitrat
-# mineral/magnesium-citrate has 192 products in 4 languages @2019-04-26
-# ingredient/fr:citrate-de-magnésium has 151 products in 4 languages @2019-04-26
 description:en: MAGNESIUM CITRATE is a magnesium preparation in salt form with citric acid in a 1:1 ratio (1 magnesium atom per citrate molecule). The name "magnesium citrate" is ambiguous and sometimes may refer to other salts such as trimagnesium citrate which has a magnesium:citrate ratio of 3:2. It is also used in the pill form as a magnesium dietary supplement. It contains 11.23% magnesium by weight.  As a food additive, magnesium citrate is used to regulate acidity and is known as E number E345.
 # azb:منیزیوم سیترات
 vegan:en: yes
@@ -2144,7 +2126,6 @@ yi: אייזן
 yo: Iron
 za: Diet
 zh: 铁
-# ingredient/iron has 8977 products @2019-03-02
 description:en: IRON is a chemical element with symbol Fe (from Latin:ferrum) and atomic number 26. Iron is pervasive, but particularly rich sources of dietary iron include red meat, oysters, lentils, beans, poultry, fish, leaf vegetables, watercress, tofu, chickpeas, black-eyed peas, and blackstrap molasses. Iron provided by dietary supplements is often found as iron(II) fumarate, although iron(II) sulfate is cheaper and is absorbed equally well.
 # ang:Īsen
 # arc:ܦܪܙܠܐ
@@ -2344,7 +2325,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q421291
 wikipedia:en: https://en.wikipedia.org/wiki/Iron(II)_gluconate
-# ingredient/fr:gluconate-de-fer has 37 products in 6 languages @2019-02-22
 
 < en: iron gluconate
 en: ferrous gluconate to stabilize color
@@ -2380,7 +2360,6 @@ sl: železov fumarat
 sr: Gvožđe(II) fumarat
 sv: ferrofumarat
 zh: 延胡索酸亚铁
-# ingredient/fr:fumarate-ferreux has 54 products in 4 languages @2019-02-06
 description:en: IRON(II) GLUCONATE, or ferrous gluconate,[1] is a black compound often used as an iron supplement. It is the iron(II) salt of gluconic acid.
 # azb:دمیر (II) فومارات
 # sr-el:Gvožđe(II) fumarat
@@ -2488,9 +2467,6 @@ th: ไอร์ออนซัลเฟต
 uk: Сульфат заліза
 vi: Sắt sulfat
 zh: 硫酸亚铁
-# ingredient/fr:sulfate-de-fer has 158 products in 4 languages @2019-05-10
-# mineral/ferrous-sulphate has 3843 products in 7 languages @2019-05-10
-# ingredient/fr:sulfates-de-fer has 69 products in 3 languages @2019-03-06
 description:en: IRON(II) SULFATE denotes a range of salts with the formula FeSO4·xH2O. The hydrated form is used medically to treat iron deficiency. It is on the World Health Organization's List of Essential Medicines, the most important medications needed in a basic health system.
 # azb:دمیر سولفات
 # sr-ec:гвожђе сулфат
@@ -2585,7 +2561,6 @@ sl: železov difosfat, železov pirofosfat
 sv: ferridifosfat, ferripyrofosfat, järndifosfat
 ta: இரும்பு பைரோபாசுபேட்டு
 zh: 焦磷酸铁
-# ingredient/fr:diphosphate-ferrique has 116 products in 7 languages @2019-05-07
 # usage:de:Mineralstoff (Eisendiphosphat)
 description:en: IRON(II) PHOSPHATE, Fe3(PO4)2, is an iron salt of phosphoric acid.
 vegan:en: yes
@@ -2750,7 +2725,6 @@ hu: foszfát, foszfátok
 it: fosfato
 nl: fosfaat
 pt: fosfato, fosfatos
-# ingredient/fr:phosphates has 57 products @2019-02-22
 # usage:fr:Séquestrant : phosphate
 # usage:fr:stabilisants : phosphates
 # sodium (mono, hexameta, and/or tripoly) phosphate
@@ -2948,7 +2922,6 @@ ur: خارصین
 uz: Rux
 vi: kẽm
 zh: 锌
-# ingredient/zinc has 859 products in 6 languages @2019-01-25
 description:en: ZINC is a chemical element with symbol Zn and atomic number 30.
 # ast:Cinc
 # azb:زنگ
@@ -3109,7 +3082,6 @@ sk: glukónan zinočnatý
 sl: cinkov glukonat
 sr: Cink glukonat
 sv: zinkglukonat
-# ingredient/fr:gluconate-de-zinc has 113 products in 4 languages @2019-03-29
 description:en: ZINC GLUCONATE  is the zinc salt of gluconic acid. It is an ionic compound consisting of two anions of gluconate for each zinc(II) cation. Zinc gluconate is a popular form for the delivery of zinc as a dietary supplement
 # azb:قلوکونات چینکو
 vegan:en: yes
@@ -3189,7 +3161,6 @@ th: สังกะสีออกไซด์
 uk: Оксид цинку
 vi: Kẽm ôxít
 zh: 氧化鋅
-# ingredient/fr:oxyde-de-zinc has 111 products in 4 languages @2019-03-29
 description:en: ZINC OXIDE is an inorganic compound with the formula ZnO. Zinc oxide is added to many food products, including breakfast cereals, as a source of zinc, a necessary nutrient.
 # azb:اوکسید چینکو
 # csb:Cynkòwò bielëna
@@ -3288,8 +3259,6 @@ tr: zinc sulfate
 uk: Цинковий купорос
 vi: Kẽm sulfat
 zh: 硫酸锌
-# ingredient/fr:sulfate-de-zinc has 421 products in 4 languages @2019-05-18
-# mineral/zinc-sulphate has 692 products in 9 languages @2019-05-18
 # usage:pt:zinco (sulfato de zinco)
 description:en: ZINC SULFATE has the formula ZnSO4 as well as any of three hydrates. As a supplement it is used to treat zinc deficiency and to prevent the condition in those at high risk.
 vegan:en: yes
@@ -3445,7 +3414,6 @@ yo: Bàbàowó
 za: Doengz
 zh: 铜
 zu: Umthofu
-# ingredient/copper has 96 products in 4 languages @2019-03-08
 description:en: COPPER is a chemical element with symbol Cu (from Latin:cuprum) and atomic number 29.
 # ang:Coper
 # ast:Cobre
@@ -3602,7 +3570,6 @@ sl: bakrov glukonat
 sr: Bakar glukonat
 sv: kopparglukonat
 zh: 葡萄糖酸铜
-# ingredient/fr:gluconate-de-cuivre has 105 products @2019-03-16
 description:en: COPPER GLUCONATE is the copper salt of D-gluconic acid.
 vegan:en: yes
 vegetarian:en: yes
@@ -3657,7 +3624,6 @@ ru: сульфат меди
 sk: síran meďnatý
 sl: bakrov sulfat
 sv: kopparsulfat
-# ingredient/fr:sulfate-de-cuivre has 223 products in 4 languages @2019-05-13
 description:en: COPPER(II) SULFATE, also known as copper sulphate, are the inorganic compounds with the chemical formula CuSO4(H2O)x, where x can range from 0 to 5.
 # azb:پاخیر(II) سولفات
 # nan:Liû-sng tâng
@@ -3798,7 +3764,6 @@ vi: mangan
 yi: מאנגאן
 yo: Manganisi
 zh: 锰
-# ingredient/en:Manganese has 3 products @2019-05-12
 description:en: MANGANESE is a chemical element with symbol Mn and atomic number 25. Manganese is an essential human dietary element. It is present as a coenzyme in several biological processes, which include macronutrient metabolism, bone formation, free radical defense systems.
 # ast:Manganesu
 # azb:منگنز
@@ -3948,8 +3913,6 @@ sv: manganglukonat
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q27268214
-# ingredient/fr:gluconate-de-manganèse has 43 products in 4 languages @2019-05-11
-# mineral/manganese-gluconate has 61 products in 4 languages @2019-05-11
 
 < en: Manganese
 en: manganese glycerophosphate
@@ -4012,8 +3975,6 @@ tr: Manganez sülfat
 uk: Сульфат марганцю
 vi: Mangan sulfat
 zh: 硫酸锰
-# ingredient/manganese-sulfate has 354 products @2019-05-12
-# mineral/manganese-sulphate has 346 products @2019-05-12
 description:en: MANGANESE SULFATE usually refers to the inorganic compound with the formula MnSO4·H2O. Magnesium sulfate is used as a brewing salt in making beer. It may also be used as a coagulant for making tofu.
 # azb:سولفات منقنز
 # wuu:硫酸锰
@@ -4199,7 +4160,6 @@ vi: selen
 yi: סעלעניום
 yo: Selenium
 zh: 硒
-# ingredient/fr:sélénium has 74 products in 4 languages @2018-12-21
 description:en: SELENIUM is a chemical element with symbol Se and atomic number 34.
 # ast:Seleniu
 # be-tarask:Сэлен
@@ -4282,7 +4242,6 @@ sr: Natrijum selenat
 sv: natriumselenat
 vi: Natri selenat
 zh: 硒酸鹽
-# ingredient/fr:sélénate-de-sodium has 97 products in 4 languages @2019-04-21
 description:en: SODIUM SELENATE is the inorganic compound with the formula Na2SeO4. Chosen for its selenium content and high solubility, sodium selenate is a common ingredient in over-the-counter vitamin supplements.
 # azb:سلنات سودیوم
 # sr-el:Natrijum selenat
@@ -4351,7 +4310,6 @@ sv: natriumselenit
 ta: சோடியம் செலீனைட்டு
 vi: Natri selenit
 zh: 亞硒酸鹽
-# ingredient/fr:sélénite%20de%20sodium has 320 products in 5 languages @2019-05-16
 description:en: SODIUM SELENITE is the inorganic compound with the formula Na2SeO3. Because selenium is an essential element, sodium selenite is an ingredient in dietary supplements such as multi-vitamin/mineral products.
 # azb:سلنیت سودیوم
 # pt-br:selenito de sódio
@@ -4550,7 +4508,6 @@ fr: chlorure de chrome
 it: cloruro di cromo
 pt: cloreto de crômio
 ro: Clorură de crom
-# ingredient/fr:chlorure-de-chrome has 113 products in 4 languages @2019-03-16
 vegan:en: yes
 vegetarian:en: yes
 
@@ -4826,8 +4783,6 @@ sr: Natrijum molibdat
 ta: சோடியம் மாலிப்டேட்டு
 vi: Natri molipđat
 zh: 钼酸钠
-# ingredient/fr:molybdate-de-sodium has 83 products in 4 languages @2019-02-18
-# mineral/sodium-molybdate has 114 products @2019-02-18
 description:en: SODIUM MOLYBDATE, Na2MoO4, is useful as a source of molybdenum.
 # azb:سودیوم مولیبدات
 # zh-cn:钼酸钠
@@ -4947,7 +4902,6 @@ vi: iốt
 yi: יאד
 yo: Iodine
 zh: 碘
-# ingredient/fr:iode has 92 products in 4 languages @2019-03-20
 # sel de cuisine [iodé, fluoré]
 description:en: IODINE is a chemical element with symbol I and atomic number 53.
 # ast:Yodu
@@ -5042,8 +4996,6 @@ tr: Potasyum iyodür
 uk: Йодид калію
 vi: Kali iođua
 zh: 碘化钾
-# mineral/potassium-iodide has 718 products in 8 languages @2019-04-24
-# ingredient/fr:iodure-de-potassium has 504 products in 4 languages @2019-04-24
 description:en: POTASSIUM IODIDE is a chemical compound, medication, and dietary supplement. As a medication it is used to treat hyperthyroidism, in radiation emergencies, and to protect the thyroid gland when certain types of radiopharmaceuticals are used.
 # pnb:پوٹاشیم آیوڈائیڈ
 # sr-ec:калијум-јодид
@@ -5154,7 +5106,6 @@ ta: கால்சியம் அயோடேட்டு
 tr: Kalsiyum iyodat
 vi: Canxi iodat
 zh: 碘酸鈣
-# ingredient/calcium-iodate has 76 products in 2 languages@2019-05-07
 description:en: CALCIUM IODATES are inorganic compound composed of calcium and iodate anion. Calcium iodate can also be used as an iodine supplement.
 # azb:کلسیوم یدات
 # en-ca:Calcium iodate
@@ -5280,7 +5231,6 @@ yi: נאטריום
 yo: Sodiomu
 zh: 钠
 # usage:fr:sels minéraux de mer (sodium, potassium, magnésium, calcium)
-# ingredient/fr:sodium has 317 products @2019-05-06
 description:en: SODIUM is a chemical element with symbol Na (from Latin natrium) and atomic number 11. In humans, sodium is an essential mineral that regulates blood volume, blood pressure, osmotic equilibrium and pH; the minimum physiological requirement for sodium is 500 milligrams per day.
 # arz:صوديوم
 # ast:Sodiu

--- a/taxonomies/nucleotides.txt
+++ b/taxonomies/nucleotides.txt
@@ -150,7 +150,6 @@ sv: Adenosinmonofosfat
 tr: Adenozin monofosfat
 uk: Аденозинмонофосфат
 vi: Adenosine monophosphate
-# adenosine 5'-monophosphate has 3 products @2019-06-23
 # yue:單磷酸腺苷
 # zh:單磷酸腺苷
 # zh-cn:单磷酸腺苷
@@ -159,7 +158,6 @@ vi: Adenosine monophosphate
 # zh-hk:單磷酸腺苷
 # zh-sg:单磷酸腺苷
 # zh-tw:單磷酸腺苷
-# adenosine 5'-monophosphate has 3 products @2019-06-23
 description:en: ADENOSINE MONOPHOSPHATE (AMP) is a nucleotide. AMP plays an important role in many cellular metabolic processes
 wikidata:en: Q318369
 
@@ -350,7 +348,6 @@ ro: săruri de sodiu ale IMP
 sk: sodné soli IMP
 sl: natrijeve soli IMP
 sv: natriumsalter av IMP
-# ingredient/disodium-inosine-5'-monophosphate has 2 products @2019-06-23
 
 < en: nucleotides
 en: uridine monophosphate, uridine-monophosphate, uridine-5'-monophosphate, uridine 5'-phosphoric acid, UMP
@@ -408,6 +405,5 @@ ro: săruri de sodiu ale UMP
 sk: sodné soli UMP
 sl: natrijeve soli UMP
 sv: natriumsalter av UMP
-# ingredient/disodium-uridine-5'-monophosphate has 1 product @2019-06-23
 
 

--- a/taxonomies/other_nutritional_substances.txt
+++ b/taxonomies/other_nutritional_substances.txt
@@ -78,7 +78,6 @@ uk: Карнитин
 zh: 肉碱
 description:en: Carnitine is a quaternary ammonium compound involved in metabolism in most mammals, plants and some bacteria. The body synthesizes enough carnitine from lysine side chains to keep up with the needs of energy production in the body as carnitine acts as a transporter of long-chain fatty acids into the mitochondria to be oxidized and produce energy. Food sources rich in L-carnitine are animal products such as meat, poultry, fish, and milk. Redder meats tend to have higher levels of L-carnitine. Some individuals with genetic or medical disorders (like preterm infants) cannot make enough, so this makes carnitine a conditionally essential nutrient for them.
 vegan:en: maybe
-# ingredient/Carnitine has 194 products @2019-06-23
 vegetarian:en: maybe
 # azb:کارنیتین
 # sr-ec:карнитин
@@ -120,7 +119,6 @@ sl: L-karnitin
 sv: L-karnitin
 description:en: L-CARNITINE is the left isomer of carnitine, a quaternary ammonium compound involved in metabolism in most mammals, plants and some bacteria. The body synthesizes enough carnitine from lysine side chains to keep up with the needs of energy production in the body as carnitine acts as a transporter of long-chain fatty acids into the mitochondria to be oxidized and produce energy. Food sources rich in L-carnitine are animal products such as meat, poultry, fish, and milk. Redder meats tend to have higher levels of L-carnitine. Some individuals with genetic or medical disorders (like preterm infants) cannot make enough, so this makes carnitine a conditionally essential nutrient for them.
 wikidata:en: Q20735709
-# ingredient/l-carnitine has 146 products @2019-06-23
 
 # <en:Carnitine
 # en:L-carnitine hydrochloride
@@ -170,7 +168,6 @@ sk: L-karnitín-L-vínan
 sl: L-karnitin-L-tartrat
 sv: L-karnitin-L-tartrat
 wikidata:en: Q64782495
-# ingredient/l-carnitine-l-tartrate has 40 products @2019-06-23
 
 en: taurine
 ar: حمض التورين
@@ -221,8 +218,6 @@ uk: Таурин
 vi: Taurine
 wa: Torene
 zh: 牛磺酸
-# ingredient/fr:taurine has 309 products in 6 languages @2019-5-17
-# other-nutritional-substance/taurine has 591 products in 8 languages @2019-05-17
 description:en: Taurine is an organic compound that is widely distributed in animal tissues. Taurine has many fundamental biological roles. Taurine is a common additive to energy drinks, which are often promoted as such.
 vegan:en: maybe
 vegetarian:en: maybe
@@ -274,7 +269,6 @@ uk: Холін
 zh: 胆碱
 description:en: CHOLINE is a water-soluble vitamin-like essential nutrient. The US Food and Drug Administration requires that infant formula not made from cow's milk be supplemented with choline. Choline-providing dietary supplement ingredients include: choline chloride, choline bitartrate, citicoline (CDP-choline), L-alpha-glycerophosphocholine (Alpha-GPC), lecithin, phosphatidylcholine. Cruciferous vegetables, such as Brussels sprouts and broccoli, are good sources of choline.
 vegan:en: maybe
-# ingredient/choline has 73 products @2019-06-23
 vegetarian:en: maybe
 # zh_CN:胆碱
 wikidata:en: Q193166
@@ -308,7 +302,6 @@ sr: Holin hlorid
 # sr-el:Holin hlorid
 sv: kolinklorid
 zh: 氯化膽鹼素
-# ingredient/choline-chloride has 18 products in 4 languages @2019-06-23
 description:en: Choline chloride is an organic compound containing both quaternary ammonium salt and an alcohol. It is an important additive in feed especially for chickens where it accelerates growth. The US Food and Drug Administration requires that infant formula not made from cow's milk be supplemented with choline. Choline-providing dietary supplement ingredients include: choline chloride, choline bitartrate, citicoline (CDP-choline), L-alpha-glycerophosphocholine (Alpha-GPC), lecithin, phosphatidylcholine.
 wikidata:en: Q2964153
 wikipedia:en: https://en.wikipedia.org/wiki/Choline_chloride
@@ -339,7 +332,6 @@ sk: cholín dvojvínan
 sl: holin bitartrat
 sv: kolinbitartrat
 wikidata:en: Q18324709
-# ingredient/choline-bitartrate has 84 products @2019-06-23
 
 # <en:Choline
 # en:choline citrate
@@ -405,7 +397,6 @@ sv: inositol
 uk: Інозитол
 zh: 肌醇
 description:en: INOSITOL is a carbocyclic sugar that is abundant in brain and other mammalian tissues, mediates cell signal transduction and participates in osmoregulation. It is a sugar alcohol with half the sweetness of table sugar. It is made naturally in humans from glucose. A human kidney will produce around two grams each day. Foods containing the highest concentrations of inositol include fruits, beans, grains, and nuts.
-# ingredient/inositol has 296 products @2019-06-23
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q407997

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -227,7 +227,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q18225
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_A
-# vitamin/vitamin-a has 1768 products in 17 languages @2018-11-20
 
 < en: vitamin A
 en: retinol
@@ -280,7 +279,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q7316808
 wikipedia:en: https://en.wikipedia.org/wiki/Retinyl_acetate
-# vitamin/retinyl-acetate has 42 products @2018-11-20
 
 # description:en:Retinyl palmitate, or vitamin A palmitate, is the ester of retinol (vitamin A) and palmitic acid, with formula C36H60O2.
 
@@ -315,7 +313,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q7316807
 wikipedia:en: https://en.wikipedia.org/wiki/Retinyl_palmitate
-# vitamin/retinyl-palmitate has 14 products in 5 languages @2018-11-20
 
 # description:en:β-Carotene is an organic, strongly colored red-orange pigment abundant in plants and fruits. Plant carotenoids are the primary dietary source of provitamin A worldwide, with β-carotene as the best-known provitamin A carotenoid.
 
@@ -378,7 +375,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q306135
 wikipedia:en: https://en.wikipedia.org/wiki/Beta-Carotene
-# ingredient/fr:bêtacarotène has 116 products in 4 languages @2019-04-25
 
 # description:en: A provitamin is a substance that may be converted within the body to a vitamin. For example, "provitamin A" is a name for β-carotene, Whether beta-carotene is used as colour or vitamin depends on additional information on the ingredient list. It can be preceded by the wording colorant or provitamin A. Or it occurs in a (non-obvious) listing of other vitamins.
 
@@ -397,7 +393,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q306135
 wikipedia:en: https://en.wikipedia.org/wiki/Beta-Carotene
-# vitamin/beta-carotene has 865 products in 8 languages @2018-11-20
 
 < en: beta-carotene
 en: beta-carotene dye
@@ -406,7 +401,6 @@ de: Farbstoff Beta-Carotin
 es: colorante de beta-caroteno
 fr: colorant bêta-carotène
 hu: béta-karotin színezék
-# fr:colorant-bêta-carotène has 71 products in 4 languages @2019-03-27
 it: colorante betacaroteno, colorante beta-carotene
 nl: bètacaroteenkleurstof
 vegan:en: yes
@@ -506,7 +500,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q175621
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_D
-# vitamin/vitamin-d has 2516 products in 13 languages @2018-11-21
 
 # description:en:Ergocalciferol, also known as vitamin D2 and calciferol, is a type of vitamin D found in food and used as a dietary supplement.
 
@@ -551,7 +544,6 @@ uk: Ергокальциферол
 zh: 麦角钙化醇, 维生素D2
 vegan:en: yes
 vegetarian:en: yes
-# vitamin/ergocalciferol has 690 products @2018-11-21
 wikidata:en: Q139200
 # sr-ec:ергокалциферол
 # sr-el:Ergokalciferol
@@ -641,7 +633,6 @@ vegetarian:en: maybe
 # zh-tw:膽鈣化醇, 维生素D3
 wikidata:en: Q139347
 wikipedia:en: https://en.wikipedia.org/wiki/Cholecalciferol
-# vitamin/cholecalciferol has 2996 products in 8 languages @2018-11-21
 
 # description:en:VITAMIN E is a group of eight fat soluble compounds that include four tocopherols and four tocotrienols. In order to distinguish between the vitamin and antioxidant role, vitamin E is call tocoferol. The oxidant is called Tocopherol-rich extract or E306.
 
@@ -723,7 +714,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q141180
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_E
-# ingredient/vitamin-e has 1830 products in 13 languages @2018-11-25
 
 
 < en: Vitamin E
@@ -925,7 +915,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q182338
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_K
-# ingredient/vitamin-k has 85 products in 4 languages @2018-11-25
 
 < en: vitamin K
 en: phylloquinone, phytomenadione, Vitamin K1
@@ -969,8 +958,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q186093
 wikipedia:en: https://en.wikipedia.org/wiki/Phytomenadione
-# ingredient/fr:k1 has 79 products@2019-04-16
-# vitamin/phylloquinone has 180 products in 8 languages @2019-4-16
 
 < en: vitamin K
 en: menaquinone, vitamin K2
@@ -1121,7 +1108,6 @@ vegetarian:en: yes
 wikidata:en: Q199678
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_C
 # description:en:Vitamin C, also known as ascorbic acid and L-ascorbic acid, is a vitamin found in food and used as a dietary supplement.
-# en:ascorbic-acid has 17518 products in 17 languages @2018-11-17
 
 < en: Vitamin C
 en: L-ascorbic acid, ascorbic acid
@@ -1342,7 +1328,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q83187
 wikipedia:en: https://en.wikipedia.org/wiki/Thiamine
-# ingredient/vitamin-b1 has 4607 products in 11 languages @2018-11-23
 
 < en: Thiamin
 en: thiamin hydrochloride
@@ -1398,7 +1383,6 @@ sl: tiamin mononitrat
 sv: tiaminmononitrat
 vegan:en: maybe
 vegetarian:en: maybe
-# ingredient/fr:mononitrate-de-thiamine has 83 products in 4 languages @2019-03-11
 
 # description:en:Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement.
 
@@ -1458,7 +1442,6 @@ uk: Рибофлавін, Вітамін B2
 wa: riboflavene, vitamene B2
 zh: 核黄素
 vegan:en: maybe
-# ingredient/vitamin-b2 has 4263 products in 10 languages @2018-11-23
 vegetarian:en: yes
 # ast:Vitamina B2
 # be-tarask:Рыбафлявін
@@ -1526,7 +1509,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q134658
 wikipedia:en: https://en.wikipedia.org/wiki/Niacin
-# ingredient/vitamin-b3 has 744 products in 8 languages @2018-11-23
 
 < en: niacin
 en: nicotinic acid
@@ -1609,7 +1591,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q192423
 wikipedia:en: https://en.wikipedia.org/wiki/Nicotinamide
-# ingredient/fr:nicotinamide has 172 products in 2 languages @2019-01-16
 
 # description:en:Vitamin B6 refers to a group of chemically similar compounds which can be interconverted in biological systems.
 
@@ -1676,7 +1657,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q205130
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_B6
-# ingredient/vitamin-b6 has 2556 products in 12 languages  @2018-11-24
 
 < en: vitamin B6
 en: pyridoxine
@@ -1736,7 +1716,6 @@ sv: pyridoxinhydroklorid
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q26841284
-# ingredient/pyridoxine-hydrochloride has 1751 products in 5 languages @2018-11-24
 
 < en: vitamin B6
 en: pyridoxamine hydrochloride
@@ -1883,9 +1862,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q127060
 wikipedia:en: https://en.wikipedia.org/wiki/Folate
-# en:vitamin/folic-acid has 23535 products in 17 languages @2018-11-19
-# ingredient/fr:acide-folique has 22121 products in 13 languages @2018-11-19
-# ingredient/fr:folacine has 48 products in 2 languages @2019-04-16
 
 < en: Folate
 en: calcium-L-methylfolate
@@ -2002,7 +1978,6 @@ zh: 维生素B12
 vegan:en: yes
 vegetarian:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_B12
-# ingredient/vitamin-b12 has 2117 products in 10 languages @2018-11-25
 
 < en: Vitamin B12
 en: cyanocobalamin, cyanocobalamine
@@ -2125,7 +2100,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q181354
 wikipedia:en: https://en.wikipedia.org/wiki/Biotin
-# ingredient/biotin has 145 products in 3 languages @2018-11-24
 
 < en: biotin
 en: D-biotin
@@ -2160,7 +2134,6 @@ pt: vitamina B8
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q25113695
-# ingredient/vitamin-b8 has 35 products in 3 languages @2018-11-24
 
 # description:en:Pantothenic acid, also called vitamin B5 (a B vitamin), is a water-soluble vitamin.
 
@@ -2236,8 +2209,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q179894
 wikipedia:en: https://en.wikipedia.org/wiki/Pantothenic_acid
-# vitamin/pantothenic-acid has 1373 products in 12 languages @2018-11-19
-# fr:acide-pantothénique has 900 products in 9 languages @2018-11-19
 
 # description:en:Another common supplemental form of the vitamin is CALCIUM PANTOTHENATE. Calcium pantothenate is often used in dietary supplements because, as a salt, it is more stable than pantothenic acid.
 
@@ -2256,7 +2227,6 @@ nn: kalsiumpantotenat
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q27261387
-# ingredient/fr:pantothénate-de-calcium has 109 products in 4 languages @2019-04-21
 
 < en: pantothenic acid
 en: calcium D-pantothenate, D-pantothenate calcium


### PR DESCRIPTION
These counts are mostly quite old (though there are a couple from 2025), and while the historical data might be interesting, it would probably be better to extract that from the database as needed, rather than storing it as comments in the taxonomy files.

I mostly consider these when they appear as noise in PRs, being moved around, but maybe there is some use for them that I’m not aware of.

This also reduces the size of the taxonomy files (if only marginally), which may help some editors better deal with them.

The changes were made using `sed --follow-symlinks -iE '/[pattern]/d' taxonomies/**.txt` with the following patterns:
- `^# openfoodfacts:`
- `# [[:digit:]]\+ products`
- `# [[:digit:]]\+ entry`
- `# [[:digit:]]\+ entries`
- `# [[:digit:]]\+ in [[:digit:]]\+ @20`
- `# .* has [[:digit:]]\+ products\?`