### PR TITLE
ci(pr_actions): `git add` new test result files

### DIFF
--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -93,9 +93,11 @@ jobs:
       with:
         commit_message: "test: Update tests results"
         branch: "${{ steps.get-branch.outputs.branch }}"
+        file_pattern: 'tests/**/expected_test_results/**'
         commit_user_name: Open Food Facts Bot
         commit_user_email: contact@openfoodfacts.org
         commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
+        add_options: '--all'
         push_options: ""
         status_options: '--untracked-files=no'
         skip_dirty_check: false


### PR DESCRIPTION
Currently `/update_tests_results` will only update test results for already existing files. If you make a test that expects/requires a new `expected_test_results` file, it won’t get added by this command alone.

This makes the action use `git add --all` as well as limiting the file pattern to only match files that are actually under `expected_test_results` directories.