### PR TITLE
taxonomy: Bami and nasi goreng

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -105909,11 +105909,11 @@ gpc_category_code:en: 10000018
 gpc_category_description:en: Definition: Includes any products that can be described/observed as any variety of fish or a combination of fish, that has gone through further manufacturing processes, such as reformed, cooked, dried and salted, however these products can also be coated, in sauce, stuffed or filled. Definition Excludes: Specifically excludes products that have added ingredients included such as rice, couscous and pasta. However products may contain a small quantity of vegetables such as those in a sauce or stuffing/filling. These products have been treated or packaged in such a way as to extend their consumable life. Excludes products such as Fish with additional vegetables, dough or grains, Frozen and Perishable Prepared and Processed Fish, all Unprepared and Unprocessed Fish.
 gpc_category_name:en: Fish - Prepared/Processed (Shelf Stable)
 
-< en: Fish preparations
+< en: Fish spreads
 < en: Salted spreads
-en: Anchoïade
-xx: Anchoïade
-fr: Anchoïade
+en: Anchoïades, Anchoiades
+xx: Anchoïades, Anchoiades
+fr: Anchoïades, Anchoiades
 wikidata:en: Anchoïade
 
 < en: Fish preparations

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -76119,6 +76119,103 @@ pt: Gomasio
 sv: Gomasio
 wikidata:en: Q685077
 
+< en: Condiments
+en: Nasi goreng seasoning mixes
+
+< en: Condiments
+en: Bami goreng seasoning mixes
+
+< en: Condiments
+en: Nasi goreng pastes
+
+< en: Condiments
+en: Wasabi pastes
+de: Wasabi Pasten
+es: Pastas de wasabi
+fr: Pâtes au wasabi, pâtes de wasabi
+hr: Wasabi paste
+lt: Vasabi pasta
+nl: Wasabipastas
+pl: Pasty wasabi
+wikidata:en: Q68437707
+
+< en: Condiments
+en: Curry pastes, Curry paste
+da: Karrypastaer
+de: Currypasten, Currypaste
+es: Pasta de curry
+fi: currytahnat
+fr: Pâtes de curry, Curry paste
+hr: Curry paste
+it: Pasta di curry
+lt: Kario pasta
+nb: Karripastaer
+nl: Curry pastas
+nn: Karripastaer, Karripastaar
+pl: Pasty curry
+sv: Currypastor
+wikidata:en: Q5195232
+
+< en: Curry pastes
+en: Red curry pastes, Red curry paste
+da: Røde karrypastaer
+de: Rote Currypasten, Rote Currypaste
+fr: Pâtes de curry rouges
+hr: Crvene curry paste
+lt: Raudonojo kario pasta
+nb: Røde karripastaer
+nl: Rode currypastas
+nn: Raude karripastaer
+pl: Czerwone pasty curry
+sv: Röda currypastor
+wikidata:en: Q67201118
+
+< en: Curry pastes
+en: Green curry pastes, Green curry paste
+da: Grønne karrypastaer
+de: Grüne Currypasten, Grüne Currypaste
+fr: Pâtes de curry verte, Pâtes de curry vert
+hr: Zelene curry paste
+lt: Žaliojo kario pasta
+nb: Grønne karripastaer
+nl: Groene Currypastas
+nn: Grøne karripastaer
+pl: Zielone pasty curry
+sv: Gröna currypastor
+wikidata:en: Q67201120
+
+< en: Curry pastes
+en: Phanaeng curry pastes, Phanaeng curry paste, Panang curry pastes, Panang curry paste, Penang curry pastes, Penang curry paste
+de: Panaeng Currypasten, Panaeng Currypaste, Panang Currypasten, Panang Currypaste
+hr: Phanaeng curry paste
+pl: Pasty curry panang
+wikidata:en: Q67206285
+
+< en: Curry pastes
+en: Massaman curry pastes, Massaman curry paste
+de: Massaman Currypasten, Massaman Currypaste
+fr: Pâtes de curry Massaman
+hr: Masaman curry paste
+pl: Pasty curry Massaman
+wikidata:en: Q67206116
+
+< en: Curry pastes
+en: Yellow curry pastes, Yellow curry paste
+da: Gule karrypastaer
+de: Gelbe Currypasten, Gelbe Currypaste
+fr: Pâtes de curry jaunes
+hr: Žute curry paste
+lt: Geltonojo kario pasta
+nb: Gule karripastaer
+nl: Gele Currypastas
+nn: Gule karripastaer
+pl: Żółte pasty curry
+sv: Gulor currypastor
+wikidata:en: Q67201117
+
+< en: Curry pastes
+en: Vindaloo curry pastes
+
 # don't put this category in vinegars, those products CONTAIN vinegar, they ARE NOT vinegars
 < en: Condiments
 en: Glazes with vinegar
