### PR TITLE
feat: handle “*/” in ingredient lists

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -6966,7 +6966,7 @@ sub preparse_ingredients_text ($ingredients_lc, $text) {
 		foreach my $symbol (@symbols) {
 			# Find the last occurence of the symbol or symbol in parenthesis:  * (*)
 			# we need a negative look ahead (?!\)) to make sure we match (*) completely (otherwise we would match *)
-			if ($text =~ /^(.*)(\($symbol\)|$symbol)(?!\))\s*(:|=)?\s*/i) {
+			if ($text =~ /^(.*)(\($symbol\)|$symbol)(?!\))\s*(:|=|\/)?\s*/i) {
 				my $after = $';
 				#print STDERR "symbol: $symbol - after: $after\n";
 				foreach my $labelid (@labels) {

--- a/tests/unit/expected_test_results/ingredients/en-percent-or-quantity-regexp.json
+++ b/tests/unit/expected_test_results/ingredients/en-percent-or-quantity-regexp.json
@@ -106,6 +106,7 @@
       "en:salmon",
       "en:oily-fish",
       "en:tuna",
+      "en:saltwater-fish",
       "en:mackerel",
       "en:sardine"
    ],

--- a/tests/unit/expected_test_results/ingredients/sv-asterisk-slash.json
+++ b/tests/unit/expected_test_results/ingredients/sv-asterisk-slash.json
@@ -1,0 +1,181 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "ingredients" : [
+      {
+         "ciqual_food_code" : "11082",
+         "id" : "en:sea-salt",
+         "is_in_taxonomy" : 1,
+         "percent" : 93,
+         "percent_estimate" : 93,
+         "percent_max" : 93,
+         "percent_min" : 93,
+         "text" : "Havssalt",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "11033",
+         "id" : "en:basil",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 3.9375,
+         "percent_max" : 7,
+         "percent_min" : 0.875,
+         "text" : "basilika",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "11070",
+         "id" : "en:thyme",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 1.53125,
+         "percent_max" : 6.125,
+         "percent_min" : 0,
+         "text" : "timjan",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "11068",
+         "id" : "en:rosemary",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.765625,
+         "percent_max" : 3.0625,
+         "percent_min" : 0,
+         "text" : "rosmarin",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "20034",
+         "ecobalyse_code" : "onion-non-eu",
+         "id" : "en:onion",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.3828125,
+         "percent_max" : 2.04166666666667,
+         "percent_min" : 0,
+         "text" : "lök",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "11069",
+         "id" : "en:sage",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.19140625,
+         "percent_max" : 1.53125,
+         "percent_min" : 0,
+         "text" : "salvia",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "11035",
+         "id" : "en:oregano",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.095703125,
+         "percent_max" : 1.225,
+         "percent_min" : 0,
+         "text" : "oregano",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_proxy_food_code" : "11000",
+         "ecobalyse_code" : "d8c8a918-a11a-502f-a5cf-90052d96c133",
+         "id" : "en:garlic",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.0478515625,
+         "percent_max" : 1.02083333333333,
+         "percent_min" : 0,
+         "text" : "vitlök",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_food_code" : "11082",
+         "id" : "en:low-sodium-unrefined-sea-salt",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.0478515625,
+         "percent_max" : 0.875,
+         "percent_min" : 0,
+         "text" : "oraffinerat havssalt med låg natriumhalt",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {},
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_lc" : "sv",
+   "ingredients_n" : 9,
+   "ingredients_n_tags" : [
+      "9",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:sea-salt",
+      "en:basil",
+      "en:thyme",
+      "en:rosemary",
+      "en:onion",
+      "en:sage",
+      "en:oregano",
+      "en:garlic",
+      "en:low-sodium-unrefined-sea-salt"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:sea-salt",
+      "en:salt",
+      "en:basil",
+      "en:herb",
+      "en:thyme",
+      "en:rosemary",
+      "en:onion",
+      "en:vegetable",
+      "en:root-vegetable",
+      "en:onion-family-vegetable",
+      "en:sage",
+      "en:oregano",
+      "en:garlic",
+      "en:low-sodium-unrefined-sea-salt",
+      "en:unrefined-salt",
+      "en:unrefined-sea-salt"
+   ],
+   "ingredients_text" : "Havssalt (93%)**, basilika*, timjan*, rosmarin*, lök*, salvia, oregano* och vitlök* */ ekologiskt odlat **/oraffinerat havssalt med låg natriumhalt",
+   "ingredients_with_specified_percent_n" : 1,
+   "ingredients_with_specified_percent_sum" : 93,
+   "ingredients_with_unspecified_percent_n" : 8,
+   "ingredients_with_unspecified_percent_sum" : 7,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:basil",
+      "en:low-sodium-unrefined-sea-salt",
+      "en:oregano",
+      "en:rosemary",
+      "en:sage",
+      "en:sea-salt",
+      "en:thyme"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 7,
+   "known_ingredients_n" : 9,
+   "labels" : "en:organic",
+   "labels_hierarchy" : [
+      "en:organic"
+   ],
+   "labels_lc" : "sv",
+   "labels_tags" : [
+      "en:organic"
+   ],
+   "lc" : "sv",
+   "misc_tags" : [
+      "en:some-ingredients-with-specified-percent",
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/tests/unit/expected_test_results/recipes/nectars.guava-nectar.json
+++ b/tests/unit/expected_test_results/recipes/nectars.guava-nectar.json
@@ -14,7 +14,7 @@
          "vegetarian" : "yes"
       },
       {
-         "ciqual_food_code": "13083",
+         "ciqual_food_code" : "13083",
          "id" : "en:guava",
          "is_in_taxonomy" : 1,
          "percent" : 25,

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -958,6 +958,16 @@ puffed orange and caramelized unknown_fruit4.",
 		}
 
 	],
+	# handling of */ and **/ in the tail of the ingredients list
+	[
+		# https://se.openfoodfacts.org/product/7350056848709/%C3%B6rtsalt-original-spicemaster
+		'sv-asterisk-slash',
+		{
+			lc => 'sv',
+			ingredients_text =>
+				'Havssalt (93%)**, basilika*, timjan*, rosmarin*, lök*, salvia, oregano* och vitlök* */ ekologiskt odlat **/oraffinerat havssalt med låg natriumhalt',
+		},
+	],
 	# Recipes with ingredients by weight and volume
 	[
 		'en-ingredients-with-a-specific-density',


### PR DESCRIPTION
“/” can be used to denote that what follows is the ‘definition’ or ‘explanation’ of the ‘footnote’ denoted by “*”, “**”, or similar (ie., what’s in `$symbols_regexp`).

Needed-for: https://se.openfoodfacts.org/product/7350056848709/%C3%B6rtsalt-original-spicemaster