### PR TITLE
feat: add authenticated product history API

### DIFF
--- a/docs/api/ref/api-v3.yaml
+++ b/docs/api/ref/api-v3.yaml
@@ -258,6 +258,112 @@ paths:
       security:
         - cookieAuth: []
           userAgentAuth: []
+  "/api/v3/product/{code}/history":
+    get:
+      tags:
+        - Products
+      summary: Get Authenticated Product History
+      operationId: get-api-v3-product-code-history
+      description: |-
+        Return the metadata for a product's revisions, newest revision first.
+
+        Authentication is required. Any authenticated Open Food Facts account may use this endpoint; moderator status is not required. Authentication can use the session cookie or a bearer token.
+
+        The response intentionally contains metadata only: it does not include product snapshots, field diffs, or IP addresses. The public product page's moderator-only history display is unchanged.
+      parameters:
+        - name: code
+          in: path
+          description: The barcode of the product whose history is requested.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            example: "3017620422003"
+        - name: page
+          in: query
+          required: false
+          description: Page number, starting at 1. Defaults to 1.
+          schema:
+            type: integer
+            default: 1
+            example: 1
+        - name: page_size
+          in: query
+          required: false
+          description: Number of revisions per page. Defaults to 20 and is capped at 1000.
+          schema:
+            type: integer
+            default: 20
+            maximum: 1000
+            example: 20
+      responses:
+        "200":
+          description: Product history metadata, ordered latest-first.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: ./responses/response-status/response_status.yaml
+                  - type: object
+                    required:
+                      - code
+                      - history
+                      - page
+                      - page_size
+                      - total
+                    properties:
+                      code:
+                        type: string
+                        example: "3017620422003"
+                      history:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - rev
+                            - t
+                          properties:
+                            rev:
+                              type: integer
+                              description: Revision number. Legacy records without a stored revision receive their derived revision number.
+                              example: 12
+                            t:
+                              type: integer
+                              description: Unix timestamp of the revision.
+                              example: 1712345678
+                            userid:
+                              type: string
+                              example: example-user
+                            comment:
+                              type: string
+                              example: Updated ingredients
+                            app_uuid:
+                              type: string
+                              example: 123e4567-e89b-12d3-a456-426614174000
+                            app_version:
+                              type: string
+                              example: 1.2.0
+                            clientid:
+                              type: string
+                              example: mobile
+                      page:
+                        type: integer
+                        example: 1
+                      page_size:
+                        type: integer
+                        example: 20
+                      total:
+                        type: integer
+                        description: Total number of revisions before pagination.
+                        example: 12
+        "401":
+          description: Authentication is required.
+        "404":
+          description: Product not found.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
   "/api/v3/product/{code}/images":
     post:
       tags:
@@ -877,6 +983,11 @@ components:
       type: apiKey
       in: header
       name: User-Agent
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Keycloak access token passed in the Authorization header.
 
   schemas:
     ExternalKnowledgePanelList:

--- a/lib/ProductOpener/API.pm
+++ b/lib/ProductOpener/API.pm
@@ -84,6 +84,7 @@ use ProductOpener::APIAttributeGroups qw/attribute_groups_api preferences_api/;
 use ProductOpener::APICurrentUser qw/read_current_user_permissions_api/;
 use ProductOpener::APIHealth qw/read_health_api/;
 use ProductOpener::APIProductRead qw/read_product_api/;
+use ProductOpener::APIProductHistory qw/read_product_history_api/;
 use ProductOpener::APIProductWrite qw/write_product_api/;
 use ProductOpener::APIProductImagesUpload qw/upload_product_image_api delete_product_image_api/;
 use ProductOpener::APIProductRevert qw/revert_product_api/;
