### PR TITLE
ci(pr_actions): deduplicate the git commit step(s)

### DIFF
--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -54,9 +54,11 @@ jobs:
     - &run-linting
       name: Run linting
       run: make lint front_lint
-    - name: Push changes if needed
+    - &git-commit
+      name: Push changes if needed
       uses: stefanzweifel/git-auto-commit-action@v7
       with:
+        &git-commit-options
         commit_message: "chore: Linting changes"
         branch: "${{ steps.get-branch.outputs.branch }}"
         commit_user_name: Open Food Facts Bot
@@ -88,20 +90,12 @@ jobs:
     - &run-update-tests-results
       name: Run update tests results
       run: make update_tests_results
-    - name: Push changes if needed
-      uses: stefanzweifel/git-auto-commit-action@v7
+    - <<: *git-commit
       with:
+        <<: *git-commit-options
         commit_message: "test: Update tests results"
-        branch: "${{ steps.get-branch.outputs.branch }}"
         file_pattern: 'tests/**/expected_test_results/**'
-        commit_user_name: Open Food Facts Bot
-        commit_user_email: contact@openfoodfacts.org
-        commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
         add_options: '--all'
-        push_options: ""
-        status_options: '--untracked-files=no'
-        skip_dirty_check: false
-        create_branch: no
     - *step-reaction-completed
 
   # Action to lint _and_ update test results in one go
@@ -121,16 +115,8 @@ jobs:
       run: make create_folders
     - *run-linting
     - *run-update-tests-results
-    - name: Push changes if needed
-      uses: stefanzweifel/git-auto-commit-action@v7
+    - <<: *git-commit
       with:
+        <<: *git-commit-options
         commit_message: "chore: Linting and test results changes"
-        branch: "${{ steps.get-branch.outputs.branch }}"
-        commit_user_name: Open Food Facts Bot
-        commit_user_email: contact@openfoodfacts.org
-        commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
-        push_options: ""
-        status_options: '--untracked-files=no'
-        skip_dirty_check: false
-        create_branch: no
     - *step-reaction-completed


### PR DESCRIPTION
It’s basically the same git commit step used for all three `/` actions, so this utilises YAML anchors and merge keys to simplify this.