### PR TITLE
taxonomy(food): edits for sundried tomato product

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -3649,6 +3649,8 @@ wikidata:en: Q136952141
 
 xx: Van Eigen Deeg
 
+xx: Vefa
+
 xx: Vega
 wikidata:en: Q48803460
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -70933,45 +70933,45 @@ en: Green shiso
 it: shiso verde
 ja: アオジソ, 青紫蘇, 青じそ, 青ジソ, 大葉
 
-
 < en: herb
 en: sumac
 ar: سماق
-az: Sumaq
-be: Сумах
-bg: Сумак
+az: sumaq
+be: сумах, сумак
+bg: сумак
 ca: sumac
-cs: Sumah
-da: Sumak
-#diq:Sumaq
+cs: sumah
+da: sumak
+de: Sumak
 el: σουμάκι
-eo: Sumako
-es: sumac
-eu: Zumake
-fi: Sumakit
-fr: Sumac
-ga: Sumach
-gl: Sumagre
+eo: sumako
+es: sumac, zumaque
+eu: zumake
+fi: sumakit
+fr: sumac
+ga: sumach
+gl: sumagre
 he: סומאק
 hr: ruj
-hy: Աղտոր
-id: Sumac
-io: Sumako
-it: Sommacco
+hy: աղտոր
+id: sumac
+io: sumako
+it: sommacco
 ja: スマック
-jv: Sumac
-ku: Simaq
-lt: Žagrenis
-nl: Sumak, zuurkruid
-nv: Kʼįįʼ
-pl: Sumak, sumaku
-ru: Сумак
-#sco:Sumac
-tr: Sumak
-uk: Сумах
+jv: sumac
+ku: simaq
+lt: žagrenis
+nl: sumak, zuurkruid
+nv: kʼįįʼ
+pl: sumak, sumaku
+ru: сумак
+sv: sumak, sumac
+tr: sumak
+uk: сумах
+#diq: sumaq
+#sco: sumac
+comment:en: Be careful with the translation, it should refer to the spice, not the plant species.
 wikidata:en: Q16131953
-wikipedia:en: https://en.wikipedia.org/wiki/Sumac
-# comment:en:Be careful with the translation, it should refer to the spice, not the plant species.
 
 ###################################################################################################
 #

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -360,6 +360,7 @@ wikidata:en: Q104439353
 < en: chopped
 en: finely chopped
 da: finhakket, finhakkede
+fr: finement hachées, finement hachée, finement hachés
 sv: finhackad, finhackat, finhackade
 wikidata:en: Q26883106
 

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -333,7 +333,6 @@ nl: schijfjes
 pt: laminado, laminada, laminados, laminadas, em lâminas, em lâmina, em rodela, em rodelas, rodela de, rodelas de
 sv: skivad, skivade, skivat
 
-# en:description:Cut or diced into small pieces
 < en: cut
 en: chopped
 ca: picat, picada, picats, picades, trossejat, trossejada, trossejades
@@ -354,7 +353,15 @@ pt: picado, picada, picados, picadas
 sv: hackad, hackat, hackade
 uk: рублений, рублена, рублене, рублені
 # nl:parse:gehakte_$
+description:en: Cut or diced into small pieces
+wikidata:en: Q104439353
 # en:wiktionary:chopped
+
+< en: chopped
+en: finely chopped
+da: finhakket, finhakkede
+sv: finhackad, finhackat, finhackade
+wikidata:en: Q26883106
 
 en: cubes, cubed
 ca: cub, cubs


### PR DESCRIPTION
- Adds “Vefa” brand.
- Imports translations from Wikidata for sumac ingredient.
- Adds `wikidata` to “chopped” processing.
- Adds new “finely chopped” processing.
- Cleans up some comments.
- Removes misleading `wikipedia`.
- Normalises towards lower-case forms.

Needed-for: https://se.openfoodfacts.org/product/7350005811112/soltorkade-tomater-sumac-vefa