### PR TITLE
fix(beauty categories): duplicate synonyms, missing en: names and fr translations

### DIFF
--- a/.test_groups_cache/unit_groups.json
+++ b/.test_groups_cache/unit_groups.json
@@ -14,8 +14,8 @@
       "tests/unit/packaging_food_contact.t",
       "tests/unit/product_schema_changes.t",
       "tests/unit/reuse_knowledge_panels.t",
-      "tests/unit/tags_unit.t",
-      "tests/unit/text.t"
+      "tests/unit/tags.t",
+      "tests/unit/test.t"
     ],
     "total_time": 450.0
   },
@@ -34,8 +34,8 @@
       "tests/unit/packaging_stats.t",
       "tests/unit/products.t",
       "tests/unit/routing.t",
-      "tests/unit/taxonomies.t",
-      "tests/unit/texts.t"
+      "tests/unit/tags_unit.t",
+      "tests/unit/text.t"
     ],
     "total_time": 450.0
   },
@@ -54,8 +54,8 @@
       "tests/unit/parse_origins_from_text.t",
       "tests/unit/products_comparison.t",
       "tests/unit/send_image_to_cloud_vision.t",
-      "tests/unit/taxonomies_enhancer.t",
-      "tests/unit/units.t"
+      "tests/unit/taxonomies.t",
+      "tests/unit/texts.t"
     ],
     "total_time": 450.0
   },
@@ -74,8 +74,8 @@
       "tests/unit/paths.t",
       "tests/unit/products_tags.t",
       "tests/unit/spam_user.t",
-      "tests/unit/taxonomy_suggestions.t",
-      "tests/unit/vitamins.t"
+      "tests/unit/taxonomies_enhancer.t",
+      "tests/unit/units.t"
     ],
     "total_time": 450.0
   },
@@ -93,10 +93,11 @@
       "tests/unit/packager_codes.t",
       "tests/unit/process_product_edit_rules.t",
       "tests/unit/recipes.t",
-      "tests/unit/store.t",
-      "tests/unit/templates.t"
+      "tests/unit/storage_conditions.t",
+      "tests/unit/taxonomy_suggestions.t",
+      "tests/unit/vitamins.t"
     ],
-    "total_time": 420.0
+    "total_time": 450.0
   },
   {
     "tests": [
@@ -112,8 +113,8 @@
       "tests/unit/packaging.t",
       "tests/unit/producers.t",
       "tests/unit/redis.t",
-      "tests/unit/tags.t",
-      "tests/unit/test.t"
+      "tests/unit/store.t",
+      "tests/unit/templates.t"
     ],
     "total_time": 420.0
   }

--- a/.test_groups_cache/unit_groups.mk
+++ b/.test_groups_cache/unit_groups.mk
@@ -1,8 +1,17 @@
-# Auto-calculated 6 groups for 88 tests (total estimated time: 44m)
+# Auto-calculated 6 groups for 89 tests (total estimated time: 44m)
 # Generated test groups for unit tests
