### PR TITLE
taxonomy(labels): put 'no <substance>' before '<substance>-free'

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -5266,8 +5266,8 @@ zh: 低饱和脂肪含量
 description:en: In EU, a claim that a food is low in saturated fat may only be made if the sum of saturated fatty acids and trans-fatty acids in the product does not exceed 1,5 g per 100 g for solids or 0,75 g/100 ml for liquids and in either case the sum of saturated fatty acids and trans-fatty acids must not provide more than 10 % of energy. (see: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213)
 
 < en: Low or no saturated fat
-en: saturated fat-free
-xx: saturated fat-free
+en: No saturated fat, saturated fat-free
+xx: No saturated fat, saturated fat-free
 bg: без наситени мазнини
 ca: sense greixos saturats
 de: ohne gesättigte Fettsäuren
@@ -23737,7 +23737,7 @@ bg: Без остатъци от пестициди
 fr: Sans résidus de pesticides, sans résidu de pesticide, zéro résidus de pesticides, zéro résidu de pesticide
 
 # obligation of means: cultivated without pesticides (but can be a specific year, or after flowers bloom)
-en: Pesticide-free, without pesticide, no pesticide
+en: No pesticide, pesticide-free, without pesticide
 bg: Без пестициди
 fr: Sans pesticides, cultivé sans pesticides
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -23737,7 +23737,7 @@ bg: Без остатъци от пестициди
 fr: Sans résidus de pesticides, sans résidu de pesticide, zéro résidus de pesticides, zéro résidu de pesticide
 
 # obligation of means: cultivated without pesticides (but can be a specific year, or after flowers bloom)
-en: No pesticide, pesticide-free, without pesticide
+en: no pesticides, pesticide-free, without pesticide, no pesticide
 bg: Без пестициди
 fr: Sans pesticides, cultivé sans pesticides
 


### PR DESCRIPTION
### What
There is some [guidance](https://github.com/openfoodfacts/openfoodfacts-server/blob/41177330b827160af552dc5efdcc80d1dc9bca8d/taxonomies/labels.txt#L3) at the top of the `labels.txt` taxonomy file that indicates that for multi-valued labels that indicate the _absence_ of a substance, the form `No <substance>` should appear before `<subtance>-free`.

This is the case for most of the existing cases; for example:

https://github.com/openfoodfacts/openfoodfacts-server/blob/41177330b827160af552dc5efdcc80d1dc9bca8d/taxonomies/labels.txt#L1520

(English label names: `No wheat, without wheat, Wheat-free`)

### Large Language Models usage disclosure
I did not use any LLMs for this pull request, neither during its preparation, nor to submit it.

### Screenshot or video
N/A

### Related issue(s) and discussion
None (strictly speaking I know that an issue should be created first; I can do this if needed)
