### PR TITLE
fix: Hide nutrition section from Open Beauty Facts product edit form

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -1035,6 +1035,10 @@ CSS
 
 	$template_data_ref_display->{nutrition_checked} = $checked;
 
+	# The nutrition feature is computed for the product and not for the site, as the producers
+	# platform can host products of different types
+	$template_data_ref_display->{nutrition_feature_enabled} = feature_enabled("nutrition", $product_ref) ? 1 : 0;
+
 	# For product types for which the nutrition feature is disabled (e.g. beauty products),
 	# the nutrition section is normally hidden in the edit form.
 	# We still display it if the product already has nutrition facts (or the "no nutrition data

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -1034,6 +1034,15 @@ CSS
 	}
 
 	$template_data_ref_display->{nutrition_checked} = $checked;
+
+	# For product types for which the nutrition feature is disabled (e.g. beauty products),
+	# the nutrition section is normally hidden in the edit form.
+	# We still display it if the product already has nutrition facts (or the "no nutrition data
+	# on packaging" checkbox is set), so that contributors can delete them.
+	$template_data_ref_display->{product_has_nutrition_data}
+		= ((has_no_nutrition_data_on_packaging($product_ref)) or (has_non_estimated_nutrition_data($product_ref)))
+		? 1
+		: 0;
 	$template_data_ref_display->{display_tab_ingredients_image}
 		= display_input_tabs($product_ref, "ingredients_image", $product_ref->{sorted_langs},
 		\%Langs, \@ingredients_fields, $request_ref);

--- a/lib/ProductOpener/Nutrition.pm
+++ b/lib/ProductOpener/Nutrition.pm
@@ -89,6 +89,7 @@ use ProductOpener::Units qw/unit_to_kcal unit_to_kj unit_to_g g_to_unit get_stan
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Food qw/:all/;
 use ProductOpener::API qw/add_error add_warning/;
+use ProductOpener::ProductsFeatures qw/feature_enabled/;
 use ProductOpener::NutritionEstimation qw/estimate_nutrients_from_ingredients/;
 
 # FIXME: remove single_param and use request_param