-UNIT_GROUP_1_TESTS := additives.t api.t cache_safe_cache_ops.t dataqualitydimensions.t food.t images.t ingredients_clean.t ingredients_percent.t load_csv_or_excel_file.t nutriscore.t packaging_food_contact.t product_schema_changes.t reuse_knowledge_panels.t tags_unit.t text.t
-UNIT_GROUP_2_TESTS := additives_tags.t attributes.t contribution_knowledge_panels.t dataqualityfood.t food_groups.t import.t ingredients_contents.t ingredients_preparsing.t maintain_knowledge_panels.t nutrition.t packaging_stats.t products.t routing.t taxonomies.t texts.t
-UNIT_GROUP_3_TESTS := all_pod_correct.t auth_oidc_cache.t convert_gs1_xml_to_json.t dataqualityfood_labels.t forest_footprint.t import_convert_carrefour_france.t ingredients_extract.t ingredients_processing.t match_ingredient_origin.t nutrition_ciqual.t parse_origins_from_text.t products_comparison.t send_image_to_cloud_vision.t taxonomies_enhancer.t units.t
-UNIT_GROUP_4_TESTS := allergens.t auth_oidc_state_validation.t cursor.t display.t forest_footprint_2026.t import_gs1.t ingredients_nesting.t ingredients_tags.t nova.t nutrition_estimation.t paths.t products_tags.t spam_user.t taxonomy_suggestions.t vitamins.t
-UNIT_GROUP_5_TESTS := allergens_tags.t booleans.t data_quality_tags_panel.t environmental_impact.t health.t ingredients.t ingredients_nutriscore.t knowledge_panels.t numbers.t packager_codes.t process_product_edit_rules.t recipes.t store.t templates.t
-UNIT_GROUP_6_TESTS := analyze_and_enrich_product_data.t brevo.t dataquality.t environmental_score.t i18n.t ingredients_analysis.t ingredients_parsing_todo.t lang.t nutrient_levels.t packaging.t producers.t redis.t tags.t test.t
+UNIT_GROUP_1_TESTS := additives.t api.t cache_safe_cache_ops.t dataqualitydimensions.t food.t images.t ingredients_clean.t ingredients_percent.t load_csv_or_excel_file.t nutriscore.t packaging_food_contact.t product_schema_changes.t reuse_knowledge_panels.t tags.t test.t
+UNIT_GROUP_2_TESTS := additives_tags.t attributes.t contribution_knowledge_panels.t dataqualityfood.t food_groups.t import.t ingredients_contents.t ingredients_preparsing.t maintain_knowledge_panels.t nutrition.t packaging_stats.t products.t routing.t tags_unit.t text.t
+UNIT_GROUP_3_TESTS := all_pod_correct.t auth_oidc_cache.t convert_gs1_xml_to_json.t dataqualityfood_labels.t forest_footprint.t import_convert_carrefour_france.t ingredients_extract.t ingredients_processing.t match_ingredient_origin.t nutrition_ciqual.t parse_origins_from_text.t products_comparison.t send_image_to_cloud_vision.t taxonomies.t texts.t
+UNIT_GROUP_4_TESTS := allergens.t auth_oidc_state_validation.t cursor.t display.t forest_footprint_2026.t import_gs1.t ingredients_nesting.t ingredients_tags.t nova.t nutrition_estimation.t paths.t products_tags.t spam_user.t taxonomies_enhancer.t units.t
+UNIT_GROUP_5_TESTS := allergens_tags.t booleans.t data_quality_tags_panel.t environmental_impact.t health.t ingredients.t ingredients_nutriscore.t knowledge_panels.t numbers.t packager_codes.t process_product_edit_rules.t recipes.t storage_conditions.t taxonomy_suggestions.t vitamins.t
+UNIT_GROUP_6_TESTS := analyze_and_enrich_product_data.t brevo.t dataquality.t environmental_score.t i18n.t ingredients_analysis.t ingredients_parsing_todo.t lang.t nutrient_levels.t packaging.t producers.t redis.t store.t templates.t
+
+# Group Statistics:
+# Group 1: 15 tests, 7m 30s
+# Group 2: 15 tests, 7m 30s
+# Group 3: 15 tests, 7m 30s
+# Group 4: 15 tests, 7m 30s
+# Group 5: 15 tests, 7m 30s
+# Group 6: 14 tests, 7m 0s
+# Max group time: 8m, Min: 7m, Avg: 7m

--- a/taxonomies/beauty/categories.txt
+++ b/taxonomies/beauty/categories.txt
@@ -510,10 +510,12 @@ wikidata:en: Q34396
 
 < en: Soaps
 en: Scented soaps
+fr: Savons parfumés, Savon parfumé
 incompatible_with:en: categories:en:unscented-soaps
 
 < en: Soaps
 en: Unscented soaps
+fr: Savons non parfumés, Savon non parfumé, Savons sans parfum
 incompatible_with:en: categories:en:scented-soaps
 
 < en: Soaps
@@ -629,6 +631,7 @@ wikidata:en: Q97925317
 
 < en: Soaps
 en: Bar soaps
+fr: Savons solides, Savon solide, Pains de savon, Pain de savon
 google_product_taxonomy_id:en: 2503
 incompatible_with:en: categories:en:liquid-soaps
 wikidata:en: Q27883554
@@ -636,6 +639,7 @@ wikidata:en: Q27883554
 < en: Bar soaps
 < en: Scented soaps
 en: Scented bar soaps
+fr: Savons solides parfumés, Savon solide parfumé
 
 < en: Hygiene
 en: Hydro-alcoholic gels, alcohol-based gels
@@ -1608,10 +1612,12 @@ wikidata:en: Q47471797
 
 < en: Depilatory wax
 en: Cold depilatory wax
