### PR TITLE
taxonomy(beauty/inci_functions): fix two errors

### DIFF
--- a/taxonomies/beauty/inci_functions.txt
+++ b/taxonomies/beauty/inci_functions.txt
@@ -1561,7 +1561,6 @@ description:en:
 en: Opacifying
 el: Προωθητικα
 es: Opacificante
-et: Rasutaasteaine
 fi: Ihokarvoja poistava aine
 fr: Opacifiant
 lt: Drumstiklis
@@ -1588,7 +1587,6 @@ description:sl: Zmanjšuje prozornost ali prosojnost kozmetičnih izdelkov.
 en: Oral care
 el: Ρυθμιστεσ ιξωδουσ
 es: Cuidado oral
-et: Redutseerija
 #fi: Kalvonmuodostaja
 fr: Hygiène buccale
 lt: Burnos priežiūros medžiaga


### PR DESCRIPTION
Removes two Estonian INCI function translations/synonyms that both also exist on another entry. I chose which to keep (and thus which to delete) based on LibreTranslate machine translation and searching for the names in Estonian.

Fixes these errors:
```
[inci_functions] error: Failed to build inci_functions taxonomy with 2 error(s):
[inci_functions] error: ERROR - duplicate_synonym - 1745 - et:redutseerija already is associated to en:oral-care (inci_functions) - et:redutseerija cannot be mapped to entry en:reducing
[inci_functions] error: ERROR - duplicate_synonym - 1779 - et:rasutaasteaine already is associated to en:opacifying (inci_functions) - et:rasutaasteaine cannot be mapped to entry en:refatting
```

Source: https://annaabi.ee/Kosmeetikas-kasutatavad-vahendid-m33210.html
Source: https://et.wikipedia.org/wiki/Redutseerija