### PR TITLE
fix: also match parent ingredients for Forest Footprint 2026

### DIFF
--- a/lib/ProductOpener/ForestFootprint2026.pm
+++ b/lib/ProductOpener/ForestFootprint2026.pm
@@ -491,7 +491,7 @@ sub get_forest_footprint_2026_ingredient_footprint ($product_ref, $ingredient_re
 			$ingredient_id = $tag;
 			last;
 		}
-	}		
+	}
 
 	if (not exists $forest_footprint_2026_data{ingredients}{$ingredient_id}) {
 		$log->debug("ingredient not in forest footprint 2026 data", {ingredient_id => $ingredient_id})

--- a/lib/ProductOpener/ForestFootprint2026.pm
+++ b/lib/ProductOpener/ForestFootprint2026.pm
@@ -481,6 +481,18 @@ sub get_forest_footprint_2026_ingredient_footprint ($product_ref, $ingredient_re
 		{ingredient_id => $ingredient_id})
 		if $log->is_debug();
 
+	# We check if we have a mapping for this ingredient in the forest footprint 2026 data,
+	# or for one of its parents
+
+	my @tags_to_check = get_tag_with_parents("ingredients", $ingredient_id);
+
+	foreach my $tag (@tags_to_check) {
+		if (exists $forest_footprint_2026_data{ingredients}{$tag}) {
+			$ingredient_id = $tag;
+			last;
+		}
+	}		
+
 	if (not exists $forest_footprint_2026_data{ingredients}{$ingredient_id}) {
 		$log->debug("ingredient not in forest footprint 2026 data", {ingredient_id => $ingredient_id})
 			if $log->is_debug();

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -164,6 +164,7 @@ BEGIN {
 		&create_property_to_tag_mapping_table
 
 		&get_taxonomy_tag_path
+		&get_tag_with_parents
 
 		&get_minimal_tags_subset
 		&gen_tags_list_with_parents
@@ -2903,6 +2904,26 @@ sub gen_tags_list_with_parents($tag_lc, $tagtype, $tags_ref) {
 	} keys %tags;
 
 	return @sorted_list;
+}
+
+=head2 get_tag_with_parents ($tagtype, $tagid)
+
+Given a canonical tagid, return a list of the tag and all its parents,
+sorted by closeness to the tag (the tag itself first, then its parents, then the parents of the parents, etc.)
+and alphabetical order for parents with the same closeness.
+
+=cut
+
+sub get_tag_with_parents ($tagtype, $tagid) {
+
+	my @tag_with_parents = ($tagid);
+
+	if (defined $all_parents{$tagtype}{$tagid}) {
+		print STDERR "get_tag_with_parents - tagtype: $tagtype - tagid: $tagid - parents: @{$all_parents{$tagtype}{$tagid}} \n";
+		push @tag_with_parents, @{$all_parents{$tagtype}{$tagid}};
+	}
+
+	return @tag_with_parents;
 }
 
 sub gen_ingredients_tags_hierarchy_taxonomy ($tag_lc, $tags_list) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2919,7 +2919,8 @@ sub get_tag_with_parents ($tagtype, $tagid) {
 	my @tag_with_parents = ($tagid);
 
 	if (defined $all_parents{$tagtype}{$tagid}) {
-		print STDERR "get_tag_with_parents - tagtype: $tagtype - tagid: $tagid - parents: @{$all_parents{$tagtype}{$tagid}} \n";
+		print STDERR
+			"get_tag_with_parents - tagtype: $tagtype - tagid: $tagid - parents: @{$all_parents{$tagtype}{$tagid}} \n";
 		push @tag_with_parents, @{$all_parents{$tagtype}{$tagid}};
 	}
 
@@ -4903,7 +4904,7 @@ The type of the tag (e.g. categories, labels, allergens)
 sub cmp_taxonomy_tags_alphabetically ($tagtype, $target_lc, $a, $b) {
 
 	return ($translations_to{$tagtype}{$a}{$target_lc} || $translations_to{$tagtype}{$a}{"xx"} || $a)
-		cmp($translations_to{$tagtype}{$b}{$target_lc} || $translations_to{$tagtype}{$b}{"xx"} || $b);
+		cmp ($translations_to{$tagtype}{$b}{$target_lc} || $translations_to{$tagtype}{$b}{"xx"} || $b);
 }
 
 # To avoid doing file operations for each call to get_knowledge_content (e.g. for each ingredient of a product),

--- a/tests/integration/expected_test_results/api_v2_product_read/get-existing-product.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-existing-product.json
@@ -618,6 +618,34 @@
          "en:sugary-snacks",
          "en:biscuits-and-cakes"
       ],
+      "forest_footprint_2026" : {
+         "grade" : "b",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.002578125,
+               "grade" : "b",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.002578125,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 5.20833333333333,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.002578125
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00162037037037037,
          "grade" : "a",

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
@@ -618,6 +618,34 @@
          "en:sugary-snacks",
          "en:biscuits-and-cakes"
       ],
+      "forest_footprint_2026" : {
+         "grade" : "b",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.002578125,
+               "grade" : "b",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.002578125,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 5.20833333333333,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.002578125
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00162037037037037,
          "grade" : "a",

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-all.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-all.json
@@ -618,6 +618,34 @@
          "en:sugary-snacks",
          "en:biscuits-and-cakes"
       ],
+      "forest_footprint_2026" : {
+         "grade" : "b",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.002578125,
+               "grade" : "b",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.002578125,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 5.20833333333333,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.002578125
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00162037037037037,
          "grade" : "a",

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -1284,6 +1284,34 @@
          "en:sugary-snacks",
          "en:biscuits-and-cakes"
       ],
+      "forest_footprint_2026" : {
+         "grade" : "b",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.002578125,
+               "grade" : "b",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.002578125,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 5.20833333333333,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.002578125
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00162037037037037,
          "grade" : "a",

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-raw.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-raw.json
@@ -599,6 +599,34 @@
          "en:sugary-snacks",
          "en:biscuits-and-cakes"
       ],
+      "forest_footprint_2026" : {
+         "grade" : "b",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.002578125,
+               "grade" : "b",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.002578125,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 5.20833333333333,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.002578125
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00162037037037037,
          "grade" : "a",

--- a/tests/integration/expected_test_results/api_v2_product_read/get-with-blame.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-with-blame.json
@@ -832,6 +832,34 @@
          "en:sugary-snacks",
          "en:biscuits-and-cakes"
       ],
+      "forest_footprint_2026" : {
+         "grade" : "b",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.002578125,
+               "grade" : "b",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.002578125,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 5.20833333333333,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.002578125
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00162037037037037,
          "grade" : "a",

--- a/tests/integration/expected_test_results/protected_product/get-edited-protected-product-api-v2-moderator.json
+++ b/tests/integration/expected_test_results/protected_product/get-edited-protected-product-api-v2-moderator.json
@@ -454,6 +454,34 @@
       "entry_dates_tags" : "--ignore--",
       "estimate_ingredients_percent_service" : "product_opener",
       "food_groups_tags" : [],
+      "forest_footprint_2026" : {
+         "grade" : "c",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.004640625,
+               "grade" : "c",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.004640625,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 9.375,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.004640625
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00145833333333333,
          "grade" : "a",

--- a/tests/integration/expected_test_results/protected_product/get-edited-protected-product-api-v2.json
+++ b/tests/integration/expected_test_results/protected_product/get-edited-protected-product-api-v2.json
@@ -454,6 +454,34 @@
       "entry_dates_tags" : "--ignore--",
       "estimate_ingredients_percent_service" : "product_opener",
       "food_groups_tags" : [],
+      "forest_footprint_2026" : {
+         "grade" : "c",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.004640625,
+               "grade" : "c",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.004640625,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 9.375,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.004640625
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00145833333333333,
          "grade" : "a",

--- a/tests/integration/expected_test_results/protected_product/get-edited-protected-product-web-form-moderator.json
+++ b/tests/integration/expected_test_results/protected_product/get-edited-protected-product-web-form-moderator.json
@@ -454,6 +454,34 @@
       "entry_dates_tags" : "--ignore--",
       "estimate_ingredients_percent_service" : "product_opener",
       "food_groups_tags" : [],
+      "forest_footprint_2026" : {
+         "grade" : "c",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.004640625,
+               "grade" : "c",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.004640625,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 9.375,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.004640625
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00145833333333333,
          "grade" : "a",

--- a/tests/integration/expected_test_results/protected_product/get-edited-protected-product-web-form.json
+++ b/tests/integration/expected_test_results/protected_product/get-edited-protected-product-web-form.json
@@ -454,6 +454,34 @@
       "entry_dates_tags" : "--ignore--",
       "estimate_ingredients_percent_service" : "product_opener",
       "food_groups_tags" : [],
+      "forest_footprint_2026" : {
+         "grade" : "c",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.004640625,
+               "grade" : "c",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.004640625,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 9.375,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.004640625
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00145833333333333,
          "grade" : "a",

--- a/tests/integration/expected_test_results/protected_product/get-edited-unprotected-product-api-v2.json
+++ b/tests/integration/expected_test_results/protected_product/get-edited-unprotected-product-api-v2.json
@@ -453,6 +453,34 @@
       "entry_dates_tags" : "--ignore--",
       "estimate_ingredients_percent_service" : "product_opener",
       "food_groups_tags" : [],
+      "forest_footprint_2026" : {
+         "grade" : "c",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.004640625,
+               "grade" : "c",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.004640625,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 9.375,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.004640625
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00145833333333333,
          "grade" : "a",

--- a/tests/integration/expected_test_results/protected_product/get-edited-unprotected-product-web-form.json
+++ b/tests/integration/expected_test_results/protected_product/get-edited-unprotected-product-web-form.json
@@ -453,6 +453,34 @@
       "entry_dates_tags" : "--ignore--",
       "estimate_ingredients_percent_service" : "product_opener",
       "food_groups_tags" : [],
+      "forest_footprint_2026" : {
+         "grade" : "c",
+         "primary_ingredients" : {
+            "en:cocoa" : {},
+            "en:coffee" : {},
+            "en:palm-oil" : {
+               "footprint_per_kg" : 0.004640625,
+               "grade" : "c",
+               "ingredients" : [
+                  {
+                     "equivalence_ingredient" : 1,
+                     "equivalence_ingredient_category" : 1,
+                     "footprint_per_kg" : 0.004640625,
+                     "ingredient_category_id" : "en:palm-oil",
+                     "ingredient_id" : "en:palm-oil-and-fat",
+                     "label_id" : "en:organic",
+                     "origin_footprint" : 0.055,
+                     "origin_id" : "en:unknown",
+                     "percent" : 9.375,
+                     "primary_ingredient_id" : "en:palm-oil",
+                     "risk_factor" : 0.9,
+                     "transformation_factor" : 1
+                  }
+               ]
+            }
+         },
+         "total_footprint_per_kg" : 0.004640625
+      },
       "forest_footprint_data" : {
          "footprint_per_kg" : 0.00145833333333333,
          "grade" : "a",

--- a/tests/integration/expected_test_results/search_v1/search-no-filter.json
+++ b/tests/integration/expected_test_results/search_v1/search-no-filter.json
@@ -416,6 +416,34 @@
          "entry_dates_tags" : "--ignore--",
          "estimate_ingredients_percent_service" : "product_opener",
          "food_groups_tags" : [],
+         "forest_footprint_2026" : {
+            "grade" : "c",
+            "primary_ingredients" : {
+               "en:cocoa" : {},
+               "en:coffee" : {},
+               "en:palm-oil" : {
+                  "footprint_per_kg" : 0.00515625,
+                  "grade" : "c",
+                  "ingredients" : [
+                     {
+                        "equivalence_ingredient" : 1,
+                        "equivalence_ingredient_category" : 1,
+                        "footprint_per_kg" : 0.00515625,
+                        "ingredient_category_id" : "en:palm-oil",
+                        "ingredient_id" : "en:palm-oil-and-fat",
+                        "label_id" : null,
+                        "origin_footprint" : 0.055,
+                        "origin_id" : "en:unknown",
+                        "percent" : 9.375,
+                        "primary_ingredient_id" : "en:palm-oil",
+                        "risk_factor" : 1,
+                        "transformation_factor" : 1
+                     }
+                  ]
+               }
+            },
+            "total_footprint_per_kg" : 0.00515625
+         },
          "forest_footprint_data" : {
             "footprint_per_kg" : 0.0074375,
             "grade" : "a",
@@ -3025,6 +3053,34 @@
          "entry_dates_tags" : "--ignore--",
          "estimate_ingredients_percent_service" : "product_opener",
          "food_groups_tags" : [],
+         "forest_footprint_2026" : {
+            "grade" : "c",
+            "primary_ingredients" : {
+               "en:cocoa" : {},
+               "en:coffee" : {},
+               "en:palm-oil" : {
+                  "footprint_per_kg" : 0.00916666666666666,
+                  "grade" : "c",
+                  "ingredients" : [
+                     {
+                        "equivalence_ingredient" : 1,
+                        "equivalence_ingredient_category" : 1,
+                        "footprint_per_kg" : 0.00916666666666666,
+                        "ingredient_category_id" : "en:palm-oil",
+                        "ingredient_id" : "en:palm-oil-and-fat",
+                        "label_id" : null,
+                        "origin_footprint" : 0.055,
+                        "origin_id" : "en:unknown",
+                        "percent" : 16.6666666666667,
+                        "primary_ingredient_id" : "en:palm-oil",
+                        "risk_factor" : 1,
+                        "transformation_factor" : 1
+                     }
+                  ]
+               }
+            },
+            "total_footprint_per_kg" : 0.00916666666666666
+         },
          "generic_name_en" : "Tester",
          "id" : "2000000000398",
          "images" : {},

--- a/tests/unit/expected_test_results/attributes/en-maybe-vegan.json
+++ b/tests/unit/expected_test_results/attributes/en-maybe-vegan.json
@@ -662,6 +662,34 @@
    ],
    "estimate_ingredients_percent_service" : "product_opener",
    "food_groups_tags" : [],
+   "forest_footprint_2026" : {
+      "grade" : "c",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.00916666666666666,
+            "grade" : "c",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.00916666666666666,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 16.6666666666667,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.00916666666666666
+   },
    "images" : {
       "selected" : {}
    },

--- a/tests/unit/expected_test_results/attributes/en-no-unwanted-ingredients.json
+++ b/tests/unit/expected_test_results/attributes/en-no-unwanted-ingredients.json
@@ -853,6 +853,34 @@
       "en:milk-and-dairy-products",
       "en:cheese"
    ],
+   "forest_footprint_2026" : {
+      "grade" : "d",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.0366666666666667,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.0366666666666667,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 66.6666666666667,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.0366666666666667
+   },
    "images" : {
       "selected" : {}
    },

--- a/tests/unit/expected_test_results/attributes/en-unwanted-ingredients.json
+++ b/tests/unit/expected_test_results/attributes/en-unwanted-ingredients.json
@@ -853,6 +853,34 @@
       "en:milk-and-dairy-products",
       "en:cheese"
    ],
+   "forest_footprint_2026" : {
+      "grade" : "d",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.034375,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.034375,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 62.5,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.034375
+   },
    "images" : {
       "selected" : {}
    },

--- a/tests/unit/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/tests/unit/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -662,6 +662,34 @@
    ],
    "estimate_ingredients_percent_service" : "product_opener",
    "food_groups_tags" : [],
+   "forest_footprint_2026" : {
+      "grade" : "d",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.055,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.055,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-kernel-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 100,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.055
+   },
    "images" : {
       "selected" : {}
    },

--- a/tests/unit/expected_test_results/attributes/fr-palm-oil.json
+++ b/tests/unit/expected_test_results/attributes/fr-palm-oil.json
@@ -660,6 +660,34 @@
    ],
    "estimate_ingredients_percent_service" : "product_opener",
    "food_groups_tags" : [],
+   "forest_footprint_2026" : {
+      "grade" : "d",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.01375,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.01375,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 25,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.01375
+   },
    "images" : {
       "selected" : {}
    },

--- a/tests/unit/expected_test_results/forest_footprint_2026/fr-chocolate-cookies.json
+++ b/tests/unit/expected_test_results/forest_footprint_2026/fr-chocolate-cookies.json
@@ -4,7 +4,7 @@
       "grade" : "b",
       "primary_ingredients" : {
          "en:cocoa" : {
-            "footprint_per_kg" : 0.02428125,
+            "footprint_per_kg" : 0.028328125,
             "grade" : "b",
             "ingredients" : [
                {
@@ -34,6 +34,20 @@
                   "primary_ingredient_id" : "en:cocoa",
                   "risk_factor" : 1,
                   "transformation_factor" : 1
+               },
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.004046875,
+                  "ingredient_category_id" : "en:cocoa",
+                  "ingredient_id" : "en:cocoa",
+                  "label_id" : null,
+                  "origin_footprint" : 0.296,
+                  "origin_id" : "en:unknown",
+                  "percent" : 1.3671875,
+                  "primary_ingredient_id" : "en:cocoa",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
                }
             ]
          },
@@ -56,9 +70,29 @@
                   "transformation_factor" : 1.25
                }
             ]
+         },
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.00150390625,
+            "grade" : "b",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.00150390625,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 2.734375,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
          }
       },