+fr: Cire épilatoire à froid
 wikidata:en: Q47471806
 
 < en: Depilatory wax
 en: Face depilatory wax
+fr: Cire épilatoire visage
 
 #### Rasage
 
@@ -2291,6 +2297,7 @@ fr: Huile de massage comestible
 
 < en: Body
 en: Body gels
+fr: Gels pour le corps, Gel pour le corps, Gels corporels
 
 < en: Body gels
 en: Slimming gels, Anti-cellulite gels
@@ -5053,6 +5060,7 @@ zh: 化妆品
 
 en: Eyes
 da: Øjne
+fr: Yeux
 sv: Ögon
 
 #### Maquillage pour les yeux
@@ -5294,11 +5302,13 @@ zh: 煤精铅笔
 < en: Eyes
 en: Eyewash
 da: Øjenskyl
+fr: Solutions de lavage oculaire, Bains oculaires
 sv: Ögonskölj
 
 < en: Eyes
 en: Eye drops
 da: Øjendråber
+fr: Collyres, Collyre, Gouttes pour les yeux
 sv: Ögondroppar
 wikidata:xx: Q552308
 
@@ -6097,10 +6107,12 @@ wikidata:en: Q827658
 < en: Lip balms
 < en: Sunscreen
 en: Lip balms with sun protection
+fr: Baumes à lèvres solaires, Baume à lèvres solaire
 
 < en: Facial creams
 < en: Sunscreen
 en: Facial sunscreens, Face sunscreens
+fr: Solaires visage, Solaire visage, Crèmes solaires visage
 sv: Ansiktssolkrämer
 
 < en: Suncare
@@ -7146,16 +7158,19 @@ zh: 婴儿湿巾
 en: Cotton buds, Cotton swabs
 da: Vatpinde
 de: Wattestäbchen
+fr: Cotons-tiges, Coton-tige, Bâtonnets ouatés
 nb: Bomullspinner
 sv: Bomullspinnar
 google_product_taxonomy_id:en: 2934
 wikidata:en: Q12201
 
 en: Petroleum jellies, Vaseline
+fr: Vaselines, Vaseline
 sv: Petroleumgeléer, Vaselin
 google_product_taxonomy_id:en: 6753
 wikidata:en: Q457239
 
 en: Halloween cosmetics, Halloween makeup, Halloween products, Halloween supplies
+fr: Maquillage d'Halloween, Cosmétiques d'Halloween
 xx: Halloween-makeup
 

--- a/taxonomies/beauty/categories.txt
+++ b/taxonomies/beauty/categories.txt
@@ -2593,7 +2593,7 @@ es: Cremas de día y de noche
 et: Päeva- ja öökreemid
 fa: کرم های روز و شب
 fi: Päivä- ja yövoiteet
-fr: Crèmes jour et nuit, Crèmes jour et nuit, Soin jour et nuit
+fr: Crèmes jour et nuit, Crème jour et nuit, Soin jour et nuit
 ga: Uachtair lae agus oíche
 he: קרמי יום ולילה
 hr: Dnevne i noćne kreme
@@ -2637,7 +2637,7 @@ zh: 日霜和晚霜
 
 < en: Facial creams
 en: Anti-aging face care products
-fr: Soins anti-âge visage, Crête anti-âge visage
+fr: Soins anti-âge visage, Soin anti-âge visage, Crème anti-âge visage
 
 < en: Anti-aging face care products
 en: Anti-wrinkles creams
@@ -2854,7 +2854,7 @@ nl: Reinigers, make-up removers
 no: Rensemidler, sminkefjernere
 pl: Oczyszczacze, zmywacze do makijażu
 pt: Produtos de limpeza, removedores de maquiagem
-ro: Demachiante, demachiante
+ro: Demachiante
 ru: Очищающие средства, средства для снятия макияжа
 sk: Čistiace prostriedky, odličovače
 sl: Čistila, odstranjevalci ličil
@@ -6023,7 +6023,7 @@ es: Protector solar
 et: Päikesekaitsekreem
 fa: کرم ضد آفتاب
 fi: Aurinkovoide
-fr: Crèmes solaire, crème solaire
+fr: Crèmes solaires, crème solaire, Écrans solaires, Écran solaire
 ga: Grianchosaint
 he: קרם הגנה
 hr: Krema za sunčanje
@@ -6359,7 +6359,7 @@ es: Perfumes de mujer
 et: Naiste parfüümid
 fa: عطر زنانه
 fi: Naisten parfyymit
