### PR TITLE
fix(webmanifest): add back lost members

### DIFF
--- a/html/images/favicon/site.webmanifest
+++ b/html/images/favicon/site.webmanifest
@@ -1,19 +1,43 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Open Food Facts",
+    "short_name": "OFF",
+    "description": "A collaborative, free and open database of ingredients, nutrition facts and information on food products from around the world",
+    "scope": "/",
     "icons": [
+        {
+            "src": "/images/favicon/android-chrome-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png"
+        },
         {
             "src": "/images/favicon/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/images/favicon/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
+            "src": "/images/favicon/favicon-32x32.png",
+            "type": "image/png",
+            "sizes": "32x32"
+        },
+        {
+            "src": "/images/favicon/favicon-16x16.png",
+            "type": "image/png",
+            "sizes": "16x16"
         }
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "standalone",
+    "related_applications": [
+        {
+            "platform": "play",
+            "id": "org.openfoodfacts.scanner",
+            "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner"
+        },
+        {
+            "platform": "ios",
+            "id": "id588797948",
+            "url": "https://apps.apple.com/app/id588797948"
+        }
+    ]
 }


### PR DESCRIPTION
### What

This adds backs certain members/properties that used to be included/served via `manifest.pl`, but are no longer part of `site.webmanifest`, with a few changes:

- Since this is a static file, we can’t set the language based on which (sub)domain the request is coming from, so:
  - `name` and `short_name` don’t include language reference.
  - `lang` and `start_url` are omitted.
  - `description` is only in English now, not served in the localised language for the (sub)domain.
- `prefer_related_applications` only takes `true` or `false`, not `null`, so omitted that here. If we want it one way or another, that can be done in another commit/PR.

The values are based on the `manifest.pl` still available on OFF.net: https://world.openfoodfacts.net/cgi/manifest.pl

### Large Language Models usage disclosure

Only my own fleshy brain.

### Related issue(s) and discussion

Fixes: https://github.com/openfoodfacts/openfoodfacts-server/issues/14204
Reference: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference
Reference: https://developer.chrome.com/blog/app-install-banners-native