### PR TITLE
fix: #1587 week and month name double utf8 encoding

### DIFF
--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -479,7 +479,7 @@ sub build_lang ($Languages_ref) {
 				DateTime->new(year => 2000, time_zone => 'UTC', month => $month, locale => $locale)->month_name;
 		}
 
-		$Lang{months}{$l} = encode_json(\@months);
+		$Lang{months}{$l} = decode("utf8", encode_json(\@months));
 
 		my @weekdays = ();
 		foreach my $weekday (0 .. 6) {
@@ -488,7 +488,7 @@ sub build_lang ($Languages_ref) {
 				->day_name;
 		}
 
-		$Lang{weekdays}{$l} = encode_json(\@weekdays);
+		$Lang{weekdays}{$l} = decode("utf8", encode_json(\@weekdays));
 	}
 
 	return;

--- a/tests/unit/lang.t
+++ b/tests/unit/lang.t
@@ -82,11 +82,13 @@ is($Lang{weekdays}{en}, "[\"Sunday\",\"Monday\",\"Tuesday\",\"Wednesday\",\"Thur
 # qr/février/ contains U+00E9 (one code point).  A byte string stores "é" as the
 # two-byte UTF-8 sequence \xc3\xa9, which does NOT match U+00E9, so the like()
 # below would fail if encode_json() were used without the subsequent decode().
-like($Lang{months}{fr}, qr/février/, 'French months contain février as a Unicode character string (not double-encoded bytes)');
+like($Lang{months}{fr}, qr/février/,
+	'French months contain février as a Unicode character string (not double-encoded bytes)');
 
 # Russian weekdays are Cyrillic; any match on a Cyrillic letter confirms the value
 # is a character string and not raw UTF-8 bytes.
-like($Lang{weekdays}{ru}, qr/\x{43f}\x{43e}\x{43d}/, 'Russian weekdays contain Cyrillic as Unicode code points (not double-encoded bytes)');
+like($Lang{weekdays}{ru}, qr/\x{43f}\x{43e}\x{43d}/,
+	'Russian weekdays contain Cyrillic as Unicode code points (not double-encoded bytes)');
 
 # https://github.com/openfoodfacts/openfoodfacts-server/issues/1116
 sub test_logo_exists {

--- a/tests/unit/lang.t
+++ b/tests/unit/lang.t
@@ -88,8 +88,7 @@ like($Lang{months}{fr}, qr/février/,
 # Russian weekdays are Cyrillic; any match on a Cyrillic letter confirms the value
 # is a character string and not raw UTF-8 bytes.
 like($Lang{weekdays}{ru},
-	qr/\x{43f}\x{43e}\x{43d}/,
-	'Russian weekdays contain Cyrillic as Unicode code points (not double-encoded bytes)');
+	qr/\x{43f}\x{43e}\x{43d}/, 'Russian weekdays contain Cyrillic as Unicode code points (not double-encoded bytes)');
 
 # https://github.com/openfoodfacts/openfoodfacts-server/issues/1116
 sub test_logo_exists {

--- a/tests/unit/lang.t
+++ b/tests/unit/lang.t
@@ -87,7 +87,8 @@ like($Lang{months}{fr}, qr/février/,
 
 # Russian weekdays are Cyrillic; any match on a Cyrillic letter confirms the value
 # is a character string and not raw UTF-8 bytes.
-like($Lang{weekdays}{ru}, qr/\x{43f}\x{43e}\x{43d}/,
+like($Lang{weekdays}{ru},
+	qr/\x{43f}\x{43e}\x{43d}/,
 	'Russian weekdays contain Cyrillic as Unicode code points (not double-encoded bytes)');
 
 # https://github.com/openfoodfacts/openfoodfacts-server/issues/1116

--- a/tests/unit/lang.t
+++ b/tests/unit/lang.t
@@ -72,6 +72,22 @@ is($Lang{months}{en},
 );
 is($Lang{weekdays}{en}, "[\"Sunday\",\"Monday\",\"Tuesday\",\"Wednesday\",\"Thursday\",\"Friday\",\"Saturday\"]");
 
+# Regression tests: months/weekdays for non-ASCII languages must be Perl character
+# strings, not UTF-8 byte strings.  When a byte string is later interpolated into
+# a heredoc and written through a ">:encoding(UTF-8)" filehandle (as done in
+# gen_top_tags_per_country.pl), Perl double-encodes the bytes, producing mojibake
+# in the Highcharts tooltip labels (e.g. "DÃ©ardaoin" instead of "Déardaoin").
+#
+# With "use utf8" active, regex literals are compiled with Unicode code points.
+# qr/février/ contains U+00E9 (one code point).  A byte string stores "é" as the
+# two-byte UTF-8 sequence \xc3\xa9, which does NOT match U+00E9, so the like()
+# below would fail if encode_json() were used without the subsequent decode().
+like($Lang{months}{fr}, qr/février/, 'French months contain février as a Unicode character string (not double-encoded bytes)');
+
+# Russian weekdays are Cyrillic; any match on a Cyrillic letter confirms the value
+# is a character string and not raw UTF-8 bytes.
+like($Lang{weekdays}{ru}, qr/\x{43f}\x{43e}\x{43d}/, 'Russian weekdays contain Cyrillic as Unicode code points (not double-encoded bytes)');
+
 # https://github.com/openfoodfacts/openfoodfacts-server/issues/1116
 sub test_logo_exists {
 	my $logo = shift;


### PR DESCRIPTION
<!-- 
⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ There's an agreement by a maintainer or core contributor in the linked issue to assign it to the author of this PR
-->

<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `style`, for Code style changes (formatting, whitespace, etc.)
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
  - `test`, for Adding or updating tests
  - `build`, for Build system or dependency changes
  - `revert`, for Reverting previous changes
  - `l10n`, for Localization and translation updates
  - `taxonomy`, for Changes to product categories and tags taxonomy
-->
<!-- IMPORTANT CHECKLIST: Make sure you've done all the following (You can delete the checklist before submitting)-->
<!-- - [ ] Code is well documented-->
<!-- - [ ] Include unit tests for new functionality-->
<!-- - [ ] Code passes GitHub workflow checks in your branch-->
<!-- - [ ] If you have multiple commits please combine them into one commit by squashing them.-->
<!-- - [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)-->

### What
The product count weekday names were being double-utf8-encoded.

https://ie-ga.openfoodfacts.org/product-count
https://ru.openfoodfacts.org/product-count
https://jp.openfoodfacts.org/product-count


### Large Language Models usage disclosure
<!-- ⚠️ If you used an LLM, please disclose which LLM you used (and its version) and how (agentic, autocomplete). Please confirm you have run successfully the code on your device. Also provide a screenshot or video as proof -->
VSCode Copilot using Claude Sonnet 4.6.
Before running `make build_lang_test`, the new tests in `make test-unit test=lang.t` fail. Afterwards, they pass.


### Screenshot or video
<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->
<img width="395" height="165" alt="image" src="https://github.com/user-attachments/assets/434778e0-f849-4ae9-a2d4-808805e54ff2" />
<img width="326" height="155" alt="image" src="https://github.com/user-attachments/assets/06c13958-a8a1-4cb6-917b-61b7149cf9a8" />


<img width="767" height="621" alt="image" src="https://github.com/user-attachments/assets/8cc56e33-f834-4e1f-867c-efb05aeb9e87" />
<img width="593" height="127" alt="image" src="https://github.com/user-attachments/assets/25dc489f-03b5-427e-a488-a925b3ad4cfc" />


### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
<!-- Replace with the appropriate issue number(s) -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #1587 