-fr: Parfums femme, Parfum femmes, Parfum femme, Parfum femmes
+fr: Parfums femme, Parfums femmes, Parfum femme, Parfum femmes
 ga: Cumhráin ban
 hr: Ženski parfemi
 hu: Női parfümök
@@ -6411,7 +6411,7 @@ es: Perfumes para niños
 et: Lasteparfüümid
 fa: عطر کودکانه
 fi: Lasten hajuvedet
-fr: Parfums enfants, Parfum enfants, Parfum enfant, Parfum enfant
+fr: Parfums enfants, Parfums enfant, Parfum enfants, Parfum enfant
 ga: Cumhráin páistí
 hr: Dječji parfemi
 hu: Gyerekparfümök
@@ -6983,7 +6983,7 @@ mk: Лубрикантни гелови, лубриканти
 ms: Gel pelincir, pelincir
 mt: Ġellijiet lubrifikanti, lubrifikanti
 nb: Glidemidler, Smøremidler, smøregeler
-nl: Glijmiddelen, glijmiddelen
+nl: Glijmiddelen
 pl: Żele intymne, Żele nawilżające, lubrykanty
 pt: Lubrificantes pessoais, Géis lubrificantes, lubrificantes
 ro: Geluri lubrifiante, lubrifianți
@@ -7072,7 +7072,7 @@ es: Toallitas húmedas para bebés
 et: Niisked salvrätikud beebidele
 fa: دستمال مرطوب کودک
 fi: Vauvojen kosteuspyyhkeet
-fr: Lingettes pour bébé, Lingettes bébé, Lingettes bébés, Lingette bébés, Lingette bébés
+fr: Lingettes pour bébé, Lingettes bébé, Lingettes bébés, Lingette bébé
 ga: Tuáillíní fliucha do leanaí
 he: מגבונים לחים לתינוקות
 hr: Vlažne maramice za bebe

--- a/taxonomies/beauty/categories.txt
+++ b/taxonomies/beauty/categories.txt
@@ -7171,6 +7171,6 @@ google_product_taxonomy_id:en: 6753
 wikidata:en: Q457239
 
 en: Halloween cosmetics, Halloween makeup, Halloween products, Halloween supplies
-fr: Maquillage d'Halloween, Cosmétiques d'Halloween
 xx: Halloween-makeup
+fr: Maquillage d'Halloween, Cosmétiques d'Halloween
 

--- a/taxonomies/beauty/categories.txt
+++ b/taxonomies/beauty/categories.txt
@@ -1689,7 +1689,6 @@ wikidata:en: Q1545022
 
 < en: Aftershaves
 en: Aftershave lotions, After-shave lotions
-fr: Lotion post-rasage
 ar: غسول بعد الحلاقة
 az: Tıraşdan sonra losyon
 bg: Лосион след бръснене
@@ -1703,6 +1702,7 @@ es: Loción para después del afeitado
 et: Pärast raseerimist losjoon
 fa: لوسیون بعد از اصلاح
 fi: Parranajon jälkeen käytettävä lotion
+fr: Lotion post-rasage
 ga: Lóis iar-bhearrtha
 he: תחליב לאחר גילוח
 hr: Losion poslije brijanja
@@ -1744,7 +1744,6 @@ zh: 剃须后乳液
 
 < en: Aftershaves
 en: Aftershave balms, After-shave balms
-fr: Baumes Après-rasage, Lotion Après-rasage, Baume Après-rasage
 ar: بلسم بعد الحلاقة
 az: Tıraşdan sonra balzam
 bg: Балсам след бръснене
@@ -1758,6 +1757,7 @@ es: Bálsamo para después del afeitado
 et: Pärast raseerimist palsam
 fa: بالم بعد از اصلاح
 fi: Parranajon jälkeen käytettävä balsami
+fr: Baumes Après-rasage, Lotion Après-rasage, Baume Après-rasage
 ga: Balm iar-bhearrtha
 he: באלם לאחר גילוח
 hr: Balzam poslije brijanja
@@ -2317,7 +2317,6 @@ fr: Gommages pour le corps, Gommages corporels, Gommage pour le corps, Gommage c
 
 < en: Body
 en: Leg care products, Leg care
-fr: Soins pour les jambes, Soin pour les jambes
 ar: العناية بالساقين
 az: Ayaq baxımı
 bg: Грижа за краката
