### PR TITLE
chore(taxonomy): some comments clean-up

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1932,7 +1932,7 @@ e_number:en: 159
 vegan:en: yes
 vegetarian:en: yes
 
-#en:comment:Use only the generic name in E160 (ending on -oid)
+#comment:en: Use only the generic name in E160 (ending on -oid)
 en: E160, Carotenoids
 xx: E160
 bg: E160, Каротеноиди
@@ -1971,7 +1971,7 @@ vegan:en: maybe
 vegetarian:en: maybe
 wikidata:en: Q191907
 
-#en:comment: E160a are mixed carotenes and E160b the beta-variants (put those there)
+#comment:en: E160a are mixed carotenes and E160b the beta-variants (put those there)
 en: E160a, carotene
 xx: E160a
 bg: E160a, Каротин
@@ -7630,7 +7630,7 @@ e_number:en: 313
 vegan:en: yes
 vegetarian:en: yes
 
-# en:comment:Careful with overlap between E314 and E241. It seems to be the same, E241 has the role as preservative and E314 as antioxidant.
+#comment:en: Careful with overlap between E314 and E241. It seems to be the same, E241 has the role as preservative and E314 as antioxidant.
 en: E314, Guaiacum
 xx: E314
 ar: E314, غاياكوم
@@ -13720,7 +13720,7 @@ anses_additives_of_interest:en: yes
 e_number:en: 450
 wikidata:en: Q290828
 
-#en:comment:Is this the same as E546? Siphosphate versus polyphosphate
+#comment:en: Is this the same as E546? Siphosphate versus polyphosphate
 < en: E450
 en: E450(viii)
 xx: E450(viii)

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -6809,8 +6809,8 @@ ca: emmental francès ratllat, formatge emmental ratllat
 es: queso emmental francés rallado, queso emmenthal francés rallado
 
 
-# en:description:FROMAGE BLANC is a fresh cheese originating from the north of France and the south of Belgium.
-# en:comment:This cheese has translation issues as it is very similar to other fresh cheeses
+#description:en: FROMAGE BLANC is a fresh cheese originating from the north of France and the south of Belgium.
+#comment:en: This cheese has translation issues as it is very similar to other fresh cheeses
 
 < en: cheese
 en: fromage blanc
@@ -9576,7 +9576,7 @@ wikidata:en: Q5057832
 wikipedia:en: https://en.wikipedia.org/wiki/Celery_salt
 # mainIngredient:en:salt
 
-#en:comment:salt based on Kalium and not Natrium
+#comment:en: salt based on Kalium and not Natrium
 < en: salt
 en: potassium salt, potassium chloride
 bg: калиева сол
@@ -32360,7 +32360,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Trehalose
 # usage:en:trehalose (source of glucose)
 
 < en: molasses
-#en:description:Melado is a mixture of sugar and molasses; crude sugar as it comes from the pans without being drained.
+#description:en: Melado is a mixture of sugar and molasses; crude sugar as it comes from the pans without being drained.
 < en: sugar
 en: melado
 de: Melado
@@ -37171,7 +37171,7 @@ pl: płatki drożdżowe
 sv: näringsjästflinga, näringsjästflingor
 
 # see ingredients_processing.txt
-#en:comment: fr:poudre-a-lever is an additive class.
+#comment:en: fr:poudre-a-lever is an additive class.
 < en: yeast
 en: yeast powder, raising powder
 bg: мая на прах
@@ -37191,7 +37191,7 @@ ru: Дрожжевой порошок
 sv: torrjäst, jästpulver
 
 #en:processing:en:powder
-#en:comment:misses a parent, so entries can not be removed
+#comment:en: misses a parent, so entries can not be removed
 #<en:raising agent???
 en: baking powder
 bg: бакпулвер
@@ -47730,7 +47730,7 @@ usda_ndb_name:en: Soursop, raw
 #                                Strawberry
 #
 ###################################################################################################
-# en:description:The garden strawberry (or simply strawberry; Fragaria × ananassa) is a widely grown hybrid species of the genus Fragaria, collectively known as the strawberries.
+#description:en: The garden strawberry (or simply strawberry; Fragaria × ananassa) is a widely grown hybrid species of the genus Fragaria, collectively known as the strawberries.
 
 < en: berries
 en: strawberry, strawberries
@@ -52218,7 +52218,7 @@ eurocode_2_group_3:en: 8.15.24
 wikidata:en: q263203
 wikipedia:en: https://en.wikipedia.org/wiki/Red_cabbage
 
-# en:comment:IN french chou chinois is used for both varieties. And in other languages as well.
+#comment:en: IN french chou chinois is used for both varieties. And in other languages as well.
 
 < en: cabbage
 en: Chinese cabbage, Napa cabbage
@@ -75071,7 +75071,7 @@ pt: Chá preto descafeinado
 # ingredient/tree-sorrel no products @2019-05-08
 
 
-# en:description:Vanilla is a flavoring derived from orchids of the genus Vanilla, primarily from the Mexican species, flat-leaved vanilla (V.planifolia).
+#description:en: Vanilla is a flavoring derived from orchids of the genus Vanilla, primarily from the Mexican species, flat-leaved vanilla (V.planifolia).
 
 < en: plant
 en: vanilla
@@ -76287,7 +76287,7 @@ wikidata:en: Q1636443
 wikipedia:en: https://en.wikipedia.org/wiki/Himanthalia_elongata
 
 
-# en:description:ASCOPHYLLUM NODOSUM is a large, common cold water seaweed or brown alga (Phaeophyceae) in the family Fucaceae, being the only species in the genus Ascophyllum.
+#description:en: ASCOPHYLLUM NODOSUM is a large, common cold water seaweed or brown alga (Phaeophyceae) in the family Fucaceae, being the only species in the genus Ascophyllum.
 
 < en: seaweed
 en: Ascophyllum
@@ -76407,7 +76407,7 @@ eurocode_2_group_3:en: 8.55.10
 usda_ndb_code:en: 11444
 usda_ndb_name:en: Seaweed, irishmoss, raw
 
-# en:description:ASPERGILLUS ORYZAE, known in English as koji, is a filamentous fungus (a mold) used in Chinese and other East Asian cuisines to ferment soybeans for making soy sauce and fermented bean paste
+#description:en: ASPERGILLUS ORYZAE, known in English as koji, is a filamentous fungus (a mold) used in Chinese and other East Asian cuisines to ferment soybeans for making soy sauce and fermented bean paste
 
 #< en:mold
 en: koji, kōji, koji culture, koji spores, koji starter
@@ -79392,7 +79392,7 @@ it: uova di merluzzo leggermente affumicate
 < en: lightly smoked cod roe
 fi: sokerisuolattu miedosti savustettu turskan mäti, sokerisuolattu miedosti savustettu turskakalojen mäti
 
-# en:description:The Atlantic cod (Gadus morhua) is a benthopelagic fish of the family Gadidae, widely consumed by humans.
+#description:en: The Atlantic cod (Gadus morhua) is a benthopelagic fish of the family Gadidae, widely consumed by humans.
 
 < en: cod
 en: atlantic cod, Gadus morhua
@@ -79421,7 +79421,7 @@ wikidata:en: Q199788
 wikipedia:en: https://en.wikipedia.org/wiki/Atlantic_cod
 
 
-# en:description:The Pacific cod, Gadus macrocephalus, is a species of ray-finned fish in the family Gadidae.
+#description:en: The Pacific cod, Gadus macrocephalus, is a species of ray-finned fish in the family Gadidae.
 
 < en: cod
 en: pacific cod
@@ -79481,7 +79481,7 @@ wikidata:en: Q2017562
 wikipedia:en: https://en.wikipedia.org/wiki/Cilus_gilberti
 
 
-# en:description:The deepwater redfish (Sebastes mentella), also known as the beaked redfish, ocean perch,[2] Atlantic redfish, Norway haddock, red perch, golden redfish, or hemdurgan
+#description:en: The deepwater redfish (Sebastes mentella), also known as the beaked redfish, ocean perch,[2] Atlantic redfish, Norway haddock, red perch, golden redfish, or hemdurgan
 
 < en: fish
 en: deepwater redfish
@@ -80107,7 +80107,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Haddock
 #
 ###################################################################################################
 
-# en:description:The term hake /heɪk/ refers to fish in either of:Family Merlucciidae of northern and southern oceans or the Family Phycidae (sometimes subfamily Phycinae in family Gadidae) of the northern oceans.
+#description:en: The term hake /heɪk/ refers to fish in either of:Family Merlucciidae of northern and southern oceans or the Family Phycidae (sometimes subfamily Phycinae in family Gadidae) of the northern oceans.
 
 < en: cod
 < en: white fish
