### PR TITLE
taxonomy(food): garlic (paste) category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -112771,17 +112771,18 @@ protected_name_type:en: pgi
 
 < en: Culinary plants
 < en: Vegetables based foods
-en: Garlic and their products
+en: Garlics and their products, Garlic and their products
+da: Hvidløg og hvidløgsprodukter
 de: Knoblauch und Knoblauchprodukte
 es: Ajos y derivados
-fi: valkosipulit ja valkosipulituotteet
-fr: Ail et dérivés, Ails et dérivés
+fi: Valkosipulit ja valkosipulituotteet
+fr: Ails et dérivés, Ail et dérivés
 he: שום ומוצריו
 hr: Češnjak i njihovi proizvodi
 hu: Fokhagyma és belőle készült termékek
 it: Aglio e derivati
 nl: Knoflook en -afgeleide producten
-wikidata:en: Q23400
+sv: Vitlökar och vitlöksprodukter
 
 < en: Culinary plants
 < en: Vegetables based foods
@@ -112803,7 +112804,7 @@ da: Tørret ramsløg
 pl: Czosnek niedźwiedzi suszony
 sv: Torkad ramslök
 
-< en: Garlic and their products
+< en: Garlics and their products
 ga: Ajos aliñados en vinagre
 
 < en: Vegetables based foods
@@ -113340,7 +113341,7 @@ hr: Kiseli patlidžani
 ja: ナスのピクルス
 nl: Ingemaakte aubergines
 
-< en: Garlic and their products
+< en: Garlics and their products
 < en: Vegetable pickles
 en: Pickled garlic
 de: Eingelegter Knoblauch
@@ -115367,31 +115368,141 @@ ciqual_food_name:fr: Fenouil, graine
 expected_ingredients:en: en:fennel-seeds
 opposite:en: en:fennel-bulbs
 
-< en: Garlic and their products
-en: Garlic
+< en: Garlics and their products
+en: Garlics, Garlic
+af: Knoffel
+am: ነጭ ሽንኩርት
+ar: ثوم
+as: নহৰু
+ay: Ajusa
+az: Sarımsaq
+ba: Һарымһаҡ
+be: Часнок
 bg: Чесън
+bi: Galik
+bm: Tumɛ
+bn: রসুন
+bo: སྒོག་ལོག
+br: Kignen
+bs: Bijeli luk
+ca: All
+ce: КӀонцерг
+co: Aglia
+cs: Česnek kuchyňský
+cv: Ыхра
+cy: Garlleg
+da: Hvidløg
 de: Knoblauch
+dv: ލޮނުމެދު
+el: Σκόρδο
+eo: Ajloj
 es: Ajos
-fi: valkosipuli
-fr: Ail, Ails
+et: Küüslauk
+eu: Baratxuri
+fa: سیر
+fi: Valkosipuli
+fo: Hvítleykur
+fr: Ails, Ail
+fy: Knyflok
+ga: Gairleog
+gd: Creamh
+gl: Allo
+gn: Áho
+gu: લસણ
+gv: Garleid
+ha: Tafarnuwa
 he: שום
-hr: češnjaci, češnjak
+hi: लहसुन
+hr: Češnjaci, Češnjak
+ht: Lay
 hu: Fokhagyma
+hy: Սխտոր
+io: Alio
+is: Hvítlaukur
 it: Aglio
 ja: ニンニク, にんにく, ガーリック
+jv: Bawang
+ka: Ნიორი
+kk: Сарымсақ
+km: ខ្ទឹមស
+kn: ಬೆಳ್ಳುಳ್ಳಿ
+ko: 마늘
+ks: رۄہن
+ku: Sîr
+kw: Kennin ewinek
+ky: Сарымсак
 la: Allium sativum