@@ -2331,6 +2330,7 @@ es: Cuidado de las piernas
 et: Jalgade hooldus
 fa: مراقبت از پا
 fi: Jalkojen hoito
+fr: Soins pour les jambes, Soin pour les jambes
 ga: Cúram cos
 he: טיפוח רגליים
 hr: Njega stopala

--- a/taxonomies/beauty/categories.txt
+++ b/taxonomies/beauty/categories.txt
@@ -868,9 +868,11 @@ google_product_taxonomy_id:en: 2747
 wikidata:en: Q1267611
 
 < en: Showers and baths
+en: Shower creams, Cream shower gels
 fr: Crèmes douche, Douche crème
 
 < en: Showers and baths
+en: Shower oils
 fr: Huiles douche
 
 #### Hygiène intime
@@ -987,6 +989,7 @@ google_product_taxonomy_id:en: 2564
 wikidata:en: Q976338
 
 < fr: Tampons hygiéniques
+en: Regular tampons
 fr: Tampons réguliers
 
 < en: Intimate hygiene
@@ -1669,6 +1672,7 @@ vi: Cạo râu
 zh: 剃须
 
 < en: Shaving
+en: Pre-shave products, Pre-shave
 fr: Avant rasage
 
 < en: Shaving
@@ -1678,6 +1682,7 @@ google_product_taxonomy_id:en: 529
 wikidata:en: Q1545022
 
 < en: Aftershaves
+en: Aftershave lotions, After-shave lotions
 fr: Lotion post-rasage
 ar: غسول بعد الحلاقة
 az: Tıraşdan sonra losyon
@@ -1732,6 +1737,7 @@ vi: Sữa dưỡng sau khi cạo râu
 zh: 剃须后乳液
 
 < en: Aftershaves
+en: Aftershave balms, After-shave balms
 fr: Baumes Après-rasage, Lotion Après-rasage, Baume Après-rasage
 ar: بلسم بعد الحلاقة
 az: Tıraşdan sonra balzam
@@ -2068,6 +2074,7 @@ vi: Kem dưỡng thể
 zh: 身体乳霜
 
 < en: Body creams
+en: Foot creams
 ar: كريمات للقدم
 az: Ayaq kremləri
 bg: Кремове за крака
@@ -2119,9 +2126,11 @@ vi: Kem dưỡng da chân
 zh: 护脚霜
 
 < en: Body creams
+en: Body balms and butters, Body butters
 fr: Baumes et beurres pour le corps, baumes et beurres corporels
 
 < en: Body creams
+en: Moisturizing creams, Moisturising creams
 ar: كريمات مرطبة
 az: Nəmləndirici kremlər
 bg: Хидратиращи кремове
@@ -2225,6 +2234,7 @@ vi: Dầu dưỡng thể
 zh: 身体油
 
 < en: Body oils
+en: Massage oils
 ar: زيت التدليك
 az: Masaj yağı
 bg: Масажно олио
@@ -2276,15 +2286,18 @@ vi: Dầu mát-xa
 zh: 按摩油
 
 < fr: Huile de massage
+en: Edible massage oils
 fr: Huile de massage comestible
 
 < en: Body
 en: Body gels
 
 < en: Body gels
+en: Slimming gels, Anti-cellulite gels
 fr: Gel Amincissant
 
 < en: Body gels
+en: Massage gels
 fr: Gel de massage
 
 < en: Body
@@ -2296,6 +2309,7 @@ en: Body scrubs, body exfoliants
 fr: Gommages pour le corps, Gommages corporels, Gommage pour le corps, Gommage corporel
 
 < en: Body
+en: Leg care products, Leg care
 fr: Soins pour les jambes, Soin pour les jambes
 ar: العناية بالساقين
 az: Ayaq baxımı
@@ -2694,6 +2708,7 @@ zh: 抗皱霜
 ####
 
 < en: Face
+en: Eye contour creams, Eye creams
 fr: Contours des yeux
 
 < en: Face
@@ -4368,6 +4383,7 @@ vi: Dầu gội có chiết xuất tự nhiên
 zh: 天然提取物洗发水
 
 < fr: Shampooings aux extraits naturels
+en: Linden shampoos
 ar: شامبو بخلاصة الزيزفون
 az: Şampunlar cövhəri ilə
 bg: Шампоани с екстракт от липа
