### PR TITLE
taxonomy(food): spice blend category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -79885,28 +79885,71 @@ description:en: Sichuan pepper is a spice made from the dried pericarp (outer sh
 wikidata:en: Q756800
 
 < en: Spices
-en: Spice mixes, Spice Mix
+en: Spice blends, Spice mixes, Spice Mix
+ar: خلطات توبل
+bg: Смеси от подправки
+ca: Mescla d'espècies
+cs: Směs koření
+da: Krydderiblandinger, Krydderblandinger
 de: Gewürzmischung
-es: Mezcla de especias
-fi: maustesekoitus
+el: Μείγμα μπαχαρικών
+eo: Spicomiksaĵoj
+es: Mezclas de especias, Mezcla de especias
+fi: Maustesekoitus
 fr: Mélanges d'épices, Mélange d'épices, Mélange d'épice, Mélanges d'épice
 hr: Mješavina začina
-it: Mix di spezie, Spezie miste
-ja: ミックススパイス
+hu: Fűszerkeverék
+hy: Համեմունքների խառնուրդ
+id: Campuran rempah-rempah
+it: Mix di spezie, Spezie miste, Miscela di spezie
+ja: ミックススパイス, 混合スパイス
+jv: Bumbu campur
+kn: ಮಸಾಲೆ
+ko: 배합 향신료
+la: Tritura
 lt: Prieskonių mišinys
-nl: Specerijenmengelingen
+lv: Garšvielu maisījums
+mk: Зачинска смеса
+ms: Campuran rempah
+nb: Krydderiblandinger, Krydderblandinger
+nl: Specerijenmengelingen, Kruidenmix
+nn: Krydderiblandingar, Krydderblandingar
 pl: Mieszanki przypraw, Mieszanka przypraw
-ru: Смесь специй
+ro: Amestec de condimente
+ru: Смесь специй, Смесь приправ
+sl: Začimbna mešanica
+sv: Kryddblandningar, Kryddmixar
+th: มาซาลา
+uk: Суміш приправ
 agribalyse_proxy_food_code:en: 11056
-agribalyse_proxy_food_name:en: Mix of 4 spices
-agribalyse_proxy_food_name:fr: Quatre épices
+ciqual_proxy_food_code:en: 11056
+ciqual_proxy_food_name:en: Mix of 4 spices
+ciqual_proxy_food_name:fr: Quatre épices
+description:en: Blends of 2 or more spices.
 wikidata:en: Q1521067
 
-< en: Spice mixes
+< en: Spice blends
+en: Masalas, Indian spice blends
+xx: Masala
+ar: مصالحة
+cs: Masála
+eo: Hinda spica miksaĵoj
+fa: مصالح
+hu: Maszala
+ja: マサラ
+ko: 마살라
+ml: മസാല
+ru: Масала
+uk: Масала
+zh: 瑪撒拉
+description:en: Indian spice blends.
+wikidata:en: Q654253
+
+< en: Spice blends
 en: Guacamole spice mix
 fr: Mélange d'épices pour guacamole
 
-< en: Spice mixes
+< en: Spice blends
 en: Mix of 4 spices, Mix of four spices
 fr: Quatre épices
 hr: Mješavina 4 začina


### PR DESCRIPTION
- Renames spice mixes to spice blends.
  - A spice mix is ambiguous in that it can both mean a blend of spices, but also a variety pack of different individual spice (or spice blends).
- Adds masala/Indian spice blend category.
  - It will have children soon. :)
- Adds `ciqual` proxy code.
- Adds a couple of `description`s.
- Imports some translations from Wikidata.
- Adds Danish, Swedish, and Norwegian translations.
- Normalises towards sentence-cased plural forms.

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/14175
Follow-up-to: 64e761fd222e3c63d948d84c9cdb1d37ea35370e