@@ -79775,7 +79872,7 @@ description:en: Sichuan pepper is a spice made from the dried pericarp (outer sh
 wikidata:en: Q756800
 
 < en: Spices
-en: Spice Mix
+en: Spice mixes, Spice Mix
 de: Gewürzmischung
 es: Mezcla de especias
 fi: maustesekoitus
@@ -79792,11 +79889,11 @@ agribalyse_proxy_food_name:en: Mix of 4 spices
 agribalyse_proxy_food_name:fr: Quatre épices
 wikidata:en: Q1521067
 
-< en: Spice Mix
+< en: Spice mixes
 en: Guacamole spice mix
 fr: Mélange d'épices pour guacamole
 
-< en: Spice Mix
+< en: Spice mixes
 en: Mix of 4 spices, Mix of four spices
 fr: Quatre épices
 hr: Mješavina 4 začina
@@ -83917,94 +84014,6 @@ lt: Alyvuogių padažai
 nl: Sauzen met olijven
 #wikidata:en:
 
-< en: Sauces
-en: Wasabi pastes
-de: Wasabi Pasten
-es: Pastas de wasabi
-fr: Pâtes au wasabi, pâtes de wasabi
-hr: Wasabi paste
-lt: Vasabi pasta
-nl: Wasabipastas
-pl: Pasty wasabi
-wikidata:en: Q68437707
-
-< en: Meal sauces
-en: Curry pastes, Curry paste
-da: Karrypastaer
-de: Currypasten, Currypaste
-es: Pasta de curry
-fi: currytahnat
-fr: Pâtes de curry, Curry paste
-hr: Curry paste
-it: Pasta di curry
-lt: Kario pasta
-nb: Karripastaer
-nl: Curry pastas
-nn: Karripastaer, Karripastaar
-pl: Pasty curry
-sv: Currypastor
-wikidata:en: Q5195232
-
-< en: Curry pastes
-en: Red curry pastes, Red curry paste
-da: Røde karrypastaer
-de: Rote Currypasten, Rote Currypaste
-fr: Pâtes de curry rouges
-hr: Crvene curry paste
-lt: Raudonojo kario pasta
-nb: Røde karripastaer
-nl: Rode currypastas
-nn: Raude karripastaer
-pl: Czerwone pasty curry
-sv: Röda currypastor
-wikidata:en: Q67201118
-
-< en: Curry pastes
-en: Green curry pastes, Green curry paste
-da: Grønne karrypastaer
-de: Grüne Currypasten, Grüne Currypaste
-fr: Pâtes de curry verte, Pâtes de curry vert
-hr: Zelene curry paste
-lt: Žaliojo kario pasta
-nb: Grønne karripastaer
-nl: Groene Currypastas
-nn: Grøne karripastaer
-pl: Zielone pasty curry
-sv: Gröna currypastor
-wikidata:en: Q67201120
-
-< en: Curry pastes
-en: Phanaeng curry pastes, Phanaeng curry paste, Panang curry pastes, Panang curry paste, Penang curry pastes, Penang curry paste
-de: Panaeng Currypasten, Panaeng Currypaste, Panang Currypasten, Panang Currypaste
-hr: Phanaeng curry paste
-pl: Pasty curry panang
-wikidata:en: Q67206285
-
-< en: Curry pastes
-en: Massaman curry pastes, Massaman curry paste
-de: Massaman Currypasten, Massaman Currypaste
-fr: Pâtes de curry Massaman
-hr: Masaman curry paste
-pl: Pasty curry Massaman
-wikidata:en: Q67206116
-
-< en: Curry pastes
-en: Yellow curry pastes, Yellow curry paste
-da: Gule karrypastaer
-de: Gelbe Currypasten, Gelbe Currypaste
-fr: Pâtes de curry jaunes
-hr: Žute curry paste
-lt: Geltonojo kario pasta
-nb: Gule karripastaer
-nl: Gele Currypastas
-nn: Gule karripastaer
-pl: Żółte pasty curry
-sv: Gulor currypastor
-wikidata:en: Q67201117
-
-< en: Curry pastes
-en: Vindaloo curry pastes
-
 en: Meals, Prepared meals, Prepared dishes
 bg: Готови ястия
 ca: Menjar preparat
@@ -84104,6 +84113,16 @@ en: Pad thai
 xx: Pad Thaï, Pad Thai
 ja: パッタイ
 wikidata:en: Q730298
+
+< en: Meals
+en: Bami goreng
+xx: Bami goreng
+wikidata:en: Q1188729
+
+< en: Rice dishes
+en: Nasi goreng
+xx: Nasi goreng
+wikidata:en: Q510666
 
 < en: Meals
 en: Meal replacements, meal substitutes

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -76129,6 +76129,18 @@ en: Bami goreng seasoning mixes
 en: Nasi goreng pastes
 
 < en: Condiments
+en: Anchovy paste
+de: Sardellenpaste
+es: Pasta de anchoas
+fi: anjovistahna
+fr: Pâte d'anchois
+hr: Pasta od inćuna
+it: Pasta di acciughe, pasta d'acciughe
+ja: アンチョビペースト
+nl: Ansjovispasta
+wikidata:en: Q3897482
+
+< en: Condiments
 en: Wasabi pastes
 de: Wasabi Pasten
 es: Pastas de wasabi
@@ -105896,20 +105908,12 @@ gpc_category_code:en: 10000018
 gpc_category_description:en: Definition: Includes any products that can be described/observed as any variety of fish or a combination of fish, that has gone through further manufacturing processes, such as reformed, cooked, dried and salted, however these products can also be coated, in sauce, stuffed or filled. Definition Excludes: Specifically excludes products that have added ingredients included such as rice, couscous and pasta. However products may contain a small quantity of vegetables such as those in a sauce or stuffing/filling. These products have been treated or packaged in such a way as to extend their consumable life. Excludes products such as Fish with additional vegetables, dough or grains, Frozen and Perishable Prepared and Processed Fish, all Unprepared and Unprocessed Fish.
 gpc_category_name:en: Fish - Prepared/Processed (Shelf Stable)
 
-
 < en: Fish preparations
 < en: Salted spreads
-en: Anchovy paste
-de: Sardellenpaste
-es: Pasta de anchoas
-fi: anjovistahna
-fr: Pâte d'anchois, Anchoïade
-hr: Pasta od inćuna
-it: Pasta di acciughe, pasta d'acciughe
-ja: アンチョビペースト
-nl: Ansjovispasta
-wikidata:en: Q3897482
-
+en: Anchoïade
+xx: Anchoïade
+fr: Anchoïade
+wikidata:en: Anchoïade
 
 < en: Fish preparations
 en: Surimi, crab stick, crab sticks, mock crab, seafood sticks, seafood stick, fish stick, fish sticks, imitation crab, seafood extender, seafood extenders

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -76129,6 +76129,7 @@ en: Bami goreng seasoning mixes
 en: Nasi goreng pastes
 
 < en: Condiments
+< en: Fish preparations
 en: Anchovy paste
 de: Sardellenpaste
 es: Pasta de anchoas


### PR DESCRIPTION
* Created bami and nasi goreng; nasi and bami goreng seasoning mixes; and nasi goreng pastes.
* moved wasabi paste and curry pastes from sauces to condiments
* renamed "spice mix" to "spice mixes"
* separated "anchoïades" and "anchovy pastes" which are not the same thing
