### PR TITLE
fix: avoid a warning in 1003 to 1002 downgrade

### DIFF
--- a/lib/ProductOpener/ProductSchemaChanges.pm
+++ b/lib/ProductOpener/ProductSchemaChanges.pm
@@ -611,7 +611,7 @@ sub convert_schema_1003_to_1002_refactor_product_nutrition_schema ($product_ref,
 		# if per is 100ml then 1002 product version nutrient per field is 100g
 		my $per;
 		if ( not defined $nutrient_set_ref->{per} ) {
-			$per = "100g";
+			$per = "_100g";
 		} else {
 			$per = $nutrient_set_ref->{per} eq "100ml" ? "_100g" : "_" . $nutrient_set_ref->{per};
 		}

--- a/lib/ProductOpener/ProductSchemaChanges.pm
+++ b/lib/ProductOpener/ProductSchemaChanges.pm
@@ -609,7 +609,12 @@ sub convert_schema_1003_to_1002_refactor_product_nutrition_schema ($product_ref,
 				or $nutrient_set_ref->{preparation} eq "_prepared"
 		) ? "_prepared" : "";
 		# if per is 100ml then 1002 product version nutrient per field is 100g
-		my $per = $nutrient_set_ref->{per} eq "100ml" ? "_100g" : "_" . $nutrient_set_ref->{per};
+		my $per;
+		if ( not defined $nutrient_set_ref->{per} ) {
+			$per = "100g";
+		} else {
+			$per = $nutrient_set_ref->{per} eq "100ml" ? "_100g" : "_" . $nutrient_set_ref->{per};
+		}
 
 		# first create the nutriments and nutriments_estimated fields
 		my $nutriments_ref = {};

--- a/lib/ProductOpener/ProductSchemaChanges.pm
+++ b/lib/ProductOpener/ProductSchemaChanges.pm
@@ -610,9 +610,10 @@ sub convert_schema_1003_to_1002_refactor_product_nutrition_schema ($product_ref,
 		) ? "_prepared" : "";
 		# if per is 100ml then 1002 product version nutrient per field is 100g
 		my $per;
-		if ( not defined $nutrient_set_ref->{per} ) {
+		if (not defined $nutrient_set_ref->{per}) {
 			$per = "_100g";
-		} else {
+		}
+		else {
 			$per = $nutrient_set_ref->{per} eq "100ml" ? "_100g" : "_" . $nutrient_set_ref->{per};
 		}
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -4882,7 +4882,7 @@ The type of the tag (e.g. categories, labels, allergens)
 sub cmp_taxonomy_tags_alphabetically ($tagtype, $target_lc, $a, $b) {
 
 	return ($translations_to{$tagtype}{$a}{$target_lc} || $translations_to{$tagtype}{$a}{"xx"} || $a)
-		cmp($translations_to{$tagtype}{$b}{$target_lc} || $translations_to{$tagtype}{$b}{"xx"} || $b);
+		cmp ($translations_to{$tagtype}{$b}{$target_lc} || $translations_to{$tagtype}{$b}{"xx"} || $b);
 }
 
 # To avoid doing file operations for each call to get_knowledge_content (e.g. for each ingredient of a product),

--- a/taxonomies/packaging_shapes.txt
+++ b/taxonomies/packaging_shapes.txt
@@ -1992,3 +1992,4 @@ fr: Valve, valves, soupape, soupapes
 # Used on top of a bottle to reduce the flow (e.g. for oil)
 en: Reducer
 fr: Réducteur
+


### PR DESCRIPTION
in ProductSchemaChanges.pm

fixes a warning seen many time as I run convert_schema_product_dump (so downgrading):

```
[Sun Aug  2 10:13:55 2026] convert_product_schema_dump.tmp.pl: Use of uninitialized value in string eq at /srv/off/lib/ProductOpener/ProductSchemaChanges.pm line 612, <STDIN> line 4626950.
[Sun Aug  2 10:13:55 2026] convert_product_schema_dump.tmp.pl: Use of uninitialized value in concatenation (.) or string at /srv/off/lib/ProductOpener/ProductSchemaChanges.pm line 612, <STDIN> line 4626950.
```

(not sure if it's the right way to fix it)