+lb: Knuewelek
+lg: Emisuwa egikaluba
+li: Witlouk
+lo: ຜັກທຽມ
+lt: Valgomasis česnakas
+lv: Ķiploks
+mg: Tongolo gasy
+mk: Лук
+ml: വെളുത്തുള്ളി
+mn: Саримс
+mr: लसूण
+ms: Bawang putih
+mt: Tewm
+my: ကြက်သွန်ဖြူ
+nb: Hvitløker, Kvitløker
+ne: लसुन
 nl: Knoflook
-pl: Czosnek
+nn: Kvitlaukar, Kvitløkar
+nv: Tłʼohchin díchʼííʼí
+oc: Alh cultivat
+or: ରସୁଣ
+os: Нуры
+pa: ਲਸਣ
+pl: Czosnek, Czosnek pospolity
+ps: هوږه
+pt: Alho
+qu: Ahus
+ro: Usturoi
+ru: Чеснок
+sa: लशुनम्
+sc: Azu
+sd: ٿوم
+se: Vilgeslávki
+sh: Češnjak
+si: සුදු ලූනු
+sk: Cesnak kuchynský
+sl: Česen
+so: Toon
+sq: Hudhra
+sr: Бели лук
+su: Bawang bodas
+sv: Vitlökar
+sw: Kitunguu saumu
+ta: பூண்டு
+te: వెల్లుల్లి
+tg: Сирпиёз
+th: กระเทียม
+tk: Sarymsak
+tl: Bawang
+tr: Sarımsak
+tt: Сарымсак
+ug: سامساق
+uk: Часник
+ur: لہسن
+uz: Sarimsoq
+vi: Tỏi
+vo: Läl
+wa: A
+wo: Laac
+yi: קנאָבל
+za: Suenq
+zh: 蒜
+zu: UmVithu
 agribalyse_proxy_food_code:en: 11000
-agribalyse_proxy_food_name:en: Garlic, fresh
-agribalyse_proxy_food_name:fr: Ail, cru
-gpc_category_code:en: 10006003
-gpc_category_description:en: Definition: Includes any product that can be described/observed as a fresh commercial variety of Garlic of varieties (cultivars) grown from Allium sativum L. to be supplied fresh to the consumer. Definition Excludes: Specifically excludes: Prepared/Processed or Unprepared/Unprocessed and Shelf Stable or Frozen Garlic.
-gpc_category_name:en: Garlic
+ciqual_proxy_food_code:en: 11000
+ciqual_proxy_food_name:en: Garlic, fresh
+ciqual_proxy_food_name:fr: Ail, cru
 sales_format:en: weight, package
 wikidata:en: Q23400
 
-< en: Garlic
+< en: Garlics
 it: Aglio di Voghiera
 xx: Aglio di Voghiera
 origins:en: en:italy
@@ -115399,7 +115510,7 @@ protected_name_file_number:en: PDO-IT-0638
 protected_name_type:en: pdo
 #wikidata:en:
 
-< en: Garlic
+< en: Garlics
 it: Aglio Bianco Polesano
 xx: Aglio Bianco Polesano
 origins:en: en:italy
@@ -115407,24 +115518,29 @@ protected_name_file_number:en: PDO-IT-0566
 protected_name_type:en: pdo
 #wikidata:en:
 
-< en: Garlic and their products
+< en: Garlics and their products
 fr: Ail doux au piment
 
 < en: Fresh vegetables
-< en: Garlic
-en: Fresh garlic
+< en: Garlics
+en: Fresh garlics, Fresh garlic
 bg: Пресен чесън
+da: Friske hvidløg
 de: Frischer Knoblauch
 fr: Ail frais, Ail cru
 hr: Svježi češnjak
 nl: Verse knoflook
+sv: Färska vitlökar
 agribalyse_food_code:en: 11000
 ciqual_food_code:en: 11000
 ciqual_food_name:en: Garlic, fresh
 ciqual_food_name:fr: Ail, cru
+gpc_category_code:en: 10006003
+gpc_category_description:en: Definition: Includes any product that can be described/observed as a fresh commercial variety of Garlic of varieties (cultivars) grown from Allium sativum L. to be supplied fresh to the consumer. Definition Excludes: Specifically excludes: Prepared/Processed or Unprepared/Unprocessed and Shelf Stable or Frozen Garlic.
+gpc_category_name:en: Garlic
 season_in_country_fr:en: 7,8,9,10,11,12
 
