### PR TITLE
fix: make report problem panel flavor-aware

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -7299,6 +7299,18 @@ msgctxt "incomplete_or_incorrect_data_subtitle_off"
 msgid "Category, labels, ingredients, allergens, nutritional information, photos etc."
 msgstr "Category, labels, ingredients, allergens, nutritional information, photos etc."
 
+msgctxt "incomplete_or_incorrect_data_subtitle_obf"
+msgid "Category, labels, ingredients, allergens, photos etc."
+msgstr "Category, labels, ingredients, allergens, photos etc."
+
+msgctxt "incomplete_or_incorrect_data_subtitle_opf"
+msgid "Category, labels, ingredients, product characteristics, photos etc."
+msgstr "Category, labels, ingredients, product characteristics, photos etc."
+
+msgctxt "incomplete_or_incorrect_data_subtitle_opff"
+msgid "Category, labels, ingredients, allergens, nutritional information, photos etc."
+msgstr "Category, labels, ingredients, allergens, nutritional information, photos etc."
+
 msgctxt "incomplete_or_incorrect_data_content_correct"
 msgid "If the information does not match the information on the packaging, you can complete or correct it. Thank you!"
 msgstr "If the information does not match the information on the packaging, you can complete or correct it. Thank you!"
@@ -7306,6 +7318,18 @@ msgstr "If the information does not match the information on the packaging, you 
 msgctxt "incomplete_or_incorrect_data_content_correct_off"
 msgid "Open Food Facts is a collaborative database, and every contribution is useful for all."
 msgstr "Open Food Facts is a collaborative database, and every contribution is useful for all."
+
+msgctxt "incomplete_or_incorrect_data_content_correct_obf"
+msgid "Open Beauty Facts is a collaborative database, and every contribution is useful for all."
+msgstr "Open Beauty Facts is a collaborative database, and every contribution is useful for all."
+
+msgctxt "incomplete_or_incorrect_data_content_correct_opf"
+msgid "Open Products Facts is a collaborative database, and every contribution is useful for all."
+msgstr "Open Products Facts is a collaborative database, and every contribution is useful for all."
+
+msgctxt "incomplete_or_incorrect_data_content_correct_opff"
+msgid "Open Pet Food Facts is a collaborative database, and every contribution is useful for all."
+msgstr "Open Pet Food Facts is a collaborative database, and every contribution is useful for all."
 
 msgctxt "report_to_nutripatrol_explain"
 msgid "If you want to report vandalism, inappropriate content or erroneous data you can't fix yourself, report it to our moderators team."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -7292,6 +7292,18 @@ msgctxt "incomplete_or_incorrect_data_subtitle_off"
 msgid "Category, labels, ingredients, allergens, nutritional information, photos etc."
 msgstr "Category, labels, ingredients, allergens, nutritional information, photos etc."
 
+msgctxt "incomplete_or_incorrect_data_subtitle_obf"
+msgid "Category, labels, ingredients, allergens, photos etc."
+msgstr "Category, labels, ingredients, allergens, photos etc."
+
+msgctxt "incomplete_or_incorrect_data_subtitle_opf"
+msgid "Category, labels, ingredients, product characteristics, photos etc."
+msgstr "Category, labels, ingredients, product characteristics, photos etc."
+
+msgctxt "incomplete_or_incorrect_data_subtitle_opff"
+msgid "Category, labels, ingredients, allergens, nutritional information, photos etc."
+msgstr "Category, labels, ingredients, allergens, nutritional information, photos etc."
+
 msgctxt "incomplete_or_incorrect_data_content_correct"
 msgid "If the information does not match the information on the packaging, you can complete or correct it. Thank you!"
 msgstr "If the information does not match the information on the packaging, you can complete or correct it. Thank you!"
@@ -7299,6 +7311,18 @@ msgstr "If the information does not match the information on the packaging, you 
 msgctxt "incomplete_or_incorrect_data_content_correct_off"
 msgid "Open Food Facts is a collaborative database, and every contribution is useful for all."
 msgstr "Open Food Facts is a collaborative database, and every contribution is useful for all."
+
+msgctxt "incomplete_or_incorrect_data_content_correct_obf"
+msgid "Open Beauty Facts is a collaborative database, and every contribution is useful for all."
+msgstr "Open Beauty Facts is a collaborative database, and every contribution is useful for all."
+
+msgctxt "incomplete_or_incorrect_data_content_correct_opf"
+msgid "Open Products Facts is a collaborative database, and every contribution is useful for all."
+msgstr "Open Products Facts is a collaborative database, and every contribution is useful for all."
+
+msgctxt "incomplete_or_incorrect_data_content_correct_opff"
+msgid "Open Pet Food Facts is a collaborative database, and every contribution is useful for all."
+msgstr "Open Pet Food Facts is a collaborative database, and every contribution is useful for all."
 
 msgctxt "report_to_nutripatrol_explain"
 msgid "If you want to report vandalism, inappropriate content or erroneous data you can't fix yourself, report it to our moderators team."
