### PR TITLE
taxonomy(food): mirin/rice wine edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -1560,7 +1560,6 @@ uk: Ферментовані продукти
 vi: Thực phẩm lên men
 zh: 发酵食品
 
-
 < en: Fermented vegetables
 en: Kimchi
 xx: Kimchi
@@ -1994,16 +1993,53 @@ protected_name_type:en: gi
 #wikidata:en:
 
 < en: Alcoholic beverages
+en: Rice wines
+ca: Vi d'arròs
+cs: Rýžové víno
+cy: Gwin reis
+da: Risvine
+de: Reiswein
+eo: Rizalkoholaĵoj
+es: Vinos de arroz, Vino de arroz
+eu: Arroz ardo
+fa: شراب برنج
+fi: Riisiviini
+fr: Alcools de riz, Alcool de riz
+gl: Viño de arroz
+hu: Rizsbor
+hy: Բրնձի գինի
+id: Arak beras
+it: Vino di riso
+ja: ライスワイン
+ko: 미주
+la: Vinum ex oryza
+ms: Arak beras
+nb: Risviner
+nl: Rijstwijn
+nn: Risvinar
+pl: Wino ryżowe, Wina ryżowe
+pt: Vinhos de arroz, Vinho de arroz
+ru: Рисовое вино
+sl: Riževo vino
+sv: Risviner
+tr: Pirinç şarabı
+uk: Рисове вино
+zh: 米酒
+agribalyse_proxy_food_code:en: 1026
+ciqual_proxy_food_code:en: 1026
+ciqual_proxy_food_name:en: Sake or rice wine
+wikidata:en: Q1142986
+
+< en: Rice wines
 xx: Sake
-en: Sake, Rice wines
+en: Sake
 bg: Саке
-fr: Saké, Alcools de riz
+fr: Saké
 hu: Szaké
 it: Sake, Sakè
 ja: 日本酒, にほんしゅ
 nl: Saké
-pl: Sake, Wina ryżowe
-pt: Saquê, vinhos de arroz
+pt: Saquê
 agribalyse_food_code:en: 1026
 ciqual_food_code:en: 1026
 ciqual_food_name:en: Sake or rice wine
@@ -2018,21 +2054,24 @@ pt: Shochu
 en: Awamori
 xx: Awamori
 agribalyse_proxy_food_code:en: 1026
-cagribalyse_proxy_food_name:en: Sake or rice wine
+ciqual_proxy_food_code:en: 1026
+ciqual_proxy_food_name:en: Sake or rice wine
 wikidata:en: Q1069948
 
 < en: Shoshu
 en: Kome-shochu
 xx: Kome-shochu
 agribalyse_proxy_food_code:en: 1026
-cagribalyse_proxy_food_name:en: Sake or rice wine
+ciqual_proxy_food_code:en: 1026
+ciqual_proxy_food_name:en: Sake or rice wine
 
 < en: Shoshu
 en: Kasutori-shochu, sake kasu
 xx: Kasutori-shochu, sake kasu
 pt: Kasutori-shochu, saquê kasu
 agribalyse_proxy_food_code:en: 1026
-cagribalyse_proxy_food_name:en: Sake or rice wine
+ciqual_proxy_food_code:en: 1026
+ciqual_proxy_food_name:en: Sake or rice wine
 
 < en: Shoshu
 en: Imo-Shoshu
@@ -2054,25 +2093,48 @@ xx: Kokuto-Shoshu, Kokutojochu
 en: Kuri-Shoshu
 xx: Kuri-Shoshu
 
-< en: Alcoholic beverages
+< en: Condiments
 en: Mirin
 xx: Mirin
 ar: ميرين
-de: Mirin, Reiswein
+bn: মিরিন
+cv: Мирин
 el: Μιρίν
-eo: Mirino
+eo: Mirinoj
 fa: میرین, چاشنی
 he: מירין
-hu: Mirin
+hi: मीरीन
 hy: Միրին
 ja: みりん
 ko: 미림
-no: Mirin, Risvin
+ml: മിറിൻ
+pa: ਮੀਰੀਨ
 ru: Мирин
 th: มิริง
 uk: Мірін
+ur: میرین
 zh: 味醂
 wikidata:en: Q1045910
+
+< en: Mirin
+< en: Rice wines
+en: Hon mirin, True mirin, Authentic mirin
+xx: Hon mirin
+ja: 本みりん
+description:en: “True mirin.” Contains ~14% alcohol and is produced by a 40–60 day mashing process.
+
+< en: Mirin
+< en: Rice wines
+en: Shio mirin, Salt mirin
+xx: Shio mirin
+ja: 塩みりん
+description:en: “Salt mirin.” Contains a minimum of 1.5% salt to prevent consumption (and be exempt from alcohol tax).
+
+< en: Mirin
+en: Shin mirin, Mirin-fu chomiryo, New mirin, Mirin-like seasoning
+xx: Shin mirin, Mirin-fu chomiryo
+ja: 新みりん, みりん風調味料, みりん風味調味料, 新味料
+description:en: “New mirin” or “mirin‐like seasoning”. Contains less than 1% alcohol and is technically a mirin substitute, but is still sold as “mirin”.
 
 < en: Alcoholic beverages
 en: Beers, Beer


### PR DESCRIPTION
- Splits out rice wine from sake.
  - All sake is rice wine, not all rice wine is sake.
- Moves “Mirin” out of alcoholic beverages and into condiments, and adds three “mirin” types as children.
  - Regardless of the type of “mirin”, its primary use is as a condiment/seasoning.
  - Two of them are actual rice wines and have been set as children of the new rice wine category.
- Adds/fixes some `agribalyse`/`ciqual` and `wikidata` properties.
- Imports some translations from Wikidata.
- Normalises towards sentence-cased plural forms.

Source: https://en.wikipedia.org/w/index.php?title=Mirin&oldid=1345671002