-      "total_footprint_per_kg" : 0.02552880859375
+      "total_footprint_per_kg" : 0.03107958984375
    },
    "ingredients" : [
       {

--- a/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-cocoa-and-palm-oil-mixed-labels.json
+++ b/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-cocoa-and-palm-oil-mixed-labels.json
@@ -1,6 +1,6 @@
 {
    "forest_footprint_2026" : {
-      "grade" : "b",
+      "grade" : "d",
       "primary_ingredients" : {
          "en:cocoa" : {
             "footprint_per_kg" : 0.0222,
@@ -21,9 +21,29 @@
                   "transformation_factor" : 1
                }
             ]
+         },
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.02475,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.02475,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : "en:organic",
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 50,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 0.9,
+                  "transformation_factor" : 1
+               }
+            ]
          }
       },
-      "total_footprint_per_kg" : 0.0222
+      "total_footprint_per_kg" : 0.04695
    },
    "ingredients" : [
       {

--- a/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-cocoa-and-palm-oil-with-rspo-label.json
+++ b/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-cocoa-and-palm-oil-with-rspo-label.json
@@ -1,6 +1,6 @@
 {
    "forest_footprint_2026" : {
-      "grade" : "c",
+      "grade" : "d",
       "primary_ingredients" : {
          "en:cocoa" : {
             "footprint_per_kg" : 0.148,
@@ -21,9 +21,29 @@
                   "transformation_factor" : 1
                }
             ]
+         },
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.0275,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.0275,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 50,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
          }
       },
-      "total_footprint_per_kg" : 0.148
+      "total_footprint_per_kg" : 0.1755
    },
    "ingredients" : [
       {

--- a/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-palm-oil-child.json
+++ b/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-palm-oil-child.json
@@ -1,0 +1,150 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "forest_footprint_2026" : {
+      "grade" : "d",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.0229166666666667,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.0229166666666667,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 41.6666666666667,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.0229166666666667
+   },
+   "ingredients" : [
+      {
+         "from_palm_oil" : "maybe",
+         "id" : "en:vegetable-oil",
+         "ingredients" : [
+            {
+               "ciqual_food_code" : "16129",
+               "ecobalyse_code" : "45658c32-66d9-4305-a34b-21d6a4cef89c",
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 41.6666666666667,
+               "percent_max" : 100,
+               "percent_min" : 16.6666666666667,
+               "text" : "huile de palme",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            },
+            {
+               "ciqual_food_code" : "17130",
+               "ecobalyse_code" : "96b301d9-d21b-4cea-8903-bd7917e95a30",
+               "from_palm_oil" : "no",
+               "id" : "en:colza-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 25,
+               "percent_max" : 50,
+               "percent_min" : 0,
+               "text" : "huile de colza",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            }
+         ],
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 66.6666666666667,
+         "percent_max" : 100,
+         "percent_min" : 33.3333333333333,
+         "text" : "huiles végétales",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_food_code" : "18066",
+         "ecobalyse_code" : "36b3ffec-51e7-4e26-b1b5-7d52554e0aa6",
+         "id" : "en:water",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "eau",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_food_code" : "11058",
+         "id" : "en:salt",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "sel",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil" : [
+         "en:palm-oil"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_n" : 5,
+   "ingredients_n_tags" : [
+      "5",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:vegetable-oil",
+      "en:water",
+      "en:salt",
+      "en:palm-oil",
+      "en:colza-oil"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:vegetable-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:water",
+      "en:salt",
+      "en:palm-oil",
+      "en:palm-oil-and-fat",
+      "en:colza-oil",
+      "en:rapeseed-oil"
+   ],
+   "ingredients_text" : "huiles végétales (palme, colza), eau, sel",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 4,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:salt",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 2,
+   "known_ingredients_n" : 5,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-palm-oil.json
+++ b/tests/unit/expected_test_results/forest_footprint_2026/fr-ingredients-palm-oil.json
@@ -1,0 +1,87 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "forest_footprint_2026" : {
+      "grade" : "d",
+      "primary_ingredients" : {
+         "en:cocoa" : {},
+         "en:coffee" : {},
+         "en:palm-oil" : {
+            "footprint_per_kg" : 0.055,
+            "grade" : "d",
+            "ingredients" : [
+               {
+                  "equivalence_ingredient" : 1,
+                  "equivalence_ingredient_category" : 1,
+                  "footprint_per_kg" : 0.055,
+                  "ingredient_category_id" : "en:palm-oil",
+                  "ingredient_id" : "en:palm-oil-and-fat",
+                  "label_id" : null,
+                  "origin_footprint" : 0.055,
+                  "origin_id" : "en:unknown",
+                  "percent" : 100,
+                  "primary_ingredient_id" : "en:palm-oil",
+                  "risk_factor" : 1,
+                  "transformation_factor" : 1
+               }
+            ]
+         }
+      },
+      "total_footprint_per_kg" : 0.055
+   },
+   "ingredients" : [
+      {
+         "ciqual_food_code" : "16129",
+         "ecobalyse_code" : "45658c32-66d9-4305-a34b-21d6a4cef89c",
+         "from_palm_oil" : "yes",
+         "id" : "en:palm-oil",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "huile de palme",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil" : [
+         "en:palm-oil"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:palm-oil"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:palm-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:palm-oil-and-fat"
+   ],
+   "ingredients_text" : "huile de palme",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 1,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
+   "ingredients_without_ecobalyse_ids" : [],
+   "ingredients_without_ecobalyse_ids_n" : 0,
+   "known_ingredients_n" : 1,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/tests/unit/expected_test_results/taxonomies/eurocodes.csv
+++ b/tests/unit/expected_test_results/taxonomies/eurocodes.csv
@@ -40,7 +40,7 @@ eurocode_2_group_2	eurocode_2_group_3	ingredient
 7.10	7.10.30	en:red-bean
 7.10	7.10.30	en:white-beans
 7.10	7.10.34	en:dried-lima-bean
-7.10	7.10.38	en:dried-mature-mung-bean
+7.10	7.10.38	en:mung-bean
 7.10	7.10.46	en:black-eyed-pea
 7.10	7.10.50	en:soya-bean
 7.10	7.10.xx	en:carob-bean

--- a/tests/unit/forest_footprint_2026.t
+++ b/tests/unit/forest_footprint_2026.t
@@ -230,7 +230,20 @@ my @tests = (
 			origins_tags => ["en:unknown"],
 		}
 	],
-
+	[
+		'fr-ingredients-palm-oil',
+		{
+			lc => "fr",
+			ingredients_text => "huile de palme",
+		}
+	],
+	[
+		'fr-ingredients-palm-oil-child',
+		{
+			lc => "fr",
+			ingredients_text => "huiles végétales (palme, colza), eau, sel",
+		}
+	],
 );
 
 my $json = JSON->new->allow_nonref->canonical;


### PR DESCRIPTION
This PR contains only the Forest Footprint 2026 related changes from https://github.com/openfoodfacts/openfoodfacts-server/pull/14185 and does not contain the fix to the computation of parents..