### PR TITLE
taxonomy(food): floral water edits

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -3819,6 +3819,9 @@ xx: XXL Nutrition
 xx: Yamakawa
 wikidata:en: Q11468260
 
+xx: Yamama, يمامة
+ar: يمامة
+
 xx: Yamaoyaji
 wikidata:en: Q118314587
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67800,8 +67800,7 @@ es: Aromas, Aromatizantes, Sabor
 et: Maitseained
 eu: Zapore
 fa: چشایی
-fi: Maku
-fi: maut
+fi: Maut, Maku
 fr: Arômes, Arôme, Arômes alimentaires, Arôme alimentaire
 ga: Blasóir
 gl: Sabor

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67847,7 +67847,6 @@ nl: Gebaksaromas
 < en: Plant-based foods and beverages
 en: Herbal distillates, Floral waters, Flower waters, Hydrosols, Hydrolates, Herbal waters, Essential waters
 ar: تقطير عشبي
-ca: Licor d'herbes
 cy: Distyllad llysieuol
 da: Blomstervand
 de: Pflanzenwässer, Blütenwässer

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67570,7 +67570,7 @@ hr: Brašno od kasave
 lt: Kasavos miltai
 nl: Maniokmelen
 
-en: Food additives, Foos additive
+en: Food additives, Food additive
 ar: مضاف غذائي
 az: Qida əlavələri
 ba: Аҙыҡ өҫтәмәләре
@@ -67786,20 +67786,163 @@ wikidata:en: Q179731
 
 < en: Food additives
 en: Flavors, flavours, flavouring, flavoring
+ar: نكهة
+be: Араматызатар
+bg: Ароматизанти
+bs: Aromatiziranje
+ca: Sabor
+cs: Chuť
+cy: Ychwanegiadau
+da: Aromaer
 de: Aromen, Aroma
-es: Aromas, Aromatizantes
+eo: Gustigaĵoj
+es: Aromas, Aromatizantes, Sabor
+et: Maitseained
+eu: Zapore
+fa: چشایی
+fi: Maku
 fi: maut
 fr: Arômes, Arôme, Arômes alimentaires, Arôme alimentaire
+ga: Blasóir
+gl: Sabor
+hi: सुवास
 hr: arome, aroma
-it: Aromi
-lt: Aromatai, aromatas
+ht: Gou
+hu: Ételízesítő
+id: Perisa
+it: Aromi, Sapore
+ja: 香料
+jv: Rasa
+kk: Ароматты қосылыстар
+ko: 향미
+kw: Sawrans
+la: Sapor
+lt: Aromatai, Aromatas, Gardis
+lv: Aromāts
+ms: Perisa
+nb: Aromaer
 nl: Aromas, Smaakstoffen
+nn: Aromaer, Aromaar
+oc: Flavor
 pl: Aromaty, Aromat
-zh: 香精
+pt: Sabor
+ro: Aromă
+ru: Ароматизаторы
+sl: Aroma
+sv: Aromer
+th: รส
+tl: Lasa
+tr: Aroma
+tt: Хушисләткечләр
+uk: Ароматизатор
+vi: Hương liệu
+zh: 香精, 香料
+wikidata:en: Q4173974
 
 < en: Flavors
 fr: Arômes pâtisserie, Arôme pâtisserie
 nl: Gebaksaromas
+
+< en: Flavors
+< en: Plant-based foods and beverages
+en: Herbal distillates, Floral waters, Flower waters, Hydrosols, Hydrolates, Herbal waters, Essential waters
+ar: تقطير عشبي
+ca: Licor d'herbes
+cy: Distyllad llysieuol
+da: Blomstervand
+de: Pflanzenwässer, Blütenwässer
+es: Destilados herbal
+fa: عرقیات گیاهی
+fr: Hydrolat
+ig: Herbal distillate
+is: Blómavatn
+ja: ハイドロゾル
+pl: Wody kwiatowe, Woda kwiatowa
+ru: Гидролат
+sd: عرق
+sl: Hidrolat
+sv: Blomvatten
+uk: Гідролат
+zh: 純露
+wikidata:en: Q905870
+
+< en: Herbal distillates
+en: Orange blossom waters, Orange flower waters
+ar: ماء الزهر
+ca: Aiguanaf
+cy: Dŵr blodau orennau
+da: Appelsinblomstvand
+de: Orangenblütenwasser
+eo: Oranĝflora akvoj
+es: Aguas de azahar
+eu: Laranja-lore ura
+fi: Appelsiininkukkavesi
+fr: Eaux de fleur d'oranger, Eau de fleur d'oranger
+it: Acqua di fiori d'arancio
+ja: オレンジ花水
+jv: Banyu kembang jeruk
+ko: 오렌지꽃물
+nl: Oranjebloesemwater
+oc: Aiganafa
+pl: Wody z kwiatów pomarańczy, Woda z kwiatów pomarańczy
+pt: Água-de-flor-de-laranjeira
+ru: Флёрдоранжевая вода
+sl: Voda cvetov pomaranče
+sv: Apelsinblomvatten
+zh: 橙花水
+wikidata:en: Q902582
+
+< en: Herbal distillates
+en: Rose waters, Rosewaters
+ar: ماء الورد, ماء ورد
+az: Gülab
+bg: Розова вода
+bn: গোলাপ জল
+ca: Aigua de roses
+cy: Dŵr rhosod
+da: Rosenvand
+de: Rosenwasser
+el: Ροδόνερο
+eo: Rozakvoj
+es: Aguas de rosas, Agua de rosas
+eu: Arrosa-ur
+fa: گلاب
+fi: Ruusuvesi
+fr: Eaux de rose, Eau de rose
+hi: गुलाब जल
+id: Air mawar
+it: Acqua di rose
+ja: ローズウォーター
+jv: Banyu mawar
+kk: Раушан суы
+ko: 장미수
+ku: Gulav
+la: Aqua rosacea
+mk: Розова вода
+ml: അത്തർ
+ms: Air mawar
+nb: Rosenvann, Rosenvatn, Rosevann, Rosevatn
+nl: Rozenwater
+nn: Rosevatn
+pl: Wody różane, Woda różana
+pt: Agua de rosas
+ro: Apă de trandafiri
+ru: Розовая вода
+sh: Ružina vodica
+sl: Rožna voda
+sr: Ружина водица
+sv: Rosenvatten
+ta: பன்னீர்
+tg: Гулоб
+th: น้ำดอกไม้เทศ
+tl: Tubig-rosas
+tr: Gülsuyu
+uk: Трояндова вода
+ur: عرق گلاب
+uz: Atirgul suvi
+vi: Nước hoa hồng
+zh: 蔷薇水
+wikidata:en: Q900450
 
 < en: Food additives
 en: Ascorbic acids, Ascorbates

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -74014,13 +74014,55 @@ hr: narančasto lišće
 it: foglie d'arancio
 
 < en: plant