@@ -447,6 +448,12 @@ my $dispatch_table = {
 		HEAD => \&read_product_api,
 		OPTIONS => sub {return;},
 		PATCH => \&write_product_api,
+	},
+	# Authenticated product history metadata
+	product_history => {
+		GET => \&read_product_history_api,
+		HEAD => \&read_product_history_api,
+		OPTIONS => sub {return;},
 	},
 	# Product image upload
 	product_images => {

--- a/lib/ProductOpener/APIProductHistory.pm
+++ b/lib/ProductOpener/APIProductHistory.pm
@@ -1,0 +1,164 @@
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2026 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+=head1 NAME
+
+ProductOpener::APIProductHistory - authenticated product history API
+
+=cut
+
+package ProductOpener::APIProductHistory;
+
+use ProductOpener::PerlStandards;
+use Exporter qw< import >;
+
+use Log::Any qw($log);
+
+BEGIN {
+	use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
+	@EXPORT_OK = qw(
+		&read_product_history_api
+	);
+	%EXPORT_TAGS = (all => [@EXPORT_OK]);
+}
+
+use vars @EXPORT_OK;
+
+use ProductOpener::API qw/add_error normalize_requested_code/;
+use ProductOpener::HTTP qw/single_param/;
+use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Products qw/is_valid_code product_id_for_owner product_path retrieve_product/;
+use ProductOpener::Store qw/retrieve_object/;
+use ProductOpener::Users qw/$Owner_id/;
+
+my $default_page_size = 20;
+my $max_page_size = 1000;
+
+=head2 read_product_history_api ($request_ref)
+
+Process GET /api/v3/product/{code}/history requests.
+
+The endpoint deliberately reads the compact change metadata from the product's
+history file. It does not return diffs, snapshots, or IP addresses.
+
+=cut
+
+sub read_product_history_api ($request_ref) {
+	$log->debug("read_product_history_api - start", {request => $request_ref}) if $log->is_debug();
+
+	my $response_ref = $request_ref->{api_response};
+
+	# init_user() has already authenticated both session cookies and bearer
+	# tokens by the time API handlers are dispatched.
+	if (not defined $request_ref->{user_id}) {
+		add_error(
+			$response_ref,
+			{
+				message => {id => "authentication_required"},
+				impact => {id => "failure"},
+			},
+			401
+		);
+		return;
+	}
+
+	my ($code) = normalize_requested_code($request_ref->{code}, $response_ref);
+	if (not is_valid_code($code // '')) {
+		add_error(
+			$response_ref,
+			{
+				message => {id => "invalid_code"},
+				field => {id => "code", value => $request_ref->{code}},
+				impact => {id => "failure"},
+			},
+			400
+		);
+		$response_ref->{result} = {id => "product_not_found"};
+		return;
+	}
+
+	my $product_ref = retrieve_product(product_id_for_owner($Owner_id, $code));
+	if (not defined $product_ref or not defined $product_ref->{code}) {
+		add_error(
+			$response_ref,
+			{
+				message => {id => "product_not_found"},
+				field => {id => "code", value => $code},
+				impact => {id => "failure"},
+			},
+			404
+		);
+		$response_ref->{result} = {id => "product_not_found"};
+		return;
+	}
+
+	my $changes_ref = retrieve_object("$BASE_DIRS{PRODUCTS}/" . product_path($product_ref) . "/changes");
+	$changes_ref = [] if ref($changes_ref) ne 'ARRAY';
+
+	my $total = scalar @{$changes_ref};
+	my $current_rev = $product_ref->{rev};
+	$current_rev = $total if not defined $current_rev or $current_rev !~ /^\d+$/;
+
+	# Product list endpoints parse pagination values by keeping the leading
+	# numeric portion. Match that behavior here, including zero for empty or
+	# non-numeric values, and clamp only page_size to the established maximum.
+	my $page = _pagination_parameter('page', 1);
+	my $page_size = _pagination_parameter('page_size', $default_page_size);
+	$page_size = $max_page_size if $page_size > $max_page_size;
+
+	my @revisions;
+	for (my $index = $total - 1; $index >= 0; $index--) {
+		my $change_ref = $changes_ref->[$index];
+
+		my $revision = $change_ref->{rev};
+		if (not defined $revision or $revision !~ /^\d+$/) {
+			$revision = $current_rev;
+		}
+		$current_rev--;
+
+		my $revision_ref = {rev => 0 + $revision};
+		foreach my $field (qw/t userid comment app_uuid app_version clientid/) {
+			$revision_ref->{$field} = $change_ref->{$field} if defined $change_ref->{$field};
+		}
+		push @revisions, $revision_ref;
+	}
+
+	my @paged_revisions;
+	if ($page_size > 0 and $page >= 1) {
+		my $offset = ($page - 1) * $page_size;
+		if ($offset < $total) {
+			my $last = $offset + $page_size - 1;
+			$last = $total - 1 if $last >= $total;
+			@paged_revisions = @revisions[$offset .. $last];
+		}
+	}
+
+	# Reuse the existing localized result message; the response payload carries
+	# the endpoint-specific history data below.
+	$response_ref->{result} = {id => "product_found"};
+	$response_ref->{code} = $code;
+	$response_ref->{history} = \@paged_revisions;
+	$response_ref->{page} = 0 + $page;
+	$response_ref->{page_size} = 0 + $page_size;
+	$response_ref->{total} = 0 + $total;
+
+	return;
+}
+
+sub _pagination_parameter ($name, $default) {
+	my $value = single_param($name);
+	return $default if not defined $value;
+	$value =~ s/\D.*$//;
+	return ($value // 0) + 0;
+}
+
+1;

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -359,10 +359,22 @@ sub api_route($request_ref) {
 	if ($api_action =~ /^products?/) {    # api/v3/product/[code]
 		param("code", $components[3]);
 		$request_ref->{code} = $components[3];
+		# GET /api/v3/product/[barcode]/history is an authenticated metadata-only
+		# view of the product history. Keep this v3-only so v2 remains unchanged.
+		if (   ($api_version >= 3)
+			and (defined $components[4])
+			and ($components[4] eq "history"))
+		{
+			$api_action = "product_history";
+			if (defined $components[5]) {
+				# endpoint not recognized
+				$request_ref->{status_code} = 404;
+			}
+		}
 		# We also have a specific endpoint for image upload
 		# /api/v3/product/[barcode]/images
 		# And an endpoint DELETE /api/v3/product/[barcode]/images/uploaded/[imgid]
-		if ((defined $components[4]) and ($components[4] eq "images")) {
+		elsif ((defined $components[4]) and ($components[4] eq "images")) {
 			$api_action = "product_images";
 			if ((defined $components[5]) and ($components[5] eq "uploaded") and (defined $components[6])) {
 				$request_ref->{imgid} = $components[6];

--- a/tests/integration/api_v3_product_history.t
+++ b/tests/integration/api_v3_product_history.t
@@ -1,0 +1,95 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use Test2::V0;
+use ProductOpener::APITest qw/create_user construct_test_url edit_product login new_client wait_application_ready/;
+use ProductOpener::Test qw/remove_all_products remove_all_users/;
+use ProductOpener::TestDefaults qw/%default_product_form %default_user_form/;
+use ProductOpener::Products qw/product_path retrieve_product/;
+use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Store qw/retrieve_object store_object/;
+use JSON::MaybeXS qw/decode_json/;
+
+wait_application_ready(__FILE__);
+remove_all_products();
+remove_all_users();
+
+my $bearer_ua = new_client();
+create_user($bearer_ua, \%default_user_form);
+
+my $code = '1234567890100';
+foreach my $name ('first', 'second', 'third') {
+	edit_product(
+		$bearer_ua,
+		{
+			%default_product_form,
+			code => $code,
+			product_name => "History product $name",
+			comment => "Comment $name",
+		}
+	);
+}
+
+# Make the fixture exercise legacy history records without rev and the
+# metadata fields that are intentionally exposed by the API.
+my $product_ref = retrieve_product($code);
+my $changes_path = "$BASE_DIRS{PRODUCTS}/" . product_path($product_ref) . "/changes";
+my $changes_ref = retrieve_object($changes_path);
+delete $changes_ref->[0]{rev};
+$changes_ref->[0]{comment} = 'Legacy comment';
+$changes_ref->[2]{comment} = 'Updated ingredients';
+$changes_ref->[2]{app_uuid} = 'fixture-uuid';
+$changes_ref->[2]{app_version} = '1.2.0';
+$changes_ref->[2]{clientid} = 'mobile';
+store_object($changes_path, $changes_ref);
+
+sub get_history ($ua, $query = '') {
+	my $response = $ua->get(construct_test_url("/api/v3/product/$code/history$query"));
+	my $body = eval {decode_json($response->decoded_content)};
+	is($@, '', 'history response is valid JSON') if $response->code == 200;
+	return ($response, $body);
+}
+
+my $anonymous_ua = new_client();
+my ($response) = get_history($anonymous_ua);
+is($response->code, 401, 'anonymous request requires authentication');
+
+my ($bearer_response, $bearer_body) = get_history($bearer_ua);
+is($bearer_response->code, 200, 'bearer-token request is accepted');
+is($bearer_body->{code}, $code, 'response contains the normalized product code');
+is($bearer_body->{total}, 3, 'total count is returned');
+is([map {$_->{rev}} @{$bearer_body->{history}}], [3, 2, 1], 'revisions are latest-first and legacy rev is derived');
+is($bearer_body->{history}[0]{comment}, 'Updated ingredients', 'comments are returned');
+is($bearer_body->{history}[0]{app_uuid}, 'fixture-uuid', 'app UUID is returned');
+is($bearer_body->{history}[0]{app_version}, '1.2.0', 'app version is returned');
+is($bearer_body->{history}[0]{clientid}, 'mobile', 'client ID is returned');
+ok(!exists $bearer_body->{history}[0]{diffs}, 'diffs are not returned');
+ok(!exists $bearer_body->{history}[0]{ip}, 'IP addresses are not returned');
+ok(!exists $bearer_body->{history}[0]{product}, 'product snapshots are not returned');
+
+my $session_ua = new_client();
+login($session_ua, $default_user_form{userid}, $default_user_form{password});
+my ($session_response) = get_history($session_ua);
+is($session_response->code, 200, 'session-cookie request is accepted for a normal user');
+
+my ($page_response, $page_body) = get_history($bearer_ua, '?page=2&page_size=2');
+is($page_response->code, 200, 'paginated request succeeds');
+is($page_body->{page}, 2, 'page is returned');
+is($page_body->{page_size}, 2, 'page size is returned');
+is([map {$_->{rev}} @{$page_body->{history}}], [1], 'pagination returns the requested page');
+
+my ($max_response, $max_body) = get_history($bearer_ua, '?page_size=1001');
+is($max_response->code, 200, 'oversized page request succeeds');
+is($max_body->{page_size}, 1000, 'page size is capped at 1000');
+
+my ($invalid_response, $invalid_body) = get_history($bearer_ua, '?page=&page_size=');
+is($invalid_response->code, 200, 'empty pagination values follow recent-changes behavior');
+is($invalid_body->{page}, 0, 'empty page is coerced to zero');
+is($invalid_body->{page_size}, 0, 'empty page size is coerced to zero');
+is(scalar @{$invalid_body->{history}}, 0, 'zero-sized page has no entries');
+
+my $unknown_response = $bearer_ua->get(construct_test_url('/api/v3/product/1234567890999/history'));
+is($unknown_response->code, 404, 'unknown product returns 404');
+
+done_testing();


### PR DESCRIPTION
## Summary

- add an authenticated API v3 product history endpoint
- document the endpoint in the OpenAPI specification
- add integration coverage for product history responses and authorization
