### PR TITLE
taxonomy(food): edits for Ramlösa mineral waters

### DIFF
--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -2897,6 +2897,9 @@ wikidata:en: Q7285134
 xx: Rally
 wikidata:en: Q104867091
 
+xx: Ramlösa
+wikidata:en: Q1624602
+
 xx: Rawfoodshop
 
 xx: Real Crisps

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -3867,6 +3867,14 @@ description:fr: consignée en Suède.
 #image:sv: pant-2kr.61x90.png
 label_categories:en: en:Environment, en:Packaging
 
+sv: pant 3kr
+xx: pant 3kr
+country:en: en:Sweden
+description:en: deposit in Sweden.
+description:fr: consignée en Suède.
+#image:sv: pant-3kr.61x90.png
+label_categories:en: en:Environment, en:Packaging
+
 en: metal recycles forever
 xx: metal recycles forever
 image:en: metal-recycles-forever.89x90.png

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -4613,30 +4613,31 @@ wikipedia:en: https://en.wikipedia.org/wiki/Silicon_dioxide
 zz: bicarbonate
 xx: Bicarbonate
 en: Bicarbonate
-bg: бикарбонат
-cs: bikarbonát
-da: bicarbonat
+bg: Бикарбонат
+cs: Bikarbonát
+da: Bicarbonat
 de: Bikarbonat
 el: Διττανθρακικό
 es: Bicarbonato
-et: nikkarbonaat
-fi: Vetykarbonaatti, bikarbonaatti
+et: Nikkarbonaat
+fi: Vetykarbonaatti, Bikarbonaatti
 fr: Bicarbonate, hydrogénocarbonates
-ga: décharbónáit
+ga: Décharbónáit
 he: ביקרבונט (מימן פחמתי)
-hu: bikarbonát
+hu: Bikarbonát
 it: Bicarbonato
-lt: bikarbonatas
-lv: bikarbonāts
-mt: bikarbonat
+lt: Bikarbonatas
+lv: Bikarbonāts
+mt: Bikarbonat
 nl: Bicarbonaat
 nl_be: Bicarbonaat
-pl: wodorowęglan
+pl: Wodorowęglan
 pt: Bicarbonato, Hidrogenocarbonatos, Hidrogenocarbonato, HCO3
 ro: Bicarbonat
-sk: bikarbonát
-sl: bikarbonat
-sv: bikarbonat
+sk: Bikarbonát
+sl: Bikarbonat
+sv: Vätekarbonat, Bikarbonat
+uk: Гідрокарбонати
 zh: 碳酸氢盐
 unit:en: mg
 wikidata:en: Q56810858
@@ -5401,32 +5402,33 @@ wikidata:en: Q677
 wikipedia:en: https://en.wikipedia.org/wiki/Iron
 
 zz: magnesium
-xx: Magnesium
+xx: Magnesium, Mg
 en: Magnesium
-af: magnesium
+af: Magnesium
 am: ማግኒዥየም
 an: Magnesio
 ar: مغنسيوم
 az: Maqnezium
-be: магній
+ba: Магний
+be: Магній
 bg: Магнезий
 bn: ম্যাগনেসিয়াম
 bo: དཀར་གཡའ།
 br: Magneziom
-bs: magnezij
-ca: magnesi
+bs: Magnezij
+ca: Magnesi
 co: Magnesiu
 cs: Hořčík
 cv: Магни
 cy: Magnesiwm
-da: magnesium
+da: Magnesium
 de: Magnesium
 dv: މެގްނީޒިއަމް
 el: Μαγνήσιο
-eo: magnezio
+eo: Magnezio
 es: Magnesio
 et: Magneesium
-eu: magnesio
+eu: Magnesio
 fa: منیزیم
 fi: Magnesium
 fo: Magnesium
@@ -5434,7 +5436,7 @@ fr: Magnésium
 fy: Magnesium
 ga: Maignéisiam
 gd: Magnesium
-gl: magnesio
+gl: Magnesio
 gu: મેગ્નેશિયમ
 gv: Magnaishum
 he: מגנזיום
@@ -5442,14 +5444,15 @@ hi: मैग्नेशियम तत्त्व
 hr: Magnezij
 ht: Manyezyòm
 hu: Magnézium
-hy: մագնեզիումia:magnesium
-id: magnesium
-io: magnezo
-is: magnesín
+hy: Մագնեզիում
+ia: Magnesium
+id: Magnesium
+io: Magnezo
+is: Magnesín
 it: Magnesio
 ja: マグネシウム
 jv: Magnesium
