### PR TITLE
fix: enable the Matomo heartbeat timer on the donation page

### DIFF
--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -97,6 +97,7 @@
   _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
   _paq.push(["setDoNotTrack", true]);
   _paq.push(["disableCookies"]);
+  _paq.push(['enableHeartBeatTimer']);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {


### PR DESCRIPTION
### What

One line added to the Matomo snippet on the donation page: `_paq.push(['enableHeartBeatTimer']);`

The donation page has its own Matomo snippet (site 5) but never enables the heartbeat. It is normally the last page of a visit, and the donation form is an embedded widget rather than a tracked action, so Matomo has no second action to measure time against and records those visits as 0 seconds. That makes it impossible to tell a visitor who read the page from one who bounced off it, which is a shame for the one page where that question matters most.

A few notes so this is easy to review:

- It adds **no new event and no new dimension**, and it changes nothing visible on the page. One side effect worth naming rather than letting you find it: the ping is the first request this page sends after load completes, so it carries Matomo's standard page-performance timings (`pf_net`, `pf_srv`, `pf_tfr`, …), which this page has never sent before. That populates the Performance report for it. I read that as a bonus, but it is a change.
- Privacy is unaffected: the ping goes through the same tracker instance that `setDoNotTrack(true)` and `disableCookies()` were already applied to, earlier in the same `_paq` queue.
- `html/donate/en.html` is the Crowdin source for the donate pages (`crowdin.yml`), so only English is edited here. ⚠️ **Be aware that this leaves things half-instrumented for a while.** Translation syncs reach these pages per language and irregularly: `html/donate/fr.html` went from 2025-11-20 to 2026-07-06 without one. Until a sync carries this through, Matomo's Pages report will show `/donate/en.html` with real dwell beside every other language at 0.00, which reads as "the non-English donation pages have no engagement" when it actually means "they are not instrumented yet". Worth a targeted sync after merge if you want that comparison to be honest.
- **Deliberately scoped to the donation page**, because the site-wide snippet in `lib/ProductOpener/Config_*.pm` and `madenearme/*.html` drags all 69 expected results through a regeneration. **That half is now open as #14221.** The two are independent: this page carries its own copy of the snippet, so it still needs this line even if #14221 merges first, and it still works if #14221 is rejected. ⚠️ The capacity question belongs to #14221, not here: this is one low-traffic page, that one is every page on the site.

### Large Language Models usage disclosure

Written with Claude Opus 5 (Anthropic), used agentically through Claude Code.

To be clear about the split of work on a one-line change: the gap was found by reading your snippet against Matomo's tracker behaviour, and the verification below is mine - a real browser, your real `matomo.js`, captured before and after, with the tracker URL repointed locally so nothing was written to your site 5.

### Screenshot or video

I served the page locally with `setTrackerUrl` repointed at a local web server, so **no request reached `analytics.openfoodfacts.org` and nothing was written to site 5**. `matomo.js` still loaded from the real host, so the tracker doing the work is the genuine one. Both runs: load the page, stay 20 seconds, navigate away. The control is the identical file with this one line removed.

![Captured tracker requests before and after](https://raw.githubusercontent.com/UrbanFercec/openfoodfacts-server/assets/w1-proof/w1-heartbeat-proof.png)

Before: one request, the pageview, and nothing on leaving. After: the same pageview, then `ping=1` on leaving, carrying the same `pv_id`. 26 seconds recorded where there were previously 0.

<details>
<summary>Raw request log from the local server, unedited</summary>

```
control.html   (no heartbeat, current behaviour)
[07/Aug/2026 08:24:26] "POST /matomo.php?action_name=...&idsite=5&rec=1&r=197236&h=8&m=24&s=26&url=http%3A%2F%2F%5B%3A%3A1%5D%3A8099%2Fcontrol.html&_id=&_idn=1&send_image=0&_refts=0&pv_id=uR35DH
(page left at 08:24:5x, no further request)

donate_en.html   (with this change)
[07/Aug/2026 08:25:20] "POST /matomo.php?action_name=...&idsite=5&rec=1&r=989054&h=8&m=25&s=20&url=http%3A%2F%2F%5B%3A%3A1%5D%3A8099%2Fdonate_en.html&_id=&_idn=1&send_image=0&_refts=0&pv_id=1SxWtI
[07/Aug/2026 08:25:46] "POST /matomo.php?ping=1&idsite=5&rec=1&r=568213&h=8&m=25&s=46&url=http%3A%2F%2F%5B%3A%3A1%5D%3A8099%2Fdonate_en.html&_id=&_idn=1&send_image=0&_refts=0&pf_net=0&pf_srv=1&pf_tfr=2&pf_dm1=36&pf_dm2=795&pf_onl=2&pv_id=1SxWtI
```

`[::1]:8099` is the local server. Checked against the live page as well: `enableHeartBeatTimer` is absent there today, and the page currently sends its pageview and nothing else.
</details>

### Related issue(s) and discussion

- **Part of #8191.** That issue asks for the web version's key events to be logged in Matomo, and alexgarel's comment there asks contributors to prioritise rather than instrument everything at once. This is deliberately the smaller thing: a data-quality fix to a number you already collect, not a new event.
- The site-wide half is #14221.
- This came out of a wider review of what Matomo currently records on web and on the app, which I have been discussing with Pierre. Happy to file a dedicated issue if you would rather have one on record.