@@ -1471,6 +1472,16 @@ sub assign_nutrition_values_from_request_parameters ($request_ref, $product_ref,
 
 	# We use a temporary input sets hash to ease setting values
 	my $input_sets_hash_ref = get_nutrition_input_sets_in_a_hash($product_ref);
+
+	# Product types for which the nutrition feature is disabled (e.g. beauty products) have no valid
+	# input set (no preparation and no per), so their nutrition facts cannot be edited nutrient by nutrient.
+	# Some of those products still have nutrition data (added before the feature was disabled, or imported):
+	# checking the "no nutrition data" checkbox deletes it, as the product edit API v2 already does.
+	if ((not feature_enabled("nutrition", $product_ref)) and (has_no_nutrition_data_on_packaging($product_ref))) {
+		delete $input_sets_hash_ref->{$source};
+		# The flag itself is not relevant for those products, we only use it as a way to delete the data
+		delete $product_ref->{nutrition}{no_nutrition_data_on_packaging};
+	}
 
 	# Assign all the nutrient values
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -146,6 +146,7 @@ use ProductOpener::Units qw/normalize_product_quantity_and_serving_size/;
 use ProductOpener::Slack qw/send_slack_message/;
 use ProductOpener::Nutrition
 	qw/has_non_estimated_nutrition_data get_nutrition_data_as_key_values_pairs has_no_nutrition_data_on_packaging/;
+use ProductOpener::ProductsFeatures qw/feature_enabled/;
 
 # needed by analyze_and_enrich_product_data()
 # may be moved to another module at some point
@@ -1850,11 +1851,18 @@ sub compute_completeness_and_missing_tags ($product_ref, $current_ref, $previous
 		my $half_step = $step * 0.5;
 		$completeness += $half_step;
 
-		my $image_step = $half_step * (1.0 / 4.0);
+		# Product types for which the nutrition feature is disabled (e.g. beauty products)
+		# do not need a nutrition photo
+		my @image_types = qw(front ingredients nutrition packaging);
+		if (not feature_enabled("nutrition", $product_ref)) {
+			@image_types = grep {$_ ne "nutrition"} @image_types;
+		}
+
+		my $image_step = $half_step * (1.0 / scalar @image_types);
 
 		my $images_completeness = 0;
 
-		foreach my $imagetype (qw(front ingredients nutrition packaging)) {
+		foreach my $imagetype (@image_types) {
 
 			if (defined $current_ref->{selected_images}{$imagetype . "_" . $lc}) {
 				$images_completeness += $image_step;
@@ -1949,14 +1957,18 @@ sub compute_completeness_and_missing_tags ($product_ref, $current_ref, $previous
 		$complete = 0;
 	}
 
-	if ((has_no_nutrition_data_on_packaging($product_ref)) or (has_non_estimated_nutrition_data($product_ref))) {
-		push @states_tags, "en:nutrition-facts-completed";
-		$notempty++;
-		$completeness += $step;
-	}
-	else {
-		push @states_tags, "en:nutrition-facts-to-be-completed";
-		$complete = 0;
+	# Product types for which the nutrition feature is disabled (e.g. beauty products)
+	# do not need nutrition facts
+	if (feature_enabled("nutrition", $product_ref)) {
+		if ((has_no_nutrition_data_on_packaging($product_ref)) or (has_non_estimated_nutrition_data($product_ref))) {
+			push @states_tags, "en:nutrition-facts-completed";
+			$notempty++;
+			$completeness += $step;
+		}
+		else {
+			push @states_tags, "en:nutrition-facts-to-be-completed";
+			$complete = 0;
+		}
 	}
 
 	if ($complete) {

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -173,9 +173,9 @@
             </div>
         </section>
 
-        [%# The nutrition section is displayed when the nutrition feature is enabled for the product,
-            or when the product already has nutrition data (e.g. beauty products with nutrition facts
-            added before the feature was disabled), so that contributors can delete it %]
+[%# The nutrition section is displayed when the nutrition feature is enabled for the product,
+    or when the product already has nutrition data (e.g. beauty products with nutrition facts
+    added before the feature was disabled), so that contributors can delete it -%]
         [% IF nutrition_feature_enabled || product_has_nutrition_data %]<!--nutrient fieldset-->
         <section class="card fieldset" id="nutrition">
             <div class="card-section">

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -41,7 +41,7 @@
                         <ul class="inline-list">
                             <li><a class="nav-link scrollto button small round white-button" href="#product_characteristics"><span>[% lang('product_characteristics') %]</span></a></li>
                             <li><a class="nav-link scrollto button small round white-button" href="#ingredients"><span>[% lang("ingredients") %]</span></a></li>
-                            [% IF feature_enabled("nutrition") || product_has_nutrition_data %]<li><a class="nav-link scrollto button small round white-button" href="#nutrition"><span>[% lang("nutrition") %]</span></a></li>[% END %]
+                            [% IF nutrition_feature_enabled || product_has_nutrition_data %]<li><a class="nav-link scrollto button small round white-button" href="#nutrition"><span>[% lang("nutrition") %]</span></a></li>[% END %]
                             <li><a class="nav-link scrollto button small round white-button" href="#packaging_section"><span>[% lang("packaging") %]</span></a></li>
                         </ul>
                     </nav><!-- .navbar -->
@@ -173,10 +173,10 @@
             </div>
         </section>
 
-        [%# The nutrition section is displayed when the nutrition feature is enabled for the product type,
+        [%# The nutrition section is displayed when the nutrition feature is enabled for the product,
             or when the product already has nutrition data (e.g. beauty products with nutrition facts
             added before the feature was disabled), so that contributors can delete it %]
-        [% IF feature_enabled("nutrition") || product_has_nutrition_data %]<!--nutrient fieldset-->
+        [% IF nutrition_feature_enabled || product_has_nutrition_data %]<!--nutrient fieldset-->
         <section class="card fieldset" id="nutrition">
             <div class="card-section">
                 <legend>[% lang('nutrition_data') %]</legend>

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -41,7 +41,7 @@
                         <ul class="inline-list">
                             <li><a class="nav-link scrollto button small round white-button" href="#product_characteristics"><span>[% lang('product_characteristics') %]</span></a></li>
                             <li><a class="nav-link scrollto button small round white-button" href="#ingredients"><span>[% lang("ingredients") %]</span></a></li>
-                            <li><a class="nav-link scrollto button small round white-button" href="#nutrition"><span>[% lang("nutrition") %]</span></a></li>
+                            [% IF feature_enabled("nutrition") || product_has_nutrition_data %]<li><a class="nav-link scrollto button small round white-button" href="#nutrition"><span>[% lang("nutrition") %]</span></a></li>[% END %]
                             <li><a class="nav-link scrollto button small round white-button" href="#packaging_section"><span>[% lang("packaging") %]</span></a></li>
                         </ul>
                     </nav><!-- .navbar -->
@@ -173,7 +173,10 @@
             </div>
         </section>
 
-        <!--nutrient fieldset-->
+        [%# The nutrition section is displayed when the nutrition feature is enabled for the product type,
+            or when the product already has nutrition data (e.g. beauty products with nutrition facts
+            added before the feature was disabled), so that contributors can delete it %]
+        [% IF feature_enabled("nutrition") || product_has_nutrition_data %]<!--nutrient fieldset-->
         <section class="card fieldset" id="nutrition">
             <div class="card-section">
                 <legend>[% lang('nutrition_data') %]</legend>
@@ -334,7 +337,7 @@
                 </div>
 
             </div>
-    </section><!--nutrient field set-->
+    </section><!--nutrient field set-->[% END %]
 
         <!--packaging field-->
         <section id="packaging_section" class="card fieldset">

--- a/tests/unit/expected_test_results/products/compute_completeness_and_missing_tags_beauty.json
+++ b/tests/unit/expected_test_results/products/compute_completeness_and_missing_tags_beauty.json
@@ -1,0 +1,48 @@
+{
+   "brands" : "Test brand",
+   "brands_tags" : [
+      "xx:test-brand"
+   ],
+   "categories_tags" : [
+      "en:shampoos"
+   ],
+   "complete" : 1,
+   "completed_t" : 0.0,
+   "completeness" : 1,
+   "emb_codes" : "EMB 12345",
+   "expiration_date" : "01/2030",
+   "ingredients_text" : "Aqua, Sodium Laureth Sulfate",
+   "lang" : "en",
+   "lc" : "en",
+   "origins" : "France",
+   "origins_tags" : [
+      "en:france"
+   ],
+   "packaging" : "Bottle",
+   "packaging_tags" : [
+      "en:bottle"
+   ],
+   "product_name" : "Test shampoo",
+   "product_type" : "beauty",
+   "quantity" : "250 ml",
+   "states" : "en:to-be-checked, en:complete, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-completed, en:origins-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:packaging-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+   "states_tags" : [
+      "en:to-be-checked",
+      "en:complete",
+      "en:ingredients-completed",
+      "en:expiration-date-completed",
+      "en:packaging-code-completed",
+      "en:characteristics-completed",
+      "en:origins-completed",
+      "en:categories-completed",
+      "en:brands-completed",
+      "en:packaging-completed",
+      "en:quantity-completed",
+      "en:product-name-completed",
+      "en:photos-validated",
+      "en:packaging-photo-selected",
+      "en:ingredients-photo-selected",
+      "en:front-photo-selected",
+      "en:photos-uploaded"
+   ]
+}

--- a/tests/unit/nutrition.t
+++ b/tests/unit/nutrition.t
@@ -2135,4 +2135,47 @@ compare_to_expected_results(
 		"prepared", "sort_sets_by_priority: prepared (priority 0) sorts before as_sold (priority 1)");
 }
 
+# Test the "no nutrition data" checkbox of the product edit form.
+# Product types for which the nutrition feature is disabled (e.g. beauty products) have no valid
+# input set: their nutrition data cannot be edited nutrient by nutrient, and checking the box
+# is the only way to delete data they may still have.
+{
+	my $product_with_nutrition_data = sub {
+		my ($product_type) = @_;
+		return {
+			product_type => $product_type,
+			nutrition => {
+				input_sets => [
+					{
+						source => "packaging",
+						preparation => "as_sold",
+						per => "100g",
+						nutrients => {fat => {value_string => "12", value => 12, unit => "g"}},
+					}
+				]
+			}
+		};
+	};
+
+	my $request_ref = {body_json => {no_nutrition_data => "on"}};
+
+	my $beauty_product_ref = $product_with_nutrition_data->("beauty");
+	assign_nutrition_values_from_request_parameters($request_ref, $beauty_product_ref, "off_europe", "packaging");
+	is($beauty_product_ref->{nutrition}{input_sets},
+		[], "no nutrition data checkbox: the nutrition data of beauty products is deleted");
+	ok(
+		!exists $beauty_product_ref->{nutrition}{no_nutrition_data_on_packaging},
+		"no nutrition data checkbox: the flag is not kept for beauty products"
+	);
+
+	my $food_product_ref = $product_with_nutrition_data->("food");
+	assign_nutrition_values_from_request_parameters($request_ref, $food_product_ref, "off_europe", "packaging");
+	is(scalar @{$food_product_ref->{nutrition}{input_sets}},
+		1, "no nutrition data checkbox: the nutrition data of food products is kept");
+	ok(
+		$food_product_ref->{nutrition}{no_nutrition_data_on_packaging},
+		"no nutrition data checkbox: the flag is set for food products"
+	);
+}
+
 done_testing();

--- a/tests/unit/product_edit_form.t
+++ b/tests/unit/product_edit_form.t
@@ -24,21 +24,22 @@ use ProductOpener::PerlStandards;
 
 use Test2::V0;
 
-use ProductOpener::Config qw/%options/;
 use ProductOpener::Display qw/process_template/;
 
-# The nutrition section of the product edit form is displayed only for product types
-# for which the nutrition feature is enabled (e.g. food products), or for products that
-# already have nutrition data, so that contributors can delete it.
+# The nutrition section of the product edit form is displayed only for products for which
+# the nutrition feature is enabled (e.g. food products), or for products that already have
+# nutrition data, so that contributors can delete it.
+# Both flags are computed for the product (and not for the site) in cgi/product_multilingual.pl,
+# as the producers platform can host products of different types.
 
-sub render_product_edit_form ($product_type, $product_has_nutrition_data = 0) {
-	local $options{product_type} = $product_type;
+sub render_product_edit_form ($nutrition_feature_enabled, $product_has_nutrition_data = 0) {
 
 	my $html = '';
 	my $template_data_ref = {
 		errors_index => -1,
 		input_sets => {},
 		pers => [],
+		nutrition_feature_enabled => $nutrition_feature_enabled,
 		product_has_nutrition_data => $product_has_nutrition_data,
 	};
 	my $request_ref = {lc => 'en'};
@@ -48,21 +49,24 @@ sub render_product_edit_form ($product_type, $product_has_nutrition_data = 0) {
 			'web/pages/product_edit/product_edit_form_display.tt.html',
 			$template_data_ref, \$html, $request_ref
 		),
-		"render the product edit form for $product_type products"
+		"render the product edit form (nutrition feature: $nutrition_feature_enabled, "
+			. "product has nutrition data: $product_has_nutrition_data)"
 	);
 
 	return $html;
 }
 
-my $food_form = render_product_edit_form('food');
+# Products with the nutrition feature (e.g. food products)
+my $food_form = render_product_edit_form(1);
 like($food_form, qr{href="#nutrition"}, 'food edit form includes the nutrition navigation link');
 like($food_form, qr{<section class="card fieldset" id="nutrition">}, 'food edit form includes the nutrition section');
 
-my $beauty_form = render_product_edit_form('beauty');
+# Products without the nutrition feature (e.g. beauty products)
+my $beauty_form = render_product_edit_form(0);
 unlike($beauty_form, qr{href="#nutrition"}, 'beauty edit form excludes the nutrition navigation link');
 unlike($beauty_form, qr{id="nutrition"}, 'beauty edit form excludes the nutrition section');
 
-my $beauty_form_with_nutrition_data = render_product_edit_form('beauty', 1);
+my $beauty_form_with_nutrition_data = render_product_edit_form(0, 1);
 like($beauty_form_with_nutrition_data,
 	qr{href="#nutrition"},
 	'beauty edit form includes the nutrition navigation link when the product has nutrition data');

--- a/tests/unit/product_edit_form.t
+++ b/tests/unit/product_edit_form.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2026 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Product Opener is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Product Opener. If not, see <https://www.gnu.org/licenses/>.
+
+use ProductOpener::PerlStandards;
+
+use Test2::V0;
+
+use ProductOpener::Config qw/%options/;
+use ProductOpener::Display qw/process_template/;
+
+# The nutrition section of the product edit form is displayed only for product types
+# for which the nutrition feature is enabled (e.g. food products), or for products that
+# already have nutrition data, so that contributors can delete it.
+
+sub render_product_edit_form ($product_type, $product_has_nutrition_data = 0) {
+	local $options{product_type} = $product_type;
+
+	my $html = '';
+	my $template_data_ref = {
+		errors_index => -1,
+		input_sets => {},
+		pers => [],
+		product_has_nutrition_data => $product_has_nutrition_data,
+	};
+	my $request_ref = {lc => 'en'};
+
+	ok(
+		process_template(
+			'web/pages/product_edit/product_edit_form_display.tt.html',
+			$template_data_ref, \$html, $request_ref
+		),
+		"render the product edit form for $product_type products"
+	);
+
+	return $html;
+}
+
+my $food_form = render_product_edit_form('food');
+like($food_form, qr{href="#nutrition"}, 'food edit form includes the nutrition navigation link');
+like($food_form, qr{<section class="card fieldset" id="nutrition">}, 'food edit form includes the nutrition section');
+
+my $beauty_form = render_product_edit_form('beauty');
+unlike($beauty_form, qr{href="#nutrition"}, 'beauty edit form excludes the nutrition navigation link');
+unlike($beauty_form, qr{id="nutrition"}, 'beauty edit form excludes the nutrition section');
+
+my $beauty_form_with_nutrition_data = render_product_edit_form('beauty', 1);
+like($beauty_form_with_nutrition_data,
+	qr{href="#nutrition"},
+	'beauty edit form includes the nutrition navigation link when the product has nutrition data');
+like(
+	$beauty_form_with_nutrition_data,
+	qr{<section class="card fieldset" id="nutrition">},
+	'beauty edit form includes the nutrition section when the product has nutrition data'
+);
+# The "no nutrition data" checkbox is the only way to delete the data of those products
+like($beauty_form_with_nutrition_data,
+	qr{name="no_nutrition_data"},
+	'beauty edit form includes the no nutrition data checkbox when the product has nutrition data');
+
+done_testing();

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -354,18 +354,50 @@ my @tests = (
 			categories_tags => ['en:beverages', 'en:carbonated-drinks'],
 		},
 	],
+	[
+		# Product types for which the nutrition feature is disabled (e.g. beauty products) must not
+		# have the en:nutrition-photo-to-be-selected and en:nutrition-facts-to-be-completed states,
+		# otherwise they could never be complete.
+		'compute_completeness_and_missing_tags_beauty',
+		{
+			product_type => 'beauty',
+			brands => 'Test brand',
+			brands_tags => ['xx:test-brand'],
+			product_name => 'Test shampoo',
+			quantity => '250 ml',
+			packaging => 'Bottle',
+			packaging_tags => ['en:bottle'],
+			categories_tags => ['en:shampoos'],
+			origins => 'France',
+			origins_tags => ['en:france'],
+			emb_codes => 'EMB 12345',
+			expiration_date => '01/2030',
+			ingredients_text => 'Aqua, Sodium Laureth Sulfate',
+		},
+		# The product has all the photos it needs: front, ingredients and packaging, but no nutrition photo
+		{
+			uploaded_images => {1 => 1},
+			selected_images => {front_en => 1, ingredients_en => 1, packaging_en => 1},
+		},
+	],
 );
 
 foreach my $test_ref (@tests) {
 
 	my $testid = $test_ref->[0];
 	my $product_ref = $test_ref->[1];
+	my $current_ref = $test_ref->[2] // {};
 
 	# Run the test
 
-	compute_completeness_and_missing_tags($product_ref, {}, {});
+	compute_completeness_and_missing_tags($product_ref, $current_ref, {});
 
 	compare_to_expected_results($product_ref, "$expected_result_dir/$testid.json", $update_expected_results);
 }
+
+# Check explicitly the states of the beauty product, as they are the point of the test above
+my $beauty_product_ref = $tests[1][1];
+is([grep {/^en:nutrition/} @{$beauty_product_ref->{states_tags}}], [], 'beauty products do not have nutrition states');
+is($beauty_product_ref->{complete}, 1, 'beauty products can be complete without nutrition facts and photo');
 
 done_testing();


### PR DESCRIPTION
- Fixes #11226

### What

- Prevent the nutrition facts section from being rendered on Open Beauty Facts product edit forms (unless nutrition facts have already been added, when transferred from OFF for example)
- Remove the "Nutrition facts to be completed", "Nutrition photo to be selected" tag for OBF
- Photos to be validated mustn't require nutrition photo
- Keep the nutrition section unchanged for Open Food Facts.
- Add unit tests covering both the food and beauty flavors.

I successfully ran:
- `make test-unit test=product_edit_form.t`
- `make checks`