-ka: მაგნიუმი
+ka: Მაგნიუმი
 ki: Magnesium
 kk: Магний
 km: ម៉ាញ៉េស្យូម
@@ -5457,14 +5460,17 @@ kn: ಮ್ಯಗ್ನೀಶಿಯಮ್
 ko: 마그네슘
 ku: Magnezyûm
 kv: Магний
+kw: Magnesiom
 ky: Магний
-la: magnesium
+la: Magnesium
 lb: Magnesium
 li: Magnesium
 ln: Manezu
+lo: ແມກນີຊຽມ
 lt: Magnis
 lv: Magnijs
-mi: konupora
+mg: Maneziôma
+mi: Konupora
 mk: Магнезиум
 ml: മഗ്നീഷ്യം
 mn: Магни
@@ -5472,49 +5478,60 @@ mr: मॅग्नेशियम
 ms: Magnesium
 mt: Manjesju
 my: မဂ္ဂနီစီယမ်
-nb: magnesium
+nb: Magnesium
 ne: म्याग्नेसियम
 nl: Magnesium
 nl_be: Magnesium
-nn: magnesium
+nn: Magnesium
 nv: Béésh Łikoní
 oc: Magnèsi
+om: Maagniziyeemii
 or: ମାଗ୍ନେସିଅମ
+os: Магни
 pa: ਮੈਗਨੇਸ਼ਿਅਮ
 pi: म्याग्नेजियम
 pl: Magnez
-pt: Magnésio, Mg
+ps: مگنېزيوم
+pt: Magnésio
 qu: Qunta q'illay
 ro: Magneziu
-ru: магний
+ru: Магний
 sa: म्याग्नेजियम
+sc: Magnèsiu
+sd: ميگنيشيئم
+se: Magnesium
 sh: Magnezij
 si: මැග්නීසියම්
 sk: Horčík
 sl: Magnezij
 so: Magniisiyaam
 sq: Magneziumi
-sr: магнезијум
+sr: Магнезијум
 su: Magnésium
-sv: magnesium
+sv: Magnesium
 sw: Magnesi
 ta: மக்னீசியம்
 te: మెగ్నీషియం
 tg: Магний
 th: แมกนีเซียม
 tl: Magnesyo
-tr: magnezyum
+tr: Magnezyum
 tt: Магний
 ug: ماگنىي
-uk: магній
+uk: Магній
+ur: میگنیشیم
 uz: Magniy
-vi: magiê
+vi: Magiê, Magnesi
+vo: Magnesin
+wa: Magneziom
 yi: מאגנעזיום
 yo: Magnésíọ̀mù
 zh: 鎂, 镁
+zu: UmGethe
 dv_2016_value:en: 420
 dv_value:en: 400
 unit:en: mg
+wikidata:en: Q660
 wikipedia:en: https://en.wikipedia.org/wiki/Magnesium
 
 zz: zinc

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -5965,6 +5965,18 @@ sv: Österlen
 wikidata:en: Q298465
 wikipedia:en: https://en.wikipedia.org/wiki/%C3%96sterlen
 
+< en: Scania
+en: Ramlösa hälsobrunn
+xx: Ramlösa hälsobrunn
+sv: Ramlösa hälsobrunn
+wikidata:en: Q9361026
+wikipedia:en: https://en.wikipedia.org/wiki/Raml%C3%B6sa_H%C3%A4lsobrunn
+wikipedia:sv: https://sv.wikipedia.org/wiki/Raml%C3%B6sa_h%C3%A4lsobrunn
+
+< en: Ramlösa hälsobrunn
+en: Döbelius spring
+sv: Döbelius källa
+
 < en: sweden
 xx: Tibro
 en: Tibro


### PR DESCRIPTION
- Adds “Ramlösa” brand.
- Adds “pant 3kr” label.
- Adds “Ramlösa hälsobrunn” and “Döbelius spring” origins.
- Adds modern Swedish name for bicarbonates.
- Moves magnesium synonym “Mg” from pt to xx.
- Adds `wikidata` property.
- Imports some translations from Wikidata.
- Normalises nutrients to sentence-case.

Needed-for: https://se.openfoodfacts.org/product/7310070010025/gr%C3%B6nt-%C3%A4pple-raml%C3%B6sa