@@ -80176,7 +80176,7 @@ description:en: Merluccius capensis (shallow-water Cape hake or South African ha
 wikidata:en: Q386641
 wikipedia:en: https://en.wikipedia.org/wiki/Merluccius_capensis
 
-# en:description:Merluccius paradoxus, the deep-water Cape hake, is a merluccid hake of the genus Merluccius, found in the south-eastern Atlantic Ocean, along the coast of Southern Africa, south of Angola.
+#description:en: Merluccius paradoxus, the deep-water Cape hake, is a merluccid hake of the genus Merluccius, found in the south-eastern Atlantic Ocean, along the coast of Southern Africa, south of Angola.
 
 < en: hake
 en: deep-water Cape hake, Cape black hake
@@ -80194,7 +80194,7 @@ wikidata:en: Q2461954
 wikipedia:en: https://en.wikipedia.org/wiki/Merluccius_paradoxus
 #44 @20021-09-14
 
-# en:description:Merluccius gayi is a merluccid hake of the genus Merluccius, with two subspecies, the South Pacific hake (M. g. gayi) and the Peruvian hake (M. g. peruanus), found in the south-western Pacific Ocean, along the coast of South America
+#description:en: Merluccius gayi is a merluccid hake of the genus Merluccius, with two subspecies, the South Pacific hake (M. g. gayi) and the Peruvian hake (M. g. peruanus), found in the south-western Pacific Ocean, along the coast of South America
 
 < en: hake
 en: South Pacific hake
@@ -81066,7 +81066,7 @@ wikidata:en: Q475211
 wikipedia:en: https://en.wikipedia.org/wiki/Chum_salmon
 
 
-# en:description:Pink salmon or humpback salmon (Oncorhynchus gorbuscha) is a species of anadromous fish in the salmon family.
+#description:en: Pink salmon or humpback salmon (Oncorhynchus gorbuscha) is a species of anadromous fish in the salmon family.
 
 < en: salmon
 en: pink salmon
@@ -81113,7 +81113,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Pink_salmon
 
 
 
-# en:description:Sockeye salmon (Oncorhynchus nerka), also called red salmon, kokanee salmon, or blueback salmon, is an anadromous species of salmon found in the Northern Pacific Ocean and rivers discharging into it.
+#description:en: Sockeye salmon (Oncorhynchus nerka), also called red salmon, kokanee salmon, or blueback salmon, is an anadromous species of salmon found in the Northern Pacific Ocean and rivers discharging into it.
 
 < en: salmon
 en: Sockeye salmon
@@ -81152,7 +81152,7 @@ wikidata:en: Q44064
 wikipedia:en: https://en.wikipedia.org/wiki/Sockeye_salmon
 
 
-# en:description:The European pilchard (Sardina pilchardus) is a species of ray-finned fish in the monotypic genus Sardina.
+#description:en: The European pilchard (Sardina pilchardus) is a species of ray-finned fish in the monotypic genus Sardina.
 
 < en: fish
 < en: oily fish
@@ -82027,7 +82027,7 @@ ciqual_food_code:en: 26213
 ciqual_food_name:en: Grenadier, from any fishing spot, raw
 ciqual_food_name:fr: Hoki, tout lieu de pêche, cru
 
-# en:description:The blue grenadier, hoki, blue hake, New Zealand whiptail, whiptail or whiptail hake (Macruronus novaezelandiae) is a merluccid hake of the family Merlucciidae found around southern Australia and New Zealand
+#description:en: The blue grenadier, hoki, blue hake, New Zealand whiptail, whiptail or whiptail hake (Macruronus novaezelandiae) is a merluccid hake of the family Merlucciidae found around southern Australia and New Zealand
 
 < en: grenadier
 < en: white fish
@@ -82050,7 +82050,7 @@ ciqual_food_name:en: Blue grenadier, raw
 ciqual_food_name:fr: Grenadier bleu ou hoki de Nouvelle-Zélande cru
 wikipedia:en: https://en.wikipedia.org/wiki/Blue_grenadier
 
-# en:description:Le grenadier patagonien appelé en espagnol merluza de cola (Macruronus magellanicus) est un poisson marin de la famille des Merlucciidae qui appartient de ce fait à l'ordre des Gadiformes.
+#description:en: Le grenadier patagonien appelé en espagnol merluza de cola (Macruronus magellanicus) est un poisson marin de la famille des Merlucciidae qui appartient de ce fait à l'ordre des Gadiformes.
 
 < en: hake
 en: Patagonian grenadier
@@ -82272,7 +82272,7 @@ hr: šur
 nl: horsmakrel
 description:en: Horse mackerel is a vague vernacular term for a range of species of fish throughout the English-speaking world.
 
-# en:description:Jack mackerels or saurels are marine fish in the genus Trachurus of the family Carangidae.
+#description:en: Jack mackerels or saurels are marine fish in the genus Trachurus of the family Carangidae.
 
 < en: mackerel
 en: jack mackerel
@@ -82762,7 +82762,7 @@ wikidata:en: Q164327
 wikipedia:en: https://en.wikipedia.org/wiki/Swordfish
 
 
-# en:description:Trout is the common name for a number of species of freshwater fish belonging to the genera Oncorhynchus, Salmo and Salvelinus, all of the subfamily Salmoninae of the family Salmonidae.
+#description:en: Trout is the common name for a number of species of freshwater fish belonging to the genera Oncorhynchus, Salmo and Salvelinus, all of the subfamily Salmoninae of the family Salmonidae.
 
 < en: fish
 < en: oily fish
@@ -83210,7 +83210,7 @@ zh: 大西洋水珍魚
 wikidata:en: Q1535870
 wikipedia:en: https://en.wikipedia.org/wiki/Greater_argentine
 
-# en:description:Brochet est un nom vernaculaire ambigu désignant en français certains poissons prédateurs.
+#description:en: Brochet est un nom vernaculaire ambigu désignant en français certains poissons prédateurs.
 
 < en: fish
 fr: brochet
@@ -83505,8 +83505,8 @@ wikidata:en: Q860002
 wikipedia:en: https://en.wikipedia.org/wiki/Cockle_(bivalve)
 
 
-# en:description:Cuttlefish or cuttles are marine molluscs of the order Sepiida.
-# fr:description:Le terme seiche est un nom vernaculaire générique pour un très grand nombre de mollusques céphalopodes classés dans le super-ordre des décapodes et regroupés dans le taxon des Sepioida, c'est-à-dire dans l'ordre des Sepiida et des Sepiolida.
+#description:en: Cuttlefish or cuttles are marine molluscs of the order Sepiida.
+#description:fr: Le terme seiche est un nom vernaculaire générique pour un très grand nombre de mollusques céphalopodes classés dans le super-ordre des décapodes et regroupés dans le taxon des Sepioida, c'est-à-dire dans l'ordre des Sepiida et des Sepiolida.
 
 < en: mollusc
 en: cuttlefish
@@ -83585,7 +83585,7 @@ wikidata:en: Q184479
 wikipedia:en: https://en.wikipedia.org/wiki/Cuttlefish
 
 
-# en:description:The common cuttlefish or European common cuttlefish (Sepia officinalis) is one of the largest and best-known cuttlefish species.
+#description:en: The common cuttlefish or European common cuttlefish (Sepia officinalis) is one of the largest and best-known cuttlefish species.
 
 < en: cuttlefish
 en: common cuttlefish, Sepia officinalis
@@ -83616,7 +83616,7 @@ ru: Лекарственная каракатица, Sepia officinalis
 wikipedia:en: https://en.wikipedia.org/wiki/Common_cuttlefish
 
 
-# en:description:Sepiella inermis, common name spineless cuttlefish, is an edible species of cuttlefish.
+#description:en: Sepiella inermis, common name spineless cuttlefish, is an edible species of cuttlefish.
 
 < en: cuttlefish
 en: spineless cuttlefish, Sepiella inermis
@@ -83629,7 +83629,7 @@ la: Sepiella inermis
 zh: 曼氏无针乌贼, Sepiella inermis
 wikipedia:en: https://en.wikipedia.org/wiki/Sepiella_inermis
 
-# en:description:The pharaoh cuttlefish (Sepia pharaonis) is a large cuttlefish species, growing to 42 cm in mantle length and 5 kg in weight
+#description:en: The pharaoh cuttlefish (Sepia pharaonis) is a large cuttlefish species, growing to 42 cm in mantle length and 5 kg in weight
 
 < en: cuttlefish
 en: pharaoh cuttlefish, Sépia Pharaonis
@@ -83718,7 +83718,7 @@ fr: moules cuites
 fr: moules du Pacifique décoquillées cuites
 
 
-# en:description:The Mediterranean mussel (Mytilus galloprovincialis) is a species of bivalve, a marine mollusc in the family Mytilidae.
+#description:en: The Mediterranean mussel (Mytilus galloprovincialis) is a species of bivalve, a marine mollusc in the family Mytilidae.
 
 < en: mussel
 en: Mediterranean mussel, Mytilus galloprovincialis
@@ -83748,7 +83748,7 @@ ciqual_food_name:en: Mediterranean mussel, raw
 ciqual_food_name:fr: Moule de Méditerranée, crue
 wikipedia:en: https://en.wikipedia.org/wiki/Mediterranean_mussel
 
-# en:description:The blue mussel (Mytilus edulis), also known as the common mussel, is a medium-sized edible marine bivalve mollusc in the family Mytilidae, the mussels.
+#description:en: The blue mussel (Mytilus edulis), also known as the common mussel, is a medium-sized edible marine bivalve mollusc in the family Mytilidae, the mussels.
 
 < en: mussel
 en: blue mussel, common mussel, Mytilus edulis
@@ -83785,7 +83785,7 @@ wikidata:en: Q27855
 fr: Mytilus edulis pêchées en Atlantique Nord
 
 
-# en:description:The Chilean mussel or Chilean blue mussel (Mytilus platensis) is a species of blue mussel native to the coasts of Chile, Argentina
+#description:en: The Chilean mussel or Chilean blue mussel (Mytilus platensis) is a species of blue mussel native to the coasts of Chile, Argentina
 
 < en: mussel
 en: Chilean mussel, Mytilus chilensis
@@ -83802,7 +83802,7 @@ wikidata:en: Q384733
 wikipedia:en: https://en.wikipedia.org/wiki/Chilean_mussel
 
 
-# en:description: The octopus is a soft-bodied, eight-limbed mollusc of the order Octopoda.
+#description:en: The octopus is a soft-bodied, eight-limbed mollusc of the order Octopoda.
 
 < en: mollusc
 en: octopus, Raw common octopus
@@ -83936,7 +83936,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Eledone_moschata
 #
 ###################################################################################################
 
-# en:description:Oyster is the common name for a number of different families of salt-water bivalve molluscs that live in marine or brackish habitats.
+#description:en: Oyster is the common name for a number of different families of salt-water bivalve molluscs that live in marine or brackish habitats.
 
 < en: mollusc
 en: oyster, oysters
@@ -84091,7 +84091,7 @@ es: viera, vieras, escalópas
 fa: شانه‌گونان
 fi: kampasimpukka, kampasimpukat
 fr: noix de saint-jacques, Saint-Jacques, noix de st-jacques, noix de st jacques, noix de coquilles saint-jacques, noix de coquilles st-jacques, coquille Saint-Jacques, coquille st jacques, coquille saint jacques, st-jacques
-# en:comment:fr:noix de saint-jacques is used as a name for any scallop species
+#comment:en: fr:noix de saint-jacques is used as a name for any scallop species
 gl: Pectínidos
 hr: jakobova kapica
 id: Simping
@@ -84136,7 +84136,7 @@ ciqual_food_name:en: Scallop, with coral, raw
 ciqual_food_name:fr: Coquille Saint-Jacques, noix et corail, crue
 
 
-# en:description:Argopecten irradians, formerly classified as Aequipecten irradians, common names Atlantic bay scallop or bay scallop, is an edible species of saltwater clam, a scallop
+#description:en: Argopecten irradians, formerly classified as Aequipecten irradians, common names Atlantic bay scallop or bay scallop, is an edible species of saltwater clam, a scallop
 
 < en: scallop
 en: Atlantic bay scallop, bay scallop
@@ -84276,7 +84276,7 @@ ciqual_food_name:en: Peru sea scallop, without coral, raw
 ciqual_food_name:fr: Pétoncle ou Peigne du Pérou, noix, crue
 
 
-# en:description:The queen scallop (Chlamys opercularis) is a medium-sized species of scallop, an edible marine bivalve mollusk in the family Pectinidae, the scallops.
+#description:en: The queen scallop (Chlamys opercularis) is a medium-sized species of scallop, an edible marine bivalve mollusk in the family Pectinidae, the scallops.
 
 < en: scallop
 en: queen scallop
@@ -84296,7 +84296,7 @@ zh: 女王扇貝
 wikidata:en: Q1746507
 wikipedia:en: https://en.wikipedia.org/wiki/Queen_scallop
 
-# en:description:Argopecten gibbus (Atlantic calico scallop) is a species of medium-sized edible marine bivalve mollusk in the family Pectinidae, the scallops
+#description:en: Argopecten gibbus (Atlantic calico scallop) is a species of medium-sized edible marine bivalve mollusk in the family Pectinidae, the scallops
 
 < en: scallop
 en: speckled Scallop
@@ -84326,7 +84326,7 @@ wikipedia:nl: https://nl.wikipedia.org/wiki/Chlamys_albida
 #
 ###################################################################################################
 
-# en:description:Ascidiacea (commonly known as the ascidians or sea squirts) is a paraphyletic class in the subphylum Tunicata of sac-like marine invertebrate filter feeders.
+#description:en: Ascidiacea (commonly known as the ascidians or sea squirts) is a paraphyletic class in the subphylum Tunicata of sac-like marine invertebrate filter feeders.
 
 #? not sure whether this should be counted as a mollusc
 < en: mollusc
@@ -85312,7 +85312,7 @@ wikidata:en: Q27690
 wikipedia:en: https://en.wikipedia.org/wiki/Homarus_gammarus
 
 
-# en:description:The American lobster (Homarus americanus) is a species of lobster found on the Atlantic coast of North America, chiefly from Labrador to New Jersey.
+#description:en: The American lobster (Homarus americanus) is a species of lobster found on the Atlantic coast of North America, chiefly from Labrador to New Jersey.
 
 < en: lobster
 en: American lobster, Homarus americanus
@@ -85433,7 +85433,7 @@ la: Panulirus argus, Panulirue argus
 zh: 眼斑龍蝦, Panulirus argus
 wikipedia:en: https://en.wikipedia.org/wiki/Panulirus_argus
 
-# en:description:Nephrops norvegicus, known variously as the Norway lobster, Dublin Bay prawn, langoustine (compare langostino) or scampi, is a slim, orange-pink lobster which grows up to 25 cm (10 in) long
+#description:en: Nephrops norvegicus, known variously as the Norway lobster, Dublin Bay prawn, langoustine (compare langostino) or scampi, is a slim, orange-pink lobster which grows up to 25 cm (10 in) long
 
 
 < en: spiny lobster
@@ -85599,7 +85599,7 @@ ciqual_food_code:en: 10059
 ciqual_food_name:en: deep water pink shrimp, raw
 ciqual_food_name:fr: Crevette rose, crue
 
-# en:description:Penaeidae is a family of marine crustacean in the suborder Dendrobranchiata, which are often referred to as penaeid shrimp or penaeid prawns.
+#description:en: Penaeidae is a family of marine crustacean in the suborder Dendrobranchiata, which are often referred to as penaeid shrimp or penaeid prawns.
 
 < en: shrimp
 en: Penaeidae, penaeid shrimp
@@ -85648,7 +85648,7 @@ it: gamberetti scarlatti
 la: Plesiopenaeus Edwardsianus
 wikipedia:es: https://es.wikipedia.org/wiki/Aristaeopsis_edwardsiana
 
-# en:description:Penaeus monodon, commonly known as the giant tiger prawn or Asian tiger shrimp (and also known by other common names), is a marine crustacean that is widely reared for food.
+#description:en: Penaeus monodon, commonly known as the giant tiger prawn or Asian tiger shrimp (and also known by other common names), is a marine crustacean that is widely reared for food.
 
 < en: deep-sea shrimp
 en: giant tiger prawn, Asian tiger shrimp, Penaeus monodon
@@ -85707,7 +85707,7 @@ wikidata:en: Q3002564
 wikipedia:en: https://en.wikipedia.org/wiki/Whiteleg_shrimp
 
 
-# en:description:Heterocarpus is a genus of deep-sea shrimp, mainly of tropical areas all over the world.
+#description:en: Heterocarpus is a genus of deep-sea shrimp, mainly of tropical areas all over the world.
 
 < en: shrimp
 en: Heterocarpus
@@ -85719,7 +85719,7 @@ la: Heterocarpus, Heterocarpus spp
 wikidata:en: Q3932367
 wikipedia:en: https://en.wikipedia.org/wiki/Heterocarpus
 
-# en:description:Crangon crangon is a commercially important species of caridean shrimp fished mainly in the southern North Sea
+#description:en: Crangon crangon is a commercially important species of caridean shrimp fished mainly in the southern North Sea
 
 < en: shrimp
 en: grey shrimp, Crangon crangon
@@ -85776,7 +85776,7 @@ vi: Tôm hồng, Pandalus borealis
 zh: 北极虾, Pandalus borealis
 wikidata:en: Q122181
 
-# en:description:Parapenaeopsis sculptilis, commonly known as the Rainbow Shrimp, is a marine crustacean that is widely reared for food
+#description:en: Parapenaeopsis sculptilis, commonly known as the Rainbow Shrimp, is a marine crustacean that is widely reared for food
 
 < en: shrimp
 en: rainbow shrimp, Parapenaeopsis sculptilis
@@ -87100,7 +87100,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sulfite
 
 
 
-# en:description:Coffee is a brewed drink prepared from roasted coffee beans, the seeds of berries from certain Coffea species.
+#description:en: Coffee is a brewed drink prepared from roasted coffee beans, the seeds of berries from certain Coffea species.
 
 en: coffee
 aa: buna
@@ -88410,7 +88410,7 @@ en: raw chicken meat and skin
 ciqual_food_code:en: 36003
 ciqual_food_name:fr: Chicken, meat and skin, raw
 
-# en:comment:"poulet fermier" is defined in https://eur-lex.europa.eu/legal-content/FR/TXT/PDF/?uri=CELEX:01991R1538-20071217&from=GA
+#comment:en: "poulet fermier" is defined in https://eur-lex.europa.eu/legal-content/FR/TXT/PDF/?uri=CELEX:01991R1538-20071217&from=GA
 # in English, it is "traditional free-range"
 < en: free range chicken
 en: traditional free-range chicken, farm reared chicken, farm raised chicken
@@ -90190,7 +90190,7 @@ ca: clara d'ou, clares d'ou, albumina d'ou
 cs: bílek
 da: æggehvide
 de: Eiklar
-# de:comment:eiweiß is a synonym of protein, or use Ei-eiweiß
+#comment:de: eiweiß is a synonym of protein, or use Ei-eiweiß
 el: ασπράδι αυγού
 eo: ovoblanko
 es: clara de huevo, albumina de huevo
@@ -90438,7 +90438,7 @@ description:fr: La meringue est une pâtisserie très légère et très fine com
 description:it: La meringa è una preparazione dolce a base di albume di uova e zucchero a velo.
 description:nl: Een meringue is een zoete lekkernij die bestaat uit gedroogd schuim, met stijfgeklopt eiwit en suiker als belangrijkste ingrediënten.
 description:pt: Suspiro ou merengue é um doce feito de claras de ovos e açúcar.
-# de:comment:eiweiß is a synonym of protein, or use Ei-eiweiß
+#comment:de: eiweiß is a synonym of protein, or use Ei-eiweiß
 #es,fr,nl,gl,jv
 wikidata:en: Q276276
 # usage:fr:meringue (blanc d'OEUF, sucre)
@@ -92001,7 +92001,7 @@ pl: makaron orzo
 wikidata:en: Q1317552
 wikipedia:en: https://en.wikipedia.org/wiki/Orzo
 
-# en:description:SPAGHETTI is a long, thin, solid, cylindrical pasta. It is a staple food of traditional Italian cuisine. Like other pasta, spaghetti is made of milled wheat and water and sometimes enriched with vitamins and minerals.
+#description:en: SPAGHETTI is a long, thin, solid, cylindrical pasta. It is a staple food of traditional Italian cuisine. Like other pasta, spaghetti is made of milled wheat and water and sometimes enriched with vitamins and minerals.
 
 < en: pasta
 en: spaghetti
@@ -93801,7 +93801,7 @@ de: Panade
 fr: panade
 mk: панада
 wikidata:en: Q3892955
-# de:comment:Panade (Weizenmehl, Sonnenblumenöl, Salz, Hefe, Gewürz Paprika)
+#comment:de: Panade (Weizenmehl, Sonnenblumenöl, Salz, Hefe, Gewürz Paprika)
 
 < en: coating
 < en: frying
@@ -97048,7 +97048,7 @@ description:sv: Gräddsås är en sås baserad på grädde och kalvfond eller bu
 wikidata:en: Q10509700
 wikipedia:de: https://de.wikipedia.org/wiki/Rahmsauce
 
-# en:description:HOT SAUCE, also known as chili sauce or pepper sauce, is any condiment, seasoning, or salsa made from chili peppers and other ingredients.
+#description:en: HOT SAUCE, also known as chili sauce or pepper sauce, is any condiment, seasoning, or salsa made from chili peppers and other ingredients.
 
 < en: sauce
 en: hot sauce, chili sauce
@@ -97412,7 +97412,7 @@ it: kombucha crudo
 #
 ###################################################################################################
 
-# en:description:NONPAREILS (or hundreds and thousands outside North America) are a decorative confectionery of tiny balls made with sugar and starch, traditionally an opaque white but now available in many colors.
+#description:en: NONPAREILS (or hundreds and thousands outside North America) are a decorative confectionery of tiny balls made with sugar and starch, traditionally an opaque white but now available in many colors.
 
 #< en: compound
 en: nonpareils, nonpareilles

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -399,12 +399,12 @@ en: minced
 it: macinato, macinata, macinate, macinati
 uk: фарш, фарш з
 
-# en:description:nuts cut into small pointed pieces
+#description:en: nuts cut into small pointed pieces
 en: nibbed
 
 #de:in Sticks geschnitten
 
-#en:description:Mechanical processing of grain or other feed materials to reduce their size
+#description:en: Mechanical processing of grain or other feed materials to reduce their size
 en: crushed, crushing
 bg: натрошенo, натрошен, натрошена, натрошени
 es: aplastada, aplastado, aplastadas, aplastados, triturado, triturada, triturados, trituradas
@@ -421,7 +421,7 @@ wikidata:en: Q2991605
 en: finely crushed
 sv: finkrossad, finkrossat, finkrossade
 
-#en:description:Special shaping by compression through a die
+#description:en: Special shaping by compression through a die
 en: pellet, pelleted, agglomerated
 fr: aggloméré
 hr: aglomerirani, peleta, peletirano
@@ -435,7 +435,7 @@ nl: geplet, geplette
 pt: enrolado, enrolada, enrolados, enroladas
 sv: valsad, valsat, valsade
 
-# en:description:Produced by grating; grate: to shred (things, usually foodstuffs), by rubbing across a grater.
+#description:en: Produced by grating; grate: to shred (things, usually foodstuffs), by rubbing across a grater.
 en: grated
 bg: настърган, настъргано, настъргана, настъргани
 ca: ratllat
@@ -487,7 +487,7 @@ uk: гранульований, гранульована, гранульован
 # fi:parse:$rae
 # sv:parse:$granulat
 
-# en:description:To reduce to smaller pieces by crushing with lateral motion.
+#description:en: To reduce to smaller pieces by crushing with lateral motion.
 en: ground
 bg: смляно, смлян, смляна, смляни, мляно
 ca: mòlt, mòlts, mòltes
@@ -708,7 +708,7 @@ fr: brisures
 nl: schilfers
 pt: descadado, descamada
 
-#en:description:rolling of moist heat-treated material
+#description:en: rolling of moist heat-treated material
 en: flakes
 bg: люспи, люспи от
 ca: flocs, flocs de, flocs d'
@@ -737,7 +737,7 @@ ja: チップス, チップ
 nl: chips
 pl: chipsy, płaty, płaty z, płaty z, chipsy z, chipsów
 
-#de:comment:result of grating
+#comment:de: result of grating
 de: raspel, raspeln
 fi: raaste
 
@@ -813,7 +813,7 @@ fr: poudre soluble, en poudre soluble, poudre soluble de
 
 #comment:en:Not all languages use (have?) a separate word for flour, but use powder instead
 #< en:powdered
-#en:description:Physical processing of grain to reduce particle size and facilitate separation into constituent fractions (principally flour, bran and middlings)
+#description:en: Physical processing of grain to reduce particle size and facilitate separation into constituent fractions (principally flour, bran and middlings)
 en: flour, bran, middlings, feed
 bg: брашно, брашно от
 ca: Farina d'
@@ -864,7 +864,7 @@ es: partido, partida, partidos, partidas
 pl: łamane, łamana, łamany
 pt: partido, partida, partidos, partidas
 
-#es:comment:deshuesadas is a generic term and can mean en:pitted or en:boned
+#comment:es: deshuesadas is a generic term and can mean en:pitted or en:boned
 #process of removing the bone from meat
 en: boned
 bg: обезкостен, обезкостено, обезкостена, обезкостени, без кокал
@@ -972,7 +972,7 @@ wikidata:en: Q104998181
 de: entspeltzt
 
 #In Spanish sin hueso can be pitted or boned. Removed from here to remove confusion.
-# en:description:Having had the pits removed
+#description:en: Having had the pits removed
 # <es:deshuesadas
 en: pitted
 bg: без костилка
@@ -1019,7 +1019,7 @@ nl: schilletjes
 
 en: zest
 
-# en:description:The soft center of a fruit
+#description:en: The soft center of a fruit
 #< en:pressed
 en: pulp, pomace, pressed pulp
 bg: пулп, пулп от
@@ -1088,7 +1088,7 @@ fr: extraction à froid, extrait à froid, extraite à froid, extraits à froid,
 it: estratto a freddo
 
 en: juice, juices, juices of, juice from
-#en:comment:juice and mango pulp, juices and purees of fruit, vegetable juice color, chicken-meat-including-chicken-juices, juice-concentrates, reconstituted-vegetable-juice-blend, tomatoes-in-tomato-juice, chicken-meat-including-natural-chicken-juices, fruit-and-vegetable-juice-color, beet-juice-color
+#comment:en: juice and mango pulp, juices and purees of fruit, vegetable juice color, chicken-meat-including-chicken-juices, juice-concentrates, reconstituted-vegetable-juice-blend, tomatoes-in-tomato-juice, chicken-meat-including-natural-chicken-juices, fruit-and-vegetable-juice-color, beet-juice-color
 az: şıresl
 bg: сок, сок от
 cs: šťáva, šťávy, šťáva z, štávy z
@@ -1097,7 +1097,7 @@ de: saft, säfte, saft von, säfte von, saft vom, säfte vom, direktsaft, direkt
 es: jugo, jugo de
 fi: mehu
 fr: jus de, jus d'
-#en:comment:au jus (tomates pelees concassees au jus) is an exception, jus de cuisson, jus cuisiné, jus de poisson, jus de moules
+#comment:en: au jus (tomates pelees concassees au jus) is an exception, jus de cuisson, jus cuisiné, jus de poisson, jus de moules
 hr: sok, sok iz, sok od, voćni sok od, od soka, soka
 hu: leve, lé
 it: succo, succo di, succo d', succhi, succhi di, succhi d'
@@ -1123,7 +1123,7 @@ hr: koncentriran sok, koncentrirani sok, koncentrirani sokovi, iz koncentriranog
 # fr:pur jus
 
 < en: juice
-#en:description: es:zumo is kept separate from the more generic es:jugo. It is only applicable to fruit.
+#description:en: es:zumo is kept separate from the more generic es:jugo. It is only applicable to fruit.
 ca: suc, suc de, suc d'
 es: zumo de, zumo
 
@@ -1314,7 +1314,7 @@ description:en: Water has been added to concentrate
 en: from comminute
 description:en: A comminute is a puree that is derived from whole citrus fruits.
 
-#en:description:Dehydration by artificial or natural processes
+#description:en: Dehydration by artificial or natural processes
 # anhydrous: No water, dehydrated: Water removed, dried: Less water.
 en: dried, dry
 ar: مجف
@@ -1420,7 +1420,7 @@ sv: torrbakad, torrbakat, torrbakade
 zh: 干烤
 # description:en:dried inside an oven
 
-# en:description:cured means dried, especially in meats
+#description:en: cured means dried, especially in meats
 #< en:dried
 en: cured
 ca: curat
@@ -1604,7 +1604,7 @@ pt: parcialmente reconstituído, parcialmente reconstituída, parcialmente recon
 sv: delvis rekonstituerat, delvis rekonstituerad, delvis rekonstituerade
 zh: 部分复原
 
-#en:description:Removal either by organic solvent of fat or oil from certain materials or by aqueous solvent of sugar or other water-soluble components. In the case of the use of organic solvent, the resulting product must be technically free of such solvent.
+#description:en: Removal either by organic solvent of fat or oil from certain materials or by aqueous solvent of sugar or other water-soluble components. In the case of the use of organic solvent, the resulting product must be technically free of such solvent.
 en: extract, extracts, extracted, extract of, extracts of, extractive, extractives, extractives of
 bg: екстракт, екстракт от
 ca: extracte
@@ -1641,7 +1641,7 @@ it: estratto naturale di
 pl: naturalny ekstrakt, naturalny ekstrakt z, naturalne ekstrakty z, naturalne ekstrakty, naturalny wyciąg, naturalny wyciąg z, naturalne wyciągi z, naturalne wyciągi
 pt: extrato natural, extratos naturais, extracto natural, extractos naturais, extrato natural de, extratos naturais de, extracto natural de, extractos naturais de, extrato natural da, extratos naturais da, extracto natural da, extractos naturais da
 
-#en:description:Pressing of material through an orifice under pressure.
+#description:en: Pressing of material through an orifice under pressure.
 en: extruded
 bg: екструдиран, екструдирано, екструдирана, екструдирани
 ca: extrudit
@@ -1661,7 +1661,7 @@ zh: 挤压
 
 #fr:obtenu par extraction hydrique
 
-#en:description:removal by mechanical extraction (by a screw or other type of press), with or without a slight heating, of fat/oil from oil-rich materials or of juice from fruits or other vegetable products en:pressed, extraite par pression
+#description:en: removal by mechanical extraction (by a screw or other type of press), with or without a slight heating, of fat/oil from oil-rich materials or of juice from fruits or other vegetable products en:pressed, extraite par pression
 # en:false:compressed
 en: pressed, extraite par pression
 bg: пресовано, пресован, пресована, пресовани
@@ -1792,13 +1792,13 @@ en: macerate
 hr: macerat
 uk: мацерований, мацерована, мацероване, мацеровані, мацерирований, мацерирована, мацерироване, мацерировані
 
-#en:description:Modification of starch to improve markedly its swelling properties in cold water
+#description:en: Modification of starch to improve markedly its swelling properties in cold water
 en: pregelatinisation, starch gelatinization
 hr: preželatinirano, preželatinizirano, želatiniziranog
 nl: voorverstijfseld, voorverstijfselde
 wikidata:en: Q7601513
 
-#en:description:mechanical separation of the component parts of kernel/grain, sometimes after steeping in water, with or without sulphur dioxide, for the extraction of starch
+#description:en: mechanical separation of the component parts of kernel/grain, sometimes after steeping in water, with or without sulphur dioxide, for the extraction of starch
 #en:germ, gluten, starch, wet-milling
 #fr:germe, gluten, amidon
 #hr:klica, gluten, škrob
@@ -1971,7 +1971,7 @@ pt: descongelado, descongelada, descongelados, descongeladas
 sv: ofryst, ofrysta, ofrossad, ofrossade
 uk: розморожений, розморожена, розморожене, розморожені
 
-#en:description:Sterilization (or sterilisation) refers to any process that removes, kills, or deactivates all forms of life and other biological agents present in or on a specific surface, object, or fluid. Sterilization can be achieved through various means, including heat, chemicals, irradiation, high pressure, and filtration.
+#description:en: Sterilization (or sterilisation) refers to any process that removes, kills, or deactivates all forms of life and other biological agents present in or on a specific surface, object, or fluid. Sterilization can be achieved through various means, including heat, chemicals, irradiation, high pressure, and filtration.
 # Sterilized: higher temperature (more than 100'C) than pasteurised, kills spores, longer conservation
 en: sterilized, sterilised
 bg: стерилизирано, стерилизиран, стерилизирана, стерилизирани
@@ -2123,7 +2123,7 @@ zh: 焯水
 en: thermally processed
 hr: termički obrađena
 
-#en:description:General term covering a number of heat treatments carried out under specific conditions to influence the nutritional value or the structure of the material
+#description:en: General term covering a number of heat treatments carried out under specific conditions to influence the nutritional value or the structure of the material
 en: cooked, boiled
 ar: مطبوخ
 bg: сготвено, сготвена, сготвен, сготвени, варено, варена, варен, варени
@@ -2333,7 +2333,7 @@ zh: 未焙烤
 en: dark toasted
 zh: 深度焙烤
 
-# en:description:To cook food under the element of a stove or only under the top element of an oven.
+#description:en: To cook food under the element of a stove or only under the top element of an oven.
 #< en:roasted
 en: grilled
 de: gegrillt, gegrillte, gegrillter, gegrilltes
@@ -2382,7 +2382,7 @@ en: enriched
 #en:false_positive:enriched with thiamin
 de: angereichert, angereicherte, angereichertes, angereicherten
 es: enriquecida
-#de:comment:Can also appear in combinations: de:Eiweißangereichertes
+#comment:de: Can also appear in combinations: de:Eiweißangereichertes
 fr: enrichi, enrichie, enrichis, enrichies
 hr: obogačena
 nl: verrijkt, verrijkte, verrijkt, verrijkte
@@ -2434,7 +2434,7 @@ ca: cobertura
 es: cobertura
 pt: coberto, coberta, cobertos, cobertas, cobertura, coberturas, coberto com, coberta com, cobertos com, cobertas com, cobertura em, coberturas em
 
-#en:comment:Mix two similar ingredients, such as different cheese types
+#comment:en: Mix two similar ingredients, such as different cheese types
 en: mixture, mixtures
 ca: barreja, barreja de
 es: mezcla, mezcla de
@@ -2443,13 +2443,13 @@ it: miscela, misto, mix
 pl: mieszanka, mieszanki
 uk: суміш, суміш з, суміші, суміші з
 
-#en:comment:salt has been added to the ingredient
+#comment:en: salt has been added to the ingredient
 #< en:added
 en: salted
 ca: salat, salada, salats, salades
 de: gesalzen, gesalzene, gesalzenes, gesalzener
 es: salado, salada, salados, saladas
-# es:comment:careful for es:ensalada
+#comment:es: careful for es:ensalada
 fi: suolattu
 fr: salé, salée, salés, salées, sales, salees
 hu: sózott
@@ -2737,7 +2737,7 @@ de: ungebleicht, ungebleichte, ungebleichter, ungebleichtes, ungebleichten, unge
 hu: fehérítetlen
 uk: невибілений, невибілена, невибілене, невибілені
 
-#en:comment:be careful for maltitol
+#comment:en: be careful for maltitol
 en: malted
 #en:falsePositive:malt
 de: gemälzt, gemälzte, gemälzter, gemälztes, gemälzten, gemälztem
@@ -2781,7 +2781,7 @@ it: non deodorizzato, non deodorizzata, non deodorizzati, non deodorizzate
 nl: niet ontgeurd, niet ontgeurde, niet ontgeurden, niet ontgeurdes
 pt: não desodorizado, não desodorizada, não desodorizados, não desodorizadas
 
-#en:comment:http://animalsmart.org/feeding-the-world/food-safety/rbst
+#comment:en: http://animalsmart.org/feeding-the-world/food-safety/rbst
 en: rbst-free
 
 #en:clarified
@@ -2846,7 +2846,7 @@ fr: raffiné physiquement, raffinée physiquement, raffinés physiquement, raffi
 it: raffinato fisicamente, raffinata fisicamente, raffinati fisicamente, raffinate fisicamente
 pt: refinado fisicamente, refinada fisicamente, refinados fisicamente, refinadas fisicamente
 
-#en:description:Complete or partial removal of mono- and disaccharides from molasses and other material containing sugar by chemical or physical means
+#description:en: Complete or partial removal of mono- and disaccharides from molasses and other material containing sugar by chemical or physical means
 #en:Desugared, partially desugared
 #fr:Dessucré, partiellement dessucré
 #hr:bez šećera, sa smanjenom količinom šećera
@@ -3019,11 +3019,11 @@ pt: en escabeche, en vinagre, avinagrado, avinagrada
 sv: picklad, inlagd, picklat, picklade, inlagt, inlagda
 wikidata:en: Q1361741
 
-# en:description:Marinated in salt (note different from en:salted)
+#description:en: Marinated in salt (note different from en:salted)
 < en: salted
 en: brined
 de: gepökelt, gepökelte, gepökelter, gepökeltes
-#de:comment:do not add pökel
+#comment:de: do not add pökel
 fr: traité en salaison, traitée en salaison, traités en salaison, traitées en salaison, saumuré, saumurée, saumurés, saumurées
 hr: za salamurenje
 it: salamoia, in salamoia
@@ -3066,13 +3066,13 @@ pl: bez smaku, bez smaku
 pt: sem sabor, sem sabor
 sv: osmakad, osmakat, osmakad
 
-# en:comment:Do NOT add smoke as a process, as this is often a separate ingredient.
+#comment:en: Do NOT add smoke as a process, as this is often a separate ingredient.
 en: smoked
 bg: пушено, пушен, пушена, опушен, опушено, опушена
 ca: fumat, fumada
 da: røget, røgede
 de: geräuchert, geräucherte, geräucherter, geräuchertes, geräucherten, geräuchertem
-#de:comment:Various rauch appear as separate ingredients
+#comment:de: Various rauch appear as separate ingredients
 es: ahumada, ahumado, ahumadas, ahumados
 fi: savustettu, savustetut, savustettua
 fr: fumé, fumés, fumée, fumées
@@ -3346,7 +3346,7 @@ description:en: Breakdown into simpler chemical constituents by appropriate trea
 nova:en: 4
 wikidata:en: Q103135
 
-#en:description:Transformation of unsaturated glycerides into saturated glycerides (of oils and fats)
+#description:en: Transformation of unsaturated glycerides into saturated glycerides (of oils and fats)
 en: hydrogenated, hardened, partially hardened
 bg: хидрогениран, хидрогенирано
 ca: hidrogenat, hidrogenada

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1462,7 +1462,7 @@ tr: Yeşil Nokta
 auth_url:en: https://www.pro-e.org/
 label_categories:en: en:Packaging
 wikidata:en: Q975485
-# en:comment:On packaging, the Green Dot means that for such packaging a financial contribution has been paid to a qualified national packaging recovery organization set up in accordance with the principles defined in European Packaging and Packaging Waste Directive 94/62 and the respective national law.
+#comment:en: On packaging, the Green Dot means that for such packaging a financial contribution has been paid to a qualified national packaging recovery organization set up in accordance with the principles defined in European Packaging and Packaging Waste Directive 94/62 and the respective national law.
 
 fr: Imprim'Vert
 label_categories:en: en:Packaging
@@ -6022,7 +6022,7 @@ label_categories:en: en:Specific diets
 #                   O R G A N I C   S E C T I O N
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-#en:description:Labels used for identifying products (and ingredients) that have been grown organically.
+#description:en: Labels used for identifying products (and ingredients) that have been grown organically.
 
 en: Organic, organically grown, organically produced, ingredient produced organically, from organic farming, From Organic Agriculture, organic ingredients, from controlled organic agriculture, from organic controlled cultivation
 bg: Био, биологично земеделие, биологично

--- a/taxonomies/other_nutritional_substances.txt
+++ b/taxonomies/other_nutritional_substances.txt
@@ -4,10 +4,10 @@
 # list copied from:
 # REGULATION (EU) No 609/2013 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL
 # of 12 June 2013
-# on food intended for infants and young children, food for special medical purposes, 
+# on food intended for infants and young children, food for special medical purposes,
 # and total diet replacement for weight control and repealing Council Directive 92/52/EEC,
 # Commission Directives 96/8/EC, 1999/21/EC, 2006/125/EC and 2006/141/EC,
-# Directive 2009/39/EC of the European Parliament and of the Council and 
+# Directive 2009/39/EC of the European Parliament and of the Council and
 # Commission Regulations (EC) No 41/2009 and (EC) No 953/2009
 # https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32013R0609&from=FR
 

--- a/taxonomies/packaging_shapes.txt
+++ b/taxonomies/packaging_shapes.txt
@@ -1428,7 +1428,7 @@ nl: Spuitbus, spuitbussen
 # image:xx:bonbonne-plastique.svg https://world.openfoodfacts.org/product/3068320125367/bouteille-d-eau-evian-6l
 # image:xx:bonbonne-verre.svg
 # suggest:packaging_materials:en: en:plastic, en:metal, en:glass
-# fr:comment:Un canister est un emballage d'allure cylindrique qui s’ouvre en totalité à une extrémité au moins
+#comment:fr: Un canister est un emballage d'allure cylindrique qui s’ouvre en totalité à une extrémité au moins
 # wikidata:en:Q17175548
 
 en: neck seal

--- a/taxonomies/unused/brands.txt
+++ b/taxonomies/unused/brands.txt
@@ -566,7 +566,7 @@ es: Medina
 #es: Marinas
 #es: Vicente Vidal
 
-#Aquilino Martínez Ramos S.L.U. 
+#Aquilino Martínez Ramos S.L.U.
 #es: Grupo Marfesa
 
 #ARC Eurobanan S.L.
@@ -1074,7 +1074,7 @@ fr: Centrale d'Achat d'Isère (38070)
 #barcodeprefix:en: en:302550
 #barcodeprefix:en: en:350091
 
-#A. Olmedo e Hijos S.L. 
+#A. Olmedo e Hijos S.L.
 #es: La Vicaría
 
 #A Factoría Ecolóxica S.L.
@@ -1084,11 +1084,11 @@ fr: Centrale d'Achat d'Isère (38070)
 #es: Bajamar
 #es: Mamía, Mamia
 
-#Bakery Iberian Investments S.L. 
+#Bakery Iberian Investments S.L.
 < es: Grupo Bimbo
 es: Martínez, Martinez
 
-#Banacol Marketing Belgium besloten vennootschap met beperkte aansprakelijkheid 
+#Banacol Marketing Belgium besloten vennootschap met beperkte aansprakelijkheid
 #es: Banacol
 
 #Bargosa S.A.
@@ -1103,7 +1103,7 @@ es: Martínez, Martinez
 #Baxters Food Group Ltd.
 #es: Baxters
 
-#Bernabé Biosca Alimentación S.A.U. 
+#Bernabé Biosca Alimentación S.A.U.
 #es: El Monaguillo
 
 #Bières de Chimay S.A.
@@ -1118,7 +1118,7 @@ es: Martínez, Martinez
 #es: Silueta
 #es: Silueta Natural 100%
 
-#Biocentury S.L.U. 
+#Biocentury S.L.U.
 #es: Bicentury
 #es: Nackis
 
@@ -1132,7 +1132,7 @@ es: Martínez, Martinez
 #BioGredos S.L.
 #es: BioGredos
 
-#BioMundo S.L. 
+#BioMundo S.L.
 #es: BioMundo
 
 #Bionsan S.C.C.L.
@@ -1154,10 +1154,10 @@ es: Martínez, Martinez
 #es: La Despensa de Bertín, La Despensa de Bertin
 #es: La Huerta de Bertín, La Huerta de Bertin
 
-#Bodegas Martúe La Guardia S.A. 
+#Bodegas Martúe La Guardia S.A.
 #es: Martúe, Martue
 
-#Bodegas Valcarlos S.L. 
+#Bodegas Valcarlos S.L.
 #es: Fortius
 
 #Bolton Cile España S.A.
@@ -1172,7 +1172,7 @@ fr: Bonduelle
 < fr: Bonduelle S.A.S.
 fr: Cassegrain
 
-#Bornay Desserts S.L. 
+#Bornay Desserts S.L.
 #es: Bornay
 #es: La Ibense Bornay
 
@@ -1187,7 +1187,7 @@ es: Hoegaarden
 < es: Carlsberg A/S
 es: Kronenbourg
 
-#Buen Grano S.L. 
+#Buen Grano S.L.
 #es: Palmelita
 
 #Bute Island Foods Ltd.
@@ -1391,8 +1391,8 @@ es: Revilla
 #es: Campomar Nature
 #es: Mas Vell
 
-#Campo de Lorca S.Coop.L. 
-#< es:Grupo Hortiberia S.A. 
+#Campo de Lorca S.Coop.L.
+#< es:Grupo Hortiberia S.A.
 #es: Campo de Lorca
 
 < es: Importaco S.A.
@@ -2263,7 +2263,7 @@ fr: Monop' Daily
 #es: Noglut
 #es: Santiveri
 
-#Casa Westfalia S.A. 
+#Casa Westfalia S.A.
 #es: Casa Westfalia
 
 #Casino Guichard-Perrachon S.A., Groupe Casino
@@ -2368,7 +2368,7 @@ es: Doña Jimena
 < es: Chocolates Eureka S.A.
 es: Atlántic, Atlantic
 
-#Chocolates Lacasa Internacional S.A. 
+#Chocolates Lacasa Internacional S.A.
 < es: Lacasa S.A.
 es: Conguitos
 
@@ -2498,7 +2498,7 @@ es: Condis
 < es: Confectionary Holding S.A.
 es: La Imperial Toledana
 
-#< es:CONFREMAR - Congelados y Frescos del Mar S.A. 
+#< es:CONFREMAR - Congelados y Frescos del Mar S.A.
 #es: Antonio y Ricardo
 #es: Antonio y Ricardo Alimentación de Calidad
 
@@ -2545,7 +2545,7 @@ es: Friscos
 < es: Conservas García S.L.
 es: Conservas García
 
-#Conservas Hijos de Manuel Sánchez Basarte S.A.U., Conservas Hijos de Manuel Sánchez Basarte S.A. 
+#Conservas Hijos de Manuel Sánchez Basarte S.A.U., Conservas Hijos de Manuel Sánchez Basarte S.A.
 #< es:Grupo Riberebro Integral S.L.
 #es: Gvtarra, Gutarra
 
@@ -2580,7 +2580,7 @@ es: Consum
 #Cooperativa do Campo Galego O Val-Narón S.C.G.
 #es: O Val Cooperativa do Campo Galego O Val-Narón, O Val Cooperativa do Campo Galego O Val-Naron
 
-#Cooperativa Hortofrutícola Campos de Jumilla S.Coop.L. 
+#Cooperativa Hortofrutícola Campos de Jumilla S.Coop.L.
 #es: Campos de Jumilla
 
 #Coop. Bio Südtirol
@@ -2600,12 +2600,12 @@ es: Cortyfresh
 < es: Cosanse - Sociedad Cooperativa Agraria San Sebastián
 es: Cosanse
 
-#< es:Costa Concentrados Levantinos S.A. 
+#< es:Costa Concentrados Levantinos S.A.
 #es: Amandín, Amandin
 #es: Costa
 #es: Costa Eco
 
-#< es:Cuevas y Cía S.A. 
+#< es:Cuevas y Cía S.A.
 #es: Cuevas
 #es: Cuevas Chef
 
@@ -2924,7 +2924,7 @@ es: Sannia
 < es: Eroski S. Coop.L. de consumo
 es: SeleQtia
 
-#< es:Escuris S.L. 
+#< es:Escuris S.L.
 #es: Conservas Escuris
 #es: Escuris
 
@@ -3080,7 +3080,7 @@ es: Solrius
 #es: CreamyRisella, Creamy Risella
 #es: MozzaRisella
 
-#< es:Frinsa del Noroeste S.A. 
+#< es:Frinsa del Noroeste S.A.
 #es: Frinsa
 #es: Ribeira
 
@@ -3218,7 +3218,7 @@ es: La Estepeña
 < es: Gamper Exportaciones S.L.
 es: Pergam
 
-#< es:Gedesco S.A. 
+#< es:Gedesco S.A.
 #es: Fresno
 #es: Maheso
 
@@ -4714,8 +4714,8 @@ es: Finca La Nava
 < es: José García Bravo S.L.
 es: José García Bravo
 
-#< es:José Ismael Corbera Ferrandis (Herbes del Molí Coop.V.) 
-#es: Artemis 
+#< es:José Ismael Corbera Ferrandis (Herbes del Molí Coop.V.)
+#es: Artemis
 #es: Herbes del Molí, Herbes del Moli
 
 #< es:José Joaquín Robles Borrego (Mantecados El Patriarca)
@@ -4829,7 +4829,7 @@ es: Sushi Daily
 < en: Kikkoman Corporation
 en: Kikkoman
 
-#< es:Kimbo Snacks S.L. 
+#< es:Kimbo Snacks S.L.
 #es: Kimbo
 #es: Toreras
 
@@ -4959,7 +4959,7 @@ es: NaturGreen
 Laboratorios Brum S.A.
 es: Brum
 
-#Lacasa S.A. 
+#Lacasa S.A.
 #es: Lacasa
 #es: Lacasitos
 #es: La Maison
@@ -5385,7 +5385,7 @@ es: Mahou Sin
 #es: Belsi
 #es: Galletas Ecológicas Belsi, Galletas Ecologicas Belsi
 
-#Manuel Mateo Candel (Manuel Mateo Candel S.L.) 
+#Manuel Mateo Candel (Manuel Mateo Candel S.L.)
 #es: Éxito, Exito
 
 #Marcas Vilop S.L.
@@ -5397,7 +5397,7 @@ es: Mahou Sin
 #María Diet S.L.
 #es: Mandolé, Mandole
 
-#María Yolanda Mateos López 
+#María Yolanda Mateos López
 #es: Frutas Los Galayos
 
 en: Miratorg
@@ -5570,7 +5570,7 @@ es: Musa
 < es: Muñozval S.L.
 es: Muñozval
 
-#Museo del Turrón S.L. 
+#Museo del Turrón S.L.
 #< es:Confectionary Holding S.L.
 #es: El Lobo
 #es: 1880
@@ -5594,7 +5594,7 @@ es: Muñozval
 #es: Botanicum
 
 #Navarro Darder S.L.
-#es: Nayda 
+#es: Nayda
 
 #Nectina S.A.
 #es: Nectina
@@ -5606,7 +5606,7 @@ es: Muñozval
 #es: El Almendro
 #es: Monerris Planelles
 
-#Nudisco S.L. 
+#Nudisco S.L.
 #es: Diamir
 
 < es: Nutrexpa S.L.
@@ -5734,7 +5734,7 @@ es: Delicias de Estepa
 < es: Olmo Mazcuñán S.L.
 es: Olmo Mazcuñán, Olmo Mazcuñan
 
-#< es:Olus Tecnología S.L. 
+#< es:Olus Tecnología S.L.
 #es: Verolus
 #es: Landare
 
@@ -5828,7 +5828,7 @@ es: Patatas Fritas Aitana
 < es: Papes Safor S.L.
 es: R.G. Noguera
 
-#Paramount International IP Holding Company 
+#Paramount International IP Holding Company
 #< es:Paramount Farms International LLC
 #es: Wonderful Pistachios
 #es: Wonderful
@@ -5919,7 +5919,7 @@ wikidata:en: Q938535
 #es: Pescanova
 
 #Pet Inc.
-#< es:General Mills Inc. 
+#< es:General Mills Inc.
 #es: Nachips
 #es: Old El Paso
 
@@ -5983,8 +5983,8 @@ es: Biosol
 < es: ProCeli Turull S.L.
 es: ProCeli
 
-#PROCOMEL - Productores y Comercializadores de Melón S.L. 
-#< es:Grupo Hortiberia S.A. 
+#PROCOMEL - Productores y Comercializadores de Melón S.L.
+#< es:Grupo Hortiberia S.A.
 #es: El Abuelo de los Melones
 #es: Sugar Baby Gold
 
@@ -6013,7 +6013,7 @@ es: Kalpa
 < es: Productos Manzanares S.L.
 es: Manzanares
 
-#< es:Productos Mata S.A. 
+#< es:Productos Mata S.A.
 #es: Hojaldrina
 #es: Mata
 
@@ -6024,7 +6024,7 @@ es: Capell
 #< es:N.V. Pur Natur S.A.
 #es: Pur Natur
 
-#Qbio Productos Orgánicos S.L. 
+#Qbio Productos Orgánicos S.L.
 #< es:Idea Team S.R.L.
 #es: Qbio Cultura de Calidad, Qbio
 
@@ -6164,7 +6164,7 @@ es: Pampero
 #< es:Associated British Foods plc
 #es: Twinings
 
-#es: Sabores de Navarra A.I.E. 
+#es: Sabores de Navarra A.I.E.
 #es: Sabores de Navarra
 
 #es: SADRYM - S.A. De Racionalización y Mecanización
@@ -6177,11 +6177,11 @@ es: Pampero
 #Sagra Investment Iberia S.L.U.
 #es: Zumosol
 
-#< es:Salsas Asturianas S.L. 
+#< es:Salsas Asturianas S.L.
 #es: El Argentino
 #es: Salsas Asturianas
 
-#Salsas de Salteras S.L. 
+#Salsas de Salteras S.L.
 #es: Salsas de Salteras
 
 #Salud e Imaginación S.L.
@@ -6191,12 +6191,12 @@ es: Pampero
 #Salvador Sala Druguet (Vegetalia S.A.)
 #es: Vegetalia
 
-#< es:Sanchis Mira S.A. 
+#< es:Sanchis Mira S.A.
 #es: Antiu Xixona
 #es: La Fama
 #es: Sanchis Mira
 
-#Sanlúcar Brands S.L. 
+#Sanlúcar Brands S.L.
 #< es:Sanlúcar Fruit S.L.
 #es: SunnyBoy
 
@@ -6204,23 +6204,23 @@ es: Pampero
 #< es:Grupo Sanmel
 #es: El Rey de la Vera
 
-#Santa María de La Rábida S.C.A. 
+#Santa María de La Rábida S.C.A.
 #es: Fresón de Palos, Freson de Palos
 
-#Santiago Apóstol de Tomelloso S.Coop.L. 
+#Santiago Apóstol de Tomelloso S.Coop.L.
 #es: Plinio
 
 #San Miguel Fábricas de Cerveza y Malta S.A.
 #< es:Grupo Mahou San Miguel S.A.
 #es: San Miguel
-#es: San Miguel 0.0 
+#es: San Miguel 0.0
 #es: San Miguel 0.0 Limón, San Miguel 0.0 Limon
 #es: San Miguel 0.0 Manzana
 #es: San Miguel 1516
 #es: San Miguel Eco Cerveza
 #es: XV San Miguel Selecta
 
-#Scana Noliko N.V. 
+#Scana Noliko N.V.
 #es: Noliko
 
 #Schweppes International Ltd.
@@ -6262,10 +6262,10 @@ es: Vida
 #es: Segafredo
 #es: Segafredo Zanetti
 
-#Selfoods S.A. 
+#Selfoods S.A.
 #es: Aranca
 
-#SEPROLESA - Selección de Productos Leoneses S.A. 
+#SEPROLESA - Selección de Productos Leoneses S.A.
 #es: La Asturiana
 
 #Sidra Fanjul S.L.
@@ -6422,7 +6422,7 @@ en: Taster's Choice, Tasters Choice
 #< es:Casa Tarradellas S.A.
 #es: Casa Tarradellas
 
-#Sogeproma S.L. 
+#Sogeproma S.L.
 #< es:Conservas Ortiz S.A.
 #es: Conservas Ortiz
 #es: Ortiz
@@ -7220,7 +7220,7 @@ es: Fuente El Pino
 < es: S.A.T. Nº 9213 Hnos. Agudo Contreras
 es: El Melonero
 
-#< es:S.A.T. Nº 9359 Bonnysa 
+#< es:S.A.T. Nº 9359 Bonnysa
 #es: Bonnysa
 #es: Chanita
 
@@ -7272,7 +7272,7 @@ es: Weiss Damm
 es: Xibeca
 
 #S.A. Vichy Catalán
-#< es:Grupo Vichy Catalán S.L. 
+#< es:Grupo Vichy Catalán S.L.
 #es: Lambda
 #es: Vichy Catalán, Vichy Catalan
 

--- a/taxonomies/unused/eu_establishments_sections.txt
+++ b/taxonomies/unused/eu_establishments_sections.txt
@@ -65,7 +65,7 @@ sv: Avsnitt IV — Viltkött
 #it:Carni Di Selvaggina
 #Lt:Laukinių Medžiojamųjų Gyvūnų Mėsa
 #nl:Vlees Van Vrij Wild
-#Pl:Dzikie Ptactwo Łowne, Mięso Zwierząt Łownych	
+#Pl:Dzikie Ptactwo Łowne, Mięso Zwierząt Łownych
 #pt:Carnes De Caça Selvagem
 #Ro:Carne De Vânat Sălbatic
 #Sv:Viltkött


### PR DESCRIPTION
Some contributors get confused by the mix of `description:en:` and `en:description` type description properties. This aims to minimise said confusion as well as otherwise clean up comments a tiny bit.

- Converts all `en:(comment|description)` to `\1:en`.
- Deletes a missed product count line.
  - See https://github.com/openfoodfacts/openfoodfacts-server/pull/14126
- Removes trailing whitespace on comment lines.

Command used:
```sh
find taxonomies/ -type f -iname '*.txt'|xargs perl -pi \
  -e '/\\d+ produits/d;' \
  -e 's/^#\\s*(\\w{2}):(description|comment):\\s*/#\\2:\\1: /;' \
  -e 's/^(#.*?)\\s*$/\\1\\n/;'
```