### PR TITLE
taxonomy: add missing es/pt/it synonyms to heart of palm

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -53819,24 +53819,6 @@ ciqual_food_name:fr: Artichaut, fond, surgelé, cru
 
 ###################################################################################################
 #
-#                                Palm heart
-#
-###################################################################################################
-
-#category/palm-hearts
-< en: shoot vegetable
-en: Palm heart, heart of palm, hearts of palm
-es: Corazón de palmito, corazones de palmito, palmito
-pt: Palmito, coração de palmeira
-fr: cœur de palmier, coeurs de palmier, chou palmiste
-de: Palmherzen
-it: Cuore di palma
-vegan:en: yes
-vegetarian:en: yes
-description:en: The heart of palm is the inner core of certain palm trees, harvested as a vegetable and typically canned or jarred in brine.
-
-###################################################################################################
-#
 #                                Asparagus
 #
 ###################################################################################################
@@ -55017,13 +54999,19 @@ usda_ndb_name:en: Cabbage, red, raw
 wikidata:en: q263203
 wikipedia:en: https://en.wikipedia.org/wiki/Red_cabbage
 
+###################################################################################################
+#
+#                                Palm heart
+#
+###################################################################################################
+
 # <en:category:en:Fresh plant-based foods
 < en: shoot vegetable
 en: heart of palm, Hearts of palm, palm heart
 ar: جمار
 de: Palmherzen, Palmherz
 eo: Palmomedolo
-es: Palmito
+es: palmito, corazón de palmito, corazones de palmito
 fa: پنیر نخل
 fi: Palmun sydän
 fr: Cœur de palmier, cœurs de palmiers, cœurs de palmier, coeur de palmier, coeurs de palmiers, coeurs de palmier, choux palmistes, chou palmiste
@@ -55031,17 +55019,18 @@ gl: Palmito
 gv: Cabbash phalm
 he: לבבות דקל
 hr: srce dlana
-it: cuori di palma, Palmito
+it: palmito, cuore di palma, cuori di palma
 ja: ハート・オブ・パーム
 jv: Pondhoh
 la: Cerebrum palmae
 lt: Palmės šerdis
 nl: Palmharten
 pl: serce palmy, serca palmy
-pt: Palmito
+pt: palmito, coração de palmeira
 ru: Сердцевина пальмы
 sv: Palmhjärta
 tl: Ubod
+description:en: The heart of palm is the inner core of certain palm trees, harvested as a vegetable and typically canned or jarred in brine.
 eurocode_2_group_3:en: 8.25.50
 usda_ndb_proxy_code:en: 43392
 usda_ndb_proxy_name:en: Hearts of palm, raw

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -53819,6 +53819,24 @@ ciqual_food_name:fr: Artichaut, fond, surgelé, cru
 
 ###################################################################################################
 #
+#                                Palm heart
+#
+###################################################################################################
+
+#category/palm-hearts
+< en: shoot vegetable
+en: Palm heart, heart of palm, hearts of palm
+es: Corazón de palmito, corazones de palmito, palmito
+pt: Palmito, coração de palmeira
+fr: cœur de palmier, coeurs de palmier, chou palmiste
+de: Palmherzen
+it: Cuore di palma
+vegan:en: yes
+vegetarian:en: yes
+description:en: The heart of palm is the inner core of certain palm trees, harvested as a vegetable and typically canned or jarred in brine.
+
+###################################################################################################
+#
 #                                Asparagus
 #
 ###################################################################################################


### PR DESCRIPTION
## What

Adds the missing Spanish, Portuguese and Italian synonyms to the existing `heart of palm` entry, so that ingredient lists naming it in those languages are actually recognised. Also adds a section header and an English description, and the `eurocode_2_group_3` value the file's own header comments already used palm heart as the example for.

## Why

Found while building a small vegan-scoring app on the OFF API. A real product, [Palmito Natural Entero (8480000862723)](https://world.openfoodfacts.org/product/8480000862723), lists only `Corazones de palmito, agua, sal y ácido cítrico E330`. Water, salt and citric acid all resolve as vegan, but `corazones de palmito` matched nothing (`is_in_taxonomy: 0`), because the entry carried only `es: Palmito`. One unrecognised ingredient is enough to drag the whole product to `vegan-status-unknown` / `vegetarian-status-unknown`, so a product whose every ingredient is unambiguously plant-derived came back undetermined.

Verified this was a taxonomy gap and not stale analysis: resubmitting the identical `ingredients_text` via the write API on staging left the tags unchanged, since there was no node to match against.

With the synonyms in place the ingredient resolves, and as @Freso notes it then inherits `vegan`/`vegetarian` from `en:vegetable` via `en:shoot-vegetable`, so no explicit properties are needed on the entry.

## Note on this PR's history

The first version of this PR wrongly added a second, duplicate entry, because I concluded no entry existed from a `grep` truncated at 20 results, where the real one fell below the cut. @Freso caught it and redirected the change to where it belonged. The diff now touches only the existing entry.