-en: orange blossom
+en: orange blossom, orange flower
+ar: ماء زهر
+ca: tarongina
+da: appelsinblomst
+de: Orangenblüten
+es: azahar
+eu: laranja-lore
+fa: بهار نارنج
 fr: fleur d'oranger
+ga: bláth oráiste
+gl: flor de laranxeira
+gn: narã poty
+it: zagara
+ja: オレンジの花
+ka: ფლერდორანჟი
+nl: orange blossom
+pt: flor de laranjeira
+ru: флёрдоранж
+sl: pomarančni cvet
+sv: apelsinblom, apelsinbloms
+uk: флердоранж
+zh: 橙花
+wikidata:en: Q1152711
 
 < en: orange blossom
-en: orange blossom water
+en: orange blossom water, orange flower water
+ar: ماء الزهر
+ca: aiguanaf
+cy: dŵr blodau orennau
+da: appelsinblomstvand
+de: Orangenblütenwasser
+eo: oranĝflora akvo
+es: agua de azahar
+eu: laranja-lore ura
+fi: appelsiininkukkavesi
 fr: eau de fleur d'oranger
 it: acqua di fiori d'arancio
+ja: オレンジ花水
+jv: banyu kembang jeruk
+ko: 오렌지꽃물
+nl: oranjebloesemwater
+oc: aiganafa
+pl: woda z kwiatów pomarańczy
+pt: água-de-flor-de-laranjeira
+ru: флёрдоранжевая вода
+sl: voda cvetov pomaranče
+sv: apelsinblomsvatten
+zh: 橙花水
+wikidata:en: Q902582
 
 < en: plant
 fr: pin sylvestre
@@ -74288,13 +74330,56 @@ pl: płatki róży, płatki róż
 ro: petale de trandafiri
 
 < en: rose petals
-en: rose water
-bg: вода от рози
+en: rose water, rosewater
+ar: ماء الورد, ماء ورد
+az: gülab
+bg: вода от рози, розова вода
+bn: গোলাপ জল
+ca: aigua de roses
+cy: dŵr rhosod
+da: rosenvand
 de: Rosenwasser
+el: ροδόνερο
+eo: rozakvo
+es: agua de rosas
+eu: arrosa-ur
+fa: گلاب
+fi: ruusuvesi
 fr: eau de rose
+hi: गुलाब जल
 hr: ružina vodica
+id: air mawar
 it: acqua di rose
+ja: ローズウォーター
+jv: banyu mawar
+kk: раушан суы
+ko: 장미수
+ku: gulav
+la: aqua rosacea
+mk: розова вода
+ml: അത്തർ
+ms: air mawar
+nb: rosenvann, rosenvatn, rosevann, rosevatn
+nl: rozenwater
+nn: rosevatn
+pl: woda różana
+pt: agua de rosas
 ro: apă de trandafiri
+ru: розовая вода
+sh: ružina vodica
+sl: rožna voda
+sr: ружина водица
+sv: rosenvatten
+ta: பன்னீர்
+tg: гулоб
+th: น้ำดอกไม้เทศ
+tl: tubig-rosas
+tr: gülsuyu
+uk: трояндова вода
+ur: عرق گلاب
+uz: atirgul suvi
+vi: nước hoa hồng
+zh: 蔷薇水
 wikidata:en: Q900450
 wikipedia:en: https://en.wikipedia.org/wiki/Rose_water
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -5424,6 +5424,7 @@ nl: GMO-vrij, Geen GMO, GGO-vrij
 pl: bez GMO
 pt: Sem OGM, Sem Organismos Geneticamente Modificados
 ru: Без ГМО, Без использования ГМО, Не содержит ГМО
+sv: Innehåller inga genetiskt modifierade organismer
 th: ไม่มีจีเอ็มโอ
 incompatible_with:en: labels:en:contains-gmos
 label_categories:en: en:Health, en:Environment


### PR DESCRIPTION
- Adds brand “Yamama”.
- Adds “Herbal distillates” category.
  - Adds children categories for orange blossom and rose waters.
- Adds Swedish “no GMO” label translation/synonym.
- Adds some `wikidata` properties.
- Adds Danish, Swedish, and Norwegian translations.
- Imports some translations from Wikidata.

Needed-for: https://se.openfoodfacts.org/product/5281099000293/rosenvatten-yamama
Needed-for: https://se.openfoodfacts.org/product/5281099000262/apelsinblomvatten-yamama