### PR TITLE
fix: allow searching products with barcodes up to 40 digits

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -5,7 +5,7 @@
 # Product Opener
 # Copyright (C) 2011-2023 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
-# Address: 21 rue des Iles, 94100 Saint-Maur des Foss茅s, France
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -657,7 +657,7 @@ elsif ($action eq 'process') {
 
 			my %terms = ();
 
-			foreach my $term (split(/,|'|鈥檤\s/, $search_terms)) {
+			foreach my $term (split(/,|'|’|\s/, $search_terms)) {
 				if (length(get_string_id_for_lang($lc, $term)) >= 2) {
 					$terms{normalize_search_terms(get_string_id_for_lang($lc, $term))} = 1;
 				}
@@ -959,4 +959,3 @@ HTML
 		}
 	}
 }
-

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -5,7 +5,7 @@
 # Product Opener
 # Copyright (C) 2011-2023 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
-# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+# Address: 21 rue des Iles, 94100 Saint-Maur des Foss茅s, France
 #
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -247,7 +247,7 @@ if (    (not defined single_param('json'))
 	and (not defined single_param('jqm_loadmore'))
 	and (not defined single_param('xml'))
 	and (not defined single_param('rss'))
-	and ($search_terms =~ /^(\d{4,24}|(?:[\^(\N{U+001D}\N{U+241D}]|https?:\/\/).+)$/))
+	and ($search_terms =~ /^(\d{4,40}|(?:[\^(\N{U+001D}\N{U+241D}]|https?:\/\/).+)$/))
 {
 
 	my $code = normalize_code($search_terms);
@@ -657,7 +657,7 @@ elsif ($action eq 'process') {
 
 			my %terms = ();
 
-			foreach my $term (split(/,|'|’|\s/, $search_terms)) {
+			foreach my $term (split(/,|'|鈥檤\s/, $search_terms)) {
 				if (length(get_string_id_for_lang($lc, $term)) >= 2) {
 					$terms{normalize_search_terms(get_string_id_for_lang($lc, $term))} = 1;
 				}
@@ -959,3 +959,4 @@ HTML
 		}
 	}
 }
+

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -319,7 +319,7 @@ is(
 			product_name => 'Test Product',
 		}
 	),
-	'Test Product 鈥?Carrefour',
+	'Test Product – Carrefour',
 	'add brand to product name'
 );
 
@@ -404,4 +404,3 @@ is([grep {/^en:nutrition/} @{$beauty_product_ref->{states_tags}}], [], 'beauty p
 is($beauty_product_ref->{complete}, 1, 'beauty products can be complete without nutrition facts and photo');
 
 done_testing();
-

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -319,7 +319,7 @@ is(
 			product_name => 'Test Product',
 		}
 	),
-	'Test Product – Carrefour',
+	'Test Product 鈥?Carrefour',
 	'add brand to product name'
 );
 
@@ -339,6 +339,9 @@ is(product_id_from_path("$BASE_DIRS{PRODUCTS}/123/456/789/product"), "123456789"
 # Test is_valid_code()
 
 is(is_valid_code('1234567890123'), 1, 'valid EAN13 code');
+is(is_valid_code('1234567890123456789012345'), 1, 'valid 25 digit product code');
+is(is_valid_code('1' x 40), 1, 'valid 40 digit product code');
+is(is_valid_code('1' x 41), '', '41 digit code is too long');
 is(is_valid_code('123'), '', '3 digit code');
 is(is_valid_code('00000123'), '', '3 digit code with leading 0s');
 is(is_valid_code('1234567890123456789012345678901234567890123456789012345678901234567890'), '', 'too long code');
@@ -401,3 +404,4 @@ is([grep {/^en:nutrition/} @{$beauty_product_ref->{states_tags}}], [], 'beauty p
 is($beauty_product_ref->{complete}, 1, 'beauty products can be complete without nutrition facts and photo');
 
 done_testing();
+


### PR DESCRIPTION
### What

Product code validation already supports codes up to 40 digits, but the search redirect gate still recognized only 4–24 numeric digits. This change aligns the search entry point with the existing validation and adds boundary tests for 25-, 40-, and 41-digit product codes.

### Large Language Models usage disclosure

Implemented with OpenAI Codex (GPT-5) as an agentic coding assistant. I reviewed the final diff and ran `git diff --check` plus a local 24/25/40/41-digit boundary check. Full Perl unit tests were not run because Docker, Perl, and Yath are unavailable in my local environment.

### Related issue(s) and discussion

- Fixes #6571
- Claim comment: https://github.com/openfoodfacts/openfoodfacts-server/issues/6571#issuecomment-5317656127