### PR TITLE
ci(pr_actions): fix `/lint+update_test_results`

### DIFF
--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -115,6 +115,8 @@ jobs:
     - *get-repository-owner-branch
     - *checkout-fork-repo
     - *fetch-origin-main
+    - name: Create folders
+      run: make create_folders
     - *run-linting
     - *run-update-tests-results
     - name: Push changes if needed


### PR DESCRIPTION
A bunch of folders get created during the lint step which are then owned by root, which in turn means that the test result updating step isn’t able to create (sub)folders.

This calls `make create_folders` before the lint step to create the folders up front as the workflow runner user, which should allow both steps to manipulate their contents further.

Fixes: https://github.com/openfoodfacts/openfoodfacts-server/issues/14222