@@ -8081,4 +8105,3 @@ msgstr "Forest footprint for the origin"
 msgctxt "forest_footprint_2026_label"
 msgid "Label"
 msgstr "Label"
-

--- a/templates/api/knowledge-panels/report_problem/incomplete_or_incorrect_data.tt.json
+++ b/templates/api/knowledge-panels/report_problem/incomplete_or_incorrect_data.tt.json
@@ -7,8 +7,8 @@
     "evaluation": "neutral",
     "title_element": {
         "title": "[% edq(lang('incomplete_or_incorrect_data_title')) %]",
-        "subtitle": "[% edq(lang('incomplete_or_incorrect_data_subtitle_off')) %]",
-        "icon_url": "[% static_subdomain %]/images/logos/off-logo-icon-light.svg",
+        "subtitle": "[% edq(lang_flavor('incomplete_or_incorrect_data_subtitle')) %]",
+        "icon_url": "[% static_subdomain %]/images/logos/[% flavor %]-logo-icon-light.svg",
     },
     "elements": [
         {
@@ -16,7 +16,7 @@
             "text_element": {
                 "html": `
                 [% lang('incomplete_or_incorrect_data_content_correct') %]
-                [% lang('incomplete_or_incorrect_data_content_correct_off') %]
+                [% lang_flavor('incomplete_or_incorrect_data_content_correct') %]
                 `         
             },
         },

--- a/tests/unit/templates.t
+++ b/tests/unit/templates.t
@@ -63,10 +63,8 @@ foreach my $flavor (qw(off obf opf opff)) {
 		lang_flavor => sub {return shift . "_" . $flavor;},
 	};
 
-	ok(
-		$tt->process($report_problem_template, $template_data_ref, \$rendered_template),
-		"report problem template renders for the $flavor flavor"
-	);
+	ok($tt->process($report_problem_template, $template_data_ref, \$rendered_template),
+		"report problem template renders for the $flavor flavor");
 	like(
 		$rendered_template,
 		qr{"subtitle": "incomplete_or_incorrect_data_subtitle_$flavor"},
@@ -82,7 +80,7 @@ foreach my $flavor (qw(off obf opf opff)) {
 		qr{incomplete_or_incorrect_data_content_correct_$flavor},
 		"report problem content uses the $flavor translation"
 	);
-	ok(-e "$data_root/html/images/logos/$flavor-logo-icon-light.svg", "$flavor logo asset exists");
+	ok(-e "$www_root/images/logos/$flavor-logo-icon-light.svg", "$flavor logo asset exists");
 }
 
 done_testing();

--- a/tests/unit/templates.t
+++ b/tests/unit/templates.t
@@ -50,4 +50,39 @@ sub test_template($) {
 
 test_template(".");
 
+my $report_problem_template = "api/knowledge-panels/report_problem/incomplete_or_incorrect_data.tt.json";
+
+foreach my $flavor (qw(off obf opf opff)) {
+	my $rendered_template = "";
+	my $template_data_ref = {
+		flavor => $flavor,
+		static_subdomain => "https://static.example.org",
+		panel => {nutripatrol_enabled => 0},
+		edq => sub {return shift;},
+		lang => sub {return "generic_" . shift;},
+		lang_flavor => sub {return shift . "_" . $flavor;},
+	};
+
+	ok(
+		$tt->process($report_problem_template, $template_data_ref, \$rendered_template),
+		"report problem template renders for the $flavor flavor"
+	);
+	like(
+		$rendered_template,
+		qr{"subtitle": "incomplete_or_incorrect_data_subtitle_$flavor"},
+		"report problem subtitle uses the $flavor translation"
+	);
+	like(
+		$rendered_template,
+		qr{https://static\.example\.org/images/logos/$flavor-logo-icon-light\.svg},
+		"report problem icon uses the $flavor logo"
+	);
+	like(
+		$rendered_template,
+		qr{incomplete_or_incorrect_data_content_correct_$flavor},
+		"report problem content uses the $flavor translation"
+	);
+	ok(-e "$data_root/html/images/logos/$flavor-logo-icon-light.svg", "$flavor logo asset exists");
+}
+
 done_testing();


### PR DESCRIPTION
### What

The report problem panel was hardcoded to Open Food Facts, so OBF, OPF and OPFF could show the OFF logo and food-specific text.

- Use the current flavor for the logo and translated text.
- Add English strings for OBF, OPF and OPFF.
- Add template tests for all four flavors.

I ran:
- `git diff --check`
- `msgfmt --check-format -o /dev/null po/common/en.po`
- targeted checks for the translation keys and logo assets for `off`, `obf`, `opf` and `opff`

I could not run `make test-unit test=templates.t` because the project test image and Perl dependencies are not installed locally.

### Large Language Models usage disclosure

OpenAI Codex using GPT-5, agentic. The local checks listed above passed.

### Screenshot or video

Not included: this changes the data returned by the template, and I do not have the full UI stack running locally.

### Related issue(s) and discussion

- Fixes: #10825