-< en: Garlic
+< en: Garlics
 en: Allium neapolitanum, Naples garlic
 de: Neapolitanischer Lauch
 fr: Ail Blanc
@@ -115433,7 +115549,7 @@ nl: Witte knoflook
 sales_format:en: weight, package
 wikidata:en: Q1817792
 
-< en: Garlic
+< en: Garlics
 en: Purple garlic
 ca: All morat
 es: Ajo morado
@@ -115459,7 +115575,7 @@ protected_name_file_number:en: PGI-FR-0470
 protected_name_type:en: pgi
 
 < en: French vegetables
-< en: Garlic
+< en: Garlics
 fr: Ail rose de Lautrec
 xx: Ail rose de Lautrec
 origins:en: en:lautrec
@@ -115467,7 +115583,7 @@ protected_name_file_number:en: PGI-FR-0193
 protected_name_type:en: pgi
 
 < en: French vegetables
-< en: Garlic
+< en: Garlics
 fr: Ail de la Drôme
 xx: Ail de la Drôme
 origins:en: en:drome
@@ -115475,7 +115591,7 @@ protected_name_file_number:en: PGI-FR-0537
 protected_name_type:en: pgi
 
 < en: French vegetables
-< en: Garlic
+< en: Garlics
 fr: Ail fumé d'Arleux
 xx: Ail fumé d'Arleux
 origins:en: en:arleux
@@ -115483,7 +115599,7 @@ protected_name_file_number:en: PGI-FR-0820
 protected_name_type:en: pgi
 
 < en: French vegetables
-< en: Garlic
+< en: Garlics
 fr: Ail violet de Cadours
 xx: Ail violet de Cadours
 origins:en: en:france
@@ -115500,9 +115616,16 @@ hu: Zöld foghagyma
 nl: Groene knoflook
 
 < en: Condiment pastes
-< en: Garlic
-en: Garlic paste
+< en: Garlics and their products
+en: Garlic pastes, Garlic paste
+da: Hvidløgspastaer
+eo: Ajlopastoj
+es: Colas de ajo
 fr: Pâtes d'ail, purées d'ail, pâte d'ail, purée d'ail
+nb: Hvitløkspastaer, Kvitløkspastaer
+nn: Kvitlaukspastaer, Kvitlaukspastaar, Kvitløkspastaer, Kvitløkspastaar
+sv: Vitlökspastor
+wikidata:en: Q57328617
 
 < en: Vegetable rods
 # <en:ingredient:en:vegetable
@@ -118418,7 +118541,7 @@ ciqual_proxy_food_name:en: Tomato, dried
 ciqual_proxy_food_name:fr: Tomate, séchée
 wikidata:en: Q106922495
 
-< en: Garlic and their products
+< en: Garlics and their products
 < en: Ground dried vegetables
 en: Garlic powders, Garlic powder, Granulated garlic, Dried garlic powder
 ar: مسحوق الثوم
@@ -122686,7 +122809,7 @@ da: Frosne hakkede skalotteløg
 sv: Frysta hackade schalottenlökar
 
 < en: Frozen vegetables
-< en: Garlic
+< en: Garlics
 en: Frozen chopped garlic
 de: Tiefgefrorener gehackter Knoblauch
 es: Ajos troceados congelados, Ajos congelados troceados


### PR DESCRIPTION
- Adds sv, da, nb/nn translations + some translations from Wikidata.
- Adds `wikidata` property.
- Removes `wikidata` property from “Garlics and their products”.
  - WD item is for the garlic plant, not for derived products.
- Normalises category names toward sentence-cased plural forms.
- Moves `gpc_category` from “Garlics” to “Fresh garlics”.
- Adds `ciqual_proxy_food` to “Garlics”.

Needed-for: https://se.openfoodfacts.org/product/7311312002471/garlic-paste-santa-maria