### PR TITLE
taxonomy(food): Asian sauce category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -81084,16 +81084,34 @@ wikidata:en: Q842618
 
 < en: Sauces
 en: Teriyaki sauces
-de: Teriyaki Soßen
+af: Teriyaki-sous
+ca: Salsa Teriyaki
+cs: Omáčka teriyaki
+da: Teriyakisovse
+de: Teriyaki Soßen, Teriyakisauce
 es: Salsas Teriyaki
-fi: teriyaki-kastikkeet
+et: Teriyaki kaste
+fi: Teriyaki-kastikkeet, Teriyaki-kastike
 fr: Sauces Teriyaki
+gl: Mollo teriyaki
 hr: Teriyaki umaci
-it: Salse Teriyaki
-ja: 照り焼きのタレ, 照り焼きソース
+id: Saus teriyaki
+is: Teriyakisósa
+it: Salse teriyaki, Salsa teriyaki
+ja: 照り焼きのタレ, 照り焼きソース, テリヤキソース
+jv: Saos teriyaki
 lt: Teriyaki padažai
+lv: Teriyaki mērce
+ms: Sos teriyaki
+nb: Teriyakisauser
 nl: Teriyakisauzen, Teriyakisaus
+nn: Teriyakisausar
 pl: Sosy Teriyaki, Sos Teriyaki
+pt: Molho de teriyaki
+ru: Соус Тэрияки
+sv: Teriyakisåser
+tr: Teriyaki sosu
+agribalyse_food_code:en: 11301
 ciqual_food_code:en: 11301
 ciqual_food_name:en: Teriyaki sauce, prepacked
 ciqual_food_name:fr: Sauce teriyaki, préemballée
@@ -109260,17 +109278,75 @@ wikidata:en: Q2046560
 
 < en: Sauces
 en: Hoisin sauces
+af: Hoisin-sous
+bn: হয়সিন সস
+ca: Salsa hoisin
+cs: Omáčka Hoisin
+da: Hoisinsovse
 de: Hoisin Saucen
+eo: Hojsin-saŭcoj
 es: Salsas hoisin
+et: Hoisin kaste
+fi: Hoisin-kastikkeet, Hoisin-kastike
 fr: Sauces hoisin
+gl: Mollo hoisin
 hr: Hoisin umaci
-ja: ホイシンソース
-nl: Hoisin sauzen
+hy: Հոյսին
+id: Saus hoisin
+is: Hoisinsósa
+it: Salse hoisin, Salsa hoisin
+ja: ホイシンソース, 海鮮醤
+jv: Saos hoisin
+ko: 해선장
+lt: Hoisin padažai
+lv: Hoisin mērce
+ml: ഹോയിസിൻ സോസ്
+ms: Sos Hoisin
+nb: Hoisinsauser
+nl: Hoisinsauzen, Hoisinsaus
+nn: Hoisinsausar
+pa: ਹੋਈਸਿਨ ਸੌਸ
+pl: Sosy hoisin, Sos hoisin
+pt: Molho de hoisin
 ru: Соусы хойсин
+sv: Hoisinsåser
+th: ซอสฮอยซิน
+tr: Hoisin sosu
+uk: Хойсін (соус)
+vi: Tương đen
+zh: 海鮮醬
 wikidata:en: Q404114
 
 < en: Sauces
 en: Koruk sauces
+
+< en: Sauces
+en: Pad thai sauces
+af: Pad thai-sous
+ca: Salsa pad thai
+cs: Omáčka pad thai
+da: Pad thai-sovse
+de: Pad Thai Soßen, Pad Thai Saucen
+es: Salsas pad thai
+et: Pad thai kaste
+fi: Pad thai-kastikkeet, Pad thai-kastike
+fr: Sauces pad thai
+gl: Mollo pad thai
+hr: Pad thai umaci
+id: Saus pad thai
+is: Pad thai-sósa
+it: Salse pad thai, Salsa pad thai
+jv: Saos pad thai
+lt: Pad thai padažai
+lv: Pad thai mērce
+ms: Sos pad thai
+nb: Pad thai-sauser
+nl: Pad thai sauzen, pad thai saus
+nn: Pad thai-sausar
+pl: Sosy pad thai, Sos pad thai
+pt: Molho de pad thai
+sv: Pad thai-såser
+tr: Pad thai sosu
 
 < en: Sauces
 en: Peanut stew, groundnut stew, Maafe


### PR DESCRIPTION
Edits to teriyaki, hoisin, and pad thai sauce categories.

- Adds new pad thai sauce category.
- Imports some translations from Wikidata.
- Adds Danish, Swedish, and Norwegian translations.
- Extrapolates translations for various Latin-script languages based on translations from other sauce variants.
- Normalises toward sentence-cased plural forms.
- Adds an `agribalyse_food_code` property.

Needed-for: https://se.openfoodfacts.org/product/7611612100656/pad-thai-sauce-spicefield