### PR TITLE
fix: don't add "Missing serving size" tag after deleting per-serving values

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -926,7 +926,8 @@ sub check_nutrition_data ($product_ref) {
 				}
 			}
 
-			if ($per eq "serving") {
+			# Only consider per-serving nutrition present when the set still has nutrient values.
+			if (($per eq "serving") and (defined $set_ref->{nutrients}) and (scalar keys %{$set_ref->{nutrients}})) {
 				$has_nutrition_per_serving = 1;
 			}
 		}

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -832,6 +832,65 @@ check_quality_and_test_product_has_quality_tag(
 	'serving size cannot be parsed', 0
 );
 
+# stale per-serving set without nutrient values should not trigger missing serving size
+# and per-100g nutrient values should still be validated
+$product_ref = {
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "serving",
+				nutrients => {}
+			},
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"fat" => {value => 120, unit => "g"}
+				}
+			}
+		]
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-missing-serving-size',
+	'empty per-serving input set should not trigger missing serving size error', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-producer-as-sold-100g-value-over-105-fat',
+	'per-100g values should still be validated when a stale per-serving set exists', 1
+);
+
+# stale per-serving set without nutrients key should also not trigger missing serving size
+$product_ref = {
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "serving"
+			},
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"energy-kj" => {value => 200, unit => "kj"}
+				}
+			}
+		]
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-missing-serving-size',
+	'per-serving input set without nutrients should not trigger missing serving size error', 0
+);
+
 # serving size not recognized (leading to undefined serving quantity)
 $product_ref = {serving_size => "50",};
 check_quality_and_test_product_has_quality_tag(


### PR DESCRIPTION
<!-- 
⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ There's an agreement by a maintainer or core contributor in the linked issue to assign it to the author of this PR
-->

<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `style`, for Code style changes (formatting, whitespace, etc.)
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
  - `test`, for Adding or updating tests
  - `build`, for Build system or dependency changes
  - `revert`, for Reverting previous changes
  - `l10n`, for Localization and translation updates
  - `taxonomy`, for Changes to product categories and tags taxonomy
-->
<!-- IMPORTANT CHECKLIST: Make sure you've done all the following (You can delete the checklist before submitting)-->
<!-- - [ ] Code is well documented-->
<!-- - [ ] Include unit tests for new functionality-->
<!-- - [ ] Code passes GitHub workflow checks in your branch-->
<!-- - [ ] If you have multiple commits please combine them into one commit by squashing them.-->
<!-- - [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)-->

### What
<!-- Describe the changes made -->
<!-- Describe why they were made instead of how they were made. -->
When unticking the "per serving" box on a record that incorrectly had it ticked and per-serving nutrition values, the data structure could (according to copilot) still have an empty set for the per-serving data, and incorrectly cause the nutrition-data-per-serving-missing-serving-size quality error.

https://uk.openfoodfacts.org/product/5000157156853/heinz-garlic-mayo

### Large Language Models usage disclosure
<!-- ⚠️ If you used an LLM, please disclose which LLM you used (and its version) and how (agentic, autocomplete). Please confirm you have run successfully the code on your device. Also provide a screenshot or video as proof -->
VSCode Copilot auto model mode - GPT-5.3-Codex, GPT-5.4.

### Screenshot or video
<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->
<img width="961" height="769" alt="image" src="https://github.com/user-attachments/assets/632fee49-46ac-4e75-9652-7f5e48046e63" />


<img width="761" height="257" alt="image" src="https://github.com/user-attachments/assets/ddb61801-0de1-4db1-ab2f-8ccf2ab79e5a" />


### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
<!-- Replace with the appropriate issue number(s) -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: <!-- #1 Note: you can also use Closes: -->

