### PR TITLE
fix: OCRed ingredients with "allergy advice" or "nutrition:" still in the text

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -5165,7 +5165,7 @@ my %phrases_after_ingredients_list = (
 		'keep cool and dry',
 		'Can be stored unopened at room temperature',
 		'cooking time',
-		'for allergens', # usually preceded by "allergy advice" in UK
+		'for allergens',    # usually preceded by "allergy advice" in UK
 		'instruction',
 		'nutrition(al)?[:]? (as sold|facts|information|typical|value[s]?)',
 		# "nutrition advice" seems to appear before ingredients rather than after.

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -5159,14 +5159,15 @@ my %phrases_after_ingredients_list = (
 	en => [
 		'adds a trivial amount',    # e.g. adds a trivial amount of added sugars per serving
 		'after opening',
+		'allergy advice',
 		'analytical constituents',    # pet food
 		'best before',    #'Best before',
 		'keep cool and dry',
 		'Can be stored unopened at room temperature',
 		'cooking time',
-		'for allergens',
+		'for allergens', # usually preceded by "allergy advice" in UK
 		'instruction',
-		'nutrition(al)? (as sold|facts|information|typical|value[s]?)',
+		'nutrition(al)?[:]? (as sold|facts|information|typical|value[s]?)',
 		# "nutrition advice" seems to appear before ingredients rather than after.
 		# "nutritional" on its own would match the ingredient "nutritional yeast" etc.
 		'of whlch saturates',

--- a/tests/unit/ingredients_clean.t
+++ b/tests/unit/ingredients_clean.t
@@ -219,6 +219,12 @@ Edit ingredients (en)",
 		"Wheat flour, palm oil, sesame seeds 4.9 %, glucose-fructose syrup, sugar, poppy seeds 2.3 %, raising agents (ammonium carbonates, calcium phosphates, sodium carbonates), salt, malted barley flour, dried yeast, wheat gluten, flavouring (contains celery). May contain egg, milk, nuts."
 	],
 
+	[
+		"en",
+		"PINK SALMON (Oncorhynchus gorbuscha) (99%) (Fish), Salt ALLERGY ADVICE: For allergens, see ingredients in bold. WARNING: This product will contain soft edible bones. NUTRITION: Typical values per 100 Energy h 578kJ/",
+		"PINK SALMON (Oncorhynchus gorbuscha) (99%) (Fish), Salt"
+	],
+
 	# Polish
 	[
 		"pl",


### PR DESCRIPTION
<!-- 
⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ There's an agreement by a maintainer or core contributor in the linked issue to assign it to the author of this PR
-->

<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `style`, for Code style changes (formatting, whitespace, etc.)
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
  - `test`, for Adding or updating tests
  - `build`, for Build system or dependency changes
  - `revert`, for Reverting previous changes
  - `l10n`, for Localization and translation updates
  - `taxonomy`, for Changes to product categories and tags taxonomy
-->
<!-- IMPORTANT CHECKLIST: Make sure you've done all the following (You can delete the checklist before submitting)-->
<!-- - [ ] Code is well documented-->
<!-- - [ ] Include unit tests for new functionality-->
<!-- - [ ] Code passes GitHub workflow checks in your branch-->
<!-- - [ ] If you have multiple commits please combine them into one commit by squashing them.-->
<!-- - [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)-->

### What
As I've been editing product ingredients, lots still have "allergy advice" or "nutrition" text still on the end. The OCR already correctly trims "for allergens", but not the text that generally precedes it, at least in the UK.
https://uk.openfoodfacts.org/facets/ingredients/allergy-advice

"Nutrition" is often followed by a colon, which the script doesn't handle.
https://uk.openfoodfacts.org/facets/ingredients/nutrition was much worse, but I've been fixing them one at a time.

<img width="1221" height="567" alt="image" src="https://github.com/user-attachments/assets/ed12540b-4ba5-40c2-812b-410f278bce88" />

### Large Language Models usage disclosure
<!-- ⚠️ If you used an LLM, please disclose which LLM you used (and its version) and how (agentic, autocomplete). Please confirm you have run successfully the code on your device. Also provide a screenshot or video as proof -->

### Screenshot or video
<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
<!-- Replace with the appropriate issue number(s) -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: <!-- #1 Note: you can also use Closes: -->