@@ -4424,15 +4440,19 @@ vi: Dầu gội có chiết xuất từ cây Linden
 zh: 菩提树提取物洗发水
 
 < fr: Shampooings aux extraits naturels
+en: Nettle shampoos
 fr: Shampooings à l'ortie
 
 < fr: Shampooings aux extraits naturels
+en: Lemon balm shampoos
 fr: Shampooings à la mélisse
 
 < fr: Shampooings aux extraits naturels
+en: Chamomile shampoos
 fr: Shampooings à la camomille
 
 < fr: Shampooings aux extraits naturels
+en: Honey shampoos
 fr: Shampooings au miel, shampooings au miel de fleurs
 
 < en: Shampoos
@@ -4540,6 +4560,7 @@ vi: Dầu gội gỡ rối tóc
 zh: 柔顺洗发水
 
 < en: Shampoos
+en: Anti-dryness shampoos
 ar: شامبو مضاد للجفاف
 az: Quruluğa qarşı şampunlar
 bg: Шампоани против изсушаване
@@ -4591,6 +4612,7 @@ vi: Dầu gội chống khô
 zh: 防干燥洗发水
 
 < en: Shampoos
+en: Anti-hair loss shampoos
 ar: شامبو ضد تساقط الشعر
 az: Saç tökülməsinə qarşı şampunlar
 bg: Шампоани против косопад
@@ -4867,6 +4889,7 @@ vi: Duỗi tóc
 zh: 拉直头发
 
 < en: Hair
+en: Hair styling products, Styling products
 fr: Coiffants
 
 < fr: Coiffants
@@ -5332,6 +5355,7 @@ vi: Trang điểm mặt
 zh: 脸部彩妆
 
 < en: Face Makeup
+en: Foundations, Foundation
 az: Tonal krem
 bg: Фон дьо тен
 da: Foundation
@@ -5380,9 +5404,11 @@ zh: 粉底
 wikidata:en: Q1418455
 
 < fr: Fonds de teint
+en: Powder foundations
 fr: Fond de teint poudre
 
 < fr: Fonds de teint
+en: Liquid foundations
 ar: كريم أساس سائل
 az: Maye tonal krem
 bg: Течен фон дьо тен
@@ -5434,9 +5460,11 @@ vi: Kem nền dạng lỏng
 zh: 粉底液
 
 < en: Face Makeup
+en: Bronzing powders, Bronzers
 fr: Poudres bronzantes
 
 < en: Face Makeup
+en: Loose powders, Loose face powders
 fr: Poudres libres
 
 < fr: Poudres libres
@@ -5446,6 +5474,7 @@ es: Polvos fijadores
 fr: Poudres fixantes
 
 < en: Face Makeup
+en: Makeup primers, Face primers
 fr: Primer
 
 < en: Face Makeup
@@ -6567,6 +6596,7 @@ zh: 科隆香水
 wikidata:en: Q2863
 
 < en: Perfumes
+en: Body mists, Body sprays
 fr: Brumes corporelles, Brumes corporelle, Brume corporelles, Brume corporelle
 
 ######## CATEGORIE Accessoires


### PR DESCRIPTION
### 1. Duplicate synonyms and typos (8 lines)

Six lines repeat a synonym within the same line, e.g. `fr: Crèmes jour et nuit, Crèmes jour et nuit, Soin jour et nuit`. Two typos: `Crête anti-âge visage` (should be `Crème`) on *Anti-aging face care products*, and a missing plural agreement on *Sunscreen*.

### 2. Missing `en:` canonical names (30 entries)

30 entries have no `en:` line at all, so their canonical id falls back to French, Arabic or Azerbaijani. Concretely, on current `main`:

| Product | Current id |
|---|---|
| Foundations | `az:tonal-krem` |
| Foot creams | `ar:كريمات-للقدم` |
| Massage oils | `ar:زيت-التدليك` |
| Liquid foundations | `ar:كريم-أساس-سائل` |
| Hair styling products | `fr:coiffants` |
| Loose powders | `fr:poudres-libres` |

These categories are effectively invisible to any English-language integration, and cannot be mapped to Wikidata or the Google Product Taxonomy the way their siblings are. This commit adds the `en:` line; existing translations are untouched.

### 3. Missing French translations (15 entries)

`Bar soaps`, `Scented soaps`, `Unscented soaps`, `Facial sunscreens`, `Cotton buds`, `Petroleum jellies`, `Eye drops` and others had no `fr:` line, although French is the primary contribution language on OBF.

---
