### PR TITLE
fix: #4431 Filtered taxonomy link to world results loses filter

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4299,6 +4299,9 @@ HTML
 
 		$tag_template_data_ref->{world_link} = $world_link;
 		$tag_template_data_ref->{world_link_url} = get_world_subdomain() . $request_ref->{world_current_link};
+		if (defined $request_ref->{query_parameters}) {
+			$tag_template_data_ref->{world_link_url} .= '?' . $request_ref->{query_parameters};
+		}
 
 	}
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4299,7 +4299,7 @@ HTML
 
 		$tag_template_data_ref->{world_link} = $world_link;
 		$tag_template_data_ref->{world_link_url} = get_world_subdomain() . $request_ref->{world_current_link};
-		if (defined $request_ref->{query_parameters}) {
+		if ($request_ref->{query_parameters}) {
 			$tag_template_data_ref->{world_link_url} .= '?' . $request_ref->{query_parameters};
 		}
 

--- a/templates/web/pages/tag/tag.tt.html
+++ b/templates/web/pages/tag/tag.tt.html
@@ -56,7 +56,7 @@
 
             [% IF country != 'en:world' %]
             <p>[% lang('countries_s').ucfirst %][% sep %]: [% display_taxonomy_tag("countries", country) %]
-                - <a href="[% world_link_url %]">[% world_link %]</a>
+                - <a href="[% world_link_url | html %]">[% world_link %]</a>
             </p>
             [% END %]
 

--- a/tests/integration/facets.t
+++ b/tests/integration/facets.t
@@ -404,6 +404,16 @@ my $tests_ref = [
 		expected_type => 'html',    # the redirect itself is html
 	},
 	{
+		test_case => 'filtered-facets-world-link-keeps-filter',
+		method => 'GET',
+		subdomain => 'uk',
+		path => '/facets/ingredients?filter=bon&status=unknown',
+		expected_status_code => 200,
+		expected_type => 'html',
+		response_content_must_match =>
+			'http:\/\/world\.openfoodfacts\.localhost\/facets\/ingredients\?filter=bon&amp;status=unknown',
+	},
+	{
 		test_case => 'redirect-facets-agg-with-json',
 		method => 'GET',
 		path => '/categories.json',

--- a/tests/integration/facets.t
+++ b/tests/integration/facets.t
@@ -409,7 +409,7 @@ my $tests_ref = [
 		subdomain => 'uk',
 		path => '/facets/ingredients?filter=bon&status=unknown',
 		expected_status_code => 200,
-		expected_type => 'html',
+		expected_type => 'none',
 		response_content_must_match =>
 			'http:\/\/world\.openfoodfacts\.localhost\/facets\/ingredients\?filter=bon&amp;status=unknown',
 	},


### PR DESCRIPTION
<!-- 
⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ There's an agreement by a maintainer or core contributor in the linked issue to assign it to the author of this PR
-->

<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `style`, for Code style changes (formatting, whitespace, etc.)
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
  - `test`, for Adding or updating tests
  - `build`, for Build system or dependency changes
  - `revert`, for Reverting previous changes
  - `l10n`, for Localization and translation updates
  - `taxonomy`, for Changes to product categories and tags taxonomy
-->
<!-- IMPORTANT CHECKLIST: Make sure you've done all the following (You can delete the checklist before submitting)-->
<!-- - [ ] Code is well documented-->
<!-- - [ ] Include unit tests for new functionality-->
<!-- - [ ] Code passes GitHub workflow checks in your branch-->
<!-- - [ ] If you have multiple commits please combine them into one commit by squashing them.-->
<!-- - [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)-->

### What
Add the query parameters to the "View the list for matching products from the entire world" link in e.g. 
https://uk.openfoodfacts.org/facets/ingredients?filter=bon&status=unknown
so instead of linking to
https://world.openfoodfacts.org/facets/ingredients
it links to
https://world.openfoodfacts.org/facets/ingredients?filter=bon&status=unknown

Also add html escaping to the link to protect against XSS.

### Large Language Models usage disclosure
<!-- ⚠️ If you used an LLM, please disclose which LLM you used (and its version) and how (agentic, autocomplete). Please confirm you have run successfully the code on your device. Also provide a screenshot or video as proof -->
VSCode Copilot using GPT-5.3-Codex.

Can't run the integration tests locally because rootless podman can't open port 80 for the frontend container, but github will run the checks anyway.
> Error response from daemon: rootlessport cannot expose privileged port 80, you can add 'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024), or choose a larger port number (>= 1024): listen tcp 127.0.0.1:80: bind: permission denied

### Screenshot or video
<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->
<img width="734" height="389" alt="image" src="https://github.com/user-attachments/assets/aca9511a-cd7f-499a-bc10-4c59afa45008" />

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
<!-- Replace with the appropriate issue number(s) -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #4431 

