### PR TITLE
taxonomy(product): drinking straw categories

### DIFF
--- a/taxonomies/product/categories.txt
+++ b/taxonomies/product/categories.txt
@@ -75783,6 +75783,73 @@ tr: İçecek Kamış ve Karıştırıcıları
 google_product_taxonomy_id:en: 5043
 wikidata:en: Q116961240
 
+< en: Drinking Straws & Stirrers
+en: Drinking straws
+ar: شفاطة
+ca: Palla
+cs: Slámka
+cy: Gwelltyn yfed
+da: Sugerør
+de: Strohhalm
+el: Καλαμάκι πόσης
+eo: Trinkŝalmo
+es: Pajilla
+et: Joogikõrs
+eu: Pajita
+fa: نی‌ نوشیدنی
+fi: Pilli
+fr: Paille
+hr: Slamčica
+hu: Szívószál
+hy: Խմելու ձողիկ
+id: Sedotan
+it: Cannuccia
+ja: ストロー
+jv: Sedhotan
+ka: Კოქტეილის ჩხირი
+ko: 빨대
+lb: Stréihallem
+lt: Šiaudelis
+mk: Сламка
+ms: Penyedut minuman
+nb: Sugerør
+nl: Rietje
+nn: Sugerøyr
+pl: Słomka
+pt: Canudo
+ro: Pai
+ru: Соломинка
+sc: Cannita
+sh: Slamčica
+sk: Slamka
+sl: Slamica
+sq: Pipëz kashte
+sr: Сламчица
+ss: Umbhobho wekunatsa
+sv: Sugrör
+sw: Mrija
+th: หลอดดูด
+tr: Pipet
+uk: Соломинка
+vi: Ống hút
+zh: 吸管
+wikidata:en: Q189211
+
+< en: Drinking straws
+en: Plastic drinking straws
+da: Plastiksugerør
+sv: Plastsugrör
+
+< en: Drinking straws
+en: Metal drinking straws
+da: Metalsugerør
+sv: Metallsugrör
+
+< en: Drinking straws
+en: Paper drinking straws
+da: Papirssugerør
+sv: Papperssugrör
+
 < en: Party Supplies
 en: Envelope Seals
 xx: Envelope Seals


### PR DESCRIPTION
Adds “Drinking straws” as its own category, with subcategories for plastic, metal, and paper straws.

Needed-for: https://se.openproductsfacts.org/product/4056489021216/papperssugr%C3%